### PR TITLE
fix: fixed blank strings in approval component on Team page

### DIFF
--- a/frontend/timesheet/src/app/pages/team/approval.tsx
+++ b/frontend/timesheet/src/app/pages/team/approval.tsx
@@ -302,14 +302,10 @@ export const Approval = () => {
                                   </div>
                                 </div>
 
-                                <HoverCard openDelay={1000} closeDelay={0}>
-                                  <HoverCardTrigger className="text-sm font-normal  col-span-2 hover:cursor-pointer">
-                                    <p dangerouslySetInnerHTML={{ __html: truncateText(description, 150) }}></p>
-                                  </HoverCardTrigger>
-                                  <HoverCardContent className="text-sm font-normal overflow-auto max-h-72 max-w-lg w-full">
-                                    <p dangerouslySetInnerHTML={{ __html: description }}></p>
-                                  </HoverCardContent>
-                                </HoverCard>
+                                <p
+                                  className="text-sm font-normal  col-span-2"
+                                  dangerouslySetInnerHTML={{ __html: description }}
+                                ></p>
                               </div>
                             </div>
                           );


### PR DESCRIPTION
### Bug Description:
Blank String is rendered in the Team's page  approval component 

`<p dangerouslySetInnerHTML={{ __html: truncateText(description, 150) }}></p>`

### Cause:
The truncation limits the HTML to 150 characters, which might break tags and result in improper parsing or rendering of the HTML.

### Solution:
Instead of truncating the HTML string, use the full description without truncation. This ensures valid HTML is rendered:

`<p className="text-sm font-normal col-span-2" dangerouslySetInnerHTML={{ __html: description }}></p>`