### PR TITLE
fix: Update leave query & make button clickable

### DIFF
--- a/frappe_pms/timesheet/api/utils.py
+++ b/frappe_pms/timesheet/api/utils.py
@@ -8,17 +8,19 @@ now = nowdate()
 
 def get_leaves_for_employee(from_date: str, to_date: str, employee: str):
 
-    from_date = getdate(from_date)
-    to_date = getdate(to_date)
-    return frappe.get_list(
-        "Leave Application",
-        filters={
-            "employee": employee,
-            "creation": ["between", [from_date, to_date]],
-            "status": ["in", ["Open", "Approved"]],
-        },
-        fields=["*", "leave_type.include_holiday"],
-    )
+    leave_application = frappe.qb.DocType("Leave Application")
+    filtered_data = (
+        frappe.qb.from_(leave_application)
+        .select("*")
+        .where(leave_application.employee == employee)
+        .where(
+            (leave_application.from_date >= from_date)
+            & (leave_application.to_date <= to_date)
+        )
+        .where(leave_application.status.isin(["Open", "Approved"]))
+    ).run(as_dict=True)
+
+    return filtered_data
 
 
 def get_week_dates(date, current_week: bool = False):

--- a/frontend/timesheet/src/app/pages/timesheet/Approval.tsx
+++ b/frontend/timesheet/src/app/pages/timesheet/Approval.tsx
@@ -92,7 +92,7 @@ export const Approval = () => {
               )}
             />
             <DialogFooter className="sm:justify-start mt-6">
-              <Button disabled={isSubmitting || !form.formState.isDirty || !form.formState.isValid}>
+              <Button disabled={isSubmitting}>
                 {isSubmitting ? <LoaderCircle className="animate-spin" /> : <Send />}
                 Submit For Approval
               </Button>


### PR DESCRIPTION
- Revert the leave query to fetch all the leaves.
- Make button clickable even if form is not dirty.

ref: https://github.com/rtCamp/ERP/issues/1928
ref: #183