### PR TITLE
fix: update the reminde_project_threshold to take the last row of Project Budget in case of Retainer project

### DIFF
--- a/frappe_pms/project_currency/tasks/reminde_project_threshold.py
+++ b/frappe_pms/project_currency/tasks/reminde_project_threshold.py
@@ -87,7 +87,7 @@ def filter_project_list(project_list: list):
             if len(custom_project_budget_hours) == 0:
                 continue
 
-            custom_project_budget_hours = custom_project_budget_hours[0]
+            custom_project_budget_hours = custom_project_budget_hours[-1]
             project_threshold = (
                 custom_project_budget_hours.consumed_hours * 100
             ) / custom_project_budget_hours.hours_purchased


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

- Fix the reminde_project_threshold cron for Retainer project

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> QA List
<!-- Add the QA list that needs to be done after PR merge -->

- [ ] Check if task take last row data or not

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
