### PR TITLE
feat(ui): add X icon to clear search text input

### DIFF
--- a/frontend/pms/src/app/components/deBounceInput.tsx
+++ b/frontend/pms/src/app/components/deBounceInput.tsx
@@ -1,5 +1,6 @@
 import { Input, InputProps } from "@/app/components/ui/input";
 import { cn, deBounce } from "@/lib/utils";
+import { Search, X } from "lucide-react";
 import { useCallback, useState } from "react";
 
 export interface DeBounceInputProps extends InputProps {
@@ -13,7 +14,7 @@ export const DeBounceInput = ({ value, className, callback, deBounceValue = 500,
     deBounce((e: React.ChangeEvent<HTMLInputElement>) => {
       callback && callback(e);
     }, deBounceValue),
-    [],
+    []
   );
 
   const handleEmployeeChange = useCallback(
@@ -21,14 +22,36 @@ export const DeBounceInput = ({ value, className, callback, deBounceValue = 500,
       setInputValue(e.target.value);
       onInputChange(e);
     },
-    [onInputChange],
+    [onInputChange]
   );
+  const clearInput = () => {
+    setInputValue("");
+    onInputChange({ target: { value: "" } } as React.ChangeEvent<HTMLInputElement>);
+  };
+
   return (
-    <Input
-      className={cn("placeholder:text-slate-400 focus-visible:ring-0 focus-visible:ring-slate-800 max-w-sm", className)}
-      {...props}
-      value={inputValue}
-      onChange={handleEmployeeChange}
-    />
+    <div className={cn("relative w-full max-w-sm", className)}>
+      <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+        <Search className="w-5 h-5 text-gray-400" aria-hidden="true" />
+      </div>
+      <Input
+        className={cn(
+          " flex-1 w-full placeholder:text-slate-400 focus-visible:ring-0 focus-visible:ring-slate-800 focus-visible:ring-offset-0 focus-visible:ring-0 py-2 pl-10 pr-10"
+        )}
+        placeholder="Search..."
+        {...props}
+        value={inputValue}
+        onChange={handleEmployeeChange}
+      />
+      {inputValue && (
+        <X
+          className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 hover:text-gray-500 cursor-pointer"
+          onClick={clearInput}
+          aria-label="Clear search"
+          role="button"
+          tabIndex={0}
+        />
+      )}
+    </div>
   );
 };

--- a/frontend/pms/src/app/components/ui/command.tsx
+++ b/frontend/pms/src/app/components/ui/command.tsx
@@ -1,10 +1,10 @@
-import * as React from "react"
-import { type DialogProps } from "@radix-ui/react-dialog"
-import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
+import * as React from "react";
+import { type DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search, X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/app/components//ui/dialog"
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent } from "@/app/components//ui/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -18,8 +18,8 @@ const Command = React.forwardRef<
     )}
     {...props}
   />
-))
-Command.displayName = CommandPrimitive.displayName
+));
+Command.displayName = CommandPrimitive.displayName;
 
 interface CommandDialogProps extends DialogProps {}
 
@@ -32,27 +32,42 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
         </Command>
       </DialogContent>
     </Dialog>
-  )
-}
+  );
+};
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-    <CommandPrimitive.Input
-      ref={ref}
-      className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
-        className
-      )}
-      {...props}
-    />
-  </div>
-))
+>(({ className, ...props }, ref) => {
+  const [value, setValue] = React.useState("");
 
-CommandInput.displayName = CommandPrimitive.Input.displayName
+  const clearInput = () => {
+    setValue("");
+    props.onValueChange?.("");
+  };
+
+  return (
+    <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+      <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        ref={ref}
+        className={cn(
+          "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+        value={value}
+        onValueChange={(newValue) => {
+          setValue(newValue);
+          props.onValueChange?.(newValue);
+        }}
+      />
+      {value && <X className="w-5 h-5 shrink-0 cursor-pointer opacity-50 hover:opacity-100" onClick={clearInput} />}
+    </div>
+  );
+});
+
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
@@ -63,22 +78,16 @@ const CommandList = React.forwardRef<
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-))
+));
 
-CommandList.displayName = CommandPrimitive.List.displayName
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-  <CommandPrimitive.Empty
-    ref={ref}
-    className="py-6 text-center text-sm"
-    {...props}
-  />
-))
+>((props, ref) => <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />);
 
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
 const CommandGroup = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Group>,
@@ -92,21 +101,17 @@ const CommandGroup = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 
-CommandGroup.displayName = CommandPrimitive.Group.displayName
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 const CommandSeparator = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <CommandPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 h-px bg-border", className)}
-    {...props}
-  />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+  <CommandPrimitive.Separator ref={ref} className={cn("-mx-1 h-px bg-border", className)} {...props} />
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
@@ -120,25 +125,14 @@ const CommandItem = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 
-CommandItem.displayName = CommandPrimitive.Item.displayName
+CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-const CommandShortcut = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-CommandShortcut.displayName = "CommandShortcut"
+const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />;
+};
+CommandShortcut.displayName = "CommandShortcut";
 
 export {
   Command,
@@ -150,4 +144,4 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
-}
+};

--- a/frontend/pms/src/app/pages/home/index.tsx
+++ b/frontend/pms/src/app/pages/home/index.tsx
@@ -76,7 +76,7 @@ const Home = () => {
   });
   useEffect(() => {
     if (data) {
-      if (homeState.action=="SET") {
+      if (homeState.action == "SET") {
         dispatch(setData(data.message));
       } else {
         dispatch(updateData(data.message));
@@ -90,7 +90,7 @@ const Home = () => {
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, error,homeState.action]);
+  }, [data, error, homeState.action]);
 
   const handleEmployeeChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -132,7 +132,6 @@ const Home = () => {
               placeholder="Employee name"
               value={employeeNameParam}
               deBounceValue={300}
-              className="min-w-40 max-w-40"
               callback={handleEmployeeChange}
             />
             <ComboxBox

--- a/frontend/pms/src/app/pages/project/index.tsx
+++ b/frontend/pms/src/app/pages/project/index.tsx
@@ -579,13 +579,7 @@ const ProjectTable = ({ viewData, meta }: ProjectProps) => {
     <>
       <Header className="gap-x-3 flex items-center overflow-x-auto">
         <section id="filter-section" className="flex gap-x-2 items-center">
-          <DeBounceInput
-            placeholder="Project Name"
-            value={searchParam}
-            deBounceValue={200}
-            className="max-w-40 min-w-40 "
-            callback={handleSearch}
-          />
+          <DeBounceInput placeholder="Project Name" value={searchParam} deBounceValue={200} callback={handleSearch} />
 
           <ComboxBox
             isMulti

--- a/frontend/pms/src/app/pages/task/index.tsx
+++ b/frontend/pms/src/app/pages/task/index.tsx
@@ -382,7 +382,6 @@ const Task = () => {
           {/* Task Search Filter */}
           <DeBounceInput
             placeholder="Search Subject..."
-            className="max-w-40 max-md:w-40 focus-visible:ring-offset-0 focus-visible:ring-0"
             deBounceValue={300}
             value={subjectSearchParam}
             callback={handleSubjectSearchChange}

--- a/frontend/pms/src/app/pages/team/index.tsx
+++ b/frontend/pms/src/app/pages/team/index.tsx
@@ -259,7 +259,6 @@ const Team = () => {
             placeholder="Employee name"
             value={employeeNameParam}
             deBounceValue={300}
-            className="max-w-40 min-w-40 "
             callback={handleEmployeeChange}
           />
           <EmployeeCombo


### PR DESCRIPTION
##### Problem
- Since the search bar do not have clear button, user has to select all the text and manually clear the text from the search. 

##### What's changed:
- Add `X` icon to clear search text input.


> Screenshots/GIFs

<img width="267" alt="image" src="https://github.com/user-attachments/assets/af4f60cf-e67a-4846-bc2d-80980a6b26e0">
<br>
<img width="455" alt="image" src="https://github.com/user-attachments/assets/2c1da6a6-a501-44b1-9caf-249959d6adc4">

