### PR TITLE
fix: Save change bugs in `Project` and `Task` page

### DIFF
--- a/frontend/pms/src/app/components/listview/createView.tsx
+++ b/frontend/pms/src/app/components/listview/createView.tsx
@@ -41,17 +41,11 @@ export const CreateView = ({
 }: CreateViewProps) => {
   const { call } = useFrappePostCall("next_pms.timesheet.doctype.pms_view_setting.pms_view_setting.create_view");
   const user = useSelector((state: RootState) => state.user);
-  const defaultRows = ["name", "creation", "modified"];
   const [label, setLabel] = useState("");
   const dispatch = useDispatch();
   const [openEmoji, setOpenEmoji] = useState(false);
   const [selectedEmoji, setSelectedEmoji] = useState("😀");
   const createView = () => {
-    defaultRows.forEach((value) => {
-      if (!rows.includes(value)) {
-        rows.push(value);
-      }
-    });
     const view = {
       dt: dt,
       rows: rows,

--- a/frontend/pms/src/app/components/listview/header/FilterValue.tsx
+++ b/frontend/pms/src/app/components/listview/header/FilterValue.tsx
@@ -42,10 +42,10 @@ const FilterValue = ({ filters }: { filters: FilterPops[] }) => {
       <div className="px-2 rounded text-sm">Filters</div>
       <div className="flex gap-x-2 overflow-scroll w-fit px-4 no-scrollbar">
         {updateFilters &&
-          updateFilters.map((filter: FilterPops) => {
+          updateFilters.map((filter: FilterPops,idx) => {
             if (Array.isArray(filter.value)) {
               return (
-                <div className="flex gap-2 flex-shrink-0">
+                <div key={idx} className="flex gap-2 flex-shrink-0">
                   <div className="bg-gray-200 px-2 py-1 rounded text-sm">{filter.label}</div>
                   {filter.value.map((value, index) => (
                     <Badge
@@ -62,7 +62,7 @@ const FilterValue = ({ filters }: { filters: FilterPops[] }) => {
               );
             }
             return (
-              <div className="flex gap-2 w-fit flex-shrink-0">
+              <div key={idx} className="flex gap-2 w-fit flex-shrink-0">
                 <div className="bg-gray-200 px-2 py-1 rounded text-sm">{filter.label}</div>
                 <Badge
                   variant="secondary"

--- a/frontend/pms/src/app/components/listview/header/index.tsx
+++ b/frontend/pms/src/app/components/listview/header/index.tsx
@@ -6,6 +6,7 @@
  *
  * Internal dependencies
  */
+import React from "react";
 import { Filter } from "@/app/components/listview/header/Filter";
 import { HeaderProps, FilterPops, ButtonProps } from "@/app/components/listview/type";
 import { Button } from "@/app/components/ui/button";
@@ -46,9 +47,9 @@ export const Header = ({
       >
         <div id="filters" className="flex gap-x-2 max-md:w-full items-center overflow-y-hidden no-scrollbar ">
           {filters &&
-            filters.map((filter: FilterPops) => {
+            filters.map((filter: FilterPops,idx) => {
               if (filter.hide) {
-                return <></>;
+                return <React.Fragment key={idx}></React.Fragment>;
               }
               return <Filter filter={filter} key={filter.queryParameterName} />;
             })}
@@ -56,9 +57,9 @@ export const Header = ({
         <div className="flex gap-x-2">
           {buttons && (
             <div className="flex gap-x-2 max-md:p-1 max-md:w-full max-md:justify-between max-md:m-2">
-              {buttons.map((button: ButtonProps) => {
+              {buttons.map((button: ButtonProps,idx) => {
                 if (button.hide) {
-                  return <></>;
+                  return <React.Fragment key={idx}></React.Fragment>;
                 }
                 return (
                   <Button
@@ -66,6 +67,7 @@ export const Header = ({
                     className={cn("p-1 h-fit", button.className)}
                     variant={button.variant || "outline"}
                     onClick={button.handleClick}
+                    key={idx}
                   >
                     {button.icon && <button.icon />}
                     {button.label}

--- a/frontend/pms/src/app/pages/task/Header.tsx
+++ b/frontend/pms/src/app/pages/task/Header.tsx
@@ -3,14 +3,17 @@
  */
 import { useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useFrappePostCall } from "frappe-react-sdk";
 import { Plus } from "lucide-react";
 /**
  * Internal dependencies
  */
 import { Header as ListViewHeader } from "@/app/components/listview/header";
+import { useToast } from "@/app/components/ui/use-toast";
+import { parseFrappeErrorMsg } from "@/lib/utils";
 import { RootState } from "@/store";
 import { setAddTaskDialog, setSearch, setSelectedProject, setSelectedStatus, TaskStatusType } from "@/store/task";
-import { ViewData } from "@/store/view";
+import { updateView, ViewData } from "@/store/view";
 import { DocMetaProps } from "@/types";
 import { createFilter } from "./utils";
 
@@ -20,11 +23,39 @@ interface HeaderProps {
   setColumnOrder: React.Dispatch<React.SetStateAction<string[]>>;
   onColumnHide: (column: string) => void;
   view: ViewData;
+  stateUpdated:boolean;
+  setStateUpdated:(value:boolean)=>void;
 }
-export const Header = ({ meta, columnOrder, setColumnOrder, onColumnHide, view }: HeaderProps) => {
+export const Header = ({ meta, columnOrder, setColumnOrder, onColumnHide, view,stateUpdated,setStateUpdated }: HeaderProps) => {
   const taskState = useSelector((state: RootState) => state.task);
   const [projectSearch, setProjectSeach] = useState<string>("");
+  const {toast} = useToast();
   const dispatch = useDispatch();
+
+  // frappe-call for updating view
+  const { call } = useFrappePostCall("next_pms.timesheet.doctype.pms_view_setting.pms_view_setting.update_view");
+
+  // Handle save changes
+  const handleSaveChanges= () => {
+    call({
+      view: view,
+    })
+      .then((res) => {
+        dispatch(updateView(res.message));
+        toast({
+          variant: "success",
+          description: "View Updated",
+        });
+        setStateUpdated(false);
+      })
+      .catch((err) => {
+        const error = parseFrappeErrorMsg(err);
+        toast({
+          variant: "destructive",
+          description: error,
+        });
+      });
+  };
 
   const handleSearch = (text: string) => {
     dispatch(setSearch(text));
@@ -135,6 +166,16 @@ export const Header = ({ meta, columnOrder, setColumnOrder, onColumnHide, view }
     },
   };
   const buttons = [
+    {
+      title: "Save changes",
+      handleClick: () => {
+        handleSaveChanges();
+      },
+      hide:!stateUpdated,
+      label: "Save changes",
+      variant: "ghost",
+      className: "h-10 px-2 py-2",
+    },
     {
       title: "Task",
       handleClick: () => {

--- a/frontend/pms/src/app/pages/task/utils.ts
+++ b/frontend/pms/src/app/pages/task/utils.ts
@@ -3,10 +3,9 @@ import { TaskState } from "@/store/task";
 
 export const createFilter = (taskState: TaskState) => {
   return {
-    search: taskState.search,
+    search: taskState.search ?? "",
     projects: taskState.selectedProject,
     status: taskState.selectedStatus,
-    groupBy: taskState.groupBy,
   };
 };
 
@@ -23,10 +22,6 @@ export const getFilter = (taskState: TaskState) => {
 
   if (taskState.selectedStatus.length > 0) {
     filters.push(["status", "in", taskState.selectedStatus]);
-  }
-
-  if (taskState.groupBy.length > 0) {
-    filters.push(["groupBy", "in", taskState.groupBy]);
   }
 
   return filters;

--- a/frontend/pms/src/store/view.ts
+++ b/frontend/pms/src/store/view.ts
@@ -68,8 +68,21 @@ const viewSlice = createSlice({
             state.views = state.views.filter(v => v.name !== action.payload)
         },
         updateView: (state, action: PayloadAction<ViewData>) => {
-            const index = state.views.findIndex(v => v.name === action.payload.name)
-            state.views[index] = action.payload
+            const index = state.views.findIndex(v => v.name === action.payload.name);
+            const updatedView =  action.payload;
+            if (typeof action.payload.filters == 'string') {
+                updatedView.filters = JSON.parse(action.payload.filters);
+            }
+            if (typeof action.payload.rows == 'string') {
+                updatedView.rows = JSON.parse(action.payload.rows);
+            }
+            if (typeof action.payload.columns == 'string') {
+                updatedView.columns = JSON.parse(action.payload.columns);
+            }
+            if (typeof action.payload.order_by == 'string') {
+                updatedView.order_by = JSON.parse(action.payload.order_by);
+            }
+            state.views[index] = updatedView
         }
     }
 });

--- a/next_pms/timesheet/doctype/pms_view_setting/pms_view_setting.py
+++ b/next_pms/timesheet/doctype/pms_view_setting/pms_view_setting.py
@@ -95,4 +95,4 @@ def update_view(view):
     doc.default = view.default or 0
     doc.public = view.public or 0
     doc.save()
-    return get_views()
+    return doc


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Resolves `Save changes` bug on Task and Project page, updates view API, and removes Toast UI as the default message on view update.

> Explain the **details** for making this change. What existing problem does the pull request solve?
- The `update_view` method now returns the `doc` instead of a `view`.
- Replaced the `Save Change` toast notification with a dedicated "Save Changes" button in the header.  
  This change was made to address an issue where excessive, infinite toast notifications appeared when changing column widths.
- Fixed an issue where the `Save Changes` functionality only worked the first time. It now works consistently for all view changes.
- Resolved a bug where `Save Changes` toast appeared when switching between views, even if no changes were made in the UI.

> QA List

- [ ] Create multiple views on Project and Task page and check if the "Save Change" button appears on the header or not.
- [ ] Change Column width to see save changes

> Screenshots/GIFs

![image](https://github.com/user-attachments/assets/50eee826-1d0d-4bbb-87df-339b00779983)

cc: @niraj2477 / @KanchanChauhan