### PR TITLE
fix: Load task details in chronological sequence

### DIFF
--- a/frontend/pms/src/app/pages/task/TaskLog.tsx
+++ b/frontend/pms/src/app/pages/task/TaskLog.tsx
@@ -177,7 +177,7 @@ export const TaskLog = ({ task, isOpen, onOpenChange }: TaskLogProps) => {
             {data?.message.worked_by?.length != 0 && (
               <>
                 <section id="worked_by w-full bg-red-500">
-                  <div className="flex gap-x-4 overflow-x-auto">
+                  <div className="flex gap-x-4 overflow-x-auto no-scrollbar">
                     {data?.message.worked_by?.map((employee: Employee) => (
                       <div key={employee.employee} className="flex items-center gap-x-2 shrink-0">
                         <Avatar className="w-6 h-6">
@@ -206,12 +206,10 @@ export const TaskLog = ({ task, isOpen, onOpenChange }: TaskLogProps) => {
               <Spinner />
             ) : (
               <>
-                <section id="log" className="max-h-96 overflow-y-auto flex flex-col gap-3">
+                <section id="log" className="max-h-96 overflow-y-auto no-scrollbar flex flex-col gap-3">
                   <>
                     {logs &&
                       Object.entries(logs.message as Record<string, LogData[]>)
-                        .slice()
-                        .reverse()
                         .map(([key, value], index: number) => {
                           return (
                             <div key={index}>

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -205,6 +205,7 @@ def get_task_log(task: str, start_date: str = None, end_date: str = None):
             & (timesheet.start_date >= str(start_date))
             & (timesheet.start_date <= str(end_date))
         )
+        .orderby(timesheet.start_date, order=frappe.qb.desc)
     )
 
     result = query.run(as_dict=True)


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:
- This PR ensures that time entries in the Task Log are displayed in chronological order by date

> Explain the **details** for making this change. What existing problem does the pull request solve?
- When opening the Task Log on the Task page, the time entries currently appear in a random order based on how users entered them in the timesheet, which can be confusing. This PR addresses the issue by ensuring that the records are displayed in chronological order by date for better clarity and usability.


> QA List
 
- [ ] Ensure time entries in the Task Log are displayed in chronological order by date


> Screenshots/GIFs

![image](https://github.com/user-attachments/assets/97f4712e-d50c-46b8-9c0c-6be513e9e8c5)


cc: @KanchanChauhan / @niraj2477 
