### PR TITLE
Chore: Add missing YAML front matter for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
 # 🐛 Bug Report
 
 ## **Description**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,9 @@
+---
+name: Feature request
+about: Suggest a new idea or feature for ERP
+labels: Feature-Request
+---
+
 # 🚀 Feature Request
 
 ## **Description**


### PR DESCRIPTION
## Description

Add accidentally removed YAML front matter in #368

## Relevant Technical Choices

Add back YAML front matter in `.github/ISSUE_TEMPLATE/feature_request.md` and `.github/ISSUE_TEMPLATE/bug_report.md` that was removed in the previous PR

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- ~[ ] I have carefully reviewed the code before submitting it for review~ NA
- ~[ ] This code is adequately covered by unit tests to validate its functionality.~ NA
- ~[ ] I have conducted thorough testing to ensure it functions as intended.~ NA
- ~[ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)~ NA

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See #368