### PR TITLE
fix: Remove `project_name` from rows in PMS View Setting

### DIFF
--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -7,6 +7,7 @@ next_pms.timesheet.patches.add_timesheet_role
 # Patches added in this section will be executed after doctypes are migrated
 next_pms.timesheet.patches.update_timesheet_weekly_status
 next_pms.timesheet.patches.add_notification_template
+next_pms.timesheet.patches.remove_project_name_from_task_rows
 
 # next_pms.project_currency.patches.update_project_billing_type Need to run this manually
 # next_pms.project_currency.patches.project_threshold_limit_reminder_email_template

--- a/next_pms/timesheet/patches/remove_project_name_from_task_rows.py
+++ b/next_pms/timesheet/patches/remove_project_name_from_task_rows.py
@@ -1,0 +1,20 @@
+import frappe
+import json
+from frappe.utils import update_progress_bar
+
+def execute():
+    settings_docs = frappe.get_all('PMS View Setting', fields=['name', 'dt', 'rows'])
+    length = len(settings_docs)
+    for i,doc in enumerate(settings_docs):
+        update_progress_bar("Removing project_name from PMS View Setting", i, length)
+        if doc.dt == "Task":
+            if doc.rows:
+                try:
+                    rows_data = json.loads(doc.rows)
+                    project_name = "project_name"                   
+                    if project_name in rows_data:
+                        rows_data.remove(project_name)
+                        frappe.db.set_value('PMS View Setting', doc.name, 'rows', json.dumps(rows_data))
+                        frappe.db.commit() 
+                except json.JSONDecodeError:
+                    frappe.log_error(f"Invalid JSON format in rows field for document {doc.name}")


### PR DESCRIPTION
## Description

To ensure consistency with the updated implementation where `project_name` is no longer required in the rows field of the PMS View Setting doctype, this patch removes any occurrences of `project_name` from the rows field. This prevents older view settings that still include `project_name` from causing a `407 Expectation Failed error` when exporting the records in Task Page in the frontend.(https://github.com/rtCamp/next-pms/issues/364)

## Relevant Technical Choices

- Iterates through all `PMS View Setting` records.
- Checks for the presence of `project_name` in the `rows` field of documents with "Task" as the `doctype`.
- Removes `project_name` if found.
- Saves the updated document to persist the changes.

## Testing Instructions

- Run bench migrate to run the patch

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

cc: @KanchanChauhan / @niraj2477 / @zeel-codder 