### PR TITLE
Fix current day highlighting util function based on timezone

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -349,5 +349,5 @@ export const currencyFormat = (currency: string) => {
 };
 
 export const getBgCsssForToday = (date: string) => { 
-  return isToday(date) ? "bg-slate-100" : "";
+  return isToday(getDateTimeForMultipleTimeZoneSupport(date)) ? "bg-slate-100" : "";
 }


### PR DESCRIPTION
## Description

The current date highlighting in tables of `Home` and `Timesheet` page across Next_PMS is inaccurate because it does not account for timezones. This leads to situations where the highlighted date might be a day ahead or behind for users in different time zones

## Relevant Technical Choices

- Add timezone support `getBgCsssForToday` utility

## Testing Instructions

- Visit `Home` or `Timesheet` page and check if correct day is highlighted 

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/8f99cdd5-5a63-464a-a6d0-299ffc8caa31" />
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/1be5cd82-f698-4361-9da3-99705fd2b041" />




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

