### PR TITLE
Resolve the issue of employee_name being empty in the EmployeeComboBox component

### DIFF
--- a/frontend/src/app/components/employeeComboBox.tsx
+++ b/frontend/src/app/components/employeeComboBox.tsx
@@ -72,7 +72,6 @@ const EmployeeCombo = ({
     undefined,
     {
       revalidateIfStale: false,
-      revalidateOnMount: false,
     }
   );
   const onEmployeeChange = (name: string) => {

--- a/frontend/src/app/pages/team/employeeDetail.tsx
+++ b/frontend/src/app/pages/team/employeeDetail.tsx
@@ -22,6 +22,7 @@ import { Typography } from "@/app/components/typography";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/app/components/ui/accordion";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
+import { Separator } from "@/app/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 import { useToast } from "@/app/components/ui/use-toast";
 import { Header, Footer, Main } from "@/app/layout/root";
@@ -59,7 +60,6 @@ import {
 } from "@/store/team";
 import { LeaveProps, NewTimesheetProps, TaskDataItemProps, TaskDataProps, timesheet } from "@/types/timesheet";
 import { Approval } from "./approval";
-import { Separator } from "@/app/components/ui/separator";
 import ExpandableHours from "../timesheet/ExpandableHours";
 
 const isDateInRange = (date: string, startDate: string, endDate: string) => {
@@ -206,7 +206,7 @@ const EmployeeDetail = () => {
         />
       )}
       <Header>
-        <EmployeeCombo onSelect={onEmployeeChange} pageLength={20} value={id as string} className="w-full lg:w-fit" ignoreDefaultFilters={true} />
+        <EmployeeCombo employeeName={employee?.message?.employee_name} onSelect={onEmployeeChange} pageLength={20} value={id as string} className="w-full lg:w-fit" ignoreDefaultFilters={true} />
       </Header>
 
       <Main>


### PR DESCRIPTION
## Description

On the Team Page, when navigating to the Employee Detail page `(/team/employee/EMP-00397)` , the EmployeeComboBox fails to display any users, even when they exist. This issue arises due to a previous commit that limits the fetched users to only `20 records`. To resolve this, we have to explicitly pass the `employee_name` as a prop to the EmployeeComboBox component.

## Relevant Technical Choices

- Pass `employee_name` prop in EmployeeComboBox component
- Remove `revalidateOnMount: false,` from EmployeeComboBox 

## Testing Instructions

- Visit team page
- Click on any employee
- Ensure EmployeeComboBox shows correct user
- Click on `emptyRow` to create a timesheet
- Ensure the `AddTime` component shows correct user

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

before:

https://github.com/user-attachments/assets/e7822ad7-30bb-4dca-976c-708f847a2b41

after:

https://github.com/user-attachments/assets/07b5465d-be59-462f-828b-7547452c9336




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

