### PR TITLE
Modify update_timesheet_detail function to prevent list mutation

### DIFF
--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -214,16 +214,23 @@ def update_timesheet_detail(
 ):
     parent_doc = frappe.get_doc("Timesheet", parent)
     parent_doc.flags.ignore_permissions = is_timesheet_manager()
-    for log in parent_doc.time_logs:
+    
+    logs_to_remove = [] # List to store logs that need to be removed
+
+    for log in parent_doc.time_logs: 
         if not name:
             continue
         if log.name == name:
             log.hours = hours
             log.description = description
             log.is_billable = is_billable
-        if getdate(log.from_time) != getdate(date) and log.name == name:
-            parent_doc.time_logs.remove(log)
-            save(date, description, task, hours, parent_doc.employee, is_billable)
+            if getdate(log.from_time) != getdate(date):
+                logs_to_remove.append(log)
+                save(date, description, task, hours, parent_doc.employee, is_billable)
+
+    for log in logs_to_remove:
+        parent_doc.time_logs.remove(log)
+    
     if not name:
         parent_doc.append(
             "time_logs",


### PR DESCRIPTION
## Description

In the previous commit, we implemented the `editDate` functionality, which mutated parent_doc.time_logs during iteration, causing runtime errors. This fix ensures the list is not modified while iterating.

## Relevant Technical Choices

- Create a temporary list to store the documents to be removed from the original list.
- After the iteration, process the temporary list to remove the marked documents.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
