### PR TITLE
Remove ignore_default_filters when skill-search filter is applied

### DIFF
--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -81,7 +81,6 @@ def get_resource_management_team_view_data(
         reports_to=reports_to,
         start=start,
         status=["Active"],
-        ignore_default_filters=True if len(skills) > 0 else False,
         ids=ids,
         ignore_permissions=True,
     )


### PR DESCRIPTION
## Description

When filtering employees based on skills using the `skill-search` dialog box, employees with statuses other than `active` were incorrectly included in the results. This PR resolves the issue, ensuring only employees with an `active` status are listed.

## Relevant Technical Choices

- Remove `ignore_default_filters` when skill-search filter is applied

## Testing Instructions

- Visit team view under resource management
- Apply skill-search
- Verify no employees have status other than `active`

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast


Searching for css skill:

before:

![image](https://github.com/user-attachments/assets/03d53efa-9323-4cca-9767-dc68477a1510)

after:

![image](https://github.com/user-attachments/assets/2b6796c7-c0e0-488f-b8e6-a18a31c0a8b2)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes #378 