### PR TITLE
Add billing type filter in resource project page

### DIFF
--- a/frontend/packages/app/src/app/components/listview/header/Filter.tsx
+++ b/frontend/packages/app/src/app/components/listview/header/Filter.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { CheckedState } from "@radix-ui/react-checkbox";
 import { Filter as Funnel } from "lucide-react";
 /**

--- a/frontend/packages/app/src/app/pages/resource_management/project/index.tsx
+++ b/frontend/packages/app/src/app/pages/resource_management/project/index.tsx
@@ -48,6 +48,7 @@ const ResourceTeamView = () => {
           page_length: resourceProjectState.pageLength,
           project_name: resourceProjectState.projectName,
           customer: resourceProjectState.customer,
+          billing_type: resourceProjectState.billingType,
           is_billable: getIsBillableValue(resourceProjectState.allocationType as string[]),
           start: resourceProjectState.start,
         }

--- a/frontend/packages/app/src/store/resource_management/project.ts
+++ b/frontend/packages/app/src/store/resource_management/project.ts
@@ -74,6 +74,7 @@ export interface ResourceTeamState {
   isLoading?: boolean;
   maxWeek: number;
   action: "SET" | "UPDATE";
+  billingType?: string[];
 }
 
 export const initialState: ResourceTeamState = {
@@ -104,6 +105,7 @@ export const initialState: ResourceTeamState = {
   },
   isNeedToFetchDataAfterUpdate: false,
   customer: [],
+  billingType: [],
   allocationType: [],
   isLoading: true,
   maxWeek: 5,
@@ -199,6 +201,7 @@ const ResourceTeamSlice = createSlice({
         view?: string;
         allocationType?: string[];
         combineWeekHours?: boolean;
+        billingType?: string[];
       }>
     ) => {
       state.projectName = action.payload.projectName;
@@ -217,6 +220,9 @@ const ResourceTeamSlice = createSlice({
       if (action.payload.view) {
         state.tableView.view = action.payload.view;
       }
+      if (action.payload.billingType) {
+        state.billingType = action.payload.billingType;
+      }
 
       state.start = 0;
       state.isLoading = true;
@@ -227,11 +233,12 @@ const ResourceTeamSlice = createSlice({
     deleteFilters: (
       state,
       action: PayloadAction<{
-        type: "project" | "customer" | "allocation-type";
+        type: "project" | "customer" | "allocation-type" | "billing-type";
         projectName?: string;
         reportingManager?: string[];
         customer?: string[];
         allocationType?: string[];
+        billingType?: string[];
       }>
     ) => {
       if (action.payload.type === "project") {
@@ -242,6 +249,9 @@ const ResourceTeamSlice = createSlice({
       }
       if (action.payload.type === "allocation-type") {
         state.allocationType = action.payload.allocationType;
+      }
+      if (action.payload.type === "billing-type") {
+        state.billingType = action.payload.billingType;
       }
 
       state.start = 0;
@@ -260,6 +270,14 @@ const ResourceTeamSlice = createSlice({
     },
     setCustomer: (state, action: PayloadAction<string[]>) => {
       state.customer = action.payload;
+      state.start = 0;
+      state.isLoading = true;
+      state.isNeedToFetchDataAfterUpdate = true;
+      state.action = "SET";
+      state.maxWeek = initialState.maxWeek;
+    },
+    setBillingType: (state, action: PayloadAction<string[]>) => {
+      state.billingType = action.payload;
       state.start = 0;
       state.isLoading = true;
       state.isNeedToFetchDataAfterUpdate = true;
@@ -313,5 +331,6 @@ export const {
   setReFetchData,
   setAllocationType,
   setMaxWeek,
+  setBillingType,
 } = ResourceTeamSlice.actions;
 export default ResourceTeamSlice.reducer;

--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -237,7 +237,13 @@ doc_events = {
         ],
         "on_trash": ["next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache"],
     },
-    "Project": {"on_update": "next_pms.project_currency.doc_events.project.on_update"},
+    "Project": {
+        "on_update": [
+            "next_pms.project_currency.doc_events.project.on_update",
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
+        "on_trash": ["next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache"],
+    },
     "Customer": {"validate": "next_pms.resource_management.doc_events.customer.validate_abbr"},
 }
 #

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -26,6 +26,7 @@ def get_resource_management_project_view_data(
     max_week: int = 2,
     project_name=None,
     customer=None,
+    billing_type=None,
     is_billable=-1,
     page_length=10,
     start=0,
@@ -37,6 +38,7 @@ def get_resource_management_project_view_data(
         is_billable = -1
         customer = None
         project_id = None
+        billing_type = None
 
     ids = None
 
@@ -46,7 +48,7 @@ def get_resource_management_project_view_data(
         ids = project_id
 
     projects, total_count = filter_project_list(
-        project_name, page_length=page_length, start=start, customer=customer, ids=ids
+        project_name, page_length=page_length, start=start, customer=customer, billing_type=billing_type, ids=ids
     )
 
     data = []

--- a/next_pms/resource_management/api/utils/helpers.py
+++ b/next_pms/resource_management/api/utils/helpers.py
@@ -136,7 +136,7 @@ def filter_employee_list(
     return employees, count
 
 
-def filter_project_list(project_name=None, customer=None, page_length=10, start=0, ids=None):
+def filter_project_list(project_name=None, customer=None, billing_type=None, page_length=10, start=0, ids=None):
     import json
 
     from next_pms.timesheet.api.utils import get_count
@@ -160,6 +160,12 @@ def filter_project_list(project_name=None, customer=None, page_length=10, start=
                 customer = json.loads(customer)
             if customer and len(customer) > 0:
                 filters["customer"] = ["in", customer]
+
+        if billing_type:
+            if isinstance(billing_type, str):
+                billing_type = json.loads(billing_type)
+            if billing_type and len(billing_type) > 0:
+                filters["custom_billing_type"] = ["in", billing_type]
 
     projects = frappe.get_list("Project", filters=filters, fields=fields, start=start, page_length=page_length)
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This PR adds the billing type filter in the resource project page with default values as `"Retainer", "Fixed Cost", "Time and Material"`.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

- Build the PMS pages `cd /apps/next_pms/frontend && npm run build`
- `bench restart`
- Check if billing filter is working or not in resource project page

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/327c0a7f-dfa1-4cd3-9bee-b05d9b1923eb

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See #397 