### PR TITLE
Fix duplicate task rows when creating timesheet for liked task

### DIFF
--- a/frontend/packages/app/src/app/components/TimesheetTable.tsx
+++ b/frontend/packages/app/src/app/components/TimesheetTable.tsx
@@ -195,7 +195,8 @@ const TimesheetTable = ({
     liked_tasks.filter((likedTask: { name: string }) => !Object.keys(tasks).includes(likedTask.name))
   );
   useEffect(()=>{
-    setFilteredLikedTasks(liked_tasks.filter((likedTask: { name: string }) => !Object.keys(tasks).includes(likedTask.name)));
+    const filteredLikedTasks = liked_tasks.filter((likedTask: { name: string }) => !Object.keys(tasks).includes(likedTask.name));
+    setFilteredLikedTasks(filteredLikedTasks);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[tasks])
 


### PR DESCRIPTION
## Description

When creating a timesheet for a liked task on timesheet page, a duplicate row of the same task appears, this PR fixes this issue.

## Relevant Technical Choices

- Add a useEffect with `[task]` as a dependency to dynamically re-render the filtered `liked` task list.

## Testing Instructions

- Visit timesheet page.
- Import liked Task.
- Create a timesheet for liked task.
- Ensure no two rows of same tasks are visible.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

before:
![image](https://github.com/user-attachments/assets/06619d47-8932-4231-9cce-ee602a49fab6)


after:


https://github.com/user-attachments/assets/58630904-190c-44d3-bc87-73aba9720e8d



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
