### PR TITLE
Fix no results message when de-selecting values in task page filters and remove visibility states

### DIFF
--- a/frontend/packages/app/src/app/pages/project/index.tsx
+++ b/frontend/packages/app/src/app/pages/project/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   Spinner,
@@ -30,7 +30,7 @@ import _ from "lodash";
  */
 
 import ViewWrapper from "@/app/components/listview/ViewWrapper";
-import { parseFrappeErrorMsg, createFalseValuedObject } from "@/lib/utils";
+import { parseFrappeErrorMsg } from "@/lib/utils";
 import { RootState } from "@/store";
 import { setProjectData, setStart, setFilters, setReFetchData, updateProjectData } from "@/store/project";
 import { ViewData } from "@/store/view";
@@ -59,7 +59,6 @@ const ProjectTable = ({ viewData, meta }: ProjectProps) => {
   const [colSizing, setColSizing] = useState<ColumnSizingState>(viewData.columns ?? {});
   const [columnOrder, setColumnOrder] = useState<string[]>(viewData.rows ?? []);
   const projectState = useSelector((state: RootState) => state.project);
-  const [columnVisibility, setColumnVisibility] = useState(createFalseValuedObject(viewData.rows));
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -78,7 +77,6 @@ const ProjectTable = ({ viewData, meta }: ProjectProps) => {
     setViewInfo(viewData);
     setColSizing(viewData.columns);
     setColumnOrder(viewData.rows);
-    setColumnVisibility(createFalseValuedObject(viewData.rows));
     setHasViewUpdated(false);
   }, [dispatch, viewData]);
 
@@ -179,32 +177,15 @@ const ProjectTable = ({ viewData, meta }: ProjectProps) => {
     getSortedRowModel: getSortedRowModel(),
     onColumnSizingChange: setColSizing,
     onColumnOrderChange: setColumnOrder,
-    onColumnVisibilityChange: setColumnVisibility,
     state: {
-      columnVisibility,
       columnOrder,
       columnSizing: colSizing,
     },
   });
 
   const handleColumnHide = (id: string) => {
-    setColumnVisibility((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }));
+    setColumnOrder((prev)=>prev.filter(item => item !== id))
   };
-  const updateColumnOrder = useCallback(
-    (visibility: { [key: string]: boolean }) => {
-      let newColumnOrder;
-      if (Object.keys(visibility).length == 0) {
-        newColumnOrder = columnOrder;
-      } else {
-        newColumnOrder = viewData.rows.filter((d) => visibility[d]).map((d) => d);
-      }
-      setColumnOrder(newColumnOrder);
-    },
-    [columnOrder,viewData.rows]
-  );
 
   const updateColumnSize = (columns: Array<string>) => {
     setColSizing((prevColSizing) => {
@@ -222,10 +203,6 @@ const ProjectTable = ({ viewData, meta }: ProjectProps) => {
     updateColumnSize(columnOrder);
   }, [columnOrder]);
 
-  useEffect(() => {
-    updateColumnOrder(columnVisibility);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnVisibility]);
 
   const handleLoadMore = () => {
     if (!projectState.hasMore || projectState.isLoading) return;

--- a/frontend/packages/app/src/app/pages/task/index.tsx
+++ b/frontend/packages/app/src/app/pages/task/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { getUTCDateTime, getFormatedDate } from "@next-pms/design-system/date";
@@ -17,7 +17,7 @@ import ViewWrapper from "@/app/components/listview/ViewWrapper";
 import { useToast } from "@/app/components/ui/use-toast";
 import { LIKED_TASK_KEY } from "@/lib/constant";
 import { addAction, toggleLikedByForTask } from "@/lib/storage";
-import { parseFrappeErrorMsg, createFalseValuedObject } from "@/lib/utils";
+import { parseFrappeErrorMsg } from "@/lib/utils";
 import { RootState } from "@/store";
 import { setStart, updateTaskData, setTaskData, setSelectedTask, setFilters, setReFetchData } from "@/store/task";
 import { SetAddTimeDialog, SetTimesheet } from "@/store/timesheet";
@@ -61,7 +61,6 @@ const TaskTable = ({ viewData, meta }: TaskTableProps) => {
   const [hasViewUpdated, setHasViewUpdated] = useState(false);
   const [colSizing, setColSizing] = useState<ColumnSizingState>(viewData.columns ?? {});
   const [columnOrder, setColumnOrder] = useState<string[]>(viewData.rows ?? []);
-  const [columnVisibility, setColumnVisibility] = useState(createFalseValuedObject(viewData.rows));
 
   const { call: toggleLikeCall } = useFrappePostCall("frappe.desk.like.toggle_like");
 
@@ -76,28 +75,12 @@ const TaskTable = ({ viewData, meta }: TaskTableProps) => {
     setViewInfo(viewData);
     setColSizing(viewData.columns);
     setColumnOrder(viewData.rows);
-    setColumnVisibility(createFalseValuedObject(viewData.rows));
     setHasViewUpdated(false);
   }, [dispatch, viewData]);
 
   const handleColumnHide = (id: string) => {
-    setColumnVisibility((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }));
+    setColumnOrder((prev)=>prev.filter(item => item !== id))
   };
-  const updateColumnOrder = useCallback(
-    (visibility: { [key: string]: boolean }) => {
-      let newColumnOrder;
-      if (Object.keys(visibility).length == 0) {
-        newColumnOrder = columnOrder;
-      } else {
-        newColumnOrder = viewData.rows.filter((d) => visibility[d]).map((d) => d);
-      }
-      setColumnOrder(newColumnOrder!);
-    },
-    [columnOrder, viewData.rows]
-  );
 
   const updateColumnSize = (columns: Array<string>) => {
     setColSizing((prevColSizing) => {
@@ -115,10 +98,6 @@ const TaskTable = ({ viewData, meta }: TaskTableProps) => {
     updateColumnSize(columnOrder);
   }, [columnOrder]);
 
-  useEffect(() => {
-    updateColumnOrder(columnVisibility);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnVisibility]);
 
   const handleAddTime = (taskName: string) => {
     const timesheetData = {
@@ -257,7 +236,6 @@ const TaskTable = ({ viewData, meta }: TaskTableProps) => {
     enableColumnResizing: true,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    onColumnVisibilityChange: setColumnVisibility,
     columnResizeMode: "onChange",
     onColumnOrderChange: setColumnOrder,
     onColumnSizingChange: setColSizing,
@@ -265,7 +243,6 @@ const TaskTable = ({ viewData, meta }: TaskTableProps) => {
       sorting: [{ id: "liked", desc: false }],
     },
     state: {
-      columnVisibility,
       columnOrder,
       columnSizing: colSizing,
     },


### PR DESCRIPTION
## Description

On the `Task` page, when applying filters such as project or status, deselecting a filter value incorrectly shows a `"no results"` message even when data exists.
Additionally, on both the `Task` and `Project` pages, using the `column selector` to add multiple columns and then removing them causes all added columns to be removed, which is unintended behaviour.

## Relevant Technical Choices

- Remove `columnVisibility` states and update `handleColumnHide` fxn to fix issue with columnSelector.
- Remove the check `task.isNeedToFetchDataAfterUpdate` to fix the no results message on task page.

## Testing Instructions

For Project and status filter on task page:
- Visit Task page 
- Click on either of filters `Project` or `Status`
- Select a option
- No de-select the earlier selected option
- Ensure no results message is not shown

For ColumnSelector on Task or Project page:
- Visit either `Task` or `Project` page
- Click on `columns` present at rightmost part of header
- Add multiple columns using `add columns` option
- Now remove any column by clicking on `X`
- Ensure only removed column is removed from the list

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

Before:

https://github.com/user-attachments/assets/a1f821ae-589d-4aa1-9464-8eb9e0aeca64



After:

https://github.com/user-attachments/assets/aeb20a81-c396-46f7-954b-235aa8c41bad



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
