### PR TITLE
Add the useEffect to change timeline width on sidebar collapse

### DIFF
--- a/frontend/packages/app/src/app/pages/resource_management/timeline/index.tsx
+++ b/frontend/packages/app/src/app/pages/resource_management/timeline/index.tsx
@@ -230,7 +230,7 @@ const ResourceTimeLineComponet = () => {
   }, [allocationData.isNeedToDelete, allocationData.new, allocationData.old, handleFormSubmit, setAllocationData]);
 
   useEffect(() => {
-    // This way will make suer timeline width changes on user collapsed the sidebar
+    // This way will make sure the timeline width changes when the user collapses the sidebar.
     setTimeout(() => {
       const container = document.querySelector<HTMLDivElement>(".react-calendar-timeline");
       const scrollContainer = document.querySelector<HTMLDivElement>(".rct-scroll");


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This PR fixes the given issue: https://github.com/rtCamp/next-pms/issues/295#issuecomment-2615059885

Note: There was no direct way to update the width of the page on sidebar width change, so for now, a `useEffect` has been added to change the timeline page width on sidebar change using DOM manipulation.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

- Build the PMS pages `cd /apps/next_pms/frontend/pms` && `npm run build`
- Do `bench restart`
- Go to the timeline page
- Check if the width changes or not

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/98a3fa1b-8d7c-41e4-83ed-c75bd3854499

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See https://github.com/rtCamp/next-pms/issues/295