### PR TITLE
Reset start value on filter change in timeline page

### DIFF
--- a/frontend/packages/app/src/app/pages/resource_management/store/timeLineContext.tsx
+++ b/frontend/packages/app/src/app/pages/resource_management/store/timeLineContext.tsx
@@ -192,7 +192,7 @@ const TimeLineContextProvider = ({ children }: TimeLineContextProviderProps) => 
   };
 
   const updateFilters = (updatedFilters: ResourceAllocationTimeLineFilterProps) => {
-    setFilters({ ...filters, ...updatedFilters });
+    setFilters({ ...filters, ...updatedFilters, start: 0 });
     setEmployees([]);
     setAllocations([]);
     setCustomer({});


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

- In case we have more than 20 values on the timeline page and someone updates the filter, the data was not reset to the first values. This PR solves this issue.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
- Build the PMS pages: `cd /apps/next_pms/frontend/pms` && `npm run build`
- Restart the bench: `bench restart`
- Go to the timeline page
- Check if with more than 20 values, after filter update, the list starts from zero or not

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See https://github.com/rtCamp/next-pms/issues/295