### PR TITLE
Add need_hours_summary in body of resource team page API call

### DIFF
--- a/frontend/packages/app/src/app/pages/resource_management/team/index.tsx
+++ b/frontend/packages/app/src/app/pages/resource_management/team/index.tsx
@@ -62,6 +62,7 @@ const ResourceTeamView = () => {
         ...req,
         employee_name: resourceTeamState.employeeName,
         page_length: resourceTeamState.pageLength,
+        need_hours_summary: true,
       };
       if (resourceAllocationPermission.write) {
         newReqBody = {


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

As we use the same endpoint to fetch data for the resource team as well as the timeline page, there was a bug for the employee role team page because `need_hours_summary` was not passed in the API call, resulting in a page break.

This PR adds the `need_hours_summary` parameter in the team page API call for the employee role.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

- Build the PMS pages: `cd /apps/next_pms/frontend/pms` && `npm run build`
- Restart the bench: `bench restart`
- Check if the team page is working fine for the employee role or not

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See https://github.com/rtCamp/next-pms/issues/295