### PR TITLE
Fix color indicator issue in timesheet table

### DIFF
--- a/frontend/packages/app/src/app/components/timesheet-table/components/weekTotal.tsx
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/weekTotal.tsx
@@ -6,7 +6,8 @@ import { floatToTime } from "@next-pms/design-system/utils";
 /**
  * Internal dependencies
  */
-import { calculateWeeklyHour, cn } from "@/lib/utils";
+import { calculateExtendedWorkingHour, cn, calculateWeeklyHour } from "@/lib/utils";
+
 import { WorkingFrequency } from "@/types";
 type weekTotalProps = {
   total: number;
@@ -26,16 +27,16 @@ type weekTotalProps = {
  * @param {string} props.className - Class name for the component
  */
 export const WeekTotal = ({ total, expected_hour, frequency, className }: weekTotalProps) => {
-  const expectedWeekTime = calculateWeeklyHour(expected_hour, frequency);
+  const isExtended = calculateExtendedWorkingHour(total, calculateWeeklyHour(expected_hour, frequency), frequency);
   return (
     <TableCell className={cn(className)}>
       <Typography
         variant="p"
         className={cn(
           "text-right font-medium",
-          expectedWeekTime == total && "text-success",
-          expectedWeekTime < 2 && "text-warning",
-          expectedWeekTime > total && "text-destructive"
+          isExtended == 0 && "text-destructive",
+          isExtended && "text-success",
+          isExtended == 2 && "text-warning"
         )}
       >
         {floatToTime(total)}

--- a/frontend/packages/app/src/app/pages/team/components/employee.tsx
+++ b/frontend/packages/app/src/app/pages/team/components/employee.tsx
@@ -20,7 +20,7 @@ interface EmployeeProps {
   teamState: TeamState;
 }
 
-export const Employee = ({ employee,teamState }: EmployeeProps) => {
+export const Employee = ({ employee, teamState }: EmployeeProps) => {
   const [isTaskLogDialogBoxOpen, setIsTaskLogDialogBoxOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<string>("");
   const { data, isLoading } = useFrappeGetCall("next_pms.timesheet.api.timesheet.get_timesheet_data", {

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { floatToTime } from "@next-pms/design-system";
 import { getUTCDateTime, normalizeDate } from "@next-pms/design-system/date";
 import { toast } from "@next-pms/design-system/hooks";
 import { type ClassValue, clsx } from "clsx";
@@ -10,11 +11,14 @@ import { twMerge } from "tailwind-merge";
 /**
  * Internal dependencies.
  */
+import { timeStringToFloat } from "@/schema/timesheet";
 import { TScreenSize } from "@/store/app";
 import { WorkingFrequency } from "@/types";
 import { HolidayProp } from "@/types/timesheet";
 
-export const NO_VALUE_FIELDS = ["Section Break", "Column Break",
+export const NO_VALUE_FIELDS = [
+  "Section Break",
+  "Column Break",
   "Tab Break",
   "HTML",
   "Table",
@@ -22,7 +26,8 @@ export const NO_VALUE_FIELDS = ["Section Break", "Column Break",
   "Button",
   "Image",
   "Fold",
-  "Heading"];
+  "Heading",
+];
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -65,42 +70,46 @@ export function removeHtmlString(data: string) {
   return data.replace(/<\/?[^>]+(>|$)/g, "");
 }
 
-
 export function calculateExtendedWorkingHour(
   hours: number,
   expected_hours: number,
-  frequency: WorkingFrequency,
+  frequency: WorkingFrequency
 ) {
+  const flotTime = floatToTime(hours);
+  const timeToFloat = timeStringToFloat(flotTime);
   if (frequency === "Per Day") {
-    if (hours > expected_hours) {
+    if (timeToFloat > expected_hours) {
       return 2;
-    } else if (hours < expected_hours) {
+    } else if (timeToFloat < expected_hours) {
       return 0;
     } else {
       return 1;
     }
   }
   const perDay = expected_hours / 5;
-  if (hours > perDay) {
+  if (timeToFloat > perDay) {
     return 2;
-  } else if (hours < perDay) {
+  } else if (timeToFloat < perDay) {
     return 0;
   } else {
     return 1;
   }
 }
 
-export function calculateWeeklyHour(expected_hours: number, frequency: WorkingFrequency
+export function calculateWeeklyHour(
+  expected_hours: number,
+  frequency: WorkingFrequency
 ) {
   if (frequency === "Per Day") {
     return expected_hours * 5;
   } else {
     return expected_hours;
   }
-
 }
 
-export const expectatedHours = (expected_hours: number, frequency: WorkingFrequency
+export const expectatedHours = (
+  expected_hours: number,
+  frequency: WorkingFrequency
 ): number => {
   if (frequency === "Per Day") {
     return expected_hours;
@@ -190,21 +199,22 @@ export const getErrorMessages = (error: Error) => {
 };
 
 export const checkIsMobile = () => {
-  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-}
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+};
 
 export const copyToClipboard = (text: string) => {
-  navigator.clipboard.writeText(text)
-  toast({ title: "Copied to clipboard", variant: "success" })
-}
-
+  navigator.clipboard.writeText(text);
+  toast({ title: "Copied to clipboard", variant: "success" });
+};
 
 export const canExport = (doctype: string) => {
   return window.frappe?.boot?.user?.can_export?.includes(doctype) ?? true;
-}
+};
 export const canCreate = (doctype: string) => {
   return window.frappe?.boot?.user?.can_create?.includes(doctype) ?? true;
-}
+};
 
 export const currencyFormat = (currency: string) => {
   return new Intl.NumberFormat("en-IN", {
@@ -215,7 +225,7 @@ export const currencyFormat = (currency: string) => {
 
 export const getBgCsssForToday = (date: string) => {
   return isToday(getUTCDateTime(date)) ? "bg-slate-100" : "";
-}
+};
 
 export const isDateInRange = (
   date: string,


### PR DESCRIPTION
## Description

This PR fixes an issue where the total hour color indicator does not correctly reflect the weekly hour value. Even when a user has completed their weekly hours, the indicator incorrectly suggests that fewer hours have been logged.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

1. Log in as employee.
2. Create time entries and verify if total hour color is correct.
```
less hours = red
more hours = orange
```
## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**Before** 
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/0e718e21-9476-41a2-84b8-c07cb386938e" />

**After**

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/1a7e65e5-ad0b-4ca7-b677-95e2c8f5e094" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

