### PR TITLE
Add job_id value in frappe.enqueue to prevent duplicate jobs

### DIFF
--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
@@ -37,6 +37,7 @@ def clear_cache(doc=None, method=None):
     if not is_job_enqueued(job_name):
         frappe.enqueue(
             clear_cache_job,
+            job_id=job_name,
             job_name=job_name,
             queue="default",
             is_async=False,


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
As job_name is deprecated to find duplicate jobs in the queue in Frappe, we should use job_id to check if a job is duplicate or not. This PR updates the same.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Create a job in the queue with a specific job_id.
2. Attempt to create another job with the same job_id.
3. Verify that the second job is not enqueued.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #