### PR TITLE
Calculate working hour between date range in capacity planning report

### DIFF
--- a/next_pms/resource_management/report/capacity_planning/capacity_planning.py
+++ b/next_pms/resource_management/report/capacity_planning/capacity_planning.py
@@ -38,7 +38,7 @@ def get_data(meta, filters=None):
     employees = get_list(
         "Employee",
         fields=fields,
-        filters={"status": employee_status, "name": ["in",["EMP-00234","EMP-00375"]]},
+        filters={"status": employee_status},
         order_by="employee_name ASC",
     )
     employee_names = [employee.employee for employee in employees]


### PR DESCRIPTION
## Description
This pr fixes issue with capacity planning report, where the working hours of the employee are not accounted for each day, due to which the worked hours by the employee are counted based on the allocations found and only hours per day were being taken into account.

## Relevant Technical Choices

1. Add employee name column.
2. Loop over each day and calculate working hours.

## Testing Instructions
1. Goto reports doctype and click on capacity planning report.
2. The numbers should be correct for each employee.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
