### PR TITLE
Highlight weekly status button based on total work hours.

### DIFF
--- a/frontend/packages/app/src/app/components/timesheet-table/components/submitButton.tsx
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/submitButton.tsx
@@ -6,7 +6,7 @@ import { CircleCheck, CircleX, Clock3 } from "lucide-react";
 /**
  * Internal dependencies
  */
-import { mergeClassNames } from "@/lib/utils";
+import { calculateWeeklyHour, mergeClassNames } from "@/lib/utils";
 import type { submitButtonProps } from "./types";
 
 /**
@@ -18,20 +18,33 @@ import type { submitButtonProps } from "./types";
  * @param {Function} props.onApproval - Function to call when the button is clicked
  * @param {string} props.status - Status of the timesheet
  */
-export const SubmitButton = ({ start_date, end_date, onApproval, status }: submitButtonProps) => {
+export const SubmitButton = ({
+  start_date,
+  end_date,
+  onApproval,
+  status,
+  expectedHours,
+  totalHours,
+  workingFrequency,
+}: submitButtonProps) => {
   const handleClick = () => {
     onApproval?.(start_date, end_date);
   };
+  const expectedWeeklyHours = calculateWeeklyHour(expectedHours, workingFrequency);
   return (
     <Button
       variant="ghost"
       asChild
       className={mergeClassNames(
         "font-normal",
-        (status == "Approved" || status == "Partially Approved") && "bg-green-50 text-success",
-        (status == "Rejected" || status == "Partially Rejected") && "bg-red-50 text-destructive",
-        status == "Approval Pending" && "bg-orange-50 text-warning",
-        status == "Not Submitted" && "text-slate-400"
+        (status == "Approved" || status == "Partially Approved") &&
+          "bg-success/20 text-success hover:bg-success/20 hover:text-success",
+        (status == "Rejected" || status == "Partially Rejected") &&
+          "bg-destructive/20 text-destructive hover:bg-destructive/20 hover:text-destructive",
+        status == "Approval Pending" && "bg-warning/20 text-warning hover:bg-warning/20 hover:text-warning",
+        status == "Not Submitted" &&
+          totalHours >= expectedWeeklyHours &&
+          "bg-yellow-50 text-yellow-600 hover:bg-yellow-50 hover:text-yellow-600"
       )}
       onClick={(e) => {
         e.stopPropagation();

--- a/frontend/packages/app/src/app/components/timesheet-table/components/types.ts
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/types.ts
@@ -39,6 +39,9 @@ export type submitButtonProps = {
   end_date: string;
   onApproval?: (start_date: string, end_date: string) => void;
   status: string;
+  expectedHours: number;
+  totalHours: number;
+  workingFrequency: WorkingFrequency;
 };
 
 export type TaskHoverCardProps = {

--- a/frontend/packages/app/src/app/pages/timesheet/index.tsx
+++ b/frontend/packages/app/src/app/pages/timesheet/index.tsx
@@ -218,6 +218,9 @@ function Timesheet() {
                                 end_date={value.end_date}
                                 onApproval={handleApproval}
                                 status={value.status}
+                                expectedHours={timesheet.data.working_hour}
+                                totalHours={data.totalHours}
+                                workingFrequency={timesheet.data.working_frequency as WorkingFrequency}
                               />
                             </div>
                           </AccordionTrigger>


### PR DESCRIPTION
## Description

This PR adds a visual highlight to the `"Not Submitted"` button when the expected weekly hours are met, making it easier for users to identify overdue time entries. Improves clarity and helps ensure timely submissions.

## Relevant Technical Choices

- Highlight `"Not Submitted"` status button based on `expectedTotalHours` for that week

## Testing Instructions

- Visit timesheet page.
- Add timesheets for the entire week, ensuring they match the expected total hours [ in most cases its 40 hours]. If the total work hours meet or exceed 40 hours `"Not Submitted"` button should be highlighted.

## Additional Information:

N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/e9dce824-a0ca-4383-b5ce-a3f846f0d9b3)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Partially Addresses: https://github.com/rtCamp/next-pms/issues/520