### PR TITLE
Fix typo in EmptyTableCell

### DIFF
--- a/frontend/packages/resource-management/src/components/table/cell/emptyTableCell.tsx
+++ b/frontend/packages/resource-management/src/components/table/cell/emptyTableCell.tsx
@@ -38,7 +38,7 @@ const EmptyTableCell = ({ cellClassName, title, textClassName, onCellClick }: Em
     >
       <TableCellContent
         className={textClassName}
-        TextComponet={
+        TextComponent={
           isHovered
             ? () => <CirclePlus className={mergeClassNames("text-center cursor-pointer")} size={4} />
             : () => <>{"-"}</>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This PR fixes the issue where the `-` and `+` icons were not visible on the empty page for the PM role in resource management.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->