### PR TITLE
Disable update weekly status in onsubmit-hook

### DIFF
--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -53,9 +53,9 @@ def before_submit(doc, method=None):
 
 
 def on_submit(doc, method=None):
-    from next_pms.timesheet.api.utils import update_weekly_status_of_timesheet
-
-    update_weekly_status_of_timesheet(doc.employee, getdate(doc.start_date))
+    # from next_pms.timesheet.api.utils import update_weekly_status_of_timesheet
+    # TODO: Need to check
+    # update_weekly_status_of_timesheet(doc.employee, getdate(doc.start_date))
     validate_self_approval(doc)
 
 


### PR DESCRIPTION
## Description

This PR disables update_weekly_status_of_timesheet in on_submit hook

## Relevant Technical Choices

> N/A

## Testing Instructions

> N/A

## Additional Information:

> N/A

## Screenshot/Screencast

> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
