### PR TITLE
Fix addAllocation dialog-box in resource-management

### DIFF
--- a/frontend/packages/app/src/app/pages/resource-management/components/addAllocation.tsx
+++ b/frontend/packages/app/src/app/pages/resource-management/components/addAllocation.tsx
@@ -740,7 +740,7 @@ const AddResourceAllocations = ({
             />
             <DialogFooter className="sm:justify-start w-full pt-3">
               <div className="flex gap-x-4 w-full">
-                <Button disabled={!form.formState.isValid || !form.formState.isDirty || loading}>
+                <Button disabled={!form.formState.isDirty || !form.formState.isValid || loading}>
                   {loading ? <LoaderCircle className="animate-spin w-4 h-4" /> : <Save className="w-4 h-4" />}
                   {resourceDialogState.isNeedToEdit ? "Save" : "Create"}
                 </Button>

--- a/frontend/packages/app/src/schema/resource.ts
+++ b/frontend/packages/app/src/schema/resource.ts
@@ -26,7 +26,10 @@ export const ResourceAllocationSchema = z
       .trim()
       .min(1, { message: "Please select a end date." }),
     note: z.string().optional(),
-    employee: z.string(),
+    employee: z
+      .string()
+      .trim()
+      .min(1, { message: "Please select an employee." }),
   })
   .superRefine((v, ctx) => {
     if (Number(v.hours_allocated_per_day) == 0) {


### PR DESCRIPTION
## Description

This PR fixes state management issues in the Add Allocation dialog and enforces employee combo-box as a required condition to enable the Create button.

## Relevant Technical Choices

- Resolved form state inconsistencies.
- Update schema to make employee mandatory.

## Testing Instructions

- Visit `/next-pms/resource-management/timeline`
- Create a resource allocation.
- Check if all values are valid and Create button is enabled.

## Additional Information:

> N/A

## Screenshot/Screencast


https://github.com/user-attachments/assets/d6c9f0de-bd3a-4b05-8a64-31862fc251a4



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/next-pms/issues/537