### PR TITLE
Workflow: Add build test action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,30 @@
+name: Bench Build Test
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  Bench-Build-Test:
+    runs-on: self-hosted
+    container: docker.io/frappe/bench:latest
+
+    steps:
+      - name: Create a new minimal bench
+        run: |
+          export HOME=/home/frappe && export PATH="$HOME/.local/bin:$PATH"
+          bench init frappe-bench --skip-redis-config-generation --no-procfile --skip-assets
+      - name: Get APP
+        run: |
+          export HOME=/home/frappe && export PATH="$HOME/.local/bin:$PATH"
+          cd frappe-bench && bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}
+      - name: Run Bench Build
+        run: |
+          export HOME=/home/frappe && export PATH="$HOME/.local/bin:$PATH"
+          cd frappe-bench && bench build
+      - name: Cleanup
+        if: ${{ always() }}
+        uses: rtCamp/action-cleanup@master


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the bench build test process. The workflow is triggered on pull requests and runs on a self-hosted runner using a Docker container.

Key changes include:

* [`.github/workflows/build-test.yml`](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R1-R30): Added a new workflow named "Bench Build Test" that runs on pull requests, uses concurrency control to cancel in-progress runs for the same pull request, and executes a series of steps to create a minimal bench, fetch the application, run the bench build, and perform cleanup.