### PR TITLE
fix: directly add object into response data

### DIFF
--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -356,8 +356,8 @@ def get_timesheet(dates: list, employee: str):
                 "status": task["status"],
                 "_liked_by": task["_liked_by"],
             }
-            log_data = {field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS}
-        data[task_name]["data"].append(log_data)
+
+        data[task_name]["data"].append({field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS})
 
     return [data, total_hours]
 


### PR DESCRIPTION
## Description

When we remove non-required field from log data and save it in variable before adding it to response, it does not gets updated in loop, hence this pr removes variable assignment and directly assign it to response object.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

