### PR TITLE
Parse html to get the description of holiday

### DIFF
--- a/frontend/packages/app/src/app/pages/team/employee-detail/employee-timesheet-list/timesheetListItem.tsx
+++ b/frontend/packages/app/src/app/pages/team/employee-detail/employee-timesheet-list/timesheetListItem.tsx
@@ -8,7 +8,7 @@ import { CircleDollarSign } from "lucide-react";
 /**
  * Internal dependencies
  */
-import { mergeClassNames } from "@/lib/utils";
+import { extractTextFromHTML, mergeClassNames } from "@/lib/utils";
 import type { TaskDataItemProps } from "@/types/timesheet";
 import { HourInput } from "../hourInput";
 import type { EmployeeTimesheetListItemProps } from "./types";
@@ -63,7 +63,7 @@ export const EmployeeTimesheetListItem = ({
         </Typography>
         {isHoliday && (
           <Typography variant="p" className="max-md:text-wrap text-primary/60">
-            {holidayDescription}
+            {extractTextFromHTML(holidayDescription ?? "")}
           </Typography>
         )}
         {hasLeave && !isHoliday && (

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -308,3 +308,9 @@ export const mapFieldsToObject = (
     return acc;
   }, {} as Record<string, string | number | null>);
 };
+
+export const extractTextFromHTML = (htmlContent: string) => {
+  const tempElement = document.createElement("div");
+  tempElement.innerHTML = htmlContent;
+  return tempElement?.textContent?.trim();
+};


### PR DESCRIPTION
## Description

This pr fixes issue with the holidays description shown as html rather then text on approval screen.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**Before**
![image](https://github.com/user-attachments/assets/70b9ce7f-1ae7-4f58-93fc-fdfd0cafd2f1)

**After**
![image](https://github.com/user-attachments/assets/b941e42a-6511-4f5e-a67a-8c94d55fcc14)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [x] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

