### PR TITLE
Fix text wrap in textEditor

### DIFF
--- a/frontend/packages/design-system/src/components/text-editor/index.tsx
+++ b/frontend/packages/design-system/src/components/text-editor/index.tsx
@@ -85,7 +85,7 @@ const TextEditor = ({
         {...Props}
         style={{ resize: "vertical", overflow: "auto" }}
         className={mergeClassNames(
-          "border rounded-md border-input [&>div:first-child]:border-t-0 [&>div:first-child]:border-r-0 [&>div:first-child]:border-l-0 [&>div:first-child]:border-input [&>div:first-child]:border-bottom [&>div:last-child]:border-none text-foreground bg-background ",
+          "border rounded-md border-input [&>div:first-child]:border-t-0 [&>div:first-child]:border-r-0 [&>div:first-child]:border-l-0 [&>div:first-child]:border-input [&>div:first-child]:border-bottom [&>div:last-child]:border-none text-foreground bg-background break-all whitespace-normal",
           hideToolbar && "border-none !resize-none [&_.ql-editor]:min-h-0 [&_.ql-editor]:p-2",
           className
         )}


### PR DESCRIPTION
## Description

This PR fixes long continuous text overflowing issue in textEditor.

## Relevant Technical Choices

- Add `break-all whitespace-normal` tw class.

## Testing Instructions

- Open NPMS
- Add a timesheet/edit a timesheet and add continuous long text 
- The text should not overflow the container

## Additional Information:

> N/A

## Screenshot/Screencast

Before:
![image](https://github.com/user-attachments/assets/54d732bf-f2fb-4494-a261-71a7f342db3b)

![image](https://github.com/user-attachments/assets/96c7e920-3473-417f-a306-27a92547ee1d)

After:

![image](https://github.com/user-attachments/assets/d5a19253-7e11-4724-9c56-61b4060e8a0e)

![image](https://github.com/user-attachments/assets/6a63019b-a344-499b-bba1-4da38f2861a9)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
