### PR TITLE
Fix hours mismatch in timesheet list after project change.

### DIFF
--- a/frontend/packages/app/src/app/pages/team/components/approval.tsx
+++ b/frontend/packages/app/src/app/pages/team/components/approval.tsx
@@ -120,7 +120,7 @@ export const Approval = ({ onClose, employee, startDate, endDate, isAprrovalDial
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, error]);
+  }, [data, error, isLoading]);
   useEffect(() => {
     if (timesheetData) {
       const filteredDates = timesheetData.dates

--- a/frontend/packages/app/src/app/pages/team/employee-detail/employee-timesheet-list/timesheetListItem.tsx
+++ b/frontend/packages/app/src/app/pages/team/employee-detail/employee-timesheet-list/timesheetListItem.tsx
@@ -75,7 +75,7 @@ export const EmployeeTimesheetListItem = ({
           </Typography>
         )}
       </div>
-      {tasks?.map((task: TaskDataItemProps, index: number) => {
+      {tasks?.map((task: TaskDataItemProps) => {
         const data = {
           name: task.name,
           parent: task.parent,
@@ -89,7 +89,7 @@ export const EmployeeTimesheetListItem = ({
         return (
           <div
             className="flex flex-col gap-x-2 p-1 mb-2 last:mb-0 border-b w-full max-w-full last:border-b-0"
-            key={index}
+            key={task.name}
           >
             <div className="flex gap-x-3">
               <HourInput


### PR DESCRIPTION
## Description

This PR fixes hours mismatch when changing timesheet project.

## Relevant Technical Choices

- Fix `key` issues in map function

## Testing Instructions

- Go to NPMS.
- Open Team detail page for an employee.
- Edit any existing Timesheet.
- Hours should not mismatch for changed timesheet.

## Additional Information:

> N/A

## Screenshot/Screencast

[Fix Edit Timesheet.webm](https://github.com/user-attachments/assets/6dbcd56d-8c90-4be5-9a42-8c47aece6025)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
