### PR TITLE
Add patch to remove custom fields from project dt

### DIFF
--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -18,3 +18,4 @@ next_pms.resource_management.patches.update_resource_allocation_permissions
 # next_pms.timesheet.patches.update_task_and_project_costing
 next_pms.resource_management.patches.add_resource_reminder_template
 next_pms.timesheet.patches.add_index
+next_pms.timesheet.patches.remove_custom_fields

--- a/next_pms/timesheet/patches/remove_custom_fields.py
+++ b/next_pms/timesheet/patches/remove_custom_fields.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.utils import update_progress_bar
+
+
+def execute():
+    target_fieldnames = ["custom_region", "custom_type_of_work"]
+
+    custom_fields = frappe.get_all(
+        "Custom Field",
+        filters={"dt": "Project", "fieldname": ["in", target_fieldnames], "module": "Next PMS"},
+        pluck="name",
+    )
+
+    total = len(custom_fields)
+
+    for i, custom_field_name in enumerate(custom_fields):
+        update_progress_bar("Removing Custom Fields", i, total)
+        frappe.delete_doc("Custom Field", custom_field_name, force=True)
+
+    update_progress_bar("Removing Custom Fields", total, total)


### PR DESCRIPTION
## Description

This PR removes unwanted custom fields from Project Doctype In `Next PMS` module
Fields to be removed:
- custom_region
- custom_type_of_work

## Relevant Technical Choices

- Add post-sync patch to remove custom fields which are no longer required

## Testing Instructions

> N/A

## Additional Information:

> N/A

## Screenshot/Screencast

> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)