### PR TITLE
Fix word break in text-editor component

### DIFF
--- a/frontend/packages/design-system/src/components/text-editor/index.tsx
+++ b/frontend/packages/design-system/src/components/text-editor/index.tsx
@@ -85,8 +85,9 @@ const TextEditor = ({
         {...Props}
         style={{ resize: "vertical", overflow: "auto" }}
         className={mergeClassNames(
-          "border rounded-md border-input [&>div:first-child]:border-t-0 [&>div:first-child]:border-r-0 [&>div:first-child]:border-l-0 [&>div:first-child]:border-input [&>div:first-child]:border-bottom [&>div:last-child]:border-none text-foreground bg-background break-all whitespace-normal",
+          "border rounded-md border-input [&>div:first-child]:border-t-0 [&>div:first-child]:border-r-0 [&>div:first-child]:border-l-0 [&>div:first-child]:border-input [&>div:first-child]:border-bottom [&>div:last-child]:border-none text-foreground bg-background whitespace-normal",
           hideToolbar && "border-none !resize-none [&_.ql-editor]:min-h-0 [&_.ql-editor]:p-2",
+          !hideToolbar && "break-all",
           className
         )}
         theme="snow"


### PR DESCRIPTION
## Description

This PR fixes word break in text-editor component when hovering over timesheet in timesheet table.

## Relevant Technical Choices

- Conditionally use `"break-all"` tailwind class to avoid word breaking in TextEditor component

## Testing Instructions

- Create long text timesheet (Try this: Debug the child table render issue in webform, Debug child table render issue in webform)
- Hover above the  newly created timesheet
- Text Content should not break

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/247ec0ef-263f-4b62-a66f-ef613e0e695d)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/next-pms/issues/641