### PR TITLE
Add Approval pending Status and fix get_timesheet_detail API

### DIFF
--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -480,6 +480,7 @@ def get_timesheet_details(date: str, task: str, employee: str):
         filters={
             "start_date": ["=", getdate(date)],
             "employee": employee,
+            "docstatus": ["=", 0],
         },
         ignore_permissions=employee_has_higher_access(employee, ptype="read"),
     )

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -89,7 +89,9 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
     for timesheet in current_week_timesheet:
         status_count[timesheet.custom_approval_status] += 1
 
-    if status_count["Rejected"] >= working_days.get("total_working_days"):
+    if status_count["Approval Pending"] >= working_days.get("total_working_days"):
+        week_status = "Approval Pending"
+    elif status_count["Rejected"] >= working_days.get("total_working_days"):
         week_status = "Rejected"
     elif status_count["Approved"] >= working_days.get("total_working_days"):
         week_status = "Approved"


### PR DESCRIPTION
## Description

This PR adds a check for the "Approval Pending" weekly status. If the total hours marked as "Approval Pending" exceed the employee's working hours, editing the timesheets will no longer update the weekly status. Additionally, an issue where cancelled documents were visible in the "Edit Timesheet" dialog has been fixed.


## Relevant Technical Choices

- Add `Approval Pending` Status Count

## Testing Instructions

- Add Timesheets for the entire week 
- Sent it for approval
- Edit any timesheet
- The Status should not change

## Additional Information:

> N/A

## Screenshot/Screencast


> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)