### PR TITLE
Fix timesheet accordion background in dark mode

### DIFF
--- a/frontend/packages/app/src/app/pages/team/components/employeeTimesheetTable.tsx
+++ b/frontend/packages/app/src/app/pages/team/components/employeeTimesheetTable.tsx
@@ -75,7 +75,7 @@ export const EmployeeTimesheetTable = ({ employee, teamState }: EmployeeTimeshee
               setIsTaskLogDialogBoxOpen={setIsTaskLogDialogBoxOpen}
               workingFrequency={data?.message.working_frequency}
               workingHour={data?.message.working_hour}
-              cellClassName="cursor-default max-w-20 min-w-20 w-full group text-center hover:bg-slate-100 hover:text-center hover:cursor-default"
+              cellClassName="cursor-default max-w-20 min-w-20 w-full group text-center dark:hover:bg-slate-800 hover:bg-slate-100 hover:text-center hover:cursor-default"
               totalCellClassName="max-w-24 w-full flex justify-end items-center"
               showEmptyCell={true}
             />


### PR DESCRIPTION
## Description

This PR fixes timesheet accordion background in dark mode when hovering over a timesheet.

## Relevant Technical Choices

- Add subtle slate TW class `dark:hover:bg-slate-800` 

## Testing Instructions

- Go to Team page
- Search for a user
- Open Timesheet Accordion for the user
- Hover over any timesheet in (light/dark) any mode

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/0e2c7e83-bfed-477d-bdee-bf8c518860f7)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
