### PR TITLE
Prevent date modification from erp backend

### DIFF
--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -11,16 +11,16 @@ ROLES = {
 
 #  Doc Events for Timesheet DocType
 def validate(doc, method=None):
+    set_date(doc)
     validate_time(doc)
+    validate_dates(doc)
     update_note(doc)
     flush_cache(doc)
 
 
 def before_insert(doc, method=None):
-    set_date(doc)
     validate_existing_timesheet(doc)
     validate_approved_timesheet(doc)
-    validate_dates(doc)
 
 
 def before_save(doc, method=None):
@@ -35,6 +35,7 @@ def before_save(doc, method=None):
         doc.time_logs[key].from_time = from_time
         doc.time_logs[key].to_time = to_time
         doc.time_logs[key].project = get_value("Task", {"name": doc.time_logs[key].task}, "project")
+    validate_start_date(doc)
 
 
 def on_update(doc, method=None):
@@ -290,3 +291,10 @@ def publish_timesheet_update(employee, start_date):
         after_commit=True,
         room=get_site_room(),
     )
+
+
+def validate_start_date(doc):
+    if doc.is_new():
+        return
+    if doc.has_value_changed("start_date") or doc.has_value_changed("end_date"):
+        throw(_("You cannot change the start date or end date of the timesheet after it has been created."))


### PR DESCRIPTION
## Description

This PR prevents date modification from erp backend

## Relevant Technical Choices

- Prevent date modification from erp backend

## Testing Instructions

- Go to erp
- Open Timesheet list
- Try Editing start or end date of a timesheet log
- It should not be allowed

## Additional Information:

> N/A

## Screenshot/Screencast

> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
