### PR TITLE
Fix calculation to apply amount conversion only once for costing rate

### DIFF
--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -227,6 +227,7 @@ def get_employee_costing_rate(employee: str, salary_currency: float, ctc: float,
         to_currency=currency,
         salary_currency=salary_currency,
         ctc=ctc,
+        date=start_date,
     )
     costing_rate = salary.get("hourly_salary")
 
@@ -235,7 +236,4 @@ def get_employee_costing_rate(employee: str, salary_currency: float, ctc: float,
             frappe._("Project costing rates are not set. Please contact the Project Manager for assistance.")
         )
 
-    if salary_currency != currency:
-        rate = get_exchange_rate(salary_currency, currency, start_date)
-        costing_rate = costing_rate * (rate or 1)
     return costing_rate


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This pull request updates the `get_employee_costing_rate` function in `next_pms/project_currency/overrides/timesheet.py` to improve its handling of employee costing rates. The changes focus on adding a new parameter to the salary calculation and simplifying the logic by removing currency conversion.

### Updates to employee costing rate calculation:

* Added the `date` parameter (`start_date`) to the salary calculation function call, ensuring that the calculation is date-specific.
* Removed the logic for converting the salary currency to the project currency, simplifying the function by eliminating the use of `get_exchange_rate`.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->