### PR TITLE
Fix row creation in empty child table & add min-width to childtable ui

### DIFF
--- a/frontend/packages/app/src/app/components/form-view/components/childTable.tsx
+++ b/frontend/packages/app/src/app/components/form-view/components/childTable.tsx
@@ -77,8 +77,9 @@ const ChildTable = ({ field, currencySymbol, isReadOnly }: ChildTableProps) => {
   };
 
   const handleAddRow = () => {
+    const newIdx = rows.length > 0 ? rows[rows.length - 1].idx + 1 : 1;
     const newRow: ChildRow = {
-      idx: rows[rows.length - 1].idx + 1,
+      idx: newIdx,
       ...Object.fromEntries(field?.child_meta!.map((m) => [m.fieldname, ""])),
     };
     setRows([...rows, newRow]);
@@ -130,8 +131,8 @@ const ChildTable = ({ field, currencySymbol, isReadOnly }: ChildTableProps) => {
 
   return (
     <div className="space-y-3">
-      <div className="overflow-auto border rounded-md max-h-64 relative">
-        <table className="caption-bottom text-sm w-full border-separate border-spacing-0 table-fixed">
+      <div className="overflow-x-auto border rounded-md max-h-64 relative">
+        <table className="caption-bottom text-sm w-full border-separate border-spacing-0 table-fixed max-lg:min-w-[40rem]">
           <TableHeader className="sticky top-0">
             <TableRow className="border-b">
               <TableHead className="w-10 min-w-10 h-12 px-0 border-r border-b dark:border-slate-700 dark:bg-slate-950">
@@ -152,6 +153,7 @@ const ChildTable = ({ field, currencySymbol, isReadOnly }: ChildTableProps) => {
                   return (
                     <TableHead
                       key={meta.fieldname}
+                      title={meta.label}
                       className="border-r dark:border-slate-700 px-2 py-1 text-left text-sm truncate font-normal dark:bg-slate-950"
                     >
                       {meta.label}


### PR DESCRIPTION
## Description

This PR fixes row creation in the Project Detail page when the child table is initially empty.
The issue was caused by using `rows[rows.length - 1].idx + 1`, which fails when rows is an empty array, as rows[-1] is undefined. This PR also adds a minimum width to the child table to ensure better accessibility and usability on smaller screens.

## Relevant Technical Choices

- Calculate `newIdx` based on array length, if length is zero assign `1` to the new row 

## Testing Instructions

- Go to NPMS
- Open Project Page
- Open any Project
- Add row to empty child table

## Additional Information:

> None

## Screenshot/Screencast

Before:

https://github.com/user-attachments/assets/a3d213b9-44c6-4f6b-b43b-d59b8019640c


After:

https://github.com/user-attachments/assets/08f79d85-ae5b-4681-af0e-e03ca65fb8cd



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
