### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/e2e-playwright-test.yml
+++ b/.github/workflows/e2e-playwright-test.yml
@@ -316,9 +316,12 @@ jobs:
 
       - name: Set the email body message for pull request merge or schedule message
         if: ${{ success() || failure() }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            echo "message=<p>For the latest pull request merge titled <b><a href='${{ github.event.pull_request.html_url }}'> ${{ github.event.pull_request.title }}</a></b>, the E2E automation tests have been executed on the staging environment. Below is the summary:</p>" >> $GITHUB_ENV
+            echo "message=<p>For the latest pull request merge titled <b><a href='$PR_URL'> $PR_TITLE</a></b>, the E2E automation tests have been executed on the staging environment. Below is the summary:</p>" >> $GITHUB_ENV
           else
             echo "message=<p>This is to inform you that the scheduled E2E automation tests have been executed on the staging environment. Below is the summary::</p>" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/next-pms/security/code-scanning/1](https://github.com/rtCamp/next-pms/security/code-scanning/1)

To fix this issue, we should not interpolate the untrusted input from `${{ github.event.pull_request.title }}` directly into the shell code via the `${{ }}` expression. Instead, we should assign its value to an environment variable using the `env:` field of the workflow step, then use shell-native variable expansion (`$VAR`) inside the `run:` script. This prevents interpretation by the shell and mitigates the injection risk. Specifically, for the failing step at line 321, move `${{ github.event.pull_request.title }}` to an environment variable (e.g., `PR_TITLE`), then reference it in the shell as `$PR_TITLE`. 

Changes required:
- Change the relevant step to use `env:` to set (at least) `PR_TITLE: ${{ github.event.pull_request.title }}` and `PR_URL: ${{ github.event.pull_request.html_url }}`.
- In the shell script, refer to these variables as `$PR_TITLE` and `$PR_URL`.

No changes to overall workflow logic are needed, just to how data is injected into the shell.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
