### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -1,4 +1,6 @@
 name: PR Frontend Build Test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/next-pms/security/code-scanning/14](https://github.com/rtCamp/next-pms/security/code-scanning/14)

To resolve the issue, you should add an explicit `permissions:` key with the least required privileges. The best way, in this build-only context, is to add `permissions: contents: read` at the workflow root—right after the `name:` and before `on:`—so it applies globally to all jobs (unless a job needs different permissions later, which can be overridden at the job level). No other existing functionality will be affected, and the change is minimal and easy to audit. 

#### Specific steps:
- Edit `.github/workflows/pr-test-build.yml`
- Insert the following lines after line 1 (after `name: ...`):

```yaml
permissions:
  contents: read
```

No external dependencies or additional code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
