### PR TITLE
fix: ensure timesheet company derives from project

### DIFF
--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -107,6 +107,12 @@ class TimesheetOverwrite(Timesheet):
                     data.base_billing_rate = base_billing_rate
                     data.base_billing_amount = data.base_billing_rate * hours
 
+            if not data.is_billable:
+                data.billing_rate = 0
+                data.billing_amount = 0
+                data.base_billing_rate = 0
+                data.base_billing_amount = 0
+
     def get_activity_costing_rate(self, currency=None):
         if not self.parent_project:
             return frappe.throw(frappe._("Project is not defined in Timesheet."))


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This pull request makes a small adjustment to the logic for setting the `company` field in the `update_cost` method of the `timesheet.py` override. The assignment of `self.company` is now unconditional, and the previously conditional assignment from the `Employee` record is commented out.

* The `company` field is now always set from the parent `Project`, and the fallback to the `Employee`'s company is commented out in `update_cost` of `timesheet.py`.
## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #