### PR TITLE
Update timesheet overwrite to fetch customer from project every time

### DIFF
--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -46,8 +46,7 @@ class TimesheetOverwrite(Timesheet):
         if not self.parent_project:
             return frappe.throw(frappe._("The timesheet does not include the project. Project is mandatory."))
 
-        if not self.customer:
-            self.customer = frappe.db.get_value("Project", self.parent_project, "customer")
+        self.customer = frappe.db.get_value("Project", self.parent_project, "customer")
 
         self.company = frappe.db.get_value("Project", self.parent_project, "company")
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This pull request simplifies the logic in the `update_cost` method of the `timesheet.py` override by always setting the `customer` field based on the related project's customer, regardless of its previous value.

- Logic simplification:
  * The conditional check for an existing `customer` value was removed, so now `self.customer` is always set to the customer from the parent project (`self.parent_project`).

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #