### PR TITLE
fix: timesheet query issue

### DIFF
--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -147,7 +147,6 @@ def get_count(
         doctype,
         fields=[fieldname],
         distinct=distinct,
-        limit=limit,
         filters=filters,
         or_filters=or_filters,
         ignore_permissions=ignore_permissions,


### PR DESCRIPTION
## Description

Fix timesheet entry employee pre-fetch issue which gave the following error:
```
SQL functions are not allowed as strings in SELECT:
count(tabTask.name) as total_count.
Use dict syntax like {'COUNT': '*'} instead.
```

## Relevant Technical Choices

- Replaced all string based params with the new syntax as described in this [new query builder migration guide](https://github.com/frappe/frappe/wiki/query-builder-migration)
- Used `reportview`'s `execute` with `run=0` to set up a partial query
- Used `frappe.qb` to perform `count` on the partial query
- This is the only way to do this (while avoiding `frappe.db.sql`) using the new query builder syntax

## Testing Instructions

1) Login on next-pms
2) Click on the "+" to create a new timesheet entry
3) Observe the the employee field gets auto populated
4) And project selection dropdown works
5) Observe no console errors related to these

## Additional Information:

- pre-commit checks did not pass fully due to the updated frappe semgrep rules

## Screenshot/Screencast

### Before

https://github.com/user-attachments/assets/5b652be6-c623-4b3e-9f22-af4cc73bef53

### After

https://github.com/user-attachments/assets/35091a92-9d25-42e5-bcee-86815398f452

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2625