### PR TITLE
Fix:  positional argument change in get_doc for v16

### DIFF
--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -136,7 +136,7 @@ class TimesheetOverwrite(Timesheet):
             employee = frappe.get_doc(
                 "Employee",
                 self.employee,
-                ["ctc", "salary_currency"],
+                fields=["ctc", "salary_currency"],
             )
             employee_salary = employee.ctc
             employee_currency = employee.salary_currency


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `get_activity_costing_rate` method in the `next_pms/project_currency/overrides/timesheet.py` file, V16 migration prevents get_doc to take more than 2 positional arguments

## Relevant Technical Choices

Error Log : 
```
{
    "exception": "TypeError: get_doc_str() takes from 1 to 2 positional arguments but 3 were given",
    "exc_type": "TypeError",
    "_exc_source": "next_pms (app)",
    "exc": "[\"Traceback (most recent call last):\\n  File \\\"apps/frappe/frappe/app.py\\\", line 121, in application\\n    response = frappe.api.handle(request)\\n  File \\\"apps/frappe/frappe/api/__init__.py\\\", line 63, in handle\\n    data = endpoint(**arguments)\\n  File \\\"apps/frappe/frappe/api/v1.py\\\", line 40, in handle_rpc_call\\n    return frappe.handler.handle()\\n           ~~~~~~~~~~~~~~~~~~~~~^^\\n  File \\\"apps/frappe/frappe/handler.py\\\", line 53, in handle\\n    data = execute_cmd(cmd)\\n  File \\\"apps/frappe/frappe/handler.py\\\", line 86, in execute_cmd\\n    return frappe.call(method, **frappe.form_dict)\\n           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/__init__.py\\\", line 1124, in call\\n    return fn(*args, **newargs)\\n  File \\\"apps/frappe/frappe/utils/typing_validations.py\\\", line 36, in wrapper\\n    return func(*args, **kwargs)\\n  File \\\"apps/next_pms/next_pms/api/utils.py\\\", line 75, in innerfn\\n    return func(*args, **kwargs)\\n  File \\\"apps/next_pms/next_pms/timesheet/api/timesheet.py\\\", line 163, in save\\n    timesheet.save(ignore_permissions=ignore_permissions)\\n    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 518, in save\\n    return self._save(*args, **kwargs)\\n           ~~~~~~~~~~^^^^^^^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 540, in _save\\n    return self.insert()\\n           ~~~~~~~~~~~^^\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 447, in insert\\n    self.run_before_save_methods()\\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 1332, in run_before_save_methods\\n    self.run_method(\\\"validate\\\")\\n    ~~~~~~~~~~~~~~~^^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 1181, in run_method\\n    out = Document.hook(fn)(self, *args, **kwargs)\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 1578, in composer\\n    return composed(self, method, *args, **kwargs)\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 1556, in runner\\n    add_to_return_value(self, fn(self, *args, **kwargs))\\n                              ~~^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 1178, in fn\\n    return method_object(*args, **kwargs)\\n  File \\\"apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py\\\", line 73, in validate\\n    self.update_cost()\\n    ~~~~~~~~~~~~~~~~^^\\n  File \\\"apps/next_pms/next_pms/project_currency/overrides/timesheet.py\\\", line 74, in update_cost\\n    costing_rate = self.get_activity_costing_rate(currency=self.currency)\\n  File \\\"apps/next_pms/next_pms/project_currency/overrides/timesheet.py\\\", line 136, in get_activity_costing_rate\\n    employee = frappe.get_doc(\\n        \\\"Employee\\\",\\n        self.employee,\\n        [\\\"ctc\\\", \\\"salary_currency\\\"],\\n    )\\n  File \\\"apps/frappe/frappe/model/utils/__init__.py\\\", line 218, in wrapper\\n    return dispatch(args[0])(*args, **kw)\\n           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^\\nTypeError: get_doc_str() takes from 1 to 2 positional arguments but 3 were given\\n\"]"
}
```
## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
**Issue**
<img width="1470" height="956" alt="Screenshot 2026-03-04 at 12 03 03 PM" src="https://github.com/user-attachments/assets/5065962e-864e-4cac-a554-505dacf4dd9a" />
**Before**: 
<img width="1666" height="474" alt="image" src="https://github.com/user-attachments/assets/da1c38dc-c3b8-4750-8aeb-38504913e8c9" />

**After**:

<img width="702" height="61" alt="image" src="https://github.com/user-attachments/assets/2b5f7272-7883-4944-8b37-b51810f6ae93" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes [#2682](https://github.com/rtCamp/erp-rtcamp/issues/2682)