### PR TITLE
fix(timesheet): prevent backdated time entry beyond allowed limit

### DIFF
--- a/frontend/packages/app/src/app/components/timesheet-table/components/dataCell.tsx
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/dataCell.tsx
@@ -31,7 +31,7 @@ import type { cellProps } from "./types";
  * @param {string} props.className - Class name for the cell
  */
 
-export const Cell = ({ date, data, isHoliday, onCellClick, disabled, className }: cellProps) => {
+export const Cell = ({ date, data, isHoliday, onCellClick, disabled, className, isBackdatedDisabled }: cellProps) => {
   const { hours, description, isTimeBothBillableAndNonBillable, isTimeBillable } = useMemo(() => {
     let hours = 0;
     let description = "";
@@ -50,7 +50,7 @@ export const Cell = ({ date, data, isHoliday, onCellClick, disabled, className }
     return { hours, description, isTimeBothBillableAndNonBillable, isTimeBillable };
   }, [data]);
 
-  const isDisabled = useMemo(() => disabled || data?.[0]?.docstatus === 1, [disabled, data]);
+  const isDisabled = useMemo(() => disabled || data?.[0]?.docstatus === 1 || isBackdatedDisabled, [disabled, data, isBackdatedDisabled]);
 
   const handleClick = useCallback(() => {
     if (isDisabled) return;
@@ -104,12 +104,22 @@ export const Cell = ({ date, data, isHoliday, onCellClick, disabled, className }
             />
           </span>
         </HoverCardTrigger>
-        {description && (
+        {description && !isBackdatedDisabled && (
           <HoverCardContent
             className="text-left whitespace-pre text-wrap w-full max-w-96 max-h-52 overflow-auto hover-content p-0"
             onClick={(e) => e.stopPropagation()}
           >
             <TextEditor onChange={() => {}} hideToolbar={true} readOnly={true} value={description} />
+          </HoverCardContent>
+        )}
+        {isBackdatedDisabled && (
+          <HoverCardContent
+            className="text-left whitespace-pre text-wrap w-full max-w-96 hover-content p-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Typography variant="p" className="text-sm text-muted-foreground">
+              Backdated time entry limit exceeded
+            </Typography>
           </HoverCardContent>
         )}
       </TableCell>

--- a/frontend/packages/app/src/app/components/timesheet-table/components/row/index.tsx
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/row/index.tsx
@@ -30,6 +30,7 @@ const Row = ({
   totalCellClassName,
   showEmptyCell,
   hideLikeButton,
+  isDateBackdatedDisabled,
 }: RowProps) => {
   return (
     <>
@@ -86,6 +87,7 @@ const Row = ({
                     isHoliday={result.isHoliday && !result.weekly_off}
                     onCellClick={onCellClick}
                     disabled={disabled}
+                    isBackdatedDisabled={isDateBackdatedDisabled?.(date)}
                   />
                 );
               })}

--- a/frontend/packages/app/src/app/components/timesheet-table/components/row/types.ts
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/row/types.ts
@@ -51,6 +51,7 @@ export interface RowProps {
   totalCellClassName?: string;
   showEmptyCell?: boolean;
   hideLikeButton?: boolean;
+  isDateBackdatedDisabled?: (date: string) => boolean;
 }
 
 export interface leaveRowProps {

--- a/frontend/packages/app/src/app/components/timesheet-table/components/types.ts
+++ b/frontend/packages/app/src/app/components/timesheet-table/components/types.ts
@@ -19,6 +19,7 @@ export type cellProps = {
   onCellClick?: (val) => void;
   disabled?: boolean;
   className?: string;
+  isBackdatedDisabled?: boolean;
 };
 
 export type HeaderProps = {
@@ -79,4 +80,5 @@ export type timesheetTableProps = {
   likedTaskData?: Array<object>;
   getLikedTaskData?: () => void;
   hideLikeButton?: boolean;
+  oldestAllowedDate?: string | null;
 };

--- a/frontend/packages/app/src/app/components/timesheet-table/index.tsx
+++ b/frontend/packages/app/src/app/components/timesheet-table/index.tsx
@@ -34,12 +34,22 @@ export const TimesheetTable = ({
   likedTaskData,
   getLikedTaskData,
   hideLikeButton,
+  oldestAllowedDate,
 }: timesheetTableProps) => {
   const holidayList = getHolidayList(holidays);
   const [isTaskLogDialogBoxOpen, setIsTaskLogDialogBoxOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<string>("");
   const task_date_range_key = dates[0] + "-" + dates[dates.length - 1];
   const has_liked_task = hasKeyInLocalStorage(LIKED_TASK_KEY);
+
+  // Helper function to check if a date is backdated and disabled
+  const isDateBackdatedDisabled = useCallback(
+    (date: string) => {
+      if (!oldestAllowedDate) return false;
+      return new Date(date) < new Date(oldestAllowedDate);
+    },
+    [oldestAllowedDate]
+  );
 
   const setTaskInLocalStorage = () => {
     setLikedTask(LIKED_TASK_KEY, task_date_range_key, likedTaskData!);
@@ -146,6 +156,7 @@ export const TimesheetTable = ({
             workingFrequency={workingFrequency}
             workingHour={workingHour}
             hideLikeButton={hideLikeButton}
+            isDateBackdatedDisabled={isDateBackdatedDisabled}
           />
         </TableBody>
       </Table>

--- a/frontend/packages/app/src/app/layout/index.tsx
+++ b/frontend/packages/app/src/app/layout/index.tsx
@@ -13,7 +13,7 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 import Sidebar from "@/app/layout/sidebar";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import type { RootState } from "@/store";
-import { setInitialData } from "@/store/user";
+import { setInitialData, setBackdatedSettings } from "@/store/user";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const user = useSelector((state: RootState) => state.user);
@@ -24,6 +24,17 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     revalidateIfStale: false,
     errorRetryCount: 1,
   });
+
+  const { data: backdatedData } = useFrappeGetCall(
+    "next_pms.timesheet.api.employee.get_backdated_settings",
+    {},
+    undefined,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      errorRetryCount: 1,
+    }
+  );
 
   useEffect(() => {
     if (data) {
@@ -45,6 +56,13 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, error]);
+
+  useEffect(() => {
+    if (backdatedData?.message) {
+      dispatch(setBackdatedSettings(backdatedData.message));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [backdatedData]);
 
   return (
     <ErrorFallback>

--- a/frontend/packages/app/src/app/pages/timesheet/index.tsx
+++ b/frontend/packages/app/src/app/pages/timesheet/index.tsx
@@ -281,6 +281,7 @@ function Timesheet() {
                               loadingLikedTasks={loadingLikedTasks}
                               likedTaskData={likedTaskData}
                               getLikedTaskData={getLikedTaskData}
+                              oldestAllowedDate={user.backdatedSettings?.oldest_allowed_date}
                             />
                           </AccordionContent>
                         </AccordionItem>

--- a/frontend/packages/app/src/store/user.ts
+++ b/frontend/packages/app/src/store/user.ts
@@ -22,6 +22,15 @@ interface InitiDataProps {
   employeeName: string;
 }
 
+export interface BackdatedSettings {
+  allow_backdated_entries: boolean;
+  allowed_days_employee: number;
+  allowed_days_manager: number;
+  allowed_days: number;
+  oldest_allowed_date: string | null;
+  has_manager_access: boolean;
+}
+
 export interface UserState {
   userName: string;
   image: string;
@@ -36,6 +45,7 @@ export interface UserState {
   currencies: Array<string>;
   hasBuField: boolean;
   hasIndustryField: boolean;
+  backdatedSettings: BackdatedSettings | null;
 }
 
 const initialState: UserState = {
@@ -52,6 +62,7 @@ const initialState: UserState = {
   currencies: window.frappe?.boot?.currencies ?? [],
   hasBuField: window.frappe?.boot?.has_business_unit ?? false,
   hasIndustryField: window.frappe?.boot?.has_industry ?? false,
+  backdatedSettings: null,
 };
 
 const userSlice = createSlice({
@@ -102,6 +113,9 @@ const userSlice = createSlice({
       state.reportsTo = action.payload.reportsTo;
       state.employeeName = action.payload.employeeName;
     },
+    setBackdatedSettings: (state, action: PayloadAction<BackdatedSettings>) => {
+      state.backdatedSettings = action.payload;
+    },
   },
 });
 
@@ -116,6 +130,7 @@ export const {
   setCurrency,
   setHasBuField,
   setHasIndustryField,
+  setBackdatedSettings,
 } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/next_pms/timesheet/api/employee.py
+++ b/next_pms/timesheet/api/employee.py
@@ -173,3 +173,80 @@ def validate_current_employee(ptype: str = "read"):
         return wrapper
 
     return decorator
+
+
+@frappe.whitelist()
+def get_backdated_settings(employee: str = None):
+    """
+    Get backdated time entry settings for the current user/employee.
+    Returns the allowed backdated days limit based on user role.
+    """
+    from frappe import get_roles
+    from frappe.utils import add_days, getdate, today
+    from hrms.hr.utils import get_holiday_dates_for_employee
+
+    from next_pms.resource_management.api.utils.query import get_employee_leaves
+
+    if not employee:
+        employee = get_employee_from_user()
+
+    if not employee:
+        return {
+            "allow_backdated_entries": False,
+            "allowed_days_employee": 0,
+            "allowed_days_manager": 0,
+            "oldest_allowed_date": None,
+        }
+
+    # Get settings from Timesheet Settings
+    allow_backdated_entries = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries")
+    allowed_days_employee = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_employee") or 0
+    allowed_days_manager = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_manager") or 0
+
+    # Check if user has manager/higher access roles
+    ROLES = {"Projects Manager", "HR User", "HR Manager", "Projects User"}
+    frappe_roles = set(get_roles())
+    has_access = bool(ROLES.intersection(frappe_roles))
+
+    # Determine which limit applies
+    allowed_days = allowed_days_manager if has_access else allowed_days_employee
+
+    # Calculate oldest allowed date considering holidays and leaves
+    today_date = getdate(today())
+    oldest_date = add_days(today_date, -allowed_days)
+
+    # Get holidays and leaves to adjust the calculation
+    holidays = get_holiday_dates_for_employee(employee, oldest_date, today_date)
+    leaves = get_employee_leaves(
+        start_date=add_days(oldest_date, -28),
+        end_date=add_days(today_date, 28),
+        employee=employee,
+    )
+
+    # Add leave dates to holidays list
+    for leave in leaves:
+        from_date = getdate(leave.from_date)
+        to_date = getdate(leave.to_date)
+        current_date = from_date
+        while current_date <= to_date:
+            holidays.append(str(current_date))
+            current_date = add_days(current_date, 1)
+
+    # Count holidays between oldest_date and today
+    holiday_counter = 0
+    holidays = set(holidays)
+    for holiday in holidays:
+        if oldest_date <= getdate(holiday) < today_date:
+            holiday_counter += 1
+
+    # Adjust oldest date by subtracting holidays
+    adjusted_oldest_date = add_days(oldest_date, -holiday_counter)
+
+    return {
+        "allow_backdated_entries": allow_backdated_entries,
+        "allowed_days_employee": allowed_days_employee,
+        "allowed_days_manager": allowed_days_manager,
+        "allowed_days": allowed_days,
+        "oldest_allowed_date": str(adjusted_oldest_date) if allow_backdated_entries else str(today_date),
+        "has_manager_access": has_access,
+    }


### PR DESCRIPTION
This fix resolves the issue where users could attempt to enter time for dates beyond the allowed backdated limit, which caused the backend error **“Backdated timeentry not allowed.”** A new backend API was added to fetch backdated timesheet settings and calculate the **oldest allowed date** based on user role and configuration. These settings are stored in the frontend state and used in the timesheet table to **disable dates older than the allowed limit**, visually gray them out, and show a tooltip indicating that the backdated limit has been exceeded. This prevents invalid entries at the UI level while respecting the configured limits for employees and managers.
