### PR TITLE
feat: allow roles filter to be fetched via get_employee_list

### DIFF
--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -34,15 +34,16 @@ def filter_employees(
     reports_to: None | str = None,
     business_unit=None,
     designation=None,
+    roles: list[str] | None = None,
     ignore_default_filters=False,
     ignore_permissions=False,
 ):
     import json
 
-    roles = get_roles()
+    user_roles = get_roles()
 
     if not ignore_permissions:
-        ignore_permissions = set(roles).intersection(["Timesheet User", "Timesheet Manager"])
+        ignore_permissions = set(user_roles).intersection(["Timesheet User", "Timesheet Manager"])
 
     fields = ["name", "image", "employee_name", "department", "designation"]
     employee_ids = []
@@ -103,6 +104,18 @@ def filter_employees(
     if user_group and len(user_group) > 0:
         users = get_all("User Group Member", pluck="user", filters={"parent": ["in", user_group]})
         ids = [get_value("Employee", {"user_id": user}, cache=True) for user in users]
+        employee_ids.extend(ids)
+
+    if isinstance(roles, str):
+        roles = json.loads(roles)
+
+    if roles and len(roles) > 0:
+        user_ids = get_all(
+            "Has Role",
+            filters={"role": ["in", roles], "parenttype": "User", "parent": ["!=", "Administrator"]},
+            pluck="parent",
+        )
+        ids = get_all("Employee", filters={"user_id": ["in", user_ids]}, pluck="name")
         employee_ids.extend(ids)
 
     if len(employee_ids) > 0:

--- a/next_pms/timesheet/api/employee.py
+++ b/next_pms/timesheet/api/employee.py
@@ -99,6 +99,7 @@ def get_employee_list(
     status=None,
     user_group=None,
     reports_to: str | None = None,
+    roles: list[str] | None = None,
     ignore_default_filters=False,
 ):
     from . import filter_employees
@@ -112,6 +113,7 @@ def get_employee_list(
         status=status,
         user_group=user_group,
         reports_to=reports_to,
+        roles=roles,
         ignore_permissions=status is not None,
         ignore_default_filters=ignore_default_filters,
     )


### PR DESCRIPTION

## Description

This pull request introduces enhancements to employee filtering functionality, primarily by adding support for filtering employees based on their roles. The changes ensure that both the `filter_employees` and `get_employee_list` functions can accept a list of roles and filter results accordingly.

## Relevant Technical Choices

* Added a `roles` parameter to the `filter_employees` function in `next_pms/timesheet/api/__init__.py`, enabling filtering employees by their assigned roles.
* Implemented logic to filter employees based on roles, including parsing roles from JSON if provided as a string and querying users with specified roles, excluding administrators.
* Added a `roles` parameter to the `get_employee_list` function in `next_pms/timesheet/api/employee.py`, allowing API consumers to specify roles for filtering.
* Passed the `roles` parameter from `get_employee_list` to `filter_employees` to ensure role-based filtering is applied in API responses.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/3fbfd69b-b2ea-4135-9226-2189813d9fc1" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

closes #904 