### PR TITLE
fix: resource team view information not visible

### DIFF
--- a/frontend/packages/app/src/app/pages/resource-management/store/teamContext.tsx
+++ b/frontend/packages/app/src/app/pages/resource-management/store/teamContext.tsx
@@ -89,7 +89,7 @@ const defaulTeamState: TeamContextProps = {
 const TeamContext = createContext<TeamContextProps>(defaulTeamState);
 
 const TeamContextProvider = ({ children }: ContextProviderProps) => {
-  const [teamData, setTeanData] = useState<ResourceTeamDataProps>(defaultData);
+  const [teamData, setTeamData] = useState<ResourceTeamDataProps>(defaultData);
   const [filters, setFilters] = useState<ResourceTeamFilters>(defaultFilters);
   const [tableView, setTableView] = useState<TableViewProps>(defaultTableView);
   const [apiController, setApiController] =
@@ -99,7 +99,7 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
     updatedTeamData: ResourceTeamDataProps,
     type: "SET" | "UPDATE" = "SET",
   ) => {
-    setTeanData((prev) => {
+    setTeamData((prev) => {
       if (type === "SET") {
         return {
           ...prev,
@@ -134,7 +134,7 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
     customer: ResourceTeamDataProps["customer"];
     dates?: DateProps[];
   }) => {
-    setTeanData((prev) => {
+    setTeamData((prev) => {
       const updatedData = [...prev.data];
       for (let i = 0; i < horizontalData.data.length; i++) {
         const idx = horizontalData.start + i;
@@ -180,7 +180,7 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
       start: 0,
       maxWeek: defaultFilters.maxWeek,
     }));
-    setTeanData(defaultData);
+    setTeamData(defaultData);
     setApiController((prev) => ({
       ...prev,
       isLoading: true,
@@ -207,7 +207,7 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
   };
 
   const setDates = (dates: DateProps[]) => {
-    setTeanData((prev) => ({ ...prev, dates }));
+    setTeamData((prev) => ({ ...prev, dates }));
   };
 
   const setWeekDate = (value: string) => {
@@ -223,11 +223,11 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
       isLoading: true,
       isNeedToFetchDataAfterUpdate: true,
     }));
-    setTeanData({ ...defaultData, dates: getDatesArrays(value, 10) });
+    setTeamData({ ...defaultData, dates: getDatesArrays(value, 10) });
   };
 
   const resetState = () => {
-    setTeanData(defaultData);
+    setTeamData(defaultData);
     setFilters(defaultFilters);
     setTableView(defaultTableView);
     setApiController(defaultApiController);

--- a/frontend/packages/app/src/app/pages/resource-management/store/teamContext.tsx
+++ b/frontend/packages/app/src/app/pages/resource-management/store/teamContext.tsx
@@ -12,6 +12,7 @@ import type {
   APIController,
   ContextProviderProps,
   DateProps,
+  EmployeeDataProps,
   EmployeeResourceProps,
   OptionalResourceTeamFilters,
   ResourceTeamDataProps,
@@ -75,6 +76,7 @@ const defaulTeamState: TeamContextProps = {
     setReFetchData: () => {},
     updateFilter: () => {},
     updateTeamData: () => {},
+    mergeHorizontalData: () => {},
     getHasMore: () => false,
     setMaxWeek: () => {},
     setDates: () => {},
@@ -90,41 +92,100 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
   const [teamData, setTeanData] = useState<ResourceTeamDataProps>(defaultData);
   const [filters, setFilters] = useState<ResourceTeamFilters>(defaultFilters);
   const [tableView, setTableView] = useState<TableViewProps>(defaultTableView);
-  const [apiController, setApiController] = useState<APIController>(defaultApiController);
+  const [apiController, setApiController] =
+    useState<APIController>(defaultApiController);
 
-  const updateTeamData = (updatedTeamData: ResourceTeamDataProps, type: "SET" | "UPDATE" = "SET") => {
-    if (type === "SET") {
-      setTeanData({
-        ...teamData,
-        data: updatedTeamData.data,
-        dates: updatedTeamData.dates ? updatedTeamData.dates : teamData.dates,
-        customer: updatedTeamData.customer,
-        total_count: updatedTeamData.total_count,
-        has_more: updatedTeamData.has_more,
-      });
-    } else {
-      setTeanData({
-        ...teamData,
-        data: [...teamData.data, ...updatedTeamData.data],
-        dates: updatedTeamData.dates ? updatedTeamData.dates : teamData.dates,
-        customer: { ...updatedTeamData.customer, ...updatedTeamData.customer },
-        total_count: updatedTeamData.total_count,
-        has_more: updatedTeamData.has_more,
-      });
-    }
+  const updateTeamData = (
+    updatedTeamData: ResourceTeamDataProps,
+    type: "SET" | "UPDATE" = "SET",
+  ) => {
+    setTeanData((prev) => {
+      if (type === "SET") {
+        return {
+          ...prev,
+          data: updatedTeamData.data,
+          dates: updatedTeamData.dates ? updatedTeamData.dates : prev.dates,
+          customer: updatedTeamData.customer,
+          total_count: updatedTeamData.total_count,
+          has_more: updatedTeamData.has_more,
+        };
+      } else {
+        return {
+          ...prev,
+          data: [...prev.data, ...updatedTeamData.data],
+          dates: updatedTeamData.dates ? updatedTeamData.dates : prev.dates,
+          customer: { ...prev.customer, ...updatedTeamData.customer },
+          total_count: updatedTeamData.total_count,
+          has_more: updatedTeamData.has_more,
+        };
+      }
+    });
 
-    setApiController({ ...apiController, isNeedToFetchDataAfterUpdate: false, isLoading: false });
+    setApiController((prev) => ({
+      ...prev,
+      isNeedToFetchDataAfterUpdate: false,
+      isLoading: false,
+    }));
+  };
+
+  const mergeHorizontalData = (horizontalData: {
+    start: number;
+    data: EmployeeDataProps[];
+    customer: ResourceTeamDataProps["customer"];
+    dates?: DateProps[];
+  }) => {
+    setTeanData((prev) => {
+      const updatedData = [...prev.data];
+      for (let i = 0; i < horizontalData.data.length; i++) {
+        const idx = horizontalData.start + i;
+        if (idx >= updatedData.length) break;
+        updatedData[idx] = {
+          ...updatedData[idx],
+          all_dates_data: {
+            ...updatedData[idx].all_dates_data,
+            ...horizontalData.data[i].all_dates_data,
+          },
+          all_leave_data: {
+            ...updatedData[idx].all_leave_data,
+            ...horizontalData.data[i].all_leave_data,
+          },
+          all_week_data: {
+            ...updatedData[idx].all_week_data,
+            ...horizontalData.data[i].all_week_data,
+          },
+          employee_allocations: {
+            ...updatedData[idx].employee_allocations,
+            ...horizontalData.data[i].employee_allocations,
+          },
+        };
+      }
+      return {
+        ...prev,
+        data: updatedData,
+        customer: { ...prev.customer, ...horizontalData.customer },
+        dates: horizontalData.dates ?? prev.dates,
+      };
+    });
   };
 
   const setStart = (start: number) => {
-    setFilters({ ...filters, start });
-    setApiController({ ...apiController, isLoading: true });
+    setFilters((prev) => ({ ...prev, start }));
+    setApiController((prev) => ({ ...prev, isLoading: true }));
   };
 
   const updateFilter = (updatedFilters: OptionalResourceTeamFilters) => {
-    setFilters((prev) => ({ ...prev, ...updatedFilters, start: 0, maxWeek: defaultFilters.maxWeek }));
+    setFilters((prev) => ({
+      ...prev,
+      ...updatedFilters,
+      start: 0,
+      maxWeek: defaultFilters.maxWeek,
+    }));
     setTeanData(defaultData);
-    setApiController({ ...apiController, isLoading: true, isNeedToFetchDataAfterUpdate: true });
+    setApiController((prev) => ({
+      ...prev,
+      isLoading: true,
+      isNeedToFetchDataAfterUpdate: true,
+    }));
   };
 
   const updateTableView = (updatedTableView: TableViewProps) => {
@@ -132,27 +193,36 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
   };
 
   const setReFetchData = (value: boolean) => {
-    setApiController({ ...apiController, isNeedToFetchDataAfterUpdate: value });
+    setApiController((prev) => ({
+      ...prev,
+      isNeedToFetchDataAfterUpdate: value,
+    }));
   };
 
   const setMaxWeek = (maxWeek: number) => {
-    if (maxWeek === filters.maxWeek) return;
-    setFilters({ ...filters, maxWeek });
+    setFilters((prev) => {
+      if (maxWeek === prev.maxWeek) return prev;
+      return { ...prev, maxWeek };
+    });
   };
 
   const setDates = (dates: DateProps[]) => {
-    setTeanData({ ...teamData, dates });
+    setTeanData((prev) => ({ ...prev, dates }));
   };
 
   const setWeekDate = (value: string) => {
-    setFilters({
-      ...filters,
+    setFilters((prev) => ({
+      ...prev,
       weekDate: value,
       start: 0,
       pageLength: defaultFilters.pageLength,
       maxWeek: defaultFilters.maxWeek,
-    });
-    setApiController({ ...apiController, isLoading: true, isNeedToFetchDataAfterUpdate: true });
+    }));
+    setApiController((prev) => ({
+      ...prev,
+      isLoading: true,
+      isNeedToFetchDataAfterUpdate: true,
+    }));
     setTeanData({ ...defaultData, dates: getDatesArrays(value, 10) });
   };
 
@@ -164,7 +234,7 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
   };
 
   const setCombineWeekHours = (value: boolean) => {
-    setTableView({ ...tableView, combineWeekHours: value });
+    setTableView((prev) => ({ ...prev, combineWeekHours: value }));
   };
 
   const getHasMore = () => {
@@ -190,6 +260,7 @@ const TeamContextProvider = ({ children }: ContextProviderProps) => {
           setReFetchData: setReFetchData,
           updateFilter: updateFilter,
           updateTeamData: updateTeamData,
+          mergeHorizontalData: mergeHorizontalData,
           getHasMore: getHasMore,
           setMaxWeek: setMaxWeek,
           setDates: setDates,

--- a/frontend/packages/app/src/app/pages/resource-management/store/types.ts
+++ b/frontend/packages/app/src/app/pages/resource-management/store/types.ts
@@ -164,7 +164,7 @@ export interface ProjectContextProps extends ResourceProjectState {
     updateFilter: (updatedFilters: OptionalResourceProjectFilters) => void;
     updateProjectData: (
       updatedProjectData: ResourceProjectDataProps,
-      type?: "SET" | "UPDATE"
+      type?: "SET" | "UPDATE",
     ) => void;
     getHasMore: () => boolean;
     setMaxWeek: (maxWeek: number) => void;
@@ -303,8 +303,14 @@ export interface TeamContextProps extends ResourceTeamState {
     updateFilter: (updatedFilters: OptionalResourceTeamFilters) => void;
     updateTeamData: (
       updatedTeamData: ResourceTeamDataProps,
-      type?: "SET" | "UPDATE"
+      type?: "SET" | "UPDATE",
     ) => void;
+    mergeHorizontalData: (horizontalData: {
+      start: number;
+      data: EmployeeDataProps[];
+      customer: ResourceCustomerObjectProps;
+      dates?: DateProps[];
+    }) => void;
     getHasMore: () => boolean;
     setMaxWeek: (maxWeek: number) => void;
     setDates: (dates: DateProps[]) => void;
@@ -332,11 +338,11 @@ export interface TimeLineContextProps {
   actions: {
     setEmployeesData: (
       value: ResourceAllocationEmployeeProps[],
-      hasMore: boolean
+      hasMore: boolean,
     ) => void;
     setAllocationsData: (
       value: ResourceAllocationTimeLineProps[],
-      type?: "Set" | "Update"
+      type?: "Set" | "Update",
     ) => void;
     setCustomerData: (value: ResourceAllocationCustomerProps) => void;
     getLastTimeLineItem: () => string;
@@ -344,15 +350,15 @@ export interface TimeLineContextProps {
     updateFilters: (filters: ResourceAllocationTimeLineFilterProps) => void;
     updateApiControler: (apiControler: APIControlerProps) => void;
     getAllocationWithID: (
-      id: string
+      id: string,
     ) => ResourceAllocationTimeLineProps | undefined;
     getEmployeeWithID: (id: string) => ResourceAllocationEmployeeProps;
     updateAllocation: (
       updatedAllocation: ResourceAllocationTimeLineProps,
-      type?: "Append" | "Update"
+      type?: "Append" | "Update",
     ) => ResourceAllocationTimeLineProps;
     getEmployeeWithIndex: (
-      index: number
+      index: number,
     ) => ResourceAllocationEmployeeProps | -1;
     isEmployeeExits: (name: string) => boolean | undefined;
     setAllocationData: (value: {

--- a/frontend/packages/app/src/app/pages/resource-management/team/index.tsx
+++ b/frontend/packages/app/src/app/pages/resource-management/team/index.tsx
@@ -17,20 +17,21 @@ import { ViewData } from "@/store/view";
 import AddResourceAllocations from "../components/addAllocation";
 import { ResourceTeamHeaderSection } from "./components/header";
 import { ResourceTeamTable } from "./components/table";
-import { ResourceContextProvider, ResourceFormContext } from "../store/resourceFormContext";
+import { createFilter } from "./utils";
+import {
+  ResourceContextProvider,
+  ResourceFormContext,
+} from "../store/resourceFormContext";
 import { TeamContext, TeamContextProvider } from "../store/teamContext";
 import type {
   AllocationDataProps,
   DateProps,
   EmployeeDataProps,
   ResourceTeam,
-  ResourceTeamDataProps,
 } from "../store/types";
 import type { ResourceTeamAPIBodyProps } from "../timeline/types";
 import { getDatesArrays } from "../utils/dates";
 import { getIsBillableValue } from "../utils/helper";
-import type { PreProcessDataProps } from "./components/types";
-import { createFilter } from "./utils";
 
 const ResourceTeamViewWrapper = () => {
   return (
@@ -53,28 +54,41 @@ interface ResourceTeamViewComponentProps {
  */
 const ResourceTeamView = () => {
   return (
-    <CustomViewWrapper label="ResourceTeamView" createFilter={createFilter({} as ResourceTeam)}>
+    <CustomViewWrapper
+      label="ResourceTeamView"
+      createFilter={createFilter({} as ResourceTeam)}
+    >
       {({ viewData }) => <ResourceTeamViewComponent viewData={viewData} />}
     </CustomViewWrapper>
   );
 };
 
-const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps) => {
+const ResourceTeamViewComponent = ({
+  viewData,
+}: ResourceTeamViewComponentProps) => {
   const { toast } = useToast();
-  const { teamData, filters, apiController } = useContextSelector(TeamContext, (value) => value.state);
-
-  const { updateTeamData, getHasMore, setStart, setMaxWeek, setDates, setReFetchData } = useContextSelector(
+  const { teamData, filters, apiController } = useContextSelector(
     TeamContext,
-    (value) => value.actions
+    (value) => value.state,
   );
 
-  const { permission: resourceAllocationPermission, dialogState: resourceAllocationDialogState } = useContextSelector(
-    ResourceFormContext,
-    (value) => value.state
-  );
+  const {
+    updateTeamData,
+    mergeHorizontalData,
+    getHasMore,
+    setStart,
+    setMaxWeek,
+    setDates,
+    setReFetchData,
+  } = useContextSelector(TeamContext, (value) => value.actions);
+
+  const {
+    permission: resourceAllocationPermission,
+    dialogState: resourceAllocationDialogState,
+  } = useContextSelector(ResourceFormContext, (value) => value.state);
 
   const { call: fetchData } = useFrappePostCall(
-    "next_pms.resource_management.api.team.get_resource_management_team_view_data"
+    "next_pms.resource_management.api.team.get_resource_management_team_view_data",
   );
 
   const getFilterApiBody = useCallback(
@@ -103,7 +117,7 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
 
       return newReqBody;
     },
-    [resourceAllocationPermission.write, filters]
+    [resourceAllocationPermission.write, filters],
   );
 
   const handleApiCall = useCallback(
@@ -123,56 +137,7 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
         return null;
       }
     },
-    [fetchData, getFilterApiBody, toast]
-  );
-
-  const updateHorizontalData = useCallback(
-    (horizontalPreProcessData: PreProcessDataProps, data: ResourceTeamDataProps | null, dates: DateProps[]) => {
-      if (horizontalPreProcessData) {
-        let updatedTeamData = teamData;
-
-        if (data) {
-          updatedTeamData = data;
-        }
-
-        updatedTeamData.customer = { ...updatedTeamData.customer, ...horizontalPreProcessData.customer };
-
-        const start = horizontalPreProcessData.start;
-        const updateDate = [...updatedTeamData.data];
-
-        for (let count = 0; count < horizontalPreProcessData.data.length; count++) {
-          const dataIndex = start + count;
-
-          const updateEmployeeData = updateDate[dataIndex];
-
-          updateEmployeeData.all_dates_data = {
-            ...updateEmployeeData?.all_dates_data,
-            ...horizontalPreProcessData.data[count]?.all_dates_data,
-          };
-          updateEmployeeData.all_leave_data = {
-            ...updateEmployeeData?.all_leave_data,
-            ...horizontalPreProcessData.data[count]?.all_leave_data,
-          };
-          updateEmployeeData.all_week_data = {
-            ...updateEmployeeData?.all_week_data,
-            ...horizontalPreProcessData.data[count]?.all_week_data,
-          };
-          updateEmployeeData.employee_allocations = {
-            ...updateEmployeeData?.employee_allocations,
-            ...horizontalPreProcessData.data[count]?.employee_allocations,
-          };
-
-          updateDate[dataIndex] = updateEmployeeData;
-        }
-
-        updatedTeamData.data = updateDate;
-
-        updateTeamData({ ...updatedTeamData, dates: dates });
-
-        return updatedTeamData;
-      }
-    },
-    [teamData, updateTeamData]
+    [fetchData, getFilterApiBody, toast],
   );
 
   const addVerticalPreProcessData = useCallback(async () => {
@@ -190,29 +155,18 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
 
     let currentWeek = 5;
 
-    let newData: ResourceTeamDataProps = {
-      data: [...teamData.data, ...mainThredData.data],
-      customer: { ...teamData.customer, ...mainThredData.customer },
-      dates: [],
-      total_count: mainThredData.total_count,
-      has_more: mainThredData.has_more,
-    };
-
     while (currentWeek <= filters.maxWeek) {
       const currentWeekCopy = currentWeek;
-      handleApiCall({ ...req, date: getNextDate(req.date, currentWeekCopy) }).then((res) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore: Ignore type checking for the following line
-        newData = updateHorizontalData(
-          {
-            ...res,
-            date: getNextDate(req.date, currentWeekCopy),
-            max_week: req.max_week,
-            start: req.start,
-            page_length: filters.pageLength,
-          },
-          newData
-        );
+      handleApiCall({
+        ...req,
+        date: getNextDate(req.date, currentWeekCopy),
+      }).then((res) => {
+        if (!res) return;
+        mergeHorizontalData({
+          start: req.start,
+          data: res.data,
+          customer: res.customer,
+        });
       });
       currentWeek += 5;
     }
@@ -222,14 +176,12 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
     filters.start,
     filters.weekDate,
     handleApiCall,
-    teamData.customer,
-    teamData.data,
-    updateHorizontalData,
+    mergeHorizontalData,
     updateTeamData,
   ]);
 
   const addHorizontalPreProcessData = useCallback(
-    (isNeedToUpdateReqWeeks: boolean = false, data: ResourceTeamDataProps | null = null, dates: DateProps[]) => {
+    (dates: DateProps[]) => {
       const req = {
         date: filters.weekDate,
         max_week: filters.maxWeek,
@@ -240,25 +192,30 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
 
       while (currentStart <= filters.start) {
         const currentStartCopy = currentStart;
-        handleApiCall({ ...req, start: currentStartCopy, date: getNextDate(req.date, req.max_week) }).then((res) => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore: Ignore type checking for the following line
-          data = updateHorizontalData(
-            {
-              ...res,
-              date: getNextDate(req.date, req.max_week + (isNeedToUpdateReqWeeks ? 10 : 0)),
-              max_week: req.max_week,
-              start: currentStartCopy,
-              page_length: filters.pageLength,
-            },
-            data,
-            dates
-          );
+        handleApiCall({
+          ...req,
+          start: currentStartCopy,
+          date: getNextDate(req.date, req.max_week),
+        }).then((res) => {
+          if (!res) return;
+          mergeHorizontalData({
+            start: currentStartCopy,
+            data: res.data,
+            customer: res.customer,
+            dates,
+          });
         });
         currentStart += filters.pageLength;
       }
     },
-    [filters.maxWeek, filters.pageLength, filters.start, filters.weekDate, handleApiCall, updateHorizontalData]
+    [
+      filters.maxWeek,
+      filters.pageLength,
+      filters.start,
+      filters.weekDate,
+      handleApiCall,
+      mergeHorizontalData,
+    ],
   );
 
   const loadIntialData = useCallback(async () => {
@@ -274,7 +231,7 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
 
     updateTeamData(mainThredData);
 
-    addHorizontalPreProcessData(false, mainThredData, teamData.dates);
+    addHorizontalPreProcessData(teamData.dates);
   }, [
     addHorizontalPreProcessData,
     filters.maxWeek,
@@ -303,7 +260,9 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
         const newEmployeeData = res.message?.data;
         if (newEmployeeData && newEmployeeData.length > 0) {
           const updatedData = teamData.data.map((item) => {
-            const index = newEmployeeData.findIndex((employee: EmployeeDataProps) => employee.name == item.name);
+            const index = newEmployeeData.findIndex(
+              (employee: EmployeeDataProps) => employee.name == item.name,
+            );
             if (index != -1) {
               return newEmployeeData[index];
             }
@@ -317,7 +276,14 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
         }
       });
     },
-    [fetchData, filters.allocationType, filters.maxWeek, filters.weekDate, teamData, updateTeamData]
+    [
+      fetchData,
+      filters.allocationType,
+      filters.maxWeek,
+      filters.weekDate,
+      teamData,
+      updateTeamData,
+    ],
   );
 
   const cellHeaderRef = useInfiniteScroll({
@@ -333,9 +299,9 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
     if (filters.maxWeek + 5 >= 10) {
       const newDates = getDatesArrays(filters.weekDate, filters.maxWeek + 5);
       setDates(newDates);
-      addHorizontalPreProcessData(true, null, newDates);
+      addHorizontalPreProcessData(newDates);
     } else {
-      addHorizontalPreProcessData(true, null, teamData.dates);
+      addHorizontalPreProcessData(teamData.dates);
     }
   }, [
     apiController.isLoading,
@@ -352,7 +318,11 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
       loadIntialData();
       setReFetchData(false);
     }
-  }, [apiController.isNeedToFetchDataAfterUpdate, loadIntialData, setReFetchData]);
+  }, [
+    apiController.isNeedToFetchDataAfterUpdate,
+    loadIntialData,
+    setReFetchData,
+  ]);
 
   return (
     <>
@@ -364,10 +334,15 @@ const ResourceTeamViewComponent = ({ viewData }: ResourceTeamViewComponentProps)
           handleVerticalLoadMore={handleVerticalLoadMore}
           onSubmit={onFormSubmit}
           cellHeaderRef={cellHeaderRef}
-          dateToAddHeaderRef={getNextDate(filters.weekDate, filters.maxWeek - 1)}
+          dateToAddHeaderRef={getNextDate(
+            filters.weekDate,
+            filters.maxWeek - 1,
+          )}
         />
       )}
-      {resourceAllocationDialogState.isShowDialog && <AddResourceAllocations onSubmit={onFormSubmit} />}
+      {resourceAllocationDialogState.isShowDialog && (
+        <AddResourceAllocations onSubmit={onFormSubmit} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description
This pull request refactors and improves the resource management team view's state management and data merging logic. The main focus is on centralizing and optimizing how horizontal data (i.e., data spanning multiple weeks or employees) is merged into the team state, reducing code duplication and making the data update process more robust. Additionally, several state update functions are now written in a safer, more functional style using updater functions. Some type definitions are also updated for consistency.

## Relevant Technical Choices

* Added a new `mergeHorizontalData` method to the `TeamContext` and its type definition, centralizing the logic for merging horizontally fetched data into the `teamData` state. This replaces previously duplicated or scattered logic for updating employee and customer data across weeks. 
* Updated all state setter functions (e.g., `setFilters`, `setApiController`, `setTeanData`, `setTableView`) to use updater functions, ensuring updates are always based on the latest state and preventing potential stale state bugs.
* Refactored the `ResourceTeamViewComponent` to use the new `mergeHorizontalData` function, removing the old `updateHorizontalData` callback and simplifying related logic for both vertical and horizontal data pre-processing. 
* Improved code readability and maintainability by reformatting imports, destructuring context selectors, and updating dependency arrays in hooks for clarity and correctness. 
* Updated type definitions in `types.ts` for context props and actions, adding trailing commas and aligning function signatures for consistency.
* Added `EmployeeDataProps` to the relevant import list to support the new merge logic.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

The team view loads data in two dimensions:                                                                          
  - Vertical: Pages of 20 employees (triggered by scrolling down)     
  - Horizontal: Additional date columns for those employees (triggered after each vertical load)  
  
 Bug: Scrolling down loaded new employee pages correctly, but fire-and-forget horizontal data fetches from earlier    
  pages would resolve later and call updateTeamData in SET mode with stale closure data, overwriting the entire state  
  and erasing recently loaded employees.                                                                               
                                                                                                                       
  Fix: Replaced all setState(value) calls with functional updaters setState(prev => ...) to always operate on the      
  latest state, and introduced a mergeHorizontalData function that safely merges date-column data into specific        
  employee indices without replacing the full dataset. 

## Screenshot/Screencast

**Before**

https://github.com/user-attachments/assets/f2c304d3-d78d-46c2-99b6-9cbeb3004530

**After**


https://github.com/user-attachments/assets/508b6372-e8f7-4529-b0d5-bd948ed87a66




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #