### PR TITLE
QA fix: sidebar active button state

### DIFF
--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -1,11 +1,20 @@
 /**
  * External dependencies.
  */
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
-import { Sidebar as BaseSidebar, Batches, Notifications, People, Reports, Tasks, Time } from "@rtcamp/frappe-ui-react";
+import { ErrorFallback } from "@next-pms/design-system/components";
+import {
+  Sidebar as BaseSidebar,
+  Batches,
+  Notifications,
+  People,
+  Reports,
+  Tasks,
+  Time,
+} from "@rtcamp/frappe-ui-react";
 import {
   ArrowLeftRight,
   Folder,
@@ -20,25 +29,25 @@ import {
 /**
  * Internal dependencies.
  */
-import { setLocalStorage } from "@/lib/storage";
-import { checkIsMobile } from "@/lib/utils";
-import { setSidebarCollapsed } from "@/store/user";
-import UserNavigation from "./userNavigation";
-import ViewLoader from "./viewLoader";
-import logo from "@/logo.svg";
-import { RootState } from "@/store";
-import type { ViewData } from "@/store/view";
-import { ErrorFallback } from "@next-pms/design-system/components";
 import { useContextSelector } from "use-context-selector";
-import { UserContext } from "@/lib/UserProvider";
-import { useTheme } from "@/providers/theme/hook";
-import { ROLES, ROUTES } from "@/lib/constant";
 import { useUser } from "@/hooks/useUser";
+import { ROLES, ROUTES } from "@/lib/constant";
+import { setLocalStorage } from "@/lib/storage";
+import { UserContext } from "@/lib/UserProvider";
+import { checkIsMobile } from "@/lib/utils";
+import logo from "@/logo.svg";
+import { useTheme } from "@/providers/theme/hook";
+import { RootState } from "@/store";
+import { setSidebarCollapsed } from "@/store/user";
+import type { ViewData } from "@/store/view";
 
 const Sidebar = () => {
   const user = useUser();
   const { theme, changeTheme } = useTheme();
-  const logout = useContextSelector(UserContext, (value) => value.actions.logout);
+  const logout = useContextSelector(
+    UserContext,
+    (value) => value.actions.logout,
+  );
   const navigate = useNavigate();
   const viewInfo = useSelector((state: RootState) => state.view);
   const dispatch = useDispatch();
@@ -50,9 +59,12 @@ const Sidebar = () => {
 
   const hasPmRole = user.roles.some((role: string) => ROLES.includes(role));
   const privateViews = viewInfo.views.filter(
-    (view: ViewData) => view.user === user.user && !view.default && !view.public,
+    (view: ViewData) =>
+      view.user === user.user && !view.default && !view.public,
   );
-  const publicViews = viewInfo.views.filter((view: ViewData) => view.public && !view.default);
+  const publicViews = viewInfo.views.filter(
+    (view: ViewData) => view.public && !view.default,
+  );
 
   const handleSidebarCollapse = useCallback(() => {
     dispatch(setSidebarCollapsed(checkIsMobile()));
@@ -86,7 +98,9 @@ const Sidebar = () => {
             },
             {
               label: "Switch To Desk",
-              icon: <ArrowLeftRight size={16} className="text-ink-gray-6 mr-2" />,
+              icon: (
+                <ArrowLeftRight size={16} className="text-ink-gray-6 mr-2" />
+              ),
               onClick: () => {
                 window.location.assign(ROUTES.desk);
               },
@@ -94,7 +108,11 @@ const Sidebar = () => {
             {
               label: "Toggle Theme",
               icon:
-                theme === "dark" ? <Sun className="text-ink-gray-6 mr-2" /> : <Moon className="text-ink-gray-6 mr-2" />,
+                theme === "dark" ? (
+                  <Sun className="text-ink-gray-6 mr-2" />
+                ) : (
+                  <Moon className="text-ink-gray-6 mr-2" />
+                ),
               onClick: changeTheme,
             },
             {
@@ -136,14 +154,14 @@ const Sidebar = () => {
                 label: "Tasks",
                 icon: Tasks,
                 to: "",
-                isActive: pathname.startsWith(ROUTES.task),
+                isActive: pathname === ROUTES.task,
                 onClick: () => navigate(ROUTES.task),
               },
               {
                 label: "Projects",
                 icon: Folder,
                 to: "",
-                isActive: pathname.startsWith(ROUTES.project),
+                isActive: pathname === ROUTES.project,
                 onClick: () => navigate(ROUTES.project),
               },
             ],
@@ -155,19 +173,19 @@ const Sidebar = () => {
               {
                 label: "Personal",
                 icon: Time,
-                isActive: pathname.startsWith(ROUTES["timesheet-personal"]),
+                isActive: pathname === ROUTES["timesheet-personal"],
                 onClick: () => navigate(ROUTES["timesheet-personal"]),
               },
               {
                 label: "Team",
                 icon: People,
-                isActive: pathname.startsWith(ROUTES["timesheet-team"]),
+                isActive: pathname === ROUTES["timesheet-team"],
                 onClick: () => navigate(ROUTES["timesheet-team"]),
               },
               {
                 label: "Projects",
                 icon: Folder,
-                isActive: pathname.startsWith(ROUTES["timesheet-project"]),
+                isActive: pathname === ROUTES["timesheet-project"],
                 onClick: () => navigate(ROUTES["timesheet-project"]),
               },
             ],
@@ -179,21 +197,21 @@ const Sidebar = () => {
                 label: "Allocation",
                 icon: Batches,
                 to: "",
-                isActive: false,
+                isActive: pathname === ROUTES.allocation,
                 onClick: () => navigate(ROUTES.allocation),
               },
               {
                 label: "Roadmap",
                 icon: Layers,
                 to: "",
-                isActive: false,
+                isActive: pathname === ROUTES.roadmap,
                 onClick: () => navigate(ROUTES.roadmap),
               },
               {
                 label: "Reports",
                 icon: Reports,
                 to: "",
-                isActive: false,
+                isActive: pathname === ROUTES.report,
                 onClick: () => navigate(ROUTES.report),
               },
             ],


### PR DESCRIPTION
## Description

- Going to team or project timesheet marks personal option active too.
- Last 3 options in the sidebar were not marked as active

## Screenshot/Screencast

### Before
<img width="1327" height="1042" alt="Screenshot 2026-03-19 at 11 01 05 AM" src="https://github.com/user-attachments/assets/1195b8b9-4d9b-49dc-915c-a756b3fa5862" />

### After
<img width="1327" height="1042" alt="Screenshot 2026-03-19 at 11 01 35 AM" src="https://github.com/user-attachments/assets/795d10d2-629d-4a44-b2fd-fb06d14f34c8" />


<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->