### PR TITLE
QA fix: remove filter on project search

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -122,7 +122,6 @@ const AddTime = ({ initialDate, open = false, onOpenChange, task = "", project =
         <form.Field
           name="project"
           children={(field) => {
-            console.log(field.state.value);
             return (
               <>
                 <label className="block text-xs text-ink-gray-5">Project</label>

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -75,7 +75,6 @@ const AddTime = ({ initialDate, open = false, onOpenChange, task = "", project =
   const { data: projectsData } = useFrappeGetCall("frappe.client.get_list", {
     doctype: "Project",
     fields: ["name", "project_name"],
-    filters: window.frappe?.boot?.global_filters.project,
     limit_page_length: "null",
   });
 
@@ -123,6 +122,7 @@ const AddTime = ({ initialDate, open = false, onOpenChange, task = "", project =
         <form.Field
           name="project"
           children={(field) => {
+            console.log(field.state.value);
             return (
               <>
                 <label className="block text-xs text-ink-gray-5">Project</label>


### PR DESCRIPTION
## Description

Removes global filter to allow project search. This was caused by the variable `window.frappe?.boot?.global_filters.project` having the value `[["name","in",[]]]` on staging.
This only happens for users who are contractors.

## Screenshots

### Before
<img width="1327" height="1042" alt="Screenshot 2026-03-20 at 10 42 11 AM" src="https://github.com/user-attachments/assets/5cbaf4fc-0428-4332-8bee-22edd840a251" />

### After
<img width="1327" height="1042" alt="Screenshot 2026-03-20 at 10 42 37 AM" src="https://github.com/user-attachments/assets/716e50a3-df38-40cf-9ee8-58f1fe29b57d" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)