### PR TITLE
Feat: Add "Report to" and "Approval Status" filter

### DIFF
--- a/frontend/packages/app/src/components/filters/approvalStatusFilter.tsx
+++ b/frontend/packages/app/src/components/filters/approvalStatusFilter.tsx
@@ -1,0 +1,47 @@
+import { Select } from "@rtcamp/frappe-ui-react";
+import { ApprovalStatusType } from "@/types/timesheet";
+
+type ApprovalStatusFilterProps = {
+  value?: ApprovalStatusType | null;
+  onChange: (value?: ApprovalStatusType | null) => void;
+};
+
+const ApprovalStatusFilter: React.FC<ApprovalStatusFilterProps> = ({
+  value,
+  onChange,
+}) => {
+  const options = [
+    {
+      label: "Not Submitted",
+      value: "not-submitted",
+    },
+    {
+      label: "Approval Pending",
+      value: "approval-pending",
+    },
+    {
+      label: "Approved",
+      value: "approved",
+    },
+    {
+      label: "Rejected",
+      value: "rejected",
+    },
+    {
+      label: "All",
+      value: "",
+    },
+  ];
+
+  return (
+    <Select
+      placeholder="Approval Status"
+      className="w-fit"
+      options={options}
+      value={value ?? ""}
+      onChange={(value) => onChange(value as ApprovalStatusType)}
+    />
+  );
+};
+
+export default ApprovalStatusFilter;

--- a/frontend/packages/app/src/components/filters/reportsToFilter.tsx
+++ b/frontend/packages/app/src/components/filters/reportsToFilter.tsx
@@ -1,0 +1,26 @@
+import { Combobox } from "@rtcamp/frappe-ui-react";
+import useApprovers from "@/hooks/useApprovers";
+
+type ReportsToFilterProps = {
+  value?: string | null;
+  onChange: (value: string | null) => void;
+};
+
+const ReportsToFilter: React.FC<ReportsToFilterProps> = ({
+  value,
+  onChange,
+}) => {
+  const approvers = useApprovers();
+
+  return (
+    <Combobox
+      placeholder="Reports to"
+      options={approvers}
+      value={value}
+      onChange={(value) => onChange(value ?? null)}
+      className="w-auto"
+    />
+  );
+};
+
+export default ReportsToFilter;

--- a/frontend/packages/app/src/components/filters/searchTasks.tsx
+++ b/frontend/packages/app/src/components/filters/searchTasks.tsx
@@ -1,0 +1,20 @@
+import { TextInput } from "@rtcamp/frappe-ui-react";
+
+type SearchTasksProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+const SearchTasks: React.FC<SearchTasksProps> = ({ value, onChange }) => {
+  return (
+    <TextInput
+      placeholder="Search Tasks"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        onChange(e.target.value)
+      }
+    />
+  );
+};
+
+export default SearchTasks;

--- a/frontend/packages/app/src/hooks/useApprovers.ts
+++ b/frontend/packages/app/src/hooks/useApprovers.ts
@@ -1,0 +1,29 @@
+import { useFrappeGetCall } from "frappe-react-sdk";
+import { Employee } from "@/types";
+
+type UseApproversOptions = {
+  role?: string[];
+};
+
+const useApprovers = ({ role }: UseApproversOptions = {}) => {
+  if (!role || role.length === 0) {
+    role = ["Projects Manager", "Projects User"];
+  }
+
+  const { data } = useFrappeGetCall(
+    "next_pms.timesheet.api.employee.get_employee_list",
+    {
+      role,
+    },
+  );
+
+  const approvers = ((data?.message?.data ?? []) as Employee[]).map((emp) => ({
+    label: emp.employee_name,
+    value: emp.name,
+    image: emp.image,
+  }));
+
+  return approvers;
+};
+
+export default useApprovers;

--- a/frontend/packages/app/src/hooks/useApprovers.ts
+++ b/frontend/packages/app/src/hooks/useApprovers.ts
@@ -1,5 +1,5 @@
 import { useFrappeGetCall } from "frappe-react-sdk";
-import { Employee } from "@/types";
+import type { Employee } from "@/types";
 
 type UseApproversOptions = {
   role?: string[];

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import { floatToTime } from "@next-pms/design-system";
+import { statusMap } from "@next-pms/design-system/components";
 import {
   getDateFromDateAndTimeString,
   getUTCDateTime,
@@ -17,6 +18,7 @@ import { twMerge } from "tailwind-merge";
 import { timeStringToFloat } from "@/schema/timesheet";
 import { WorkingFrequency } from "@/types";
 import { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
+import type { timesheet, TimesheetFilters } from "@/types/timesheet";
 
 export const NO_VALUE_FIELDS = [
   "Section Break",
@@ -459,3 +461,36 @@ export const calculateLeaveHours = (
     return total;
   }, 0);
 };
+
+export function filterTimesheetEntries(
+  data: Record<string, timesheet>,
+  filters: TimesheetFilters,
+): [string, timesheet][] {
+  const entries = Object.entries(data) as [string, timesheet][];
+  const query = filters.search.trim().toLowerCase();
+
+  return entries.map(([key, week]) => {
+    // Status filter
+    if (
+      filters.approvalStatus &&
+      statusMap[week.status] !== filters.approvalStatus
+    ) {
+      return [key, { ...week, tasks: {} }] as [string, timesheet];
+    }
+
+    let filteredTasks = week.tasks;
+
+    // Search filter
+    if (query) {
+      filteredTasks = Object.fromEntries(
+        Object.entries(filteredTasks).filter(
+          ([, task]) =>
+            task.name.toLowerCase().includes(query) ||
+            task.subject.toLowerCase().includes(query),
+        ),
+      );
+    }
+
+    return [key, { ...week, tasks: filteredTasks }] as [string, timesheet];
+  });
+}

--- a/frontend/packages/app/src/pages/timesheet/personal/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/index.tsx
@@ -8,8 +8,6 @@ import { getFormatedDate } from "@next-pms/design-system/date";
 import { useQueryParam } from "@next-pms/hooks";
 import {
   Button,
-  TextInput,
-  Select,
   Filter,
   FilterCondition,
   useToasts,
@@ -26,10 +24,17 @@ import { Ellipsis } from "lucide-react";
 /**
  * Internal dependencies.
  */
-import { parseFrappeErrorMsg, isDateInRange } from "@/lib/utils";
+import {
+  parseFrappeErrorMsg,
+  isDateInRange,
+  filterTimesheetEntries,
+} from "@/lib/utils";
 import { useUser } from "@/providers/user";
 import type { WorkingFrequency } from "@/types";
-import type { timesheet } from "@/types/timesheet";
+import type { TimesheetFilters } from "@/types/timesheet";
+import ApprovalStatusFilter from "../../../components/filters/approvalStatusFilter";
+import ReportsToFilter from "../../../components/filters/reportsToFilter";
+import SearchTasks from "../../../components/filters/searchTasks";
 import { InfiniteScroll } from "../../../components/infiniteScroll";
 import { TimesheetRow } from "../../../components/timesheet-row";
 import { HeaderRow } from "../../../components/timesheet-row/components/row/headerRow";
@@ -43,8 +48,14 @@ const NUMBER_OF_WEEKS_TO_FETCH = 4;
 function Timesheet() {
   const targetRef = useRef<HTMLDivElement>(null);
   const toast = useToasts();
-  const [filters, setFilters] = useState<FilterCondition[]>([]);
-  const [search, setSearch] = useState("");
+  const [compositeFilters, setCompositeFilters] = useState<FilterCondition[]>(
+    [],
+  );
+  const [filters, setFilters] = useState<TimesheetFilters>({
+    search: "",
+    approvalStatus: null,
+    reportsTo: null,
+  });
 
   const { handleApproval } = useTimesheetOutletContext();
 
@@ -146,68 +157,38 @@ function Timesheet() {
     });
   };
 
-  const filteredWeekEntries = useMemo(() => {
-    const entries = Object.entries(timesheet.data.data) as [
-      string,
-      timesheet,
-    ][];
-    const query = search.trim().toLowerCase();
-
-    if (!query) return entries;
-
-    return entries.map(([key, week]) => {
-      const filteredTasks = Object.fromEntries(
-        Object.entries(week.tasks).filter(
-          (entry) =>
-            entry[1].name.toLowerCase().includes(query) ||
-            entry[1].subject.toLowerCase().includes(query),
-        ),
-      );
-
-      return [key, { ...week, tasks: filteredTasks }] as [string, timesheet];
-    });
-  }, [timesheet.data.data, search]);
+  const filteredWeekEntries = useMemo(
+    () => filterTimesheetEntries(timesheet.data.data, filters),
+    [timesheet.data.data, filters],
+  );
 
   return (
     <div className="w-full h-full py-3.5 px-3">
       <div className="flex justify-between mb-3.5">
         <div className="flex gap-2">
-          <TextInput
-            placeholder="Search Tasks"
-            value={search}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setSearch(e.target.value)
+          <SearchTasks
+            value={filters.search}
+            onChange={(search) => setFilters((prev) => ({ ...prev, search }))}
+          />
+          <ApprovalStatusFilter
+            value={filters.approvalStatus}
+            onChange={(approvalStatus) =>
+              setFilters((prev) => ({ ...prev, approvalStatus }))
             }
           />
-          <Select
-            placeholder="Approval Status"
-            className="w-fit"
-            options={[
-              {
-                label: "Not Submitted",
-                value: "not-submitted",
-              },
-              {
-                label: "Approval Pending",
-                value: "approval-pending",
-              },
-              {
-                label: "Approved",
-                value: "approved",
-              },
-              {
-                label: "Rejected",
-                value: "rejected",
-              },
-            ]}
+          <ReportsToFilter
+            value={filters.reportsTo}
+            onChange={(reportsTo) =>
+              setFilters((prev) => ({ ...prev, reportsTo }))
+            }
           />
         </div>
         <div className="flex gap-2">
           <Filter
             fields={sampleFields}
-            value={filters}
+            value={compositeFilters}
             onChange={(newFilters) => {
-              setFilters(newFilters);
+              setCompositeFilters(newFilters);
             }}
           />
           <Button icon={() => <Ellipsis size={16} />} />
@@ -219,7 +200,7 @@ function Timesheet() {
       ) : (
         <>
           {Object.keys(timesheet.data?.data).length == 0 ? (
-            <Typography className="flex items-center justify-center">
+            <Typography className="flex justify-center items-center">
               No Data
             </Typography>
           ) : (
@@ -237,7 +218,7 @@ function Timesheet() {
                     return (
                       <>
                         {index === 0 ? (
-                          <div className="mb-4 sticky top-0 bg-surface-white z-10">
+                          <div className="sticky top-0 z-10 mb-4 bg-surface-white">
                             <HeaderRow
                               dates={value.dates}
                               showHeading={true}

--- a/frontend/packages/app/src/types/timesheet.ts
+++ b/frontend/packages/app/src/types/timesheet.ts
@@ -2,7 +2,6 @@
  * Internal dependencies.
  */
 import { WorkingFrequency } from "@/types";
-import { TaskStatusType } from "./task";
 
 export interface TaskProps {
   [key: string]: TaskDataProps;
@@ -16,7 +15,7 @@ export interface TaskDataProps {
   project: string;
   expected_time: number;
   actual_time: number;
-  status: TaskStatusType;
+  status: string;
   due_date?: string;
   data: Array<TaskDataItemProps>;
 }
@@ -72,7 +71,7 @@ export interface timesheet {
   dates: string[];
   total_hours: number;
   tasks: TaskProps;
-  status: TaskStatusType;
+  status: string;
 }
 
 export interface NewTimesheetProps {
@@ -84,4 +83,16 @@ export interface NewTimesheetProps {
   description: string;
   hours: number;
   employee: string;
+}
+
+export type ApprovalStatusType =
+  | "not-submitted"
+  | "approval-pending"
+  | "approved"
+  | "rejected";
+
+export interface TimesheetFilters {
+  search: string;
+  approvalStatus?: ApprovalStatusType | null;
+  reportsTo?: string | null;
 }


### PR DESCRIPTION
## Description
- Added "Report to" and "Approval Status" filters for timesheet
- Refactored filters into component and extracted non-view code out of view code
- Extracted filtering logic to separate function

## Relevant Technical Choices
- The "Report to" filter is supposed to be only on Team View but I have added it on personal view for testing purpose, since the teams page does not exists as of now.
- The filtering for "Reports to" filter is also not implemented because as of now we don't know which api will be used for the teams page. In case it's the same api, we will need to update the backend api to return the reporting manager in the timesheet data response.
- These can be fixed once we have the scaffold for the teams page.

## Screenshot/Screencast

<img width="1183" height="464" alt="image" src="https://github.com/user-attachments/assets/d21ad612-4244-48e0-97c7-581113642fa0" />

<img width="1203" height="424" alt="image" src="https://github.com/user-attachments/assets/fecb55cd-de2e-41ac-9d14-8e559ad12bdc" />

<img width="1201" height="463" alt="image" src="https://github.com/user-attachments/assets/f41e6945-a91b-4de4-9ee4-62ecc369ed52" />


Partially addresses #821 