### PR TITLE
feat: multiple time entries for get task log

### DIFF
--- a/next_pms/timesheet/api/employee.py
+++ b/next_pms/timesheet/api/employee.py
@@ -107,7 +107,10 @@ def get_employee_list(
     from . import filter_employees
 
     if roles and isinstance(roles, str):
-        roles = json.loads(roles)
+        try:
+            roles = json.loads(roles)
+        except json.JSONDecodeError:
+            roles = None  ## useFrappeGetCall will  pass string as JSON-String if string received its better to set it to None and handle it in filter_employees function
     employees, count = filter_employees(
         employee_name=employee_name,
         department=department,

--- a/next_pms/timesheet/api/employee.py
+++ b/next_pms/timesheet/api/employee.py
@@ -99,11 +99,15 @@ def get_employee_list(
     status=None,
     user_group=None,
     reports_to: str | None = None,
-    roles: list[str] | None = None,
+    roles: str | list[str] | None = None,
     ignore_default_filters=False,
 ):
+    import json
+
     from . import filter_employees
 
+    if roles and isinstance(roles, str):
+        roles = json.loads(roles)
     employees, count = filter_employees(
         employee_name=employee_name,
         department=department,

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -209,6 +209,7 @@ def get_task(task: str, start_date: str | datetime.date, end_date: str | datetim
     return {
         "subject": task.subject,
         "expected_time": task.expected_time,
+        "exp_end_date": task.exp_end_date or "",
         "project_name": frappe.db.get_value("Project", task.project, "project_name"),
         "project": task.project,
         "actual_time": task.actual_time,

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -253,37 +253,22 @@ def get_task_log(task: str, start_date: str = None, end_date: str = None, employ
 
     result = query.run(as_dict=True)
 
-    aggregated_data = {}
+    log_entries = {}
 
     for res in result:
-        employee_name = res.get("employee")
-        start_date = res.get("start_date")
-        hours = res.get("hours")
-        description = res.get("description")
+        key = str(res.get("start_date"))
+        if key not in log_entries:
+            log_entries[key] = []
 
-        key = start_date
-
-        if key not in aggregated_data:
-            aggregated_data[key] = {}
-
-        if employee_name not in aggregated_data[key]:
-            aggregated_data[key][employee_name] = {"hours": 0, "description": []}
-
-        aggregated_data[key][employee_name]["hours"] += hours
-        aggregated_data[key][employee_name]["description"].append(description)
-
-    response = {
-        str(key): [
+        log_entries[key].append(
             {
-                "employee": emp,
-                "hours": data["hours"],
-                "description": data["description"],
+                "employee": res.get("employee"),
+                "hours": res.get("hours"),
+                "description": [res.get("description")] if res.get("description") else [],
             }
-            for emp, data in value.items()
-        ]
-        for key, value in aggregated_data.items()
-    }
-    return response
+        )
+
+    return log_entries
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Description

* Enhanced the `roles` parameter in `get_employee_list` (`next_pms/timesheet/api/employee.py`) to accept either a string (which will be parsed as JSON) or a list of strings, increasing flexibility for API consumers.

* Added the `exp_end_date` field to the response of `get_task` in `next_pms/timesheet/api/task.py`, ensuring that the expected end date is always present in the API output (returns an empty string if not set).

* Refactored the aggregation logic in `get_task_log` (`next_pms/timesheet/api/task.py`) to simplify the structure: now groups log entries by date as a list of dictionaries, each containing employee, hours, and description (as a list), instead of a nested dictionary keyed by employee. This makes the output easier to consume and aligns with common frontend expectations.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
1. Added `expected end date` to `get_task` endpoint for modal api
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/51c3d6d9-2415-48e4-935b-9acc8804b2e2" />

2. usage of string encode query params for list (using curl) 
<img width="1466" height="87" alt="image" src="https://github.com/user-attachments/assets/0d655f79-0567-4724-a8f4-d237140411a7" />

3. simplify the structure for multiple time entries for a single task in a day for `get_task_log` api 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/2c6ad542-84f8-4a83-903e-1d0eba88b252" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #924 , #919