### PR TITLE
Feature: Allow Inline Team Timesheet Editing

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -7,10 +7,8 @@ import {
   TaskRow as BaseTaskRow,
   taskStatusMap,
 } from "@next-pms/design-system/components";
-import { prettyDate } from "@next-pms/design-system/date";
 import { useToasts } from "@rtcamp/frappe-ui-react";
 import { useFrappePostCall } from "frappe-react-sdk";
-import { CalendarFoldIcon, Folder } from "lucide-react";
 
 /**
  * Internal dependencies
@@ -19,8 +17,6 @@ import TaskPopover from "@/components/taskPopover";
 import { calculateTotalHours, parseFrappeErrorMsg } from "@/lib/utils";
 import type { TaskRowProps } from "./types";
 import { InlineTimeEntry } from "../inline-time-entry";
-
-const MOCK_END_DATE = "2024-12-31";
 
 /**
  * @description This is the task row component for the timesheet table.
@@ -63,13 +59,18 @@ export const TaskRow = ({
     const totalTimeEntries = [];
     for (const date of dates) {
       const currentTotal = calculateTotalHours(tasks, date);
+      // Check if the time entry for the day is approved or not.
+      const tasksForDate = tasks[taskKey].data.filter((entry) =>
+        entry.from_time.includes(date),
+      );
+      const isApproved = tasksForDate.some((entry) => entry.docstatus === 1);
       totalTimeEntries.push({
         time: currentTotal === 0 ? "" : floatToTime(currentTotal, 2),
         nonBillable:
           currentTotal === 0 || (taskKey && tasks[taskKey]?.is_billable)
             ? false
             : true,
-        disabled: disabled || false,
+        disabled: disabled || isApproved || false,
       });
       total += currentTotal;
     }

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -38,7 +38,6 @@ type TeamTimesheetRowProps = {
   dates: string[];
   firstWeek: boolean;
   teamMembers: TeamMember[];
-  disabled?: boolean;
   approvalPendingCount?: number;
 };
 
@@ -116,7 +115,10 @@ export const TeamTimesheetRow = ({
                               label={task.subject || task.name}
                               status={task.status}
                               className="pl-19.5"
-                              disabled={member.status === "Approved"}
+                              disabled={
+                                member.status === "Approved" ||
+                                member.status === "Processing Timesheet"
+                              }
                               dailyWorkingHours={dailyWorkingHours}
                               totalTimeEntriesInHours={totalTimeEntriesInHours}
                               employee={member.employee}

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -47,7 +47,6 @@ export const TeamTimesheetRow = ({
   dates,
   firstWeek,
   teamMembers,
-  disabled,
   approvalPendingCount,
 }: TeamTimesheetRowProps) => {
   const openWeeklyApproval = useTeamTimesheet(
@@ -117,7 +116,7 @@ export const TeamTimesheetRow = ({
                               label={task.subject || task.name}
                               status={task.status}
                               className="pl-19.5"
-                              disabled={disabled}
+                              disabled={member.status === "Approved"}
                               dailyWorkingHours={dailyWorkingHours}
                               totalTimeEntriesInHours={totalTimeEntriesInHours}
                               employee={member.employee}

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -116,7 +116,6 @@ export const TeamTimesheetTable = () => {
                       label={week.key}
                       dates={week.dates}
                       firstWeek={index === 0}
-                      disabled={true}
                       approvalPendingCount={week.approvalPendingCount}
                       teamMembers={week.members.map((member) => ({
                         label: member.employee.employee_name,

--- a/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
@@ -1,7 +1,9 @@
 /**
  * External dependencies.
  */
+import { BadgeProps, ButtonVariant } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
+import { Check, CircleCheck, CircleX, Send } from "lucide-react";
 
 /**
  * Internal dependencies.
@@ -13,6 +15,8 @@ export type ApprovalStatusType =
   | "approved"
   | "rejected"
   | "approval-pending"
+  | "partially-approved"
+  | "partially-rejected"
   | "none";
 
 export type ApprovalStatusLabelType =
@@ -33,6 +37,8 @@ export const ApprovalStatusLabelMap: Record<
   approved: "Approved",
   rejected: "Rejected",
   "approval-pending": "Approval Pending",
+  "partially-approved": "Partially Approved",
+  "partially-rejected": "Partially Rejected",
   none: "None",
 };
 
@@ -44,10 +50,10 @@ export const ApprovalStatusMap: Record<
   Approved: "approved",
   Rejected: "rejected",
   "Approval Pending": "approval-pending",
-  None: "none",
-  "Partially Approved": "approved",
-  "Partially Rejected": "rejected",
+  "Partially Approved": "partially-approved",
+  "Partially Rejected": "partially-rejected",
   "Processing Timesheet": "approval-pending",
+  None: "none",
 };
 
 export const taskStatusMap: Record<string, TaskStatusType> = {
@@ -84,3 +90,53 @@ export const totalHoursVariants = cva("text-base lining-nums tabular-nums", {
   },
   defaultVariants: { theme: "gray", weight: "medium" },
 });
+
+export const approvalStatusTheme: Record<
+  ApprovalStatusType,
+  BadgeProps["theme"]
+> = {
+  "not-submitted": "gray",
+  approved: "green",
+  rejected: "red",
+  "approval-pending": "orange",
+  "partially-approved": "green",
+  "partially-rejected": "red",
+  none: "gray",
+};
+
+export const approvalStatusIcon: Record<
+  ApprovalStatusType,
+  {
+    variant: ButtonVariant;
+    icon: React.ComponentType<{ size?: number }> | null;
+  }
+> = {
+  "not-submitted": {
+    variant: "solid",
+    icon: Send,
+  },
+  approved: {
+    variant: "ghost",
+    icon: CircleCheck,
+  },
+  rejected: {
+    variant: "ghost",
+    icon: CircleX,
+  },
+  "approval-pending": {
+    variant: "solid",
+    icon: Check,
+  },
+  "partially-approved": {
+    variant: "ghost",
+    icon: CircleCheck,
+  },
+  "partially-rejected": {
+    variant: "ghost",
+    icon: CircleX,
+  },
+  none: {
+    variant: "ghost",
+    icon: null,
+  },
+};

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/constants.ts
@@ -1,52 +1,7 @@
 /**
  * External dependencies.
  */
-import React from "react";
-import type { BadgeProps, ButtonVariant } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
-import { Check, CircleCheck, CircleX } from "lucide-react";
-
-/**
- * Internal dependencies.
- */
-import type { ApprovalStatusType } from "../constants";
-
-export const statusTheme: Record<ApprovalStatusType, BadgeProps["theme"]> = {
-  "not-submitted": "gray",
-  approved: "green",
-  rejected: "red",
-  "approval-pending": "orange",
-  none: "gray",
-};
-
-export const statusIcon: Record<
-  ApprovalStatusType,
-  {
-    variant: ButtonVariant;
-    icon: React.ComponentType<{ size?: number }> | null;
-  }
-> = {
-  "not-submitted": {
-    variant: "ghost",
-    icon: null,
-  },
-  approved: {
-    variant: "ghost",
-    icon: CircleCheck,
-  },
-  rejected: {
-    variant: "ghost",
-    icon: CircleX,
-  },
-  "approval-pending": {
-    variant: "solid",
-    icon: Check,
-  },
-  none: {
-    variant: "ghost",
-    icon: null,
-  },
-};
 
 export const buttonVariants = cva("", {
   variants: {
@@ -55,6 +10,8 @@ export const buttonVariants = cva("", {
       approved: "text-ink-green-4",
       rejected: "text-ink-red-4",
       "approval-pending": "text-ink-white",
+      "partially-approved": "text-ink-green-4",
+      "partially-rejected": "text-ink-red-4",
       none: "",
     },
     variant: {

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -8,13 +8,15 @@ import { ChevronDown } from "lucide-react";
 /**
  * Internal dependencies.
  */
-import { buttonVariants, statusIcon, statusTheme } from "./constants";
+import { buttonVariants } from "./constants";
 import { mergeClassNames as cn } from "../../../../utils";
 import {
   ApprovalStatusLabelMap,
   type TotalHoursTheme,
   type ApprovalStatusType,
   totalHoursVariants,
+  approvalStatusTheme,
+  approvalStatusIcon,
 } from "../constants";
 
 export interface MemberRowProps {
@@ -29,7 +31,7 @@ export interface MemberRowProps {
   /** Callback function when the action button is clicked. */
   onButtonClick?: () => void;
   /** Array of time entries for each day of the week for the member. */
-  timeEntries: {date: string; time: string}[];
+  timeEntries: { date: string; time: string }[];
   /** Total hours logged for the week. */
   totalHours?: string;
   /** Theme for the total hours */
@@ -73,7 +75,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
             {label}
           </span>
           {status !== "none" && (
-            <Badge theme={statusTheme[status]} className="shrink-0">
+            <Badge theme={approvalStatusTheme[status]} className="shrink-0">
               {ApprovalStatusLabelMap[status]}
             </Badge>
           )}
@@ -105,7 +107,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
       </div>
 
       <div className="flex items-center justify-end w-12 shrink-0 h-7 whitespace-nowrap">
-        {!isStatusNone && statusIcon[status]?.icon ? (
+        {!isStatusNone && approvalStatusIcon[status]?.icon ? (
           <Button
             onClick={(e) => {
               e.stopPropagation();
@@ -114,13 +116,13 @@ export const MemberRow: React.FC<MemberRowProps> = ({
             className={cn(
               buttonVariants({
                 status,
-                variant: statusIcon[status]?.variant,
+                variant: approvalStatusIcon[status]?.variant,
               }),
             )}
-            variant={statusIcon[status]?.variant}
+            variant={approvalStatusIcon[status]?.variant}
             size="sm"
             icon={() => {
-              const IconComponent = statusIcon[status]?.icon;
+              const IconComponent = approvalStatusIcon[status]?.icon;
               return IconComponent ? <IconComponent size={16} /> : null;
             }}
             title={ApprovalStatusLabelMap[status]}

--- a/frontend/packages/design-system/src/components/timesheet/rows/week/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/week/constants.ts
@@ -1,52 +1,7 @@
 /**
  * External dependencies.
  */
-import React from "react";
-import type { BadgeProps, ButtonVariant } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
-import { Send, CircleCheck, CircleX, Hourglass } from "lucide-react";
-
-/**
- * Internal dependencies.
- */
-import type { ApprovalStatusType } from "../constants";
-
-export const statusTheme: Record<ApprovalStatusType, BadgeProps["theme"]> = {
-  "not-submitted": "gray",
-  approved: "green",
-  rejected: "red",
-  "approval-pending": "orange",
-  none: "gray",
-};
-
-export const statusIcon: Record<
-  ApprovalStatusType,
-  {
-    variant: ButtonVariant;
-    icon: React.ComponentType<{ size?: number }> | null;
-  }
-> = {
-  "not-submitted": {
-    variant: "solid",
-    icon: Send,
-  },
-  approved: {
-    variant: "ghost",
-    icon: CircleCheck,
-  },
-  rejected: {
-    variant: "ghost",
-    icon: CircleX,
-  },
-  "approval-pending": {
-    variant: "ghost",
-    icon: Hourglass,
-  },
-  none: {
-    variant: "ghost",
-    icon: null,
-  },
-};
 
 export const buttonVariants = cva("", {
   variants: {
@@ -55,6 +10,8 @@ export const buttonVariants = cva("", {
       approved: "text-ink-green-4",
       rejected: "text-ink-red-4",
       "approval-pending": "text-ink-amber-4",
+      "partially-approved": "text-ink-green-4",
+      "partially-rejected": "text-ink-red-4",
       none: "",
     },
     thisWeek: { true: "", false: "" },

--- a/frontend/packages/design-system/src/components/timesheet/rows/week/weekRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/week/weekRow.tsx
@@ -8,13 +8,15 @@ import { ChevronDown } from "lucide-react";
 /**
  * Internal dependencies.
  */
-import { buttonVariants, statusIcon, statusTheme } from "./constants";
+import { buttonVariants } from "./constants";
 import { mergeClassNames as cn } from "../../../../utils";
 import {
   ApprovalStatusLabelMap,
   type TotalHoursTheme,
   totalHoursVariants,
   type ApprovalStatusType,
+  approvalStatusTheme,
+  approvalStatusIcon,
 } from "../constants";
 
 export interface WeekRowProps {
@@ -78,7 +80,7 @@ export const WeekRow: React.FC<WeekRowProps> = ({
             {label}
           </span>
           {status !== "none" && (
-            <Badge theme={statusTheme[status]} className="shrink-0">
+            <Badge theme={approvalStatusTheme[status]} className="shrink-0">
               {ApprovalStatusLabelMap[status]}
             </Badge>
           )}
@@ -136,14 +138,14 @@ export const WeekRow: React.FC<WeekRowProps> = ({
               buttonVariants({
                 status,
                 thisWeek,
-                variant: statusIcon[status]?.variant,
+                variant: approvalStatusIcon[status]?.variant,
                 collapsed,
               }),
             )}
-            variant={statusIcon[status]?.variant}
+            variant={approvalStatusIcon[status]?.variant}
             size="sm"
             icon={() => {
-              const IconComponent = statusIcon[status]?.icon;
+              const IconComponent = approvalStatusIcon[status]?.icon;
               return IconComponent ? <IconComponent size={16} /> : null;
             }}
             aria-label="Submit week"


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PRs adds a ability to allow managers to edit Team Timesheet inline and also adds missed Partially Approved and Partially Rejected status.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/857604d6-4edc-4e5d-90a4-fffb3f04e97b



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially fixes #1162