### PR TITLE
fix: add new endpoint for approver dropdown

### DIFF
--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -5,9 +5,8 @@ from frappe import get_all, get_list, get_roles, get_value, whitelist
 @whitelist(methods=["GET"])
 def get_employee_with_role(role: str | list[str]):
     """returns a list of all approvers for the given role like ["Project Manager","Project User"]"""
+    ## TODO : deprecate this method and use get_approver_details as it doesnt leak role based output only approver details
     import json
-
-    from frappe import get_all
 
     if isinstance(role, str):
         role = json.loads(role)
@@ -19,6 +18,22 @@ def get_employee_with_role(role: str | list[str]):
     )
     employees = get_all(
         "Employee", filters={"user_id": ["in", user_ids], "status": "Active"}, fields=["name", "employee_name"]
+    )
+    return employees
+
+
+@whitelist(methods=["GET"])
+def get_approver_details():
+    """returns a list of approver details"""
+    role = ["Projects Manager", "Projects User"]
+
+    user_ids = get_all(
+        "Has Role",
+        filters={"role": ["in", role], "parenttype": "User", "parent": ["!=", "Administrator"]},
+        pluck="parent",
+    )
+    employees = get_all(
+        "Employee", filters={"user_id": ["in", user_ids], "status": "Active"}, fields=["name", "employee_name", "image"]
     )
     return employees
 

--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -4,8 +4,8 @@ from frappe import get_all, get_list, get_roles, get_value, whitelist
 
 @whitelist(methods=["GET"])
 def get_employee_with_role(role: str | list[str]):
-    """returns a list of all approvers for the given role like ["Project Manager","Project User"]"""
-    ## TODO : deprecate this method and use get_approver_details as it doesnt leak role based output only approver details
+    """returns a list of all approvers for the given role like ["Projects Manager","Projects User"]"""
+    ## TODO : Deprecate this method and use get_approver_details instead, as it returns only approver details and does not expose role-based output.
     import json
 
     if isinstance(role, str):
@@ -25,11 +25,11 @@ def get_employee_with_role(role: str | list[str]):
 @whitelist(methods=["GET"])
 def get_approver_details():
     """returns a list of approver details"""
-    role = ["Projects Manager", "Projects User"]
+    roles = ["Projects Manager", "Projects User"]
 
     user_ids = get_all(
         "Has Role",
-        filters={"role": ["in", role], "parenttype": "User", "parent": ["!=", "Administrator"]},
+        filters={"role": ["in", roles], "parenttype": "User", "parent": ["!=", "Administrator"]},
         pluck="parent",
     )
     employees = get_all(


### PR DESCRIPTION
## Description

* Added a new `get_approver_details` endpoint that returns a list of approver details without exposing role-based output, using a fixed set of roles and filtering out the Administrator user. (`next_pms/timesheet/api/__init__.py`)
* Marked the existing `get_employee_with_role` function for deprecation, with a note to use `get_approver_details` instead, as it avoids leaking role-based information. (`next_pms/timesheet/api/__init__.py`)

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/71196a91-65bd-4fdd-8953-4145236161ed" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #