### PR TITLE
Feature: Add google calendar events integration to add time modal

### DIFF
--- a/frontend/packages/app/src/components/task-log/components/taskEntryList.tsx
+++ b/frontend/packages/app/src/components/task-log/components/taskEntryList.tsx
@@ -25,7 +25,7 @@ const TaskEntryList: React.FC<TaskEntryListProps> = ({
   return (
     <div
       className={cn(
-        "flex overflow-y-auto flex-col gap-3 mt-3 max-h-54 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-surface-gray-4",
+        "flex overflow-y-auto flex-col gap-3 mt-3 max-h-54 scrollbar-thin",
         className,
       )}
     >

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/calendar-events.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/calendar-events.tsx
@@ -1,0 +1,152 @@
+/**
+ * External Dependencies
+ */
+import { useState } from "react";
+import { useId } from "react";
+import {
+  formatDateTimeLabel,
+  formatDurationLabel,
+} from "@next-pms/design-system";
+import { Checkbox, Badge } from "@rtcamp/frappe-ui-react";
+import { Calendar, Clock } from "lucide-react";
+
+/**
+ * Internal Dependencies
+ */
+import type { CalendarEvent } from "./type";
+
+interface CalendarEventsProps {
+  events: CalendarEvent[];
+  onSelectionChange: (selectedLabels: string[]) => void;
+}
+
+const CalendarEvents = ({ events, onSelectionChange }: CalendarEventsProps) => {
+  const id = useId();
+  const [show, setShow] = useState(false);
+  const [selectAll, setSelectAll] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const isCalendarSetup = window.frappe?.boot?.is_calendar_setup ?? false;
+
+  const notifySelectionChange = (nextIds: string[]) => {
+    const selectedLabels = events
+      .filter((e) => nextIds.includes(e.id))
+      .map(
+        (e) =>
+          `${e.subject.trim()} | ${formatDurationLabel(e.starts_on, e.ends_on)}`,
+      )
+      .filter(Boolean);
+
+    onSelectionChange(selectedLabels);
+  };
+
+  const handleToggleShow = (val: boolean) => {
+    setShow(val);
+    if (!val) {
+      setSelectedIds([]);
+      setSelectAll(false);
+    }
+  };
+
+  const handleSelectAll = (val: boolean) => {
+    setSelectAll(val);
+    const nextIds = val ? events.map((e) => e.id) : [];
+    setSelectedIds(nextIds);
+    notifySelectionChange(nextIds);
+  };
+
+  const handleToggleEvent = (eventId: string, checked: boolean) => {
+    const nextIds = checked
+      ? [...selectedIds, eventId]
+      : selectedIds.filter((id) => id !== eventId);
+
+    setSelectedIds(nextIds);
+    setSelectAll(nextIds.length === events.length && events.length > 0);
+    notifySelectionChange(nextIds);
+  };
+
+  return (
+    <>
+      <div className="flex gap-1 items-center">
+        <Checkbox
+          htmlId={`${id}_add_calendar_events`}
+          disabled={!isCalendarSetup}
+          label="Add calendar events"
+          value={show}
+          onChange={handleToggleShow}
+        />
+
+        {!isCalendarSetup && (
+          <a href="#" className="px-2 text-base text-ink-gray-7">
+            Enable
+          </a>
+        )}
+      </div>
+
+      {show && (
+        <div className="px-2.5 py-2 rounded border border-outline-gray-2">
+          {events.length === 0 ? (
+            <p className="py-2 text-base text-center text-ink-gray-5">
+              No events found for the selected date.
+            </p>
+          ) : (
+            <>
+              <div className="flex justify-between border-b border-outline-gray-1 pb-2.5 text-base text-ink-gray-5 mb-2.5">
+                <Checkbox
+                  htmlId={`${id}_select_all`}
+                  label="Select all"
+                  extraLabelClasses="text-base text-ink-gray-5"
+                  value={selectAll}
+                  onChange={handleSelectAll}
+                />
+                <span>
+                  {selectedIds.length} of {events.length}
+                </span>
+              </div>
+
+              <div className="flex overflow-y-auto flex-col gap-3 max-h-40 scrollbar-thin">
+                {events.map((event) => {
+                  const localDate = formatDateTimeLabel(
+                    event.starts_on,
+                    "MMM d",
+                  );
+                  const localStartTime = formatDateTimeLabel(
+                    event.starts_on,
+                    "p",
+                  );
+                  const localEndTime = formatDateTimeLabel(event.ends_on, "p");
+
+                  return (
+                    <div key={event.id}>
+                      <Checkbox
+                        htmlId={`${id}_event_${event.id}`}
+                        label={event.subject}
+                        extraLabelClasses="text-ink-gray-8 text-base"
+                        value={selectedIds.includes(event.id)}
+                        onChange={(checked) =>
+                          handleToggleEvent(event.id, checked)
+                        }
+                      />
+                      <div className="flex gap-1 ml-5">
+                        <Badge
+                          label={localDate}
+                          prefix={<Calendar className="size-3" />}
+                        />
+                        <Badge
+                          label={`${localStartTime} - ${localEndTime}`}
+                          prefix={<Clock className="size-3" />}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CalendarEvents;

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/calendar-events.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/calendar-events.tsx
@@ -45,6 +45,7 @@ const CalendarEvents = ({ events, onSelectionChange }: CalendarEventsProps) => {
     if (!val) {
       setSelectedIds([]);
       setSelectAll(false);
+      notifySelectionChange([]);
     }
   };
 

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/calendarEvents.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/calendarEvents.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useId } from "react";
 import {
   formatDateTimeLabel,
@@ -41,11 +41,12 @@ const CalendarEvents = ({
     enabled: enabled && show && isCalendarSetup,
   });
 
-  const notifySelectionChange = (nextIds: string[]) => {
-    const allEventSubjects = events
-      .map((e) => e.subject.trim())
-      .filter(Boolean);
+  const allEventSubjects = useMemo(
+    () => events.map((e) => e.subject.trim()).filter(Boolean),
+    [events],
+  );
 
+  const notifySelectionChange = (nextIds: string[]) => {
     const selectedLabels = events
       .filter((e) => nextIds.includes(e.id))
       .map(

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/calendarEvents.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/calendarEvents.tsx
@@ -7,28 +7,45 @@ import {
   formatDateTimeLabel,
   formatDurationLabel,
 } from "@next-pms/design-system";
+import { Spinner } from "@next-pms/design-system/components";
 import { Checkbox, Badge } from "@rtcamp/frappe-ui-react";
 import { Calendar, Clock } from "lucide-react";
 
 /**
  * Internal Dependencies
  */
-import type { CalendarEvent } from "./type";
+import useCalendarEvents from "./useCalendarEvents";
 
 interface CalendarEventsProps {
-  events: CalendarEvent[];
-  onSelectionChange: (selectedLabels: string[]) => void;
+  initialDate: string;
+  enabled: boolean;
+  onSelectionChange: (
+    selectedLabels: string[],
+    allEventSubjects: string[],
+  ) => void;
 }
 
-const CalendarEvents = ({ events, onSelectionChange }: CalendarEventsProps) => {
+const CalendarEvents = ({
+  initialDate,
+  enabled,
+  onSelectionChange,
+}: CalendarEventsProps) => {
   const id = useId();
   const [show, setShow] = useState(false);
   const [selectAll, setSelectAll] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   const isCalendarSetup = window.frappe?.boot?.is_calendar_setup ?? false;
+  const { events, isLoading, error } = useCalendarEvents({
+    initialDate,
+    enabled: enabled && show && isCalendarSetup,
+  });
 
   const notifySelectionChange = (nextIds: string[]) => {
+    const allEventSubjects = events
+      .map((e) => e.subject.trim())
+      .filter(Boolean);
+
     const selectedLabels = events
       .filter((e) => nextIds.includes(e.id))
       .map(
@@ -37,7 +54,7 @@ const CalendarEvents = ({ events, onSelectionChange }: CalendarEventsProps) => {
       )
       .filter(Boolean);
 
-    onSelectionChange(selectedLabels);
+    onSelectionChange(selectedLabels, allEventSubjects);
   };
 
   const handleToggleShow = (val: boolean) => {
@@ -78,7 +95,11 @@ const CalendarEvents = ({ events, onSelectionChange }: CalendarEventsProps) => {
         />
 
         {!isCalendarSetup && (
-          <a href="#" className="px-2 text-base text-ink-gray-7">
+          <a
+            href="/desk/google-calendar"
+            target="_blank"
+            className="px-2 text-base text-ink-gray-7"
+          >
             Enable
           </a>
         )}
@@ -86,7 +107,13 @@ const CalendarEvents = ({ events, onSelectionChange }: CalendarEventsProps) => {
 
       {show && (
         <div className="px-2.5 py-2 rounded border border-outline-gray-2">
-          {events.length === 0 ? (
+          {isLoading ? (
+            <Spinner />
+          ) : error ? (
+            <p className="py-2 text-base text-center text-ink-gray-5">
+              Failed to load calendar events.
+            </p>
+          ) : events.length === 0 ? (
             <p className="py-2 text-base text-center text-ink-gray-5">
               No events found for the selected date.
             </p>

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External Dependencies
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { getFormatedDate, getTodayDate } from "@next-pms/design-system";
 import { DurationInput } from "@next-pms/design-system/components";
 import {
   DatePicker,
@@ -13,6 +14,7 @@ import {
   useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { useForm, useStore } from "@tanstack/react-form";
+import { addDays } from "date-fns";
 import {
   FrappeError,
   useFrappeGetCall,
@@ -25,8 +27,14 @@ import { Calendar } from "lucide-react";
  */
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
+import CalendarEvents from "./calendar-events";
 import { addTimeFormSchema } from "./schema";
-import type { AddTimeProps, ProjectData, TaskItem } from "./type";
+import type {
+  AddTimeProps,
+  CalendarEvent,
+  ProjectData,
+  TaskItem,
+} from "./type";
 
 /**
  * Add Time Component
@@ -55,6 +63,24 @@ const AddTime = ({
   const [submitting, setSubmitting] = useState(false);
   const { call: saveTime } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
+  );
+
+  const { data: eventData } = useFrappeGetCall(
+    "next_pms.api.get_user_calendar_events",
+    {
+      start_date: initialDate,
+      end_date: getFormatedDate(addDays(getTodayDate(), 7)),
+    },
+    undefined,
+    {
+      errorRetryCount: 0,
+      shouldRetryOnError: false,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const calendarEvents = ((eventData?.message || []) as CalendarEvent[]).filter(
+    (event) => !event.all_day,
   );
 
   const form = useForm({
@@ -121,6 +147,37 @@ const AddTime = ({
     mutateTasksData();
   }, [project, task, mutateTasksData]);
 
+  const handleCalendarSelectionChange = useCallback(
+    (selectedLabels: string[]) => {
+      const allEventSubjects = calendarEvents
+        .map((event) => event.subject.trim())
+        .filter(Boolean);
+
+      const currentComment = form.state.values.comment || "";
+      const preservedLines = currentComment
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(
+          (line) =>
+            line &&
+            !allEventSubjects.some(
+              (subject) =>
+                line === subject ||
+                line === `- ${subject}` ||
+                line.startsWith(`- ${subject} | `),
+            ),
+        );
+
+      const selectedSubjectLines = selectedLabels.map((label) => `- ${label}`);
+
+      form.setFieldValue(
+        "comment",
+        [...preservedLines, ...selectedSubjectLines].join("\n"),
+      );
+    },
+    [calendarEvents, form],
+  );
+
   const tasksOptions = ((tasksData?.message?.task ?? []) as TaskItem[]).map(
     (task) => ({
       label: task.subject,
@@ -153,7 +210,9 @@ const AddTime = ({
           children={(field) => {
             return (
               <>
-                <label className="block text-xs text-ink-gray-5">Project</label>
+                <label className="block text-xs text-ink-gray-5 mb-1.5">
+                  Project
+                </label>
                 <Combobox
                   inputClassName="bg-white h-8 border-outline-gray-2"
                   options={projectOptions}
@@ -175,7 +234,9 @@ const AddTime = ({
           children={(field) => {
             return (
               <>
-                <label className="block text-xs text-ink-gray-5">Task</label>
+                <label className="block text-xs text-ink-gray-5 mb-1.5">
+                  Task
+                </label>
                 <Combobox
                   inputClassName="bg-white h-8 border-outline-gray-2"
                   options={tasksOptions}
@@ -217,7 +278,9 @@ const AddTime = ({
                             Date
                           </label>
                           <div
-                            className={`relative flex items-center border border-outline-gray-2 px-[10px] py-1 rounded-lg`}
+                            className={
+                              "flex relative items-center py-1 rounded-lg border border-outline-gray-2 px-2.5"
+                            }
                           >
                             <input
                               type="text"
@@ -245,7 +308,7 @@ const AddTime = ({
             name="duration"
             children={(field) => {
               return (
-                <div className="w-full flex flex-col gap-2">
+                <div className="flex flex-col gap-2 w-full">
                   <DurationInput
                     value={field.state.value}
                     onChange={(val) => field.handleChange(val)}
@@ -260,6 +323,12 @@ const AddTime = ({
             }}
           />
         </div>
+
+        <CalendarEvents
+          events={calendarEvents}
+          onSelectionChange={handleCalendarSelectionChange}
+        />
+
         <form.Field
           name="comment"
           children={(field) => {

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import { useCallback, useEffect, useState } from "react";
-import { getFormatedDate } from "@next-pms/design-system";
 import { DurationInput } from "@next-pms/design-system/components";
 import {
   DatePicker,
@@ -14,7 +13,6 @@ import {
   useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { useForm, useStore } from "@tanstack/react-form";
-import { addDays } from "date-fns";
 import {
   FrappeError,
   useFrappeGetCall,
@@ -27,14 +25,9 @@ import { Calendar } from "lucide-react";
  */
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
-import CalendarEvents from "./calendar-events";
+import CalendarEvents from "./calendarEvents";
 import { addTimeFormSchema } from "./schema";
-import type {
-  AddTimeProps,
-  CalendarEvent,
-  ProjectData,
-  TaskItem,
-} from "./type";
+import type { AddTimeProps, ProjectData, TaskItem } from "./type";
 
 /**
  * Add Time Component
@@ -63,24 +56,6 @@ const AddTime = ({
   const [submitting, setSubmitting] = useState(false);
   const { call: saveTime } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
-  );
-
-  const { data: eventData } = useFrappeGetCall(
-    "next_pms.api.get_user_calendar_events",
-    {
-      start_date: initialDate,
-      end_date: getFormatedDate(addDays(initialDate, 7)),
-    },
-    open ? undefined : null,
-    {
-      errorRetryCount: 0,
-      shouldRetryOnError: false,
-      revalidateOnFocus: false,
-    },
-  );
-
-  const calendarEvents = ((eventData?.message || []) as CalendarEvent[]).filter(
-    (event) => !event.all_day,
   );
 
   const form = useForm({
@@ -118,6 +93,7 @@ const AddTime = ({
   });
 
   const selectedProject = useStore(form.store, (state) => state.values.project);
+  const selectedDate = useStore(form.store, (state) => state.values.date);
 
   const { data: projectsData } = useFrappeGetCall("frappe.client.get_list", {
     doctype: "Project",
@@ -148,11 +124,7 @@ const AddTime = ({
   }, [project, task, mutateTasksData]);
 
   const handleCalendarSelectionChange = useCallback(
-    (selectedLabels: string[]) => {
-      const allEventSubjects = calendarEvents
-        .map((event) => event.subject.trim())
-        .filter(Boolean);
-
+    (selectedLabels: string[], allEventSubjects: string[]) => {
       const currentComment = form.state.values.comment || "";
       const preservedLines = currentComment
         .split("\n")
@@ -175,7 +147,7 @@ const AddTime = ({
         [...preservedLines, ...selectedSubjectLines].join("\n"),
       );
     },
-    [calendarEvents, form],
+    [form],
   );
 
   const tasksOptions = ((tasksData?.message?.task ?? []) as TaskItem[]).map(
@@ -325,7 +297,8 @@ const AddTime = ({
         </div>
 
         <CalendarEvents
-          events={calendarEvents}
+          initialDate={selectedDate}
+          enabled={open}
           onSelectionChange={handleCalendarSelectionChange}
         />
 

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { useCallback, useEffect, useState } from "react";
-import { getFormatedDate, getTodayDate } from "@next-pms/design-system";
+import { getFormatedDate } from "@next-pms/design-system";
 import { DurationInput } from "@next-pms/design-system/components";
 import {
   DatePicker,
@@ -69,9 +69,9 @@ const AddTime = ({
     "next_pms.api.get_user_calendar_events",
     {
       start_date: initialDate,
-      end_date: getFormatedDate(addDays(getTodayDate(), 7)),
+      end_date: getFormatedDate(addDays(initialDate, 7)),
     },
-    undefined,
+    open ? undefined : null,
     {
       errorRetryCount: 0,
       shouldRetryOnError: false,

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/type.ts
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/type.ts
@@ -26,6 +26,15 @@ export type TaskListData = {
   task: TaskItem[];
 };
 
+export type CalendarEvent = {
+  id: string;
+  subject: string;
+  starts_on: string;
+  ends_on: string;
+  all_day: number;
+  event_type: string;
+};
+
 export interface AddTimeProps {
   initialDate: string;
   open: boolean;

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/useCalendarEvents.ts
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/useCalendarEvents.ts
@@ -1,0 +1,59 @@
+/**
+ * External Dependencies
+ */
+import { getFormatedDate } from "@next-pms/design-system";
+import { addDays } from "date-fns";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal Dependencies
+ */
+import type { CalendarEvent } from "./type";
+
+interface UseCalendarEventsProps {
+  initialDate: string;
+  endDate?: string;
+  enabled: boolean;
+}
+
+interface UseCalendarEventsResult {
+  events: CalendarEvent[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+const useCalendarEvents = ({
+  initialDate,
+  endDate,
+  enabled,
+}: UseCalendarEventsProps): UseCalendarEventsResult => {
+  const {
+    data: eventData,
+    isLoading,
+    error,
+  } = useFrappeGetCall(
+    "next_pms.api.get_user_calendar_events",
+    {
+      start_date: initialDate,
+      end_date: endDate || getFormatedDate(addDays(initialDate, 7)),
+    },
+    enabled ? undefined : null,
+    {
+      errorRetryCount: 0,
+      shouldRetryOnError: false,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const events = ((eventData?.message || []) as CalendarEvent[]).filter(
+    (event) => !event.all_day,
+  );
+
+  return {
+    events,
+    isLoading,
+    error,
+  };
+};
+
+export default useCalendarEvents;

--- a/frontend/packages/design-system/src/index.css
+++ b/frontend/packages/design-system/src/index.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 @import "react-quill/dist/quill.snow.css";
- 
+
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -66,10 +66,12 @@
   }
 }
 
-.lucide {
-  stroke-width: 1.5;
-  width: 1rem;
-  height: 1rem;
+@layer base {
+  .lucide {
+    stroke-width: 1.5;
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 .ql-formats>span {

--- a/frontend/packages/design-system/src/utils/date.ts
+++ b/frontend/packages/design-system/src/utils/date.ts
@@ -67,12 +67,12 @@ export const getDayDiff = (startString: string, endString: string): number => {
 export const checkInRange = (
   start: string,
   weeks: number,
-  dateString: string
+  dateString: string,
 ) => {
   const startDate = getFormatedDate(
     startOfWeek(getUTCDateTime(start), {
       weekStartsOn: 1,
-    })
+    }),
   );
 
   const endDate = getNextDate(startDate, weeks);
@@ -103,7 +103,7 @@ export const prettyDate = (dateString: string, isLong: boolean = false) => {
 };
 
 export const getDateFromDateAndTimeString = (
-  dateTimeString: string
+  dateTimeString: string,
 ): string => {
   // Split the date and time parts exa: '2024-05-08 00:00:00'
   const parts = dateTimeString.split(" ");
@@ -133,6 +133,59 @@ export const getDisplayDate = (date: Date): string => {
   if (isToday(utcDate)) return "Today";
   if (isYesterday(utcDate)) return "Yesterday";
   return format(utcDate, "MMM d");
+};
+
+/**
+ * Parses a datetime string into a Date.
+ * Accepts both "YYYY-MM-DD HH:mm:ss" and ISO strings.
+ *
+ * @example
+ * parseDateTimeString("2026-04-06 09:45:00") // Date("2026-04-06T09:45:00")
+ */
+export const parseDateTimeString = (value: string): Date => {
+  return parseISO(value.includes("T") ? value : value.replace(" ", "T"));
+};
+
+/**
+ * Formats a datetime string using a date-fns format pattern.
+ *
+ * @example
+ * formatDateTimeLabel("2026-04-06 09:45:00", "MMM d, h:mm a") // "Apr 6, 9:45 AM"
+ */
+export const formatDateTimeLabel = (value: string, pattern: string): string => {
+  return format(parseDateTimeString(value), pattern);
+};
+
+/**
+ * Formats a duration between two datetime strings into a compact label.
+ *
+ * @example
+ * formatDurationLabel("2026-04-06 09:00:00", "2026-04-06 09:45:00") // "45m"
+ */
+export const formatDurationLabel = (
+  startsOn: string,
+  endsOn: string,
+): string => {
+  const totalMinutes = Math.max(
+    differenceInMinutes(
+      parseDateTimeString(endsOn),
+      parseDateTimeString(startsOn),
+    ),
+    0,
+  );
+
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (minutes === 0) {
+    return `${hours}hr`;
+  }
+
+  return `${hours}hr ${minutes}m`;
 };
 
 export const formatDate = (date: string | Date): string => {


### PR DESCRIPTION
## Description
- Adds google calendar events selector into the existing add time modal.
- Users can now add time entries for google calendar events, the events with be auto fetched.

## Relevant Technical Choices
- All fields/state related to calendar events are modeled in react via state instead of the form because the event selector is only ui/presentational and the data is not submitted, instead it derives/modifies the state of the comment input which is submitted and is part of form state.

## Screenshot/Screencast
<img width="595" height="738" alt="image" src="https://github.com/user-attachments/assets/a479ee95-37bc-44ff-96b1-a20376fde3b7" />

<img width="599" height="736" alt="image" src="https://github.com/user-attachments/assets/ce5fbd5b-13da-4544-b8e2-d4518a886ff0" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #921 