### PR TITLE
Fix: Incorrect icon in members row

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/personal/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -281,7 +282,7 @@ function PersonalTimesheet() {
                   Object.entries(timesheet.data?.data).map(
                     ([key, value], index) => {
                       return (
-                        <>
+                        <Fragment key={key}>
                           {index === 0 ? (
                             <div className="sticky top-0 z-10 mb-4 bg-surface-white">
                               <HeaderRow
@@ -302,7 +303,6 @@ function PersonalTimesheet() {
                             </div>
                           ) : null}
                           <div
-                            key={key}
                             ref={
                               !isEmpty(startDateParam) &&
                               isDateInRange(
@@ -343,7 +343,7 @@ function PersonalTimesheet() {
                               status={value.status}
                             />
                           </div>
-                        </>
+                        </Fragment>
                       );
                     },
                   )}

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useState } from "react";
+import { Fragment, useCallback, useState } from "react";
 import { Spinner, Typography } from "@next-pms/design-system/components";
 import { Button, Filter, FilterCondition } from "@rtcamp/frappe-ui-react";
 import { Ellipsis } from "lucide-react";
@@ -87,7 +87,7 @@ export const TeamTimesheetTable = () => {
           <div className="min-w-225">
             {weekGroups.map((week, index) => {
               return (
-                <>
+                <Fragment key={`${week.start_date}-${week.end_date}`}>
                   {index === 0 ? (
                     <div className="sticky top-0 z-10 mb-4 bg-surface-white">
                       <HeaderRow
@@ -109,10 +109,7 @@ export const TeamTimesheetTable = () => {
                     </div>
                   ) : null}
 
-                  <div
-                    key={`${week.start_date}-${week.end_date}`}
-                    className="animate-fade-in"
-                  >
+                  <div className="animate-fade-in">
                     <TeamTimesheetRow
                       label={week.key}
                       dates={week.dates}
@@ -131,7 +128,7 @@ export const TeamTimesheetTable = () => {
                       }))}
                     />
                   </div>
-                </>
+                </Fragment>
               );
             })}
           </div>

--- a/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
@@ -3,7 +3,7 @@
  */
 import { BadgeProps, ButtonVariant } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
-import { Check, CircleCheck, CircleX, Send } from "lucide-react";
+import { CircleCheck, CircleX, Hourglass, Send } from "lucide-react";
 
 /**
  * Internal dependencies.
@@ -124,8 +124,8 @@ export const approvalStatusIcon: Record<
     icon: CircleX,
   },
   "approval-pending": {
-    variant: "solid",
-    icon: Check,
+    variant: "ghost",
+    icon: Hourglass,
   },
   "partially-approved": {
     variant: "ghost",

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/constants.ts
@@ -1,7 +1,24 @@
 /**
  * External dependencies.
  */
+import { ButtonVariant } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
+import { Check } from "lucide-react";
+import { approvalStatusIcon, ApprovalStatusType } from "../constants";
+
+export const memberStatusIcon = {
+  ...approvalStatusIcon,
+  "approval-pending": {
+    variant: "solid",
+    icon: Check,
+  },
+} as Record<
+  ApprovalStatusType,
+  {
+    variant: ButtonVariant;
+    icon: React.ComponentType<{ size?: number }> | null;
+  }
+>;
 
 export const buttonVariants = cva("", {
   variants: {

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -8,7 +8,7 @@ import { ChevronDown } from "lucide-react";
 /**
  * Internal dependencies.
  */
-import { buttonVariants } from "./constants";
+import { buttonVariants, memberStatusIcon } from "./constants";
 import { mergeClassNames as cn } from "../../../../utils";
 import {
   ApprovalStatusLabelMap,
@@ -16,7 +16,6 @@ import {
   type ApprovalStatusType,
   totalHoursVariants,
   approvalStatusTheme,
-  approvalStatusIcon,
 } from "../constants";
 
 export interface MemberRowProps {
@@ -107,7 +106,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
       </div>
 
       <div className="flex items-center justify-end w-12 shrink-0 h-7 whitespace-nowrap">
-        {!isStatusNone && approvalStatusIcon[status]?.icon ? (
+        {!isStatusNone && memberStatusIcon[status]?.icon ? (
           <Button
             onClick={(e) => {
               e.stopPropagation();
@@ -116,13 +115,13 @@ export const MemberRow: React.FC<MemberRowProps> = ({
             className={cn(
               buttonVariants({
                 status,
-                variant: approvalStatusIcon[status]?.variant,
+                variant: memberStatusIcon[status]?.variant,
               }),
             )}
-            variant={approvalStatusIcon[status]?.variant}
+            variant={memberStatusIcon[status]?.variant}
             size="sm"
             icon={() => {
-              const IconComponent = approvalStatusIcon[status]?.icon;
+              const IconComponent = memberStatusIcon[status]?.icon;
               return IconComponent ? <IconComponent size={16} /> : null;
             }}
             title={ApprovalStatusLabelMap[status]}


### PR DESCRIPTION
## Description

Fixes incorrect icon in members row.

Before:
<img width="532" height="142" alt="Screenshot 2026-04-07 at 12 15 58 PM" src="https://github.com/user-attachments/assets/5ce1075c-39eb-4269-b213-b8c3e45086e6" />
After:
<img width="532" height="142" alt="Screenshot 2026-04-07 at 12 16 13 PM" src="https://github.com/user-attachments/assets/4f99fddf-f15b-4eac-a1f0-bbb42b012c52" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
