### PR TITLE
Refactor team timesheet to use the new API

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -11,7 +11,7 @@ import type { DataProp, timesheet } from "@/types/timesheet";
 
 export type EmployeeRecord = {
   name: string;
-  image: string;
+  image: string | null;
   employee_name: string;
 };
 

--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -35,7 +35,7 @@ export type WeekGroup = {
 
 export interface TeamTimesheetContextProps {
   state: {
-    hasMoreWeeks: boolean;
+    hasMore: boolean;
     isLoadingTeamData: boolean;
     weekGroups: WeekGroup[];
     isWeeklyApprovalOpen: boolean;
@@ -43,7 +43,7 @@ export interface TeamTimesheetContextProps {
     startDate: string;
   };
   actions: {
-    loadData: () => void;
+    loadMore: () => void;
     openWeeklyApproval: (employeeId: string, date: string) => void;
     setIsWeeklyApprovalOpen: (state: boolean) => void;
   };
@@ -51,7 +51,7 @@ export interface TeamTimesheetContextProps {
 
 export const TeamTimesheetContext = createContext<TeamTimesheetContextProps>({
   state: {
-    hasMoreWeeks: false,
+    hasMore: false,
     isLoadingTeamData: false,
     weekGroups: [],
     isWeeklyApprovalOpen: false,
@@ -59,7 +59,7 @@ export const TeamTimesheetContext = createContext<TeamTimesheetContextProps>({
     startDate: "",
   },
   actions: {
-    loadData: () => null,
+    loadMore: () => null,
     openWeeklyApproval: () => null,
     setIsWeeklyApprovalOpen: () => null,
   },

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -9,362 +9,45 @@ import {
   useMemo,
   useState,
 } from "react";
-import { getFormatedDate, getTodayDate } from "@next-pms/design-system/date";
 import { useToasts } from "@rtcamp/frappe-ui-react";
-import { addDays } from "date-fns";
-import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
-import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
+import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
-import type { DataProp } from "@/types/timesheet";
 import {
   TeamTimesheetContext,
-  type EmployeeRecord,
   type TeamTimesheetContextProps,
-  type WeekGroup,
 } from "./context";
+import { useTeamTimesheetData } from "./useTeamTimesheetData";
 
-type CompactWeek = {
-  key: string;
-  start_date: string;
-  end_date: string;
-  dates: string[];
-};
-
-type TimesheetFetchRequest = {
-  employee: string;
-  startDate: string;
-  requestKey: string;
-};
-
-const mergeEmployeeTimesheetData = (
-  existing: DataProp | undefined,
-  payload: DataProp,
-) => {
-  if (!existing) return payload;
-
-  const existingLeaveIds = new Set(existing.leaves.map((leave) => leave.name));
-  const existingHolidayDates = new Set(
-    existing.holidays.map((holiday) => holiday.holiday_date),
-  );
-
-  return {
-    ...existing,
-    data: {
-      ...existing.data,
-      ...payload.data,
-    },
-    leaves: [
-      ...existing.leaves,
-      ...payload.leaves.filter((leave) => !existingLeaveIds.has(leave.name)),
-    ],
-    holidays: [
-      ...existing.holidays,
-      ...payload.holidays.filter(
-        (holiday) => !existingHolidayDates.has(holiday.holiday_date),
-      ),
-    ],
-  };
-};
-
-// TODO: Refactor to use direct API call when API is ready.
 export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   const toast = useToasts();
   const [employee, setEmployee] = useState("");
   const [startDate, setStartDate] = useState("");
   const [isWeeklyApprovalOpen, setIsWeeklyApprovalOpen] = useState(false);
-  const [weekDate, setWeekDate] = useState(getTodayDate());
-  const [hasMoreWeeks, setHasMoreWeeks] = useState(true);
-  const [compactWeeks, setCompactWeeks] = useState<Record<string, CompactWeek>>(
-    {},
-  );
-  const [memberMap, setMemberMap] = useState<Record<string, EmployeeRecord>>(
-    {},
-  );
-  const [employeeTimesheetMap, setEmployeeTimesheetMap] = useState<
-    Record<string, DataProp>
-  >({});
-  const [pendingTimesheetRequests, setPendingTimesheetRequests] = useState<
-    TimesheetFetchRequest[]
-  >([]);
-  const [fetchedRequestKeys, setFetchedRequestKeys] = useState<
-    Record<string, boolean>
-  >({});
 
   const { employeeId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
   }));
+
+  const { hasMoreWeeks, isLoadingTeamData, weekGroups, loadData, error } =
+    useTeamTimesheetData({ employeeId });
+
+  useEffect(() => {
+    if (error) {
+      toast.error(parseFrappeErrorMsg(error as FrappeError));
+    }
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [error]);
 
   const openWeeklyApproval = useCallback((employeeId: string, date: string) => {
     setEmployee(employeeId);
     setStartDate(date);
     setIsWeeklyApprovalOpen(true);
   }, []);
-
-  const clearLoadedData = useCallback(() => {
-    setEmployeeTimesheetMap({});
-    setCompactWeeks({});
-    setMemberMap({});
-    setPendingTimesheetRequests([]);
-    setFetchedRequestKeys({});
-  }, []);
-
-  const {
-    data: compactViewData,
-    error: compactViewError,
-    isLoading: isLoadingCompactView,
-  } = useFrappeGetCall("next_pms.timesheet.api.team.get_compact_view_data", {
-    date: weekDate,
-    max_week: String(NUMBER_OF_WEEKS_TO_FETCH),
-    reports_to: employeeId,
-    page_length: "100",
-    start: "0",
-  });
-
-  const activeTimesheetRequest = pendingTimesheetRequests[0] ?? null;
-
-  const {
-    data: memberTimesheetData,
-    error: memberTimesheetError,
-    isLoading: isLoadingActiveTimesheetRequest,
-  } = useFrappeGetCall(
-    "next_pms.timesheet.api.timesheet.get_timesheet_data",
-    activeTimesheetRequest
-      ? {
-          employee: activeTimesheetRequest.employee,
-          start_date: activeTimesheetRequest.startDate,
-          max_week: String(NUMBER_OF_WEEKS_TO_FETCH),
-        }
-      : undefined,
-    activeTimesheetRequest ? undefined : null,
-  );
-
-  const appendCompactWeeks = useCallback((weeks: CompactWeek[]) => {
-    setCompactWeeks((prev) => {
-      const next = { ...prev };
-
-      weeks.forEach((week) => {
-        const weekId = week.start_date;
-        next[weekId] = week;
-      });
-
-      return next;
-    });
-  }, []);
-
-  const appendMembers = useCallback((members: EmployeeRecord[]) => {
-    setMemberMap((prev) => {
-      const next = { ...prev };
-      members.forEach((member) => {
-        next[member.name] = member;
-      });
-      return next;
-    });
-  }, []);
-
-  const queueMemberRequests = useCallback(
-    (members: EmployeeRecord[]) => {
-      const membersToFetch = members.filter((member) => {
-        const requestKey = `${weekDate}::${member.name}`;
-        return !fetchedRequestKeys[requestKey];
-      });
-
-      if (membersToFetch.length === 0) return;
-
-      setPendingTimesheetRequests((prev) => {
-        const existingKeys = new Set(prev.map((request) => request.requestKey));
-        const next = [...prev];
-
-        membersToFetch.forEach((member) => {
-          const requestKey = `${weekDate}::${member.name}`;
-          if (existingKeys.has(requestKey)) return;
-
-          next.push({
-            employee: member.name,
-            startDate: weekDate,
-            requestKey,
-          });
-        });
-
-        return next;
-      });
-
-      setFetchedRequestKeys((prev) => {
-        const next = { ...prev };
-        membersToFetch.forEach((member) => {
-          const requestKey = `${weekDate}::${member.name}`;
-          next[requestKey] = true;
-        });
-        return next;
-      });
-    },
-    [fetchedRequestKeys, weekDate],
-  );
-
-  useEffect(() => {
-    if (!employeeId) {
-      clearLoadedData();
-      setHasMoreWeeks(false);
-    }
-  }, [clearLoadedData, employeeId]);
-
-  useEffect(() => {
-    if (!employeeId || !compactViewError) return;
-
-    const message = parseFrappeErrorMsg(compactViewError as never);
-    setPendingTimesheetRequests([]);
-    setHasMoreWeeks(false);
-    toast.error(message || "Failed to load team timesheets.");
-  }, [compactViewError, employeeId, toast]);
-
-  useEffect(() => {
-    if (!employeeId || !compactViewData?.message) {
-      return;
-    }
-
-    const compactPayload = compactViewData.message as {
-      data?: Record<string, EmployeeRecord>;
-      dates?: CompactWeek[];
-    };
-    const compactWeekEntries = compactPayload.dates ?? [];
-
-    appendCompactWeeks(compactWeekEntries);
-    setHasMoreWeeks(compactWeekEntries.length === NUMBER_OF_WEEKS_TO_FETCH);
-
-    const compactMembers = Object.values(compactPayload.data ?? {})
-      .filter((member) => member.name)
-      .map((member) => ({
-        name: member.name,
-        employee_name: member.employee_name,
-        image: member.image,
-      }));
-
-    appendMembers(compactMembers);
-    queueMemberRequests(compactMembers);
-  }, [
-    appendCompactWeeks,
-    appendMembers,
-    compactViewData,
-    employeeId,
-    queueMemberRequests,
-  ]);
-
-  useEffect(() => {
-    if (!activeTimesheetRequest) return;
-
-    if (memberTimesheetError) {
-      setFetchedRequestKeys((prev) => {
-        const next = { ...prev };
-        delete next[activeTimesheetRequest.requestKey];
-        return next;
-      });
-      setPendingTimesheetRequests((prev) => prev.slice(1));
-      return;
-    }
-
-    const payload = memberTimesheetData?.message as DataProp | undefined;
-    if (!payload) return;
-
-    setEmployeeTimesheetMap((prev) => {
-      return {
-        ...prev,
-        [activeTimesheetRequest.employee]: mergeEmployeeTimesheetData(
-          prev[activeTimesheetRequest.employee],
-          payload,
-        ),
-      };
-    });
-
-    setPendingTimesheetRequests((prev) => prev.slice(1));
-  }, [activeTimesheetRequest, memberTimesheetData, memberTimesheetError]);
-
-  useEffect(() => {
-    clearLoadedData();
-    setHasMoreWeeks(true);
-    setWeekDate(getTodayDate());
-  }, [clearLoadedData, employeeId]);
-
-  const weekGroups = useMemo(() => {
-    const weekMap = new Map<string, WeekGroup>(
-      Object.values(compactWeeks).map((week) => {
-        const weekId = week.start_date;
-        return [
-          weekId,
-          {
-            key: week.key,
-            start_date: week.start_date,
-            end_date: week.end_date,
-            dates: week.dates,
-            members: [],
-            approvalPendingCount: 0,
-          } as WeekGroup,
-        ];
-      }),
-    );
-
-    Object.entries(memberMap).forEach(([employeeIdKey, member]) => {
-      const employeePayload = employeeTimesheetMap[employeeIdKey];
-      if (!employeePayload?.data) return;
-
-      Object.values(employeePayload.data).forEach((week) => {
-        if (week.status === "Not Submitted") {
-          return;
-        }
-
-        const weekId = week.start_date;
-        if (!weekMap.has(weekId)) {
-          weekMap.set(weekId, {
-            key: week.key,
-            start_date: week.start_date,
-            end_date: week.end_date,
-            dates: week.dates,
-            members: [],
-            approvalPendingCount: 0,
-          });
-        }
-        const targetWeek = weekMap.get(weekId)!;
-        if (week.status === "Approval Pending") {
-          targetWeek.approvalPendingCount += 1;
-        }
-        targetWeek.members.push({
-          employee: member,
-          week,
-          holidays: employeePayload.holidays,
-          leaves: employeePayload.leaves,
-          working_hour: employeePayload.working_hour,
-          working_frequency: employeePayload.working_frequency,
-        });
-      });
-    });
-
-    return Array.from(weekMap.values()).sort(
-      (a, b) =>
-        new Date(b.start_date).getTime() - new Date(a.start_date).getTime(),
-    );
-  }, [compactWeeks, employeeTimesheetMap, memberMap]);
-
-  const isLoadingMemberTimesheets =
-    pendingTimesheetRequests.length > 0 ||
-    Boolean(activeTimesheetRequest && isLoadingActiveTimesheetRequest);
-  const isLoadingTeamData = isLoadingCompactView || isLoadingMemberTimesheets;
-
-  const loadData = useCallback(() => {
-    if (!hasMoreWeeks || isLoadingTeamData || weekGroups.length === 0) return;
-
-    const oldestWeek = weekGroups[weekGroups.length - 1];
-    setWeekDate(getFormatedDate(addDays(oldestWeek.start_date, -1)));
-  }, [hasMoreWeeks, isLoadingTeamData, weekGroups]);
-
-  useEffect(() => {
-    if (!memberTimesheetError || !activeTimesheetRequest) return;
-
-    const message = parseFrappeErrorMsg(memberTimesheetError as never);
-    toast.error(message || "Failed to load member timesheet.");
-  }, [activeTimesheetRequest, memberTimesheetError, toast]);
 
   const value: TeamTimesheetContextProps = useMemo(
     () => ({

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -33,7 +33,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
     employeeId: state.employeeId,
   }));
 
-  const { hasMoreWeeks, isLoadingTeamData, weekGroups, loadData, error } =
+  const { hasMore, isLoadingTeamData, weekGroups, loadMore, error } =
     useTeamTimesheetData({ employeeId });
 
   useEffect(() => {
@@ -52,7 +52,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   const value: TeamTimesheetContextProps = useMemo(
     () => ({
       state: {
-        hasMoreWeeks,
+        hasMore,
         isLoadingTeamData,
         weekGroups,
         isWeeklyApprovalOpen,
@@ -60,15 +60,15 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
         startDate,
       },
       actions: {
-        loadData,
+        loadMore,
         openWeeklyApproval,
         setIsWeeklyApprovalOpen,
       },
     }),
     [
-      hasMoreWeeks,
+      hasMore,
       isLoadingTeamData,
-      loadData,
+      loadMore,
       weekGroups,
       openWeeklyApproval,
       employee,

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -26,12 +26,12 @@ import { sampleFields } from "../constants";
 
 export const TeamTimesheetTable = () => {
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
-  const hasMoreWeeks = useTeamTimesheet(({ state }) => state.hasMoreWeeks);
+  const hasMore = useTeamTimesheet(({ state }) => state.hasMore);
   const isLoadingTeamData = useTeamTimesheet(
     ({ state }) => state.isLoadingTeamData,
   );
   const weekGroups = useTeamTimesheet(({ state }) => state.weekGroups);
-  const loadData = useTeamTimesheet(({ actions }) => actions.loadData);
+  const loadMore = useTeamTimesheet(({ actions }) => actions.loadMore);
   const isWeeklyApprovalOpen = useTeamTimesheet(
     ({ state }) => state.isWeeklyApprovalOpen,
   );
@@ -99,8 +99,8 @@ export const TeamTimesheetTable = () => {
       ) : (
         <InfiniteScroll
           isLoading={isLoadingTeamData}
-          hasMore={hasMoreWeeks}
-          verticalLodMore={loadData}
+          hasMore={hasMore}
+          verticalLodMore={loadMore}
           className="w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable]"
           count={NUMBER_OF_WEEKS_TO_FETCH}
         >

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -139,7 +139,7 @@ export const TeamTimesheetTable = () => {
                       teamMembers={week.members.map((member) => ({
                         label: member.employee.employee_name,
                         employee: member.employee.name,
-                        avatarUrl: member.employee.image,
+                        avatarUrl: member.employee.image ?? undefined,
                         tasks: member.week.tasks,
                         leaves: member.leaves,
                         holidays: member.holidays,

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -47,7 +47,7 @@ type UseTeamTimesheetDataResult = {
 };
 
 type UseTeamTimesheetOptions = {
-  employeeId?: string;
+  employeeId: string;
 };
 
 export function useTeamTimesheetData({
@@ -73,8 +73,6 @@ export function useTeamTimesheetData({
     start: "0",
   });
 
-  // This is the only legitimate effect here: syncing external data (the API response)
-  // into local state. No transformation happens here, that belongs in useMemo.
   useEffect(() => {
     if (!employeeId || !teamData?.message) {
       return;

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -1,0 +1,235 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getFormatedDate, getTodayDate } from "@next-pms/design-system/date";
+import { addDays } from "date-fns";
+import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal dependencies.
+ */
+import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
+import type { DataProp } from "@/types/timesheet";
+import type { EmployeeRecord, WeekGroup } from "./context";
+
+type WeekEntry = {
+  key: string;
+  start_date: string;
+  end_date: string;
+  dates: string[];
+};
+
+type TeamApiEmployee = {
+  name: string;
+  image: string | null;
+  employee_name: string;
+  working_hour: number;
+  working_frequency: DataProp["working_frequency"];
+  leaves: DataProp["leaves"];
+  holidays: DataProp["holidays"];
+  timesheet_details: DataProp["data"];
+};
+
+type ApiPayload = {
+  data?: Record<string, TeamApiEmployee>;
+  dates?: WeekEntry[];
+  has_more?: boolean;
+};
+
+type UseTeamTimesheetDataResult = {
+  hasMoreWeeks: boolean;
+  isLoadingTeamData: boolean;
+  weekGroups: WeekGroup[];
+  loadData: () => void;
+  error: FrappeError | undefined;
+};
+
+type UseTeamTimesheetOptions = {
+  employeeId?: string;
+};
+
+export function useTeamTimesheetData({
+  employeeId,
+}: UseTeamTimesheetOptions): UseTeamTimesheetDataResult {
+  const [weekDate, setWeekDate] = useState(getTodayDate());
+
+  // Each entry represents one paginated fetch.
+  // All derived data (weeks, members, timesheets) is computed from this.
+  const [pages, setPages] = useState<ApiPayload[]>([]);
+
+  // TODO: Implement proper pagination once the API paginates by week instead of by employee. Until then, this is effectively a single fetch with a large payload, so we can keep it simple.
+
+  const {
+    data: teamData,
+    error: teamDataError,
+    isLoading: isLoadingTeamApiData,
+  } = useFrappeGetCall("next_pms.timesheet.api.team.get_team_timesheet_data", {
+    date: weekDate,
+    reports_to: employeeId,
+    max_week: String(NUMBER_OF_WEEKS_TO_FETCH),
+    page_length: "100",
+    start: "0",
+  });
+
+  // This is the only legitimate effect here: syncing external data (the API response)
+  // into local state. No transformation happens here, that belongs in useMemo.
+  useEffect(() => {
+    if (!employeeId || !teamData?.message) {
+      return;
+    }
+    setPages((prev) => [...prev, teamData.message as ApiPayload]);
+  }, [teamData, employeeId]);
+
+  // All transformation lives here. Because this is pure data derivation (no side effects).
+  const { hasMoreWeeks, weekGroups } = useMemo(() => {
+    // Default to true so the UI shows a loading/fetchable state before the first page lands.
+    const hasMoreWeeks =
+      pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
+
+    // Collapse all pages into a weeks map and a per-employee map.
+    const weeksMap: Record<string, WeekEntry> = {};
+
+    type EmployeeState = {
+      member: EmployeeRecord;
+      working_hour: number;
+      working_frequency: DataProp["working_frequency"];
+      timesheetDetails: DataProp["data"];
+      leaves: DataProp["leaves"];
+      holidays: DataProp["holidays"];
+    };
+    const employeeMap: Record<string, EmployeeState> = {};
+
+    pages.forEach((payload) => {
+      (payload.dates ?? []).forEach((week) => {
+        weeksMap[week.start_date] = week;
+      });
+
+      Object.values(payload.data ?? {})
+        .filter((emp) => emp.name)
+        .forEach((emp) => {
+          if (!employeeMap[emp.name]) {
+            employeeMap[emp.name] = {
+              member: {
+                name: emp.name,
+                employee_name: emp.employee_name,
+                image: emp.image,
+              },
+              working_hour: emp.working_hour,
+              working_frequency: emp.working_frequency,
+              timesheetDetails: emp.timesheet_details ?? {},
+              leaves: emp.leaves ?? [],
+              holidays: emp.holidays ?? [],
+            };
+          } else {
+            // Merge subsequent pages for the same employee, deduplicating leaves and holidays
+            // by their unique identifiers to avoid double-rendering on overlapping date ranges.
+            const existing = employeeMap[emp.name];
+            const existingLeaveIds = new Set(
+              existing.leaves.map((l) => l.name),
+            );
+            const existingHolidayDates = new Set(
+              existing.holidays.map((h) => h.holiday_date),
+            );
+            employeeMap[emp.name] = {
+              ...existing,
+              timesheetDetails: {
+                ...existing.timesheetDetails,
+                ...(emp.timesheet_details ?? {}),
+              },
+              leaves: [
+                ...existing.leaves,
+                ...(emp.leaves ?? []).filter(
+                  (l) => !existingLeaveIds.has(l.name),
+                ),
+              ],
+              holidays: [
+                ...existing.holidays,
+                ...(emp.holidays ?? []).filter(
+                  (h) => !existingHolidayDates.has(h.holiday_date),
+                ),
+              ],
+            };
+          }
+        });
+    });
+
+    const weekMap = new Map<string, WeekGroup>(
+      Object.values(weeksMap).map((week) => [
+        week.start_date,
+        {
+          key: week.key,
+          start_date: week.start_date,
+          end_date: week.end_date,
+          dates: week.dates,
+          members: [],
+          approvalPendingCount: 0,
+        } as WeekGroup,
+      ]),
+    );
+
+    Object.values(employeeMap).forEach(
+      ({
+        member,
+        working_hour,
+        working_frequency,
+        timesheetDetails,
+        leaves,
+        holidays,
+      }) => {
+        Object.values(timesheetDetails).forEach((week) => {
+          if (week.status === "Not Submitted") {
+            return;
+          }
+          const weekId = week.start_date;
+          if (!weekMap.has(weekId)) {
+            weekMap.set(weekId, {
+              key: week.key,
+              start_date: week.start_date,
+              end_date: week.end_date,
+              dates: week.dates,
+              members: [],
+              approvalPendingCount: 0,
+            });
+          }
+          const targetWeek = weekMap.get(weekId)!;
+          if (week.status === "Approval Pending") {
+            targetWeek.approvalPendingCount += 1;
+          }
+          targetWeek.members.push({
+            employee: member,
+            week,
+            holidays,
+            leaves,
+            working_hour,
+            working_frequency,
+          });
+        });
+      },
+    );
+
+    const weekGroups = Array.from(weekMap.values()).sort(
+      (a, b) =>
+        new Date(b.start_date).getTime() - new Date(a.start_date).getTime(),
+    );
+
+    return { hasMoreWeeks, weekGroups };
+  }, [pages]);
+
+  const loadData = useCallback(() => {
+    if (!hasMoreWeeks || isLoadingTeamApiData || weekGroups.length === 0)
+      return;
+
+    const oldestWeek = weekGroups[weekGroups.length - 1];
+    setWeekDate(getFormatedDate(addDays(oldestWeek.start_date, -1)));
+  }, [hasMoreWeeks, isLoadingTeamApiData, weekGroups]);
+
+  return {
+    hasMoreWeeks,
+    isLoadingTeamData: isLoadingTeamApiData,
+    weekGroups,
+    loadData,
+    error: teamDataError,
+  };
+}

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -39,10 +39,10 @@ type ApiPayload = {
 };
 
 type UseTeamTimesheetDataResult = {
-  hasMoreWeeks: boolean;
+  hasMore: boolean;
   isLoadingTeamData: boolean;
   weekGroups: WeekGroup[];
-  loadData: () => void;
+  loadMore: () => void;
   error: FrappeError | undefined;
 };
 
@@ -50,16 +50,17 @@ type UseTeamTimesheetOptions = {
   employeeId: string;
 };
 
+const EMPLOYEE_PAGE_LENGTH = 10;
+
 export function useTeamTimesheetData({
   employeeId,
 }: UseTeamTimesheetOptions): UseTeamTimesheetDataResult {
   const [weekDate, setWeekDate] = useState(getTodayDate());
+  const [employeeStart, setEmployeeStart] = useState(0);
 
   // Each entry represents one paginated fetch.
   // All derived data (weeks, members, timesheets) is computed from this.
   const [pages, setPages] = useState<ApiPayload[]>([]);
-
-  // TODO: Implement proper pagination once the API paginates by week instead of by employee. Until then, this is effectively a single fetch with a large payload, so we can keep it simple.
 
   const {
     data: teamData,
@@ -68,9 +69,9 @@ export function useTeamTimesheetData({
   } = useFrappeGetCall("next_pms.timesheet.api.team.get_team_timesheet_data", {
     date: weekDate,
     reports_to: employeeId,
-    max_week: String(NUMBER_OF_WEEKS_TO_FETCH),
-    page_length: "100",
-    start: "0",
+    max_week: NUMBER_OF_WEEKS_TO_FETCH,
+    page_length: EMPLOYEE_PAGE_LENGTH,
+    start: employeeStart,
   });
 
   useEffect(() => {
@@ -81,153 +82,166 @@ export function useTeamTimesheetData({
   }, [teamData, employeeId]);
 
   // All transformation lives here. Because this is pure data derivation (no side effects).
-  const { hasMoreWeeks, weekGroups } = useMemo(() => {
-    // Default to true so the UI shows a loading/fetchable state before the first page lands.
-    const hasMoreWeeks =
-      pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
+  const { hasMoreWeeks, hasMoreEmployees, hasMore, weekGroups } =
+    useMemo(() => {
+      const hasMoreWeeks = true;
+      const hasMoreEmployees =
+        pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
 
-    // Collapse all pages into a weeks map and a per-employee map.
-    const weeksMap: Record<string, WeekEntry> = {};
+      // Collapse all pages into a weeks map and a per-employee map.
+      const weeksMap: Record<string, WeekEntry> = {};
 
-    type EmployeeState = {
-      member: EmployeeRecord;
-      working_hour: number;
-      working_frequency: DataProp["working_frequency"];
-      timesheetDetails: DataProp["data"];
-      leaves: DataProp["leaves"];
-      holidays: DataProp["holidays"];
-    };
-    const employeeMap: Record<string, EmployeeState> = {};
+      type EmployeeState = {
+        member: EmployeeRecord;
+        working_hour: number;
+        working_frequency: DataProp["working_frequency"];
+        timesheetDetails: DataProp["data"];
+        leaves: DataProp["leaves"];
+        holidays: DataProp["holidays"];
+      };
+      const employeeMap: Record<string, EmployeeState> = {};
 
-    pages.forEach((payload) => {
-      (payload.dates ?? []).forEach((week) => {
-        weeksMap[week.start_date] = week;
+      pages.forEach((payload) => {
+        (payload.dates ?? []).forEach((week) => {
+          weeksMap[week.start_date] = week;
+        });
+
+        Object.values(payload.data ?? {})
+          .filter((emp) => emp.name)
+          .forEach((emp) => {
+            if (!employeeMap[emp.name]) {
+              employeeMap[emp.name] = {
+                member: {
+                  name: emp.name,
+                  employee_name: emp.employee_name,
+                  image: emp.image,
+                },
+                working_hour: emp.working_hour,
+                working_frequency: emp.working_frequency,
+                timesheetDetails: emp.timesheet_details ?? {},
+                leaves: emp.leaves ?? [],
+                holidays: emp.holidays ?? [],
+              };
+            } else {
+              // Merge subsequent pages for the same employee, deduplicating leaves and holidays
+              // by their unique identifiers to avoid double-rendering on overlapping date ranges.
+              const existing = employeeMap[emp.name];
+              const existingLeaveIds = new Set(
+                existing.leaves.map((l) => l.name),
+              );
+              const existingHolidayDates = new Set(
+                existing.holidays.map((h) => h.holiday_date),
+              );
+              employeeMap[emp.name] = {
+                ...existing,
+                timesheetDetails: {
+                  ...existing.timesheetDetails,
+                  ...(emp.timesheet_details ?? {}),
+                },
+                leaves: [
+                  ...existing.leaves,
+                  ...(emp.leaves ?? []).filter(
+                    (l) => !existingLeaveIds.has(l.name),
+                  ),
+                ],
+                holidays: [
+                  ...existing.holidays,
+                  ...(emp.holidays ?? []).filter(
+                    (h) => !existingHolidayDates.has(h.holiday_date),
+                  ),
+                ],
+              };
+            }
+          });
       });
 
-      Object.values(payload.data ?? {})
-        .filter((emp) => emp.name)
-        .forEach((emp) => {
-          if (!employeeMap[emp.name]) {
-            employeeMap[emp.name] = {
-              member: {
-                name: emp.name,
-                employee_name: emp.employee_name,
-                image: emp.image,
-              },
-              working_hour: emp.working_hour,
-              working_frequency: emp.working_frequency,
-              timesheetDetails: emp.timesheet_details ?? {},
-              leaves: emp.leaves ?? [],
-              holidays: emp.holidays ?? [],
-            };
-          } else {
-            // Merge subsequent pages for the same employee, deduplicating leaves and holidays
-            // by their unique identifiers to avoid double-rendering on overlapping date ranges.
-            const existing = employeeMap[emp.name];
-            const existingLeaveIds = new Set(
-              existing.leaves.map((l) => l.name),
-            );
-            const existingHolidayDates = new Set(
-              existing.holidays.map((h) => h.holiday_date),
-            );
-            employeeMap[emp.name] = {
-              ...existing,
-              timesheetDetails: {
-                ...existing.timesheetDetails,
-                ...(emp.timesheet_details ?? {}),
-              },
-              leaves: [
-                ...existing.leaves,
-                ...(emp.leaves ?? []).filter(
-                  (l) => !existingLeaveIds.has(l.name),
-                ),
-              ],
-              holidays: [
-                ...existing.holidays,
-                ...(emp.holidays ?? []).filter(
-                  (h) => !existingHolidayDates.has(h.holiday_date),
-                ),
-              ],
-            };
-          }
-        });
-    });
+      const weekMap = new Map<string, WeekGroup>(
+        Object.values(weeksMap).map((week) => [
+          week.start_date,
+          {
+            key: week.key,
+            start_date: week.start_date,
+            end_date: week.end_date,
+            dates: week.dates,
+            members: [],
+            approvalPendingCount: 0,
+          } as WeekGroup,
+        ]),
+      );
 
-    const weekMap = new Map<string, WeekGroup>(
-      Object.values(weeksMap).map((week) => [
-        week.start_date,
-        {
-          key: week.key,
-          start_date: week.start_date,
-          end_date: week.end_date,
-          dates: week.dates,
-          members: [],
-          approvalPendingCount: 0,
-        } as WeekGroup,
-      ]),
-    );
-
-    Object.values(employeeMap).forEach(
-      ({
-        member,
-        working_hour,
-        working_frequency,
-        timesheetDetails,
-        leaves,
-        holidays,
-      }) => {
-        Object.values(timesheetDetails).forEach((week) => {
-          if (week.status === "Not Submitted") {
-            return;
-          }
-          const weekId = week.start_date;
-          if (!weekMap.has(weekId)) {
-            weekMap.set(weekId, {
-              key: week.key,
-              start_date: week.start_date,
-              end_date: week.end_date,
-              dates: week.dates,
-              members: [],
-              approvalPendingCount: 0,
+      Object.values(employeeMap).forEach(
+        ({
+          member,
+          working_hour,
+          working_frequency,
+          timesheetDetails,
+          leaves,
+          holidays,
+        }) => {
+          Object.values(timesheetDetails).forEach((week) => {
+            if (week.status === "Not Submitted") {
+              return;
+            }
+            const weekId = week.start_date;
+            if (!weekMap.has(weekId)) {
+              weekMap.set(weekId, {
+                key: week.key,
+                start_date: week.start_date,
+                end_date: week.end_date,
+                dates: week.dates,
+                members: [],
+                approvalPendingCount: 0,
+              });
+            }
+            const targetWeek = weekMap.get(weekId)!;
+            if (week.status === "Approval Pending") {
+              targetWeek.approvalPendingCount += 1;
+            }
+            targetWeek.members.push({
+              employee: member,
+              week,
+              holidays,
+              leaves,
+              working_hour,
+              working_frequency,
             });
-          }
-          const targetWeek = weekMap.get(weekId)!;
-          if (week.status === "Approval Pending") {
-            targetWeek.approvalPendingCount += 1;
-          }
-          targetWeek.members.push({
-            employee: member,
-            week,
-            holidays,
-            leaves,
-            working_hour,
-            working_frequency,
           });
-        });
-      },
-    );
+        },
+      );
 
-    const weekGroups = Array.from(weekMap.values()).sort(
-      (a, b) =>
-        new Date(b.start_date).getTime() - new Date(a.start_date).getTime(),
-    );
+      const weekGroups = Array.from(weekMap.values()).sort(
+        (a, b) =>
+          new Date(b.start_date).getTime() - new Date(a.start_date).getTime(),
+      );
 
-    return { hasMoreWeeks, weekGroups };
-  }, [pages]);
+      const hasMore = hasMoreEmployees || hasMoreWeeks;
 
-  const loadData = useCallback(() => {
-    if (!hasMoreWeeks || isLoadingTeamApiData || weekGroups.length === 0)
+      return { hasMoreWeeks, hasMoreEmployees, hasMore, weekGroups };
+    }, [pages]);
+
+  // Unified loadMore: prioritizes employee pagination, then week pagination.
+  const loadMore = useCallback(() => {
+    if (isLoadingTeamApiData) return;
+
+    // Priority 1: Load more employees for current date range
+    if (hasMoreEmployees) {
+      setEmployeeStart((prev) => prev + EMPLOYEE_PAGE_LENGTH);
       return;
+    }
 
-    const oldestWeek = weekGroups[weekGroups.length - 1];
-    setWeekDate(getFormatedDate(addDays(oldestWeek.start_date, -1)));
-  }, [hasMoreWeeks, isLoadingTeamApiData, weekGroups]);
+    // Priority 2: Load more weeks (with employee pagination reset)
+    if (hasMoreWeeks && weekGroups.length > 0) {
+      const oldestWeek = weekGroups[weekGroups.length - 1];
+      setWeekDate(getFormatedDate(addDays(oldestWeek.start_date, -1)));
+      setEmployeeStart(0);
+    }
+  }, [hasMoreEmployees, hasMoreWeeks, isLoadingTeamApiData, weekGroups]);
 
   return {
-    hasMoreWeeks,
+    hasMore,
     isLoadingTeamData: isLoadingTeamApiData,
     weekGroups,
-    loadData,
+    loadMore,
     error: teamDataError,
   };
 }

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -70,7 +70,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         </span>
         <div className="flex gap-2 items-center min-w-0">
           <Avatar image={avatarUrl} shape="circle" label={label} size="xs" />
-          <span className="text-base font-medium text-ink-gray-9 leading-3.5">
+          <span className="text-base font-medium truncate text-ink-gray-9">
             {label}
           </span>
           {status !== "none" && (

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -55,22 +55,22 @@ export const MemberRow: React.FC<MemberRowProps> = ({
   return (
     <div
       className={cn(
-        "flex items-center border-b border-outline-gray-1 transition-colors w-full justify-between px-1 py-2",
+        "flex justify-between items-center px-1 py-2 w-full border-b transition-colors border-outline-gray-1",
         className,
       )}
     >
-      <div className="flex items-center flex-1 min-w-0 gap-2 align-middle">
+      <div className="flex flex-1 gap-2 items-center min-w-0 align-middle">
         <span
           className={cn(
-            "w-4 shrink-0 transition-transform",
+            "w-4 transition-transform shrink-0",
             collapsed ? "-rotate-90" : "rotate-0",
           )}
         >
           <ChevronDown strokeWidth={1.5} size={16} />
         </span>
-        <div className="flex items-center min-w-0 gap-2">
+        <div className="flex gap-2 items-center min-w-0">
           <Avatar image={avatarUrl} shape="circle" label={label} size="xs" />
-          <span className="text-base font-medium text-ink-gray-9 truncate leading-3.5">
+          <span className="text-base font-medium text-ink-gray-9 leading-3.5">
             {label}
           </span>
           {status !== "none" && (
@@ -105,7 +105,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         </span>
       </div>
 
-      <div className="flex items-center justify-end w-12 shrink-0 h-7 whitespace-nowrap">
+      <div className="flex justify-end items-center w-12 h-7 whitespace-nowrap shrink-0">
         {!isStatusNone && memberStatusIcon[status]?.icon ? (
           <Button
             onClick={(e) => {


### PR DESCRIPTION
## Description
- Migrates the team timesheet to the new API
- Moves the data fetching and transformation logic to separate hook

## Relevant Technical Choices
- Removed multiple effects which were incorrectly used. i.e. Effects should be used for side effects only.
- Reduced multiple states into a single state from which all the other states can be derived, this reduces cascading renders.
- There will more props for useTeamTimesheetData hook which will be added when I work on the filters.

## Screenshot/Screencast
<img width="1222" height="636" alt="image" src="https://github.com/user-attachments/assets/809e03df-7726-40f6-bf75-2503c337fbf1" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1175 