### PR TITLE
Fix: Teams view basic multi-filters

### DIFF
--- a/frontend/packages/app/src/components/filters/approvalStatusFilter.tsx
+++ b/frontend/packages/app/src/components/filters/approvalStatusFilter.tsx
@@ -7,16 +7,20 @@ import { Select } from "@rtcamp/frappe-ui-react";
 type ApprovalStatusFilterProps = {
   value?: ApprovalStatusType | null;
   onChange: (value?: ApprovalStatusType | null) => void;
+  excludeOptions?: ApprovalStatusType[];
 };
-
-const options = Object.entries(ApprovalStatusLabelMap).map(([key, label]) =>
-  key === "none" ? { label: "All", value: "" } : { label, value: key },
-);
 
 const ApprovalStatusFilter: React.FC<ApprovalStatusFilterProps> = ({
   value,
   onChange,
+  excludeOptions = [],
 }) => {
+  const options = Object.entries(ApprovalStatusLabelMap)
+    .filter(([key]) => !excludeOptions.includes(key as ApprovalStatusType))
+    .map(([key, label]) =>
+      key === "none" ? { label: "All", value: "" } : { label, value: key },
+    );
+
   return (
     <Select
       placeholder="Approval Status"

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -43,15 +43,20 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const [filters, setFilters] = useState<Omit<TimesheetFilters, "search">>({
     approvalStatus: undefined,
-    reportsTo: employeeId,
+    reportsTo: undefined,
   });
 
   const debouncedSearch = useDebounce(searchInput, 400);
 
-  // Compute the full filters object with the debounced search
+  // Compute the full filters object with the debounced search.
+  // Use employeeId as the default for reportsTo until the user changes it.
   const effectiveFilters = useMemo(
-    () => ({ ...filters, search: debouncedSearch }),
-    [filters, debouncedSearch],
+    () => ({
+      ...filters,
+      search: debouncedSearch,
+      reportsTo: (filters.reportsTo ?? employeeId) || undefined,
+    }),
+    [filters, debouncedSearch, employeeId],
   );
 
   const { hasMore, isLoadingTeamData, weekGroups, loadMore, error } =

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -87,6 +87,7 @@ export const TeamTimesheetTable = () => {
           <ApprovalStatusFilter
             value={filters.approvalStatus}
             onChange={handleApprovalStatusChange}
+            excludeOptions={["not-submitted"]}
           />
         </div>
         <div className="flex gap-2">


### PR DESCRIPTION
## Description
- Fix the incorrect initial load issue where the team page was showing entries for all the users instead of the current user on the teams page.
- Remove "Not submitted" approval status from teams view.

## Screenshot/Screencast
<img width="1676" height="645" alt="image" src="https://github.com/user-attachments/assets/0bdbe512-4942-492e-8a9d-75ed47b71d3d" />


## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially addresses #821 