### PR TITLE
feat(projects): add Projects page shell with list/kanban view switcher

### DIFF
--- a/frontend/packages/app/src/lib/constant.ts
+++ b/frontend/packages/app/src/lib/constant.ts
@@ -2,7 +2,7 @@ export const ROUTES = {
   base: "/next-pms",
   home: "/",
   task: "/task",
-  project: "/project",
+  project: "/projects",
   "timesheet-personal": "/timesheet",
   "timesheet-team": "/timesheet/team",
   "timesheet-project": "/timesheet/project",

--- a/frontend/packages/app/src/pages/project/kanban.tsx
+++ b/frontend/packages/app/src/pages/project/kanban.tsx
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies.
+ */
+import { UnderConstruction } from "@/components/under-construction";
+
+function ProjectKanban() {
+  return <UnderConstruction />;
+}
+
+export default ProjectKanban;

--- a/frontend/packages/app/src/pages/project/layout.tsx
+++ b/frontend/packages/app/src/pages/project/layout.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies.
+ */
+import { useSearchParams } from "react-router-dom";
+import { Breadcrumbs, Button } from "@rtcamp/frappe-ui-react";
+import { ChevronDown, Kanban, List, Plus } from "lucide-react";
+
+/**
+ * Internal dependencies.
+ */
+import { Header } from "@/layout/header";
+import ProjectKanban from "./kanban";
+import ProjectList from "./list";
+
+const VIEWS = [
+  { key: "list", label: "List view", icon: List },
+  { key: "kanban", label: "Kanban view", icon: Kanban },
+] as const;
+
+type ViewKey = (typeof VIEWS)[number]["key"];
+
+function ProjectsLayout() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view: ViewKey =
+    searchParams.get("view") === "kanban" ? "kanban" : "list";
+  const activeView = VIEWS.find((v) => v.key === view) ?? VIEWS[0];
+
+  return (
+    <>
+      <Header>
+        <Breadcrumbs
+          items={[
+            { id: "projects", label: "Projects" },
+            {
+              id: "view",
+              label: activeView.label,
+              prefixIcon: <activeView.icon className="size-4" />,
+              suffixIcon: <ChevronDown className="w-4 h-4" />,
+              dropdown: {
+                dropdownClassName: "w-[220px] px-1",
+                groupClassName: "px-0 py-1 space-y-1",
+                itemClassName: "text-ink-gray-8 hover:text-ink-gray-7",
+                selectedKey: view,
+                selectedGroupKey: "views-group",
+                options: [
+                  {
+                    group: "",
+                    key: "views-group",
+                    items: VIEWS.map((v) => ({
+                      label: v.label,
+                      key: v.key,
+                      icon: <v.icon className="size-4 mr-2" />,
+                      onClick: () =>
+                        v.key === "list"
+                          ? setSearchParams({})
+                          : setSearchParams({ view: v.key }),
+                    })),
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+        <Button
+          variant="solid"
+          label="Add project"
+          iconLeft={() => <Plus />}
+          onClick={() => {}}
+        />
+      </Header>
+      {view === "kanban" ? <ProjectKanban /> : <ProjectList />}
+    </>
+  );
+}
+
+export default ProjectsLayout;

--- a/frontend/packages/app/src/pages/project/list.tsx
+++ b/frontend/packages/app/src/pages/project/list.tsx
@@ -3,8 +3,8 @@
  */
 import { UnderConstruction } from "@/components/under-construction";
 
-function ProjectPage() {
+function ProjectList() {
   return <UnderConstruction />;
 }
 
-export default ProjectPage;
+export default ProjectList;

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -14,7 +14,7 @@ import { useUser } from "./providers/user";
  */
 const Home = lazy(() => import("@/pages/home"));
 const Task = lazy(() => import("@/pages/task"));
-const Project = lazy(() => import("@/pages/project"));
+const ProjectsLayout = lazy(() => import("@/pages/project/layout"));
 const TimesheetLayout = lazy(() => import("@/pages/timesheet/layout"));
 const PersonalTimesheetLayout = lazy(
   () => import("@/pages/timesheet/personal/layout"),
@@ -37,7 +37,7 @@ export function Router() {
         <Route element={<LayoutWithSidebar />}>
           <Route path={ROUTES.home} element={<Home />} />
           <Route path={ROUTES.task} element={<Task />} />
-          <Route path={ROUTES.project} element={<Project />} />
+          <Route path={ROUTES.project} element={<ProjectsLayout />} />
           <Route element={<PersonalTimesheetLayout />}>
             <Route
               path={ROUTES["timesheet-personal"]}


### PR DESCRIPTION
## Summary

Implements the Projects page shell described in #1009 — a header with `Breadcrumbs` (title + view-switcher dropdown) and a primary "Add project" button, mounted at `/next-pms/projects`. The active view is driven by the `?view=` URL query param (`kanban` → Kanban, anything else → List), and both view bodies render the existing `UnderConstruction` placeholder in this PR; real table/board implementations land in follow-ups.

- Mirrors the Allocations layout pattern (Breadcrumbs + dropdown-driven view switch) for consistency.
- Sidebar & global-search Projects entries already target `ROUTES.project`, so updating the constant value to `/projects` is the only nav change required.
- `Add project` button is non-functional (no-op `onClick`), matching the AC for this ticket.

Refs: rtCamp/next-pms#1009

## Changes

- `frontend/packages/app/src/lib/constant.ts` — `ROUTES.project: "/project"` → `"/projects"` (matches AC route).
- `frontend/packages/app/src/pages/project/layout.tsx` — **new** `ProjectsLayout`. Reads `?view=` via `useSearchParams`, renders `Header` with `Breadcrumbs` (dropdown of List/Kanban, writes/clears the param) + "Add project" `Button`, then the selected view body.
- `frontend/packages/app/src/pages/project/list.tsx` — **new** `ProjectList` placeholder returning `<UnderConstruction />`.
- `frontend/packages/app/src/pages/project/kanban.tsx` — **new** `ProjectKanban` placeholder returning `<UnderConstruction />`.
- `frontend/packages/app/src/pages/project/index.tsx` — **deleted** (was the old `UnderConstruction` stub).
- `frontend/packages/app/src/route.tsx` — swap the lazy `Project` import to `ProjectsLayout`; route element for `ROUTES.project` now renders `<ProjectsLayout />`.

## Acceptance criteria (from #1009)

- [x] Projects List view is on route `/next-pms/projects?view=list` or `/next-pms/projects`
- [x] Projects Kanban view is on route `/next-pms/projects?view=kanban`
- [x] Sidebar has a Projects option for navigation (already present; highlights active via `ROUTES.project`)
- [x] Global search has a Projects option for navigation (already present)
- [x] Non-functional "Add project" button in the header
- [x] Breadcrumb dropdown switches between List view and Kanban view (Create View option omitted per discussion)

## Test plan

Verified via Claude-in-Chrome MCP on `https://pms-temp.frappe.rt.gw`:

- [x] `/next-pms/projects` loads and renders breadcrumb "Projects / List view" + "Add project" button
- [x] Sidebar Projects entry shows active state (`!bg-surface-selected shadow-sm`)
- [x] `?view=kanban` flips the breadcrumb label to "Kanban view" and renders the Kanban placeholder
- [x] `?view=list` (explicit) renders the List placeholder
- [x] Breadcrumb dropdown opens with both options (`role="menuitem"`), selecting Kanban → `?view=kanban`, selecting List → clears the param
- [x] "Add project" click fires without errors
- [x] No console errors; no 4xx/5xx network calls; 18 resources all 2xx
- [x] Production build (`npm run build:app`) passes with no type errors

## Screenshots / Figma reference

- Figma file (copy): https://www.figma.com/design/h1EnhdK8swe6FCyxUW1XHx/Frappe-PMS--Copy-
- List view frame: `1911:235924` · Kanban view frame: `2273:244356`

🤖 Generated with [Claude Code](https://claude.com/claude-code)