### PR TITLE
feat: employee status filter and business unit filter for team timesheet view

### DIFF
--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -207,6 +207,17 @@ def _get_team_timesheet_data(
         status_filter = json.loads(status_filter)
 
     parsed_filters = parse_filters(filters)
+
+    # get the employee status and business unit from the filters (drop down ui in frontend)
+    # this will be passed to the global employee filter so the pool of employees is narrowed down.
+    employee_status = None
+    employee_business_unit = None
+    for field, _operator, value in parsed_filters.get("Employee", []):
+        if field == "status":
+            employee_status = [value] if isinstance(value, str) else value
+        elif field == "custom_business_unit":
+            employee_business_unit = [value] if isinstance(value, str) else value
+
     has_filters = bool(search or any(parsed_filters.values()))
     dates, _ = build_aggregate_dates(date=date, max_week=max_week, has_filters=has_filters)
     response_dates = dates[-max_week:] if has_filters and len(dates) > max_week else dates
@@ -218,6 +229,8 @@ def _get_team_timesheet_data(
         parsed_filters=parsed_filters,
         search=search,
         timesheet_status=status_filter,
+        status=employee_status,
+        business_unit=employee_business_unit,
     )
 
     if candidate_employee_ids == []:
@@ -314,6 +327,8 @@ def _get_team_timesheet_data(
         start=start,
         page_length=page_length,
         builder=build_team_employee_payload,
+        status=employee_status,
+        business_unit=employee_business_unit,
     )
 
     res["data"] = {employee_name: payload for employee_name, payload in selected_employees}

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -390,12 +390,14 @@ def get_team_candidate_employee_ids(
     parsed_filters: dict | None = None,
     search: str | None = None,
     timesheet_status: list[str] | None = None,
+    status=None,
+    business_unit=None,
 ):
     if not dates:
         return []
 
     has_candidate_filters = bool(timesheet_status or search or any((parsed_filters or {}).values()))
-    if not has_candidate_filters:
+    if not has_candidate_filters and not status and not business_unit:
         return None
 
     employee_ids = get_matching_timesheet_employee_ids(
@@ -407,7 +409,14 @@ def get_team_candidate_employee_ids(
     if not employee_ids:
         return []
 
-    _, filtered_count = filter_employees(page_length=1, start=0, reports_to=reports_to, ids=employee_ids)
+    _, filtered_count = filter_employees(
+        page_length=1,
+        start=0,
+        reports_to=reports_to,
+        ids=employee_ids,
+        status=status,
+        business_unit=business_unit,
+    )
     if not filtered_count:
         return []
 
@@ -716,6 +725,8 @@ def paginate_qualifying_employee_payloads(
     start: int,
     page_length: int,
     builder,
+    status=None,
+    business_unit=None,
 ):
     selected = []
     total_count = 0
@@ -727,6 +738,8 @@ def paginate_qualifying_employee_payloads(
             start=employee_start,
             reports_to=reports_to,
             ids=employee_ids,
+            status=status,
+            business_unit=business_unit,
         )
         if not chunk:
             break

--- a/next_pms/timesheet/utils/constant.py
+++ b/next_pms/timesheet/utils/constant.py
@@ -17,6 +17,7 @@ ALLOWED_FILTER_FIELDS = {
     },
     "Timesheet Detail": {"project", "project_name", "task", "is_billable", "hours"},
     "Task": {"project", "status", "subject", "custom_is_billable", "expected_time", "actual_time"},
+    "Employee": {"status", "custom_business_unit"},
 }
 
 FILTER_LOOKBACK_WEEKS = 12


### PR DESCRIPTION
## Description
Add backend API for employee status and business unit filtering.

## Relevant Technical Choices

Frontend can now share the data in this format

ex:
```
GET /api/method/next_pms.timesheet.api.team.get_team_timesheet_data?date=2026-04-20&filters=[["Employee","custom_business_unit","=","Polarish"],["Employee","status","=","Active"]]
```

and they'll get output in the usual format. No extra changes from frontend POV apart from the field names. 

## Testing Instructions

Test by adding employees and filling timesheets. Then you could use the curl commands to do backend testing.
Example:

<img width="1335" height="330" alt="image" src="https://github.com/user-attachments/assets/4487944b-791e-4b75-a729-2f3dea1a0507" />

```
workspace/frappe-bench/apps
❯ curl -s -G "http://erp16.localhost/api/method/next_pms.timesheet.api.team.get_team_timesheet_data" --cookie "sid=73dac059a5e5de2c9171ad3b10774170614199c1e3206aec92dd588b" --data-urlencode "date=2026-04-20" --data-urlencode 'filters=[["Employee","custom_business_unit","=","Polarish"],["Employee","status","=","Active"]]' | jq '.message'
{
  "dates": [
    {
      "start_date": "2026-04-12",
      "end_date": "2026-04-18",
      "key": "Apr 12 - Apr 18",
      "dates": [
        "2026-04-12",
        "2026-04-13",
        "2026-04-14",
        "2026-04-15",
        "2026-04-16",
        "2026-04-17",
        "2026-04-18"
      ]
    },
    {
      "start_date": "2026-04-19",
      "end_date": "2026-04-25",
      "key": "This Week",
      "dates": [
        "2026-04-19",
        "2026-04-20",
        "2026-04-21",
        "2026-04-22",
        "2026-04-23",
        "2026-04-24",
        "2026-04-25"
      ]
    }
  ],
  "data": {
    "HR-EMP-00029": {
      "name": "HR-EMP-00029",
      "image": null,
      "employee_name": "Rahul Tiwari",
      "department": "SEED Engineering - R",
      "designation": "SEED UI/UX Designer",
      "working_hour": 8,
      "working_frequency": "Per Day",
      "status": "Partially Approved",
      "leaves": [],
      "holidays": [],
      "data": [
        {
          "date": "2026-04-12",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-13",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-14",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-15",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-16",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-17",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-18",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-19",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-20",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-21",
          "hour": 2.5,
          "is_leave": false,
          "note": "<p>wef</p>\n"
        },
        {
          "date": "2026-04-22",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-23",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-24",
          "hour": 0,
          "is_leave": false,
          "note": ""
        },
        {
          "date": "2026-04-25",
          "hour": 0,
          "is_leave": false,
          "note": ""
        }
      ],
      "timesheet_details": {
        "Apr 12 - Apr 18": {
          "start_date": "2026-04-12",
          "end_date": "2026-04-18",
          "key": "Apr 12 - Apr 18",
          "dates": [
            "2026-04-12",
            "2026-04-13",
            "2026-04-14",
            "2026-04-15",
            "2026-04-16",
            "2026-04-17",
            "2026-04-18"
          ],
          "total_hours": 0,
          "tasks": {},
          "status": "Not Submitted"
        },
        "This Week": {
          "start_date": "2026-04-19",
          "end_date": "2026-04-25",
          "key": "This Week",
          "dates": [
            "2026-04-19",
            "2026-04-20",
            "2026-04-21",
            "2026-04-22",
            "2026-04-23",
            "2026-04-24",
            "2026-04-25"
          ],
          "total_hours": 2.5,
          "tasks": {
            "TASK-2026-00008": {
              "name": "TASK-2026-00008",
              "subject": "API Development",
              "project": "PROJ-0008",
              "project_name": "SEED API Gateway Setup",
              "is_billable": 0,
              "expected_time": 0.0,
              "actual_time": 2.5,
              "status": "Working",
              "_liked_by": null,
              "exp_end_date": "",
              "data": [
                {
                  "name": "v92c9ss710",
                  "from_time": "2026-04-21 00:00:00",
                  "to_time": "2026-04-21 00:00:00",
                  "description": "<p>wef</p>",
                  "project": "PROJ-0008",
                  "task": "TASK-2026-00008",
                  "project_name": "SEED API Gateway Setup",
                  "is_billable": 0,
                  "hours": 2.5,
                  "parent": "TS-2026-00001",
                  "docstatus": 1
                }
              ]
            }
          },
          "status": "Not Submitted"
        }
      }
    }
  },
  "total_count": 1,
  "has_more": false
}

workspace/frappe-bench/apps
❯
```



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #821 