### PR TITLE
fix: prevent infinite refetch loop causing timesheet flickering

### DIFF
--- a/frontend/packages/app/src/app/components/add-leave/index.tsx
+++ b/frontend/packages/app/src/app/components/add-leave/index.tsx
@@ -55,20 +55,38 @@ const AddLeave = ({ employee, employeeName, open = false, onOpenChange, onSucces
   const [leaveType, setLeaveType] = useState<Array<string>>([]);
   const postingDate = getTodayDate();
 
-  const { data: leaveDetails } = useFrappeGetCall(
+  const { data: leaveDetails, error: leaveError } = useFrappeGetCall(
     "hrms.hr.doctype.leave_application.leave_application.get_leave_details",
     {
       employee: selectedEmployee,
       date: postingDate,
+    },
+    undefined,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      revalidateOnReconnect: false,
+      errorRetryCount: 0,
+      shouldRetryOnError: false,
     }
   );
 
   useEffect(() => {
-    if (!leaveDetails) return;
-    const leaveType = Object.keys(leaveDetails?.message?.leave_allocation);
-    const types = leaveType.concat(leaveDetails?.message?.lwps);
+    if (!leaveDetails?.message) return;
+    const leaveType = Object.keys(leaveDetails?.message?.leave_allocation || {});
+    const types = leaveType.concat(leaveDetails?.message?.lwps || []);
     setLeaveType(types);
-  }, [leaveDetails]);
+  }, [leaveDetails?.message]);
+
+  useEffect(() => {
+    if (leaveError) {
+      const error = parseFrappeErrorMsg(leaveError);
+      toast({
+        description: error,
+        variant: "destructive",
+      });
+    }
+  }, [leaveError]);
 
   const form = useForm<z.infer<typeof LeaveSchema>>({
     resolver: zodResolver(LeaveSchema),

--- a/frontend/packages/app/src/app/layout/index.tsx
+++ b/frontend/packages/app/src/app/layout/index.tsx
@@ -22,11 +22,13 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   const { data, error } = useFrappeGetCall("next_pms.timesheet.api.employee.get_data", {}, undefined, {
     revalidateOnFocus: false,
     revalidateIfStale: false,
-    errorRetryCount: 1,
+    revalidateOnReconnect: false,
+    errorRetryCount: 0,
+    shouldRetryOnError: false,
   });
 
   useEffect(() => {
-    if (data) {
+    if (data?.message) {
       const info = {
         employee: data.message?.employee ?? "",
         workingHours: data.message?.employee_working_detail?.working_hour ?? 8,
@@ -36,6 +38,9 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
       };
       dispatch(setInitialData(info));
     }
+  }, [data?.message]);
+
+  useEffect(() => {
     if (error) {
       const err = parseFrappeErrorMsg(error);
       toast({
@@ -43,8 +48,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         description: err,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, error]);
+  }, [error]);
 
   return (
     <ErrorFallback>

--- a/frontend/packages/app/src/app/pages/team/employee-detail/employeeTimesheet.tsx
+++ b/frontend/packages/app/src/app/pages/team/employee-detail/employeeTimesheet.tsx
@@ -52,9 +52,14 @@ export const EmployeeTimesheet = ({
   const [likedTaskData, setLikedTaskData] = useState([]);
 
   const getLikedTaskData = () => {
-    fetchLikedTask({}).then((res) => {
-      setLikedTaskData(res.message ?? []);
-    });
+    fetchLikedTask({})
+      .then((res) => {
+        setLikedTaskData(res.message ?? []);
+      })
+      .catch((err) => {
+        console.error("Failed to fetch liked tasks:", err);
+        setLikedTaskData([]);
+      });
   };
 
   useEffect(() => {

--- a/frontend/packages/app/src/app/pages/timesheet/index.tsx
+++ b/frontend/packages/app/src/app/pages/timesheet/index.tsx
@@ -54,6 +54,12 @@ function Timesheet() {
     employee: user.employee,
     start_date: timesheet.weekDate,
     max_week: 4,
+  }, undefined, {
+    revalidateOnFocus: false,
+    revalidateIfStale: false,
+    revalidateOnReconnect: false,
+    errorRetryCount: 0,
+    shouldRetryOnError: false,
   });
 
   useEffect(() => {
@@ -68,13 +74,16 @@ function Timesheet() {
   }, []);
 
   useEffect(() => {
-    if (data) {
+    if (data?.message) {
       if (timesheet.data?.data && Object.keys(timesheet.data?.data).length > 0) {
         dispatch({ type: "APPEND_DATA", payload: data.message });
       } else {
         dispatch({ type: "SET_DATA", payload: data.message });
       }
     }
+  }, [data?.message]);
+
+  useEffect(() => {
     if (error) {
       const err = parseFrappeErrorMsg(error);
       toast({
@@ -82,8 +91,7 @@ function Timesheet() {
         description: err,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, dispatch, error, toast]);
+  }, [error]);
 
   useEffect(() => {
     if (Object.keys(timesheet.data.data).length == 0) return;
@@ -111,9 +119,14 @@ function Timesheet() {
   const [likedTaskData, setLikedTaskData] = useState([]);
 
   const getLikedTaskData = () => {
-    fetchLikedTask({}).then((res) => {
-      setLikedTaskData(res.message ?? []);
-    });
+    fetchLikedTask({})
+      .then((res) => {
+        setLikedTaskData(res.message ?? []);
+      })
+      .catch((err) => {
+        console.error("Failed to fetch liked tasks:", err);
+        setLikedTaskData([]);
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes the issue where the Timesheets → Personal page was continuously flickering due to repeated API calls being triggered in a loop when requests failed. This change ensures the page loads once and remains stable even if some API calls fail.

## Relevant Technical Choices

- Disabled automatic retries and revalidation for API calls to prevent infinite request loops  
- Fixed `useEffect` dependencies to avoid unnecessary re-renders  
- Separated data and error handling into different `useEffect` hooks  
- Added proper `.catch()` handling for async calls  
- Added null-safe fallbacks to handle failed API responses gracefully  

## Testing Instructions

1. Log in as a Reporting Manager  
2. Navigate to Timesheets → Personal  
3. Observe the page behavior on load  

Expected Result:  
- The page loads once without flickering  
- No continuous re-rendering happens  
- API failures (if any) do not trigger repeated calls  
- Console should not show repeated API call loops  

## Additional Information:

- The issue was caused by failing API calls (404, 403, 500) combined with retry/revalidation logic  
- This PR fixes the frontend behavior; backend API issues may still need separate fixes  

## Screenshot/Screencast

Before: Page flickers continuously due to repeated API calls  
After: Page loads once and remains stable  

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.  
- [ ] This code is adequately covered by unit tests to validate its functionality. (NA)  
- [x] I have conducted thorough testing to ensure it functions as intended.  
- [ ] A member of the QA team has reviewed and tested this PR  

Fixes #<issue-number>