### PR TITLE
Refactor: Update state management for teams page

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -11,7 +11,6 @@ import {
  * Internal dependencies
  */
 import { getHolidayList } from "@/lib/utils";
-import { useTeamTimesheet } from "@/pages/timesheet/team/context";
 import type { WorkingFrequency } from "@/types";
 import type { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
 import { MemberRow } from "./components/row/memberRow";
@@ -40,6 +39,7 @@ type TeamTimesheetRowProps = {
   teamMembers: TeamMember[];
   approvalPendingCount?: number;
   setSelectedTask?: (task: string) => void;
+  openWeeklyApproval?: (employee: string, date: string) => void;
 };
 
 export const TeamTimesheetRow = ({
@@ -49,10 +49,8 @@ export const TeamTimesheetRow = ({
   teamMembers,
   approvalPendingCount,
   setSelectedTask,
+  openWeeklyApproval,
 }: TeamTimesheetRowProps) => {
-  const openWeeklyApproval = useTeamTimesheet(
-    ({ actions }) => actions.openWeeklyApproval,
-  );
   const teamMembersData = useMemo(() => {
     return teamMembers.map((member) => {
       const projects = groupTasksByProject(member.tasks);
@@ -94,7 +92,7 @@ export const TeamTimesheetRow = ({
                 className="pl-7.5"
                 collapsed={true}
                 onButtonClick={() =>
-                  openWeeklyApproval(member.employee, dates[0])
+                  openWeeklyApproval?.(member.employee, dates[0])
                 }
               >
                 {({ totalTimeEntriesInHours, dailyWorkingHours }) => (

--- a/frontend/packages/app/src/hooks/useApprovers.ts
+++ b/frontend/packages/app/src/hooks/useApprovers.ts
@@ -1,23 +1,12 @@
 import { useFrappeGetCall } from "frappe-react-sdk";
 import type { Employee } from "@/types";
 
-type UseApproversOptions = {
-  role?: string[];
-};
-
-const useApprovers = ({ role }: UseApproversOptions = {}) => {
-  if (!role || role.length === 0) {
-    role = ["Projects Manager", "Projects User"];
-  }
-
+const useApprovers = () => {
   const { data } = useFrappeGetCall(
-    "next_pms.timesheet.api.employee.get_employee_list",
-    {
-      role,
-    },
+    "next_pms.timesheet.api.get_approver_details",
   );
 
-  const approvers = ((data?.message?.data ?? []) as Employee[]).map((emp) => ({
+  const approvers = ((data?.message ?? []) as Employee[]).map((emp) => ({
     label: emp.employee_name,
     value: emp.name,
     image: emp.image,

--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -39,6 +39,7 @@ export interface TeamTimesheetContextProps {
   state: {
     hasMore: boolean;
     isLoadingTeamData: boolean;
+    isFilterRequest: boolean;
     weekGroups: WeekGroup[];
     filters: TimesheetFilters;
     searchInput: string;
@@ -57,6 +58,7 @@ export const TeamTimesheetContext = createContext<TeamTimesheetContextProps>({
   state: {
     hasMore: false,
     isLoadingTeamData: false,
+    isFilterRequest: false,
     weekGroups: [],
     filters: {
       search: "",

--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -8,8 +8,8 @@ import { createContext, useContextSelector } from "use-context-selector";
 /**
  * Internal dependencies.
  */
-import type { WorkingFrequency } from "@/types";
-import type { DataProp, TimesheetFilters, timesheet } from "@/types/timesheet";
+import type { TeamMember } from "@/components/timesheet-row/teamTimesheetRow";
+import type { TimesheetFilters } from "@/types/timesheet";
 
 export type EmployeeRecord = {
   name: string;
@@ -17,21 +17,12 @@ export type EmployeeRecord = {
   employee_name: string;
 };
 
-export type WeekEmployeeData = {
-  employee: EmployeeRecord;
-  week: timesheet;
-  holidays: DataProp["holidays"];
-  leaves: DataProp["leaves"];
-  working_hour: number;
-  working_frequency: WorkingFrequency;
-};
-
 export type WeekGroup = {
   key: string;
   start_date: string;
   end_date: string;
   dates: string[];
-  members: WeekEmployeeData[];
+  members: TeamMember[];
   approvalPendingCount: number;
 };
 

--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -40,17 +40,12 @@ export interface TeamTimesheetContextProps {
     hasMore: boolean;
     isLoadingTeamData: boolean;
     weekGroups: WeekGroup[];
-    isWeeklyApprovalOpen: boolean;
-    employee: string;
-    startDate: string;
     filters: TimesheetFilters;
     searchInput: string;
     compositeFilters: FilterCondition[];
   };
   actions: {
     loadMore: () => void;
-    openWeeklyApproval: (employeeId: string, date: string) => void;
-    setIsWeeklyApprovalOpen: (state: boolean) => void;
     handleSearchChange: (value: string) => void;
     handleApprovalStatusChange: (value?: ApprovalStatusType | null) => void;
     handleReportsToChange: (value: string | null) => void;
@@ -63,9 +58,6 @@ export const TeamTimesheetContext = createContext<TeamTimesheetContextProps>({
     hasMore: false,
     isLoadingTeamData: false,
     weekGroups: [],
-    isWeeklyApprovalOpen: false,
-    employee: "",
-    startDate: "",
     filters: {
       search: "",
       approvalStatus: undefined,
@@ -76,8 +68,6 @@ export const TeamTimesheetContext = createContext<TeamTimesheetContextProps>({
   },
   actions: {
     loadMore: () => null,
-    openWeeklyApproval: () => null,
-    setIsWeeklyApprovalOpen: () => null,
     handleSearchChange: () => null,
     handleApprovalStatusChange: () => null,
     handleReportsToChange: () => null,

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -64,13 +64,14 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
     });
 
   useEffect(() => {
+    if (isLoadingTeamData) return;
     dispatch({ type: "DATA_LOADED", payload: weekGroups });
 
     if (error) {
       toast.error(parseFrappeErrorMsg(error as FrappeError));
     }
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [weekGroups, error]);
+  }, [weekGroups, error, isLoadingTeamData]);
 
   useFrappeEventListener("timesheet_info", (payload) => {
     dispatch({ type: "REALTIME_UPDATE", payload: payload.message });
@@ -106,6 +107,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       state: {
         hasMore,
         isLoadingTeamData,
+        isFilterRequest: state.isFilterRequest,
         weekGroups: state.weekGroups,
         filters: effectiveFilters,
         searchInput: state.searchInput,
@@ -122,6 +124,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
     [
       hasMore,
       isLoadingTeamData,
+      state.isFilterRequest,
       loadMore,
       state.weekGroups,
       effectiveFilters,

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -7,7 +7,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useState,
+  useReducer,
 } from "react";
 import { type ApprovalStatusType } from "@next-pms/design-system/components";
 import { type FilterCondition } from "@rtcamp/frappe-ui-react";
@@ -17,91 +17,86 @@ import { useToasts } from "@rtcamp/frappe-ui-react";
  * Internal dependencies.
  */
 import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
+import { useFrappeEventListener } from "frappe-react-sdk";
 import { useDebounce } from "@/hooks/useDebounce";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
-import { TimesheetFilters } from "@/types/timesheet";
 import {
   TeamTimesheetContext,
   type TeamTimesheetContextProps,
 } from "./context";
+import {
+  createInitialTeamTimesheetState,
+  teamTimesheetReducer,
+} from "./reducer";
 import { useTeamTimesheetData } from "./useTeamTimesheetData";
 
 export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   const toast = useToasts();
-  const [employee, setEmployee] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [isWeeklyApprovalOpen, setIsWeeklyApprovalOpen] = useState(false);
-  const [searchInput, setSearchInput] = useState("");
-  const [compositeFilters, setCompositeFilters] = useState<FilterCondition[]>(
-    [],
+
+  const [state, dispatch] = useReducer(
+    teamTimesheetReducer,
+    undefined,
+    createInitialTeamTimesheetState,
   );
 
   const { employeeId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
   }));
 
-  const [filters, setFilters] = useState<Omit<TimesheetFilters, "search">>({
-    approvalStatus: undefined,
-    reportsTo: undefined,
-  });
-
-  const debouncedSearch = useDebounce(searchInput, 400);
+  const debouncedSearch = useDebounce(state.searchInput, 400);
 
   // Compute the full filters object with the debounced search.
   // Use employeeId as the default for reportsTo until the user changes it.
   const effectiveFilters = useMemo(
     () => ({
-      ...filters,
+      ...state.filters,
       search: debouncedSearch,
-      reportsTo: (filters.reportsTo ?? employeeId) || undefined,
+      reportsTo: (state.filters.reportsTo ?? employeeId) || undefined,
     }),
-    [filters, debouncedSearch, employeeId],
+    [state.filters, debouncedSearch, employeeId],
   );
 
   const { hasMore, isLoadingTeamData, weekGroups, loadMore, error } =
     useTeamTimesheetData({
       filters: effectiveFilters,
-      compositeFilters,
+      compositeFilters: state.compositeFilters,
     });
 
   useEffect(() => {
+    dispatch({ type: "DATA_LOADED", payload: weekGroups });
+
     if (error) {
       toast.error(parseFrappeErrorMsg(error as FrappeError));
     }
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [error]);
+  }, [weekGroups, error]);
 
-  const openWeeklyApproval = useCallback((employeeId: string, date: string) => {
-    setEmployee(employeeId);
-    setStartDate(date);
-    setIsWeeklyApprovalOpen(true);
-  }, []);
+  useFrappeEventListener("timesheet_info", (payload) => {
+    dispatch({ type: "REALTIME_UPDATE", payload: payload.message });
+  });
 
   const handleSearchChange = useCallback((value: string) => {
-    setSearchInput(value);
+    dispatch({ type: "SEARCH_CHANGED", payload: value });
   }, []);
 
   const handleApprovalStatusChange = useCallback(
     (value?: ApprovalStatusType | null) => {
-      setFilters((prev) => ({
-        ...prev,
-        approvalStatus: value ?? undefined,
-      }));
+      dispatch({
+        type: "APPROVAL_STATUS_CHANGED",
+        payload: value ?? undefined,
+      });
     },
     [],
   );
 
   const handleReportsToChange = useCallback((value: string | null) => {
-    setFilters((prev) => ({
-      ...prev,
-      reportsTo: value ?? undefined,
-    }));
+    dispatch({ type: "REPORTS_TO_CHANGED", payload: value ?? null });
   }, []);
 
   const handleCompositeFilterChange = useCallback(
     (value: FilterCondition[]) => {
-      setCompositeFilters(value);
+      dispatch({ type: "COMPOSITE_FILTERS_CHANGED", payload: value });
     },
     [],
   );
@@ -111,18 +106,13 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       state: {
         hasMore,
         isLoadingTeamData,
-        weekGroups,
-        isWeeklyApprovalOpen,
-        employee,
-        startDate,
+        weekGroups: state.weekGroups,
         filters: effectiveFilters,
-        searchInput,
-        compositeFilters,
+        searchInput: state.searchInput,
+        compositeFilters: state.compositeFilters,
       },
       actions: {
         loadMore,
-        openWeeklyApproval,
-        setIsWeeklyApprovalOpen,
         handleSearchChange,
         handleApprovalStatusChange,
         handleReportsToChange,
@@ -133,14 +123,10 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       hasMore,
       isLoadingTeamData,
       loadMore,
-      weekGroups,
-      openWeeklyApproval,
-      employee,
-      startDate,
-      isWeeklyApprovalOpen,
+      state.weekGroups,
       effectiveFilters,
-      searchInput,
-      compositeFilters,
+      state.searchInput,
+      state.compositeFilters,
       handleSearchChange,
       handleApprovalStatusChange,
       handleReportsToChange,

--- a/frontend/packages/app/src/pages/timesheet/team/reducer.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/reducer.ts
@@ -15,6 +15,7 @@ export interface TeamTimesheetState {
   compositeFilters: FilterCondition[];
   filters: Omit<TimesheetFilters, "search">;
   weekGroups: WeekGroup[];
+  isFilterRequest: boolean;
 }
 
 export type TeamTimesheetAction =
@@ -23,14 +24,14 @@ export type TeamTimesheetAction =
   | { type: "REPORTS_TO_CHANGED"; payload: string | null }
   | { type: "COMPOSITE_FILTERS_CHANGED"; payload: FilterCondition[] }
   | { type: "DATA_LOADED"; payload: WeekGroup[] }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | { type: "REALTIME_UPDATE"; payload: any };
+  | { type: "REALTIME_UPDATE"; payload: unknown };
 
 export const createInitialTeamTimesheetState = (): TeamTimesheetState => ({
   searchInput: "",
   compositeFilters: [],
   filters: { approvalStatus: undefined, reportsTo: undefined },
   weekGroups: [],
+  isFilterRequest: false,
 });
 
 export function teamTimesheetReducer(
@@ -39,25 +40,31 @@ export function teamTimesheetReducer(
 ): TeamTimesheetState {
   switch (action.type) {
     case "SEARCH_CHANGED":
-      return { ...state, searchInput: action.payload };
+      return { ...state, searchInput: action.payload, isFilterRequest: true };
 
     case "APPROVAL_STATUS_CHANGED":
       return {
         ...state,
         filters: { ...state.filters, approvalStatus: action.payload },
+        isFilterRequest: true,
       };
 
     case "REPORTS_TO_CHANGED":
       return {
         ...state,
         filters: { ...state.filters, reportsTo: action.payload ?? undefined },
+        isFilterRequest: true,
       };
 
     case "COMPOSITE_FILTERS_CHANGED":
-      return { ...state, compositeFilters: action.payload };
+      return {
+        ...state,
+        compositeFilters: action.payload,
+        isFilterRequest: true,
+      };
 
     case "DATA_LOADED":
-      return { ...state, weekGroups: action.payload };
+      return { ...state, weekGroups: action.payload, isFilterRequest: false };
 
     case "REALTIME_UPDATE":
       // Handle real-time updates to the timesheet data here.

--- a/frontend/packages/app/src/pages/timesheet/team/reducer.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/reducer.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies.
+ */
+import type { ApprovalStatusType } from "@next-pms/design-system/components";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import type { TimesheetFilters } from "@/types/timesheet";
+import type { WeekGroup } from "./context";
+
+export interface TeamTimesheetState {
+  searchInput: string;
+  compositeFilters: FilterCondition[];
+  filters: Omit<TimesheetFilters, "search">;
+  weekGroups: WeekGroup[];
+}
+
+export type TeamTimesheetAction =
+  | { type: "SEARCH_CHANGED"; payload: string }
+  | { type: "APPROVAL_STATUS_CHANGED"; payload: ApprovalStatusType | undefined }
+  | { type: "REPORTS_TO_CHANGED"; payload: string | null }
+  | { type: "COMPOSITE_FILTERS_CHANGED"; payload: FilterCondition[] }
+  | { type: "DATA_LOADED"; payload: WeekGroup[] }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | { type: "REALTIME_UPDATE"; payload: any };
+
+export const createInitialTeamTimesheetState = (): TeamTimesheetState => ({
+  searchInput: "",
+  compositeFilters: [],
+  filters: { approvalStatus: undefined, reportsTo: undefined },
+  weekGroups: [],
+});
+
+export function teamTimesheetReducer(
+  state: TeamTimesheetState,
+  action: TeamTimesheetAction,
+): TeamTimesheetState {
+  switch (action.type) {
+    case "SEARCH_CHANGED":
+      return { ...state, searchInput: action.payload };
+
+    case "APPROVAL_STATUS_CHANGED":
+      return {
+        ...state,
+        filters: { ...state.filters, approvalStatus: action.payload },
+      };
+
+    case "REPORTS_TO_CHANGED":
+      return {
+        ...state,
+        filters: { ...state.filters, reportsTo: action.payload ?? undefined },
+      };
+
+    case "COMPOSITE_FILTERS_CHANGED":
+      return { ...state, compositeFilters: action.payload };
+
+    case "DATA_LOADED":
+      return { ...state, weekGroups: action.payload };
+
+    case "REALTIME_UPDATE":
+      // Handle real-time updates to the timesheet data here.
+      // This is a placeholder and should be implemented based
+      // on the structure of the incoming data.
+      return state;
+
+    default:
+      return state;
+  }
+}

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -162,17 +162,7 @@ export const TeamTimesheetTable = () => {
                       openWeeklyApproval={(employee, date) =>
                         setWeeklyApproval({ employee, startDate: date })
                       }
-                      teamMembers={week.members.map((member) => ({
-                        label: member.employee.employee_name,
-                        employee: member.employee.name,
-                        avatarUrl: member.employee.image ?? undefined,
-                        tasks: member.week.tasks,
-                        leaves: member.leaves,
-                        holidays: member.holidays,
-                        workingHour: member.working_hour,
-                        workingFrequency: member.working_frequency,
-                        status: member.week.status,
-                      }))}
+                      teamMembers={week.members}
                     />
                   </div>
                 </Fragment>

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import { Fragment, useState } from "react";
+import { mergeClassNames as cn } from "@next-pms/design-system";
 import { Spinner, Typography } from "@next-pms/design-system/components";
 import { Button, Filter, TextInput } from "@rtcamp/frappe-ui-react";
 import { Ellipsis } from "lucide-react";
@@ -31,6 +32,9 @@ export const TeamTimesheetTable = () => {
   const isLoadingTeamData = useTeamTimesheet(
     ({ state }) => state.isLoadingTeamData,
   );
+  const isFilterRequest = useTeamTimesheet(
+    ({ state }) => state.isFilterRequest,
+  );
   const weekGroups = useTeamTimesheet(({ state }) => state.weekGroups);
   const loadMore = useTeamTimesheet(({ actions }) => actions.loadMore);
   const filters = useTeamTimesheet(({ state }) => state.filters);
@@ -51,16 +55,20 @@ export const TeamTimesheetTable = () => {
     ({ actions }) => actions.handleCompositeFilterChange,
   );
 
+  const isFilteredDataLoading = isFilterRequest && isLoadingTeamData;
+
   return (
-    <div className="w-full flex-1 min-h-0 py-3.5 px-3">
-      <WeeklyApproval
-        employee={weeklyApproval?.employee ?? ""}
-        startDate={weeklyApproval?.startDate ?? ""}
-        open={!!weeklyApproval}
-        onOpenChange={(open) => {
-          if (!open) setWeeklyApproval(null);
-        }}
-      />
+    <div className="w-full flex-1 min-h-0 py-3.5 px-3 relative">
+      {weeklyApproval && (
+        <WeeklyApproval
+          employee={weeklyApproval.employee}
+          startDate={weeklyApproval.startDate}
+          open={!!weeklyApproval}
+          onOpenChange={(open) => {
+            if (!open) setWeeklyApproval(null);
+          }}
+        />
+      )}
       {selectedTask && (
         <TeamTaskLog
           task={selectedTask}
@@ -110,7 +118,13 @@ export const TeamTimesheetTable = () => {
           isLoading={isLoadingTeamData}
           hasMore={hasMore}
           verticalLodMore={loadMore}
-          className="w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable]"
+          className={cn(
+            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable] opacity-100",
+            {
+              "opacity-50 transition-opacity duration-150":
+                isFilteredDataLoading,
+            },
+          )}
           count={NUMBER_OF_WEEKS_TO_FETCH}
         >
           <div className="min-w-225">
@@ -167,6 +181,13 @@ export const TeamTimesheetTable = () => {
           </div>
         </InfiniteScroll>
       )}
+
+      {isFilteredDataLoading ? (
+        <Spinner
+          isFull
+          className="absolute top-0 left-0 w-full h-full cursor-wait"
+        />
+      ) : null}
     </div>
   );
 };

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -22,20 +22,17 @@ import { sampleFields } from "../constants";
 
 export const TeamTimesheetTable = () => {
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
+  const [weeklyApproval, setWeeklyApproval] = useState<{
+    employee: string;
+    startDate: string;
+  } | null>(null);
+
   const hasMore = useTeamTimesheet(({ state }) => state.hasMore);
   const isLoadingTeamData = useTeamTimesheet(
     ({ state }) => state.isLoadingTeamData,
   );
   const weekGroups = useTeamTimesheet(({ state }) => state.weekGroups);
   const loadMore = useTeamTimesheet(({ actions }) => actions.loadMore);
-  const isWeeklyApprovalOpen = useTeamTimesheet(
-    ({ state }) => state.isWeeklyApprovalOpen,
-  );
-  const employee = useTeamTimesheet(({ state }) => state.employee);
-  const startDate = useTeamTimesheet(({ state }) => state.startDate);
-  const setIsWeeklyApprovalOpen = useTeamTimesheet(
-    ({ actions }) => actions.setIsWeeklyApprovalOpen,
-  );
   const filters = useTeamTimesheet(({ state }) => state.filters);
   const searchInput = useTeamTimesheet(({ state }) => state.searchInput);
   const compositeFilters = useTeamTimesheet(
@@ -57,10 +54,12 @@ export const TeamTimesheetTable = () => {
   return (
     <div className="w-full flex-1 min-h-0 py-3.5 px-3">
       <WeeklyApproval
-        employee={employee}
-        startDate={startDate}
-        open={isWeeklyApprovalOpen}
-        onOpenChange={setIsWeeklyApprovalOpen}
+        employee={weeklyApproval?.employee ?? ""}
+        startDate={weeklyApproval?.startDate ?? ""}
+        open={!!weeklyApproval}
+        onOpenChange={(open) => {
+          if (!open) setWeeklyApproval(null);
+        }}
       />
       {selectedTask && (
         <TeamTaskLog
@@ -146,6 +145,9 @@ export const TeamTimesheetTable = () => {
                       firstWeek={index === 0}
                       approvalPendingCount={week.approvalPendingCount}
                       setSelectedTask={setSelectedTask}
+                      openWeeklyApproval={(employee, date) =>
+                        setWeeklyApproval({ employee, startDate: date })
+                      }
                       teamMembers={week.members.map((member) => ({
                         label: member.employee.employee_name,
                         employee: member.employee.name,

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -98,6 +98,12 @@ export function useTeamTimesheetData({
     }
   }, [filters, compositeFilters, resetData]);
 
+  const hasActiveFilter =
+    !!filters.reportsTo ||
+    !!filters.search ||
+    !!filters.approvalStatus ||
+    compositeFilters.length > 0;
+
   const {
     data: teamData,
     error: teamDataError,
@@ -113,6 +119,7 @@ export function useTeamTimesheetData({
       ? JSON.stringify([ApprovalStatusLabelMap[filters.approvalStatus]])
       : null,
     filters: frappeFilters.length > 0 ? JSON.stringify(frappeFilters) : null,
+    skip_empty_weeks: hasActiveFilter || null,
   });
 
   useEffect(() => {
@@ -125,12 +132,10 @@ export function useTeamTimesheetData({
   // All transformation lives here. Because this is pure data derivation (no side effects).
   const { hasMoreWeeks, hasMoreEmployees, hasMore, weekGroups } =
     useMemo(() => {
-      const hasMoreWeeks = true;
+      const oneYearAgo = addDays(new Date(getTodayDate()), -365 * 2);
+      const hasMoreWeeks = new Date(weekDate) > oneYearAgo;
       const hasMoreEmployees =
         pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
-
-      // Collapse all pages into a weeks map and a per-employee map.
-      const weeksMap: Record<string, WeekEntry> = {};
 
       type EmployeeState = {
         member: EmployeeRecord;
@@ -143,13 +148,17 @@ export function useTeamTimesheetData({
       const employeeMap: Record<string, EmployeeState> = {};
 
       pages.forEach((payload) => {
-        (payload.dates ?? []).forEach((week) => {
-          weeksMap[week.start_date] = week;
-        });
-
         Object.values(payload.data ?? {})
           .filter((emp) => emp.name)
           .forEach((emp) => {
+            // Eliminate "Not Submitted" weeks at the source so all downstream
+            // logic can assume every timesheet entry is worth displaying.
+            const submittedTimesheets = Object.fromEntries(
+              Object.entries(emp.timesheet_details ?? {}).filter(
+                ([, week]) => week.status !== "Not Submitted",
+              ),
+            );
+
             if (!employeeMap[emp.name]) {
               employeeMap[emp.name] = {
                 member: {
@@ -159,7 +168,7 @@ export function useTeamTimesheetData({
                 },
                 working_hour: emp.working_hour,
                 working_frequency: emp.working_frequency,
-                timesheetDetails: emp.timesheet_details ?? {},
+                timesheetDetails: submittedTimesheets,
                 leaves: emp.leaves ?? [],
                 holidays: emp.holidays ?? [],
               };
@@ -177,7 +186,7 @@ export function useTeamTimesheetData({
                 ...existing,
                 timesheetDetails: {
                   ...existing.timesheetDetails,
-                  ...(emp.timesheet_details ?? {}),
+                  ...submittedTimesheets,
                 },
                 leaves: [
                   ...existing.leaves,
@@ -196,19 +205,7 @@ export function useTeamTimesheetData({
           });
       });
 
-      const weekMap = new Map<string, WeekGroup>(
-        Object.values(weeksMap).map((week) => [
-          week.start_date,
-          {
-            key: week.key,
-            start_date: week.start_date,
-            end_date: week.end_date,
-            dates: week.dates,
-            members: [],
-            approvalPendingCount: 0,
-          } as WeekGroup,
-        ]),
-      );
+      const weekMap = new Map<string, WeekGroup>();
 
       Object.values(employeeMap).forEach(
         ({
@@ -220,9 +217,6 @@ export function useTeamTimesheetData({
           holidays,
         }) => {
           Object.values(timesheetDetails).forEach((week) => {
-            if (week.status === "Not Submitted") {
-              return;
-            }
             const weekId = week.start_date;
             if (!weekMap.has(weekId)) {
               weekMap.set(weekId, {
@@ -261,7 +255,30 @@ export function useTeamTimesheetData({
       const hasMore = hasMoreEmployees || hasMoreWeeks;
 
       return { hasMoreWeeks, hasMoreEmployees, hasMore, weekGroups };
-    }, [pages]);
+    }, [pages, weekDate]);
+
+  // Auto-advance the week window when a fully-loaded window yields no visible
+  // weeks (all employees have "Not Submitted" timesheets for that range).
+  // This prevents a "No Data" screen when data exists in older date ranges,
+  // which happens frequently when skip_empty_weeks is active with a filter.
+  useEffect(() => {
+    if (isLoadingTeamApiData) return;
+    if (pages.length === 0) return;
+    if (hasMoreEmployees) return; // current window not fully loaded yet
+    if (weekGroups.length > 0) return; // we have visible data
+    if (!hasMoreWeeks) return;
+
+    setWeekDate((prev) =>
+      getFormatedDate(addDays(prev, -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
+    );
+    setEmployeeStart(0);
+  }, [
+    isLoadingTeamApiData,
+    hasMoreEmployees,
+    hasMoreWeeks,
+    weekGroups.length,
+    pages.length,
+  ]);
 
   // Unified loadMore: prioritizes employee pagination, then week pagination.
   const loadMore = useCallback(() => {
@@ -273,13 +290,16 @@ export function useTeamTimesheetData({
       return;
     }
 
-    // Priority 2: Load more weeks (with employee pagination reset)
-    if (hasMoreWeeks && weekGroups.length > 0) {
-      const oldestWeek = weekGroups[weekGroups.length - 1];
-      setWeekDate(getFormatedDate(addDays(oldestWeek.start_date, -1)));
+    // Priority 2: Load more weeks (with employee pagination reset).
+    // Advance by the fixed batch window from the current weekDate so we always
+    // produce a new date value.
+    if (hasMoreWeeks) {
+      setWeekDate((prev) =>
+        getFormatedDate(addDays(prev, -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
+      );
       setEmployeeStart(0);
     }
-  }, [hasMoreEmployees, hasMoreWeeks, isLoadingTeamApiData, weekGroups]);
+  }, [hasMoreEmployees, hasMoreWeeks, isLoadingTeamApiData]);
 
   return {
     hasMore,

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -12,6 +12,7 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
+import type { TeamMember } from "@/components/timesheet-row/teamTimesheetRow";
 import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
 import { buildCompositeFilters } from "@/lib/utils";
 import type { DataProp, TimesheetFilters } from "@/types/timesheet";
@@ -238,13 +239,16 @@ export function useTeamTimesheetData({
               targetWeek.approvalPendingCount += 1;
             }
             targetWeek.members.push({
-              employee: member,
-              week,
-              holidays,
+              label: member.employee_name,
+              employee: member.name,
+              avatarUrl: member.image ?? undefined,
+              tasks: week.tasks,
               leaves,
-              working_hour,
-              working_frequency,
-            });
+              holidays,
+              workingHour: working_hour,
+              workingFrequency: working_frequency,
+              status: week.status,
+            } satisfies TeamMember);
           });
         },
       );


### PR DESCRIPTION
## Description
- Refactors the state management on teams page to use reducer

## Relevant Technical Choices
- Removed weekly approval state from reducer because that state is purely UI/ephemeral (which dialog is open and for whom). The reducer should own data state (week groups, filters, loading) and shared behavioural state. Dialog-open state with its associated target belongs at the component level.

## Additional Information:
- The status filters are not returning the correct response - this is a know [issue](https://github.com/rtCamp/next-pms/issues/1260) and is due to backend.
- The realtime updates are not implemented because the legacy implementation used a different api, and after discussion with @/wreckage0907 we decided it a good to have feature and will be worked on later. Also we don't have sockets setup properly, so realtime updates do not work anyways on any other pages either (e.g. personal page)

## Screenshot/Screencast
Code Refactor / No visual changes.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)