### PR TITLE
fix: dont mutate meta object in memory

### DIFF
--- a/next_pms/timesheet/api/project.py
+++ b/next_pms/timesheet/api/project.py
@@ -37,7 +37,7 @@ def get_projects(
         filters = json.loads(filters)
 
     if not fields:
-        fields = meta.default_fields
+        fields = list(meta.default_fields)  # Copy to avoid mutating class attribute
 
     if "custom_currency" not in fields:
         fields.append("custom_currency")


### PR DESCRIPTION
## Description

`Meta.default_fields` is a shared class attribute, so mutating it with `fields.append("custom_currency")` polluted all usages—leading Frappe to include that field in queries (via `get_permitted_fields()`), which ultimately caused MySQL/MariaDB to error with *Unknown column 'custom_currency'* for doctypes that don’t have it.


## Relevant Technical Choices


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

Example Error Log : 
```
### App Versions
{
	"frappe": "16.12.0",
	"erpnext": "17.0.0-dev",
	"hrms": "17.0.0-dev",
	"next_pms": "0.1.0"
}


### Traceback

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1129, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/utils/caching.py", line 248, in inner
    ret = func(*args, **kwargs)
  File "apps/frappe/frappe/desk/doctype/notification_log/notification_log.py", line 171, in get_notification_logs
    notification_logs = frappe.db.get_list(
    	"Notification Log", fields=["*"], limit=limit, order_by="creation desc"
    )
  File "apps/frappe/frappe/database/database.py", line 824, in get_list
    return frappe.get_list(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1362, in get_list
    return frappe.model.qb_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/qb_query.py", line 212, in execute
    result = query.run(debug=debug, as_dict=not as_list, update=update)
  File "apps/frappe/frappe/query_builder/utils.py", line 131, in execute_query
    result = frappe.local.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 372, in execute_query
    return self._cursor.execute(query, values)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
  File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
    ~~~~~~~~^^^
  File "env/lib/python3.14/site-packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
MySQLdb.OperationalError: (1054, "Unknown column 'custom_currency' in 'SELECT'")


### Request Data

{
	"type": "GET",
	"args": {
		"limit": 20
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.doctype.notification_log.notification_log.get_notification_logs",
	"cache": true,
	"request_id": null
}

### Response Data

{
	"exception": "MySQLdb.OperationalError: (1054, \"Unknown column 'custom_currency' in 'SELECT'\")",
	"exc_type": "OperationalError"
}
```

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #