### PR TITLE
Add member popover and allocation popovers

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -42,6 +42,7 @@ function AddAllocationModal({
   onOpenChange,
   onEditScheduleClick,
   initialValues,
+  onSuccess,
 }: AddAllocationModalProps) {
   const toast = useToasts();
   const [submitting, setSubmitting] = useState(false);
@@ -163,12 +164,14 @@ function AddAllocationModal({
             ? "Allocation updated successfully"
             : "Allocation created successfully",
         );
+
+        closeModal();
+        onSuccess?.();
       } catch (err) {
         const error = parseFrappeErrorMsg(err as FrappeError);
         toast.error(error);
       } finally {
         setSubmitting(false);
-        closeModal();
       }
     },
   });
@@ -179,12 +182,12 @@ function AddAllocationModal({
   }, [form, mergedDefaultValues, onOpenChange]);
 
   useEffect(() => {
-    if (!open || variant !== "edit") {
+    if (!open) {
       return;
     }
 
     form.reset(mergedDefaultValues);
-  }, [form, mergedDefaultValues, open, variant]);
+  }, [form, mergedDefaultValues, open]);
 
   const recurrence = useStore(form.store, (state) => state.values.recurrence);
   const hoursPerDay = useStore(form.store, (state) => state.values.hoursPerDay);

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/types.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/types.ts
@@ -19,6 +19,7 @@ export interface AddAllocationModalProps {
   variant?: "add" | "edit";
   onEditScheduleClick?: () => void;
   initialValues?: AddAllocationInitialValues;
+  onSuccess?: () => void;
 }
 
 export type ComboboxOption = {

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -25,6 +25,7 @@ import { InfiniteScroll } from "@/components/infiniteScroll";
 import { useUser } from "@/providers/user";
 import { EMPLOYEES_PER_PAGE } from "./constants";
 import { AllocationsDuration, useAllocationsTeam } from "./context";
+import { useAllocationsTeamOutletContext } from "./outletContext";
 
 const FILTER_FIELDS: FilterField[] = [
   {
@@ -92,6 +93,12 @@ export const AllocationsTeamTable = () => {
   const { hasRoleAccess } = useUser(({ state }) => ({
     hasRoleAccess: state.hasRoleAccess,
   }));
+
+  const {
+    openAddAllocationDialog,
+    openEditAllocationDialog,
+    openDeleteAllocationDialog,
+  } = useAllocationsTeamOutletContext();
 
   const hasMembers = filteredMembers.length > 0;
   const isFilteredDataLoading = isLoading && isFilterRequest;
@@ -180,6 +187,9 @@ export const AllocationsTeamTable = () => {
               members={filteredMembers}
               weekCount={weekCount}
               hasRoleAccess={hasRoleAccess}
+              onAddAllocation={openAddAllocationDialog}
+              onEditAllocation={openEditAllocationDialog}
+              onDeleteAllocation={openDeleteAllocationDialog}
             />
           </InfiniteScroll>
         ) : null}

--- a/frontend/packages/app/src/pages/allocations/team/layout.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/layout.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies.
  */
-import { useCallback, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { Button } from "@rtcamp/frappe-ui-react";
 import { Plus } from "lucide-react";
@@ -12,22 +11,10 @@ import { Plus } from "lucide-react";
 import { Header } from "@/layout/header";
 import { AllocationsBreadcrumbs } from "@/pages/allocations/components/allocationsBreadcrumbs";
 import AddAllocationModal from "@/pages/allocations/team/add-allocation";
-import type { AllocationsTeamOutletContext } from "./outletContext";
+import { useAllocationModal } from "./useAllocationModal";
 
 function TeamTimesheetLayout() {
-  const [isAddAllocationOpen, setIsAddAllocationOpen] = useState(false);
-
-  const handleAddAllocation = useCallback(() => {
-    setIsAddAllocationOpen(true);
-  }, []);
-
-  const handleEditAllocation = useCallback(() => {
-    // TODO: wire up edit modal
-  }, []);
-
-  const handleDeleteAllocation = useCallback(() => {
-    // TODO: wire up delete modal
-  }, []);
+  const { openAddDialog, outletContext, modalProps } = useAllocationModal();
 
   return (
     <>
@@ -36,26 +23,15 @@ function TeamTimesheetLayout() {
 
         <Button
           variant="solid"
-          onClick={handleAddAllocation}
+          onClick={() => openAddDialog({})}
           label="Add allocation"
           iconLeft={() => <Plus />}
         />
       </Header>
 
-      <Outlet
-        context={
-          {
-            openAddAllocationDialog: handleAddAllocation,
-            openEditAllocationDialog: handleEditAllocation,
-            openDeleteAllocationDialog: handleDeleteAllocation,
-          } satisfies AllocationsTeamOutletContext
-        }
-      />
+      <Outlet context={outletContext} />
 
-      <AddAllocationModal
-        open={isAddAllocationOpen}
-        onOpenChange={setIsAddAllocationOpen}
-      />
+      <AddAllocationModal {...modalProps} />
     </>
   );
 }

--- a/frontend/packages/app/src/pages/allocations/team/layout.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/layout.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { Button } from "@rtcamp/frappe-ui-react";
 import { Plus } from "lucide-react";
@@ -12,9 +12,22 @@ import { Plus } from "lucide-react";
 import { Header } from "@/layout/header";
 import { AllocationsBreadcrumbs } from "@/pages/allocations/components/allocationsBreadcrumbs";
 import AddAllocationModal from "@/pages/allocations/team/add-allocation";
+import type { AllocationsTeamOutletContext } from "./outletContext";
 
 function TeamTimesheetLayout() {
   const [isAddAllocationOpen, setIsAddAllocationOpen] = useState(false);
+
+  const handleAddAllocation = useCallback(() => {
+    setIsAddAllocationOpen(true);
+  }, []);
+
+  const handleEditAllocation = useCallback(() => {
+    // TODO: wire up edit modal
+  }, []);
+
+  const handleDeleteAllocation = useCallback(() => {
+    // TODO: wire up delete modal
+  }, []);
 
   return (
     <>
@@ -23,13 +36,21 @@ function TeamTimesheetLayout() {
 
         <Button
           variant="solid"
-          onClick={() => setIsAddAllocationOpen(true)}
+          onClick={handleAddAllocation}
           label="Add allocation"
           iconLeft={() => <Plus />}
         />
       </Header>
 
-      <Outlet />
+      <Outlet
+        context={
+          {
+            openAddAllocationDialog: handleAddAllocation,
+            openEditAllocationDialog: handleEditAllocation,
+            openDeleteAllocationDialog: handleDeleteAllocation,
+          } satisfies AllocationsTeamOutletContext
+        }
+      />
 
       <AddAllocationModal
         open={isAddAllocationOpen}

--- a/frontend/packages/app/src/pages/allocations/team/outletContext.ts
+++ b/frontend/packages/app/src/pages/allocations/team/outletContext.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies.
+ */
+import { useOutletContext } from "react-router-dom";
+
+export type AllocationsTeamOutletContext = {
+  openAddAllocationDialog: () => void;
+  openEditAllocationDialog: () => void;
+  openDeleteAllocationDialog: () => void;
+};
+
+export function useAllocationsTeamOutletContext() {
+  return useOutletContext<AllocationsTeamOutletContext>();
+}

--- a/frontend/packages/app/src/pages/allocations/team/outletContext.ts
+++ b/frontend/packages/app/src/pages/allocations/team/outletContext.ts
@@ -2,11 +2,12 @@
  * External dependencies.
  */
 import { useOutletContext } from "react-router-dom";
+import type { AllocationCallbackData } from "@next-pms/design-system/components";
 
 export type AllocationsTeamOutletContext = {
-  openAddAllocationDialog: () => void;
-  openEditAllocationDialog: () => void;
-  openDeleteAllocationDialog: () => void;
+  openAddAllocationDialog: (data: AllocationCallbackData) => void;
+  openEditAllocationDialog: (data: AllocationCallbackData) => void;
+  openDeleteAllocationDialog: (data: AllocationCallbackData) => void;
 };
 
 export function useAllocationsTeamOutletContext() {

--- a/frontend/packages/app/src/pages/allocations/team/type.ts
+++ b/frontend/packages/app/src/pages/allocations/team/type.ts
@@ -4,6 +4,9 @@ export interface Employee {
   employee_name: string;
   department: string | null;
   designation: string | null;
+  rate?: string | null;
+  capacity?: string | null;
+  reportingManager?: string | null;
 }
 
 export interface Leave {

--- a/frontend/packages/app/src/pages/allocations/team/type.ts
+++ b/frontend/packages/app/src/pages/allocations/team/type.ts
@@ -36,7 +36,7 @@ export interface ResourceAllocation {
   modified: string;
   creation: string;
   status: string;
-  modified_by_avatar: string;
+  modified_by_avatar: string | null;
 }
 
 export interface Customer {

--- a/frontend/packages/app/src/pages/allocations/team/useAllocationModal.ts
+++ b/frontend/packages/app/src/pages/allocations/team/useAllocationModal.ts
@@ -1,0 +1,106 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useState } from "react";
+import type { AllocationCallbackData } from "@next-pms/design-system/components";
+import { useToasts } from "@rtcamp/frappe-ui-react";
+import { format } from "date-fns";
+import { useFrappeDeleteDoc } from "frappe-react-sdk";
+
+/**
+ * Internal dependencies.
+ */
+import type { AddAllocationInitialValues } from "@/pages/allocations/team/add-allocation/types";
+import { useAllocationsTeam } from "./context";
+import type { AllocationsTeamOutletContext } from "./outletContext";
+
+export function useAllocationModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [variant, setVariant] = useState<"add" | "edit">("add");
+  const [initialValues, setInitialValues] = useState<
+    AddAllocationInitialValues | undefined
+  >(undefined);
+
+  const refresh = useAllocationsTeam(({ actions }) => actions.refresh);
+  const toast = useToasts();
+  const { deleteDoc } = useFrappeDeleteDoc();
+
+  const openAddDialog = useCallback((data: AllocationCallbackData) => {
+    setVariant("add");
+    setInitialValues({
+      employeeId: data.employeeId,
+    });
+    setIsOpen(true);
+  }, []);
+
+  const openEditDialog = useCallback((data: AllocationCallbackData) => {
+    setVariant("edit");
+    setInitialValues({
+      allocationName: data.allocationId,
+      employeeId: data.employeeId,
+      projectId: data.projectId,
+      fromDate: data.startDate
+        ? format(data.startDate, "yyyy-MM-dd")
+        : undefined,
+      toDate: data.endDate ? format(data.endDate, "yyyy-MM-dd") : undefined,
+      hoursPerDay: data.hoursPerDay,
+      isBillable: data.billable,
+      isTentative: data.tentative,
+      note: data.note,
+    });
+    setIsOpen(true);
+  }, []);
+
+  const handleDelete = useCallback(
+    async (data: AllocationCallbackData) => {
+      if (!data.allocationId) {
+        toast.error("Allocation ID not found");
+        return;
+      }
+
+      try {
+        await deleteDoc("Resource Allocation", data.allocationId);
+        toast.success("The allocation has been deleted successfully");
+        void refresh();
+      } catch {
+        toast.error("Failed to delete the allocation");
+      }
+    },
+    [deleteDoc, toast, refresh],
+  );
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setInitialValues(undefined);
+      setVariant("add");
+    }
+  }, []);
+
+  const handleSuccess = useCallback(() => {
+    setIsOpen(false);
+    setInitialValues(undefined);
+    setVariant("add");
+    void refresh();
+  }, [refresh]);
+
+  const outletContext: AllocationsTeamOutletContext = {
+    openAddAllocationDialog: openAddDialog,
+    openEditAllocationDialog: openEditDialog,
+    openDeleteAllocationDialog: handleDelete,
+  };
+
+  const modalProps = {
+    variant,
+    open: isOpen,
+    onOpenChange: handleOpenChange,
+    initialValues,
+    onSuccess: handleSuccess,
+  };
+
+  return {
+    openAddDialog,
+    outletContext,
+    modalProps,
+  };
+}

--- a/frontend/packages/app/src/pages/allocations/team/useAllocationModal.ts
+++ b/frontend/packages/app/src/pages/allocations/team/useAllocationModal.ts
@@ -29,6 +29,10 @@ export function useAllocationModal() {
     setVariant("add");
     setInitialValues({
       employeeId: data.employeeId,
+      fromDate: data.startDate
+        ? format(data.startDate, "yyyy-MM-dd")
+        : undefined,
+      toDate: data.endDate ? format(data.endDate, "yyyy-MM-dd") : undefined,
     });
     setIsOpen(true);
   }, []);

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -54,6 +54,9 @@ export function mapTeamAllocationToMembers(
           endDate: Date;
           billable: boolean;
           tentative: boolean;
+          createdOn?: Date;
+          updatedOn?: Date;
+          updatedBy?: { name: string; image?: string };
         }[];
       }
     >
@@ -95,6 +98,14 @@ export function mapTeamAllocationToMembers(
       endDate: parseISO(alloc.allocation_end_date),
       billable: Boolean(alloc.is_billable),
       tentative: alloc.status === "Tentative",
+      createdOn: alloc.creation ? parseISO(alloc.creation) : undefined,
+      updatedOn: alloc.modified ? parseISO(alloc.modified) : undefined,
+      updatedBy: alloc.modified_by
+        ? {
+            name: alloc.modified_by,
+            image: alloc.modified_by_avatar || undefined,
+          }
+        : undefined,
     });
   }
 

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -3,6 +3,14 @@ import { parseISO } from "date-fns";
 import type { TeamAllocationResponse } from "./type";
 
 /**
+ * Parses a Frappe datetime string (YYYY-MM-DD HH:mm:ss.ssssss) into a Date.
+ * Converts the space separator to 'T' for ISO compatibility.
+ */
+function parseFrappeDatetime(datetime: string): Date {
+  return parseISO(datetime.replace(" ", "T"));
+}
+
+/**
  * Merges two Member arrays, ensuring uniqueness based on stable member identity.
  */
 export function mergeUniqueMembers(
@@ -108,8 +116,12 @@ export function mapTeamAllocationToMembers(
       billable: Boolean(alloc.is_billable),
       tentative: alloc.status === "Tentative",
       note: alloc.note ?? undefined,
-      createdOn: alloc.creation ? parseISO(alloc.creation) : undefined,
-      updatedOn: alloc.modified ? parseISO(alloc.modified) : undefined,
+      createdOn: alloc.creation
+        ? parseFrappeDatetime(alloc.creation)
+        : undefined,
+      updatedOn: alloc.modified
+        ? parseFrappeDatetime(alloc.modified)
+        : undefined,
       updatedBy: alloc.modified_by
         ? {
             name: alloc.modified_by,

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -116,7 +116,11 @@ export function mapTeamAllocationToMembers(
     return {
       id: employee.name,
       name: employee.employee_name,
-      role: employee.designation ?? undefined,
+      designation: employee.designation ?? undefined,
+      department: employee.department ?? undefined,
+      rate: employee.rate ?? undefined,
+      capacity: employee.capacity ?? undefined,
+      manager: employee.reportingManager ?? undefined,
       image: employee.image ?? undefined,
       projects,
       leaves: memberLeaves,

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -47,13 +47,18 @@ export function mapTeamAllocationToMembers(
       string,
       {
         projectName: string;
+        projectId: string;
         customerName: string;
         allocations: {
+          id: string;
+          employeeId: string;
+          projectId: string;
           hours: number;
           startDate: Date;
           endDate: Date;
           billable: boolean;
           tentative: boolean;
+          note?: string;
           createdOn?: Date;
           updatedOn?: Date;
           updatedBy?: { name: string; image?: string };
@@ -87,17 +92,22 @@ export function mapTeamAllocationToMembers(
         customer[alloc.customer]?.name ?? alloc.customer ?? "";
       projectMap.set(alloc.project, {
         projectName: alloc.project_name || alloc.project,
+        projectId: alloc.project,
         customerName,
         allocations: [],
       });
     }
 
     projectMap.get(alloc.project)!.allocations.push({
+      id: alloc.name,
+      employeeId: alloc.employee,
+      projectId: alloc.project,
       hours: alloc.hours_allocated_per_day,
       startDate: parseISO(alloc.allocation_start_date),
       endDate: parseISO(alloc.allocation_end_date),
       billable: Boolean(alloc.is_billable),
       tentative: alloc.status === "Tentative",
+      note: alloc.note ?? undefined,
       createdOn: alloc.creation ? parseISO(alloc.creation) : undefined,
       updatedOn: alloc.modified ? parseISO(alloc.modified) : undefined,
       updatedBy: alloc.modified_by

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -52,7 +52,9 @@ function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
       <div className="flex flex-col gap-2.5 relative">
         <div className="flex gap-2 items-center">
           <Calendar className="size-4 text-ink-gray-5 shrink-0" />
-          <span className="text-sm text-ink-gray-6">{entry.dateRange}</span>
+          <span className="text-sm text-ink-gray-6 truncate">
+            {entry.dateRange}
+          </span>
         </div>
 
         <div className="flex gap-2 items-center">
@@ -91,7 +93,7 @@ function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
                 />
               </div>
             )}
-            <span className="text-sm truncate text-ink-gray-6">
+            <span className="text-sm truncate text-ink-gray-6 mr-10">
               {entry.updatedOn &&
               entry.createdOn &&
               entry.updatedOn.getTime() !== entry.createdOn.getTime()

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -1,6 +1,3 @@
-/**
- * Internal popup card shown when hovering over a Gantt allocation bar.
- */
 import { Avatar, Button } from "@rtcamp/frappe-ui-react";
 import {
   AddMd,
@@ -14,7 +11,6 @@ import {
 } from "@rtcamp/frappe-ui-react/icons";
 import { format } from "date-fns";
 import { mergeClassNames as cn } from "../../../utils";
-export { allocationBarToEntry } from "./utils/allocationBarToEntry";
 
 export interface AllocationEntry {
   projectName: string;
@@ -35,6 +31,9 @@ interface AllocationItemProps {
   hasRoleAccess: boolean;
 }
 
+/**
+ * Internal popup card shown when hovering over a Gantt allocation bar.
+ */
 function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
   const StatusIcon = entry.status === "confirmed" ? Check : CalendarDeadline;
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -104,24 +104,28 @@ function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
           </div>
         )}
 
-        {hasRoleAccess && (
+        {hasRoleAccess && (entry.onEdit || entry.onDelete) && (
           <div className="flex gap-2 items-center shrink-0 absolute bottom-0 right-0 mb-1">
-            <button
-              type="button"
-              onClick={entry.onEdit}
-              className="transition-colors text-ink-gray-5 hover:text-ink-gray-7"
-              aria-label="Edit allocation"
-            >
-              <EditAlt className="size-4" />
-            </button>
-            <button
-              type="button"
-              onClick={entry.onDelete}
-              className="transition-colors text-ink-gray-5 hover:text-ink-gray-7"
-              aria-label="Delete allocation"
-            >
-              <DeleteAlt className="size-4" />
-            </button>
+            {entry.onEdit && (
+              <button
+                type="button"
+                onClick={entry.onEdit}
+                className="transition-colors text-ink-gray-5 hover:text-ink-gray-7"
+                aria-label="Edit allocation"
+              >
+                <EditAlt className="size-4" />
+              </button>
+            )}
+            {entry.onDelete && (
+              <button
+                type="button"
+                onClick={entry.onDelete}
+                className="transition-colors text-ink-gray-5 hover:text-ink-gray-7"
+                aria-label="Delete allocation"
+              >
+                <DeleteAlt className="size-4" />
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -1,0 +1,167 @@
+/**
+ * Internal popup card shown when hovering over a Gantt allocation bar.
+ */
+import { Avatar, Button } from "@rtcamp/frappe-ui-react";
+import {
+  AddMd,
+  Calendar,
+  CalendarDeadline,
+  Check,
+  DeleteAlt,
+  EditAlt,
+  Folder,
+  Time,
+} from "@rtcamp/frappe-ui-react/icons";
+import { format } from "date-fns";
+import { mergeClassNames as cn } from "../../../utils";
+export { allocationBarToEntry } from "./utils/allocationBarToEntry";
+
+export interface AllocationEntry {
+  projectName: string;
+  dateRange: string;
+  hoursPerDay: string;
+  status: "confirmed" | "tentative";
+  billable: boolean;
+  updatedByName?: string;
+  updatedByImage?: string;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  createdOn?: Date;
+  updatedOn?: Date;
+}
+
+interface AllocationItemProps {
+  entry: AllocationEntry;
+  hasRoleAccess: boolean;
+}
+
+function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
+  const StatusIcon = entry.status === "confirmed" ? Check : CalendarDeadline;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Project name */}
+      <div className="flex gap-2 items-start">
+        <Folder className="mt-px size-4 text-ink-gray-5 shrink-0" />
+        <span className="flex-1 min-w-0 text-base font-medium truncate text-ink-gray-8">
+          {entry.projectName}
+        </span>
+      </div>
+
+      {/* Details */}
+      <div className="flex flex-col gap-2.5 relative">
+        <div className="flex gap-2 items-center">
+          <Calendar className="size-4 text-ink-gray-5 shrink-0" />
+          <span className="text-sm text-ink-gray-6">{entry.dateRange}</span>
+        </div>
+
+        <div className="flex gap-2 items-center">
+          <Time className="size-4 text-ink-gray-5 shrink-0" />
+          <span className="text-sm text-ink-gray-6">{entry.hoursPerDay}</span>
+        </div>
+
+        <div className="flex gap-2 items-center">
+          <StatusIcon className="size-4 text-ink-gray-5 shrink-0" />
+          <span className="text-sm text-ink-gray-6">
+            {entry.status === "confirmed" ? "Confirmed" : "Tentative"}
+          </span>
+          <span
+            className={cn(
+              "leading-none scale-200",
+              entry.billable ? "text-ink-green-4" : "text-ink-amber-3",
+            )}
+          >
+            ·
+          </span>
+          <span className="text-sm text-ink-gray-6">
+            {entry.billable ? "Billable" : "Non-billable"}
+          </span>
+        </div>
+
+        {/* Created / Last edited row with avatar and edit/delete actions */}
+        {(entry.createdOn || entry.updatedOn) && (
+          <div className="flex flex-1 gap-2 items-center">
+            {entry.updatedByName && (
+              <div className="shrink-0">
+                <Avatar
+                  size="xs"
+                  shape="circle"
+                  image={entry.updatedByImage}
+                  label={entry.updatedByName}
+                />
+              </div>
+            )}
+            <span className="text-sm truncate text-ink-gray-6">
+              {entry.updatedOn &&
+              entry.createdOn &&
+              entry.updatedOn.getTime() !== entry.createdOn.getTime()
+                ? `Last edited on ${format(entry.updatedOn, "MMM d")}`
+                : entry.createdOn
+                  ? `Created on ${format(entry.createdOn, "MMM d")}`
+                  : null}
+            </span>
+          </div>
+        )}
+
+        {hasRoleAccess && (
+          <div className="flex gap-2 items-center shrink-0 absolute bottom-0 right-0 mb-1">
+            <button
+              type="button"
+              onClick={entry.onEdit}
+              className="transition-colors text-ink-gray-5 hover:text-ink-gray-7"
+              aria-label="Edit allocation"
+            >
+              <EditAlt className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={entry.onDelete}
+              className="transition-colors text-ink-gray-5 hover:text-ink-gray-7"
+              aria-label="Delete allocation"
+            >
+              <DeleteAlt className="size-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface GanttAllocationPopoverProps {
+  entries: AllocationEntry[];
+  onAdd?: () => void;
+  hasRoleAccess?: boolean;
+}
+
+export function GanttAllocationPopover({
+  entries,
+  onAdd,
+  hasRoleAccess = false,
+}: GanttAllocationPopoverProps) {
+  return (
+    <div className="flex flex-col gap-4 p-3 rounded-xl shadow-2xl w-70 bg-surface-modal">
+      <div className="flex flex-col">
+        {entries.map((entry, index) => (
+          <div key={index}>
+            {index > 0 && (
+              <div className="my-3 w-full h-px bg-surface-gray-3" />
+            )}
+            <AllocationItem entry={entry} hasRoleAccess={hasRoleAccess} />
+          </div>
+        ))}
+      </div>
+
+      {onAdd && hasRoleAccess && (
+        <Button
+          variant="solid"
+          theme="gray"
+          className="justify-center w-full"
+          iconLeft={() => <AddMd className="size-4" />}
+          label="Add"
+          onClick={onAdd}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -54,13 +54,14 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
       <div
         ref={ref}
         className={cn(ganttBarVariants({ variant }), className)}
+        {...divProps}
         style={{
+          ...divProps.style,
           left,
           width: Math.max(width - 2, 0), // Account for margin
           height: BAR_HEIGHT,
           top: (CELL_HEIGHT - BAR_HEIGHT) / 2,
         }}
-        {...divProps}
       >
         {!isTimeoff && isCrosshatch && (
           <CrosshatchLayer variant={variant ?? "project"} />

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { CalendarX2 } from "lucide-react";
 import { mergeClassNames as cn } from "../../../utils";
@@ -20,7 +21,10 @@ const ganttBarVariants = cva(
   },
 );
 
-interface GanttBarProps extends VariantProps<typeof ganttBarVariants> {
+interface GanttBarProps
+  extends
+    VariantProps<typeof ganttBarVariants>,
+    React.HTMLAttributes<HTMLDivElement> {
   label: string;
   left: number;
   width: number;
@@ -29,52 +33,60 @@ interface GanttBarProps extends VariantProps<typeof ganttBarVariants> {
   className?: string;
 }
 
-export function GanttBar({
-  variant,
-  label,
-  left,
-  width,
-  theme = "default",
-  billable,
-  className,
-}: GanttBarProps) {
-  const isTimeoff = variant === "timeoff";
-  const isCrosshatch = theme === "crosshatch";
+export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
+  function GanttBar(
+    {
+      variant,
+      label,
+      left,
+      width,
+      theme = "default",
+      billable,
+      className,
+      ...divProps
+    },
+    ref,
+  ) {
+    const isTimeoff = variant === "timeoff";
+    const isCrosshatch = theme === "crosshatch";
 
-  return (
-    <div
-      className={cn(ganttBarVariants({ variant }), className)}
-      style={{
-        left,
-        width: Math.max(width - 2, 0), // Account for margin
-        height: BAR_HEIGHT,
-        top: (CELL_HEIGHT - BAR_HEIGHT) / 2,
-      }}
-    >
-      {!isTimeoff && isCrosshatch && (
-        <CrosshatchLayer variant={variant ?? "project"} />
-      )}
-      {isTimeoff ? (
-        <>
-          <CalendarX2 className="shrink-0" size={16} strokeWidth={1.5} />
-          {label ? (
+    return (
+      <div
+        ref={ref}
+        className={cn(ganttBarVariants({ variant }), className)}
+        style={{
+          left,
+          width: Math.max(width - 2, 0), // Account for margin
+          height: BAR_HEIGHT,
+          top: (CELL_HEIGHT - BAR_HEIGHT) / 2,
+        }}
+        {...divProps}
+      >
+        {!isTimeoff && isCrosshatch && (
+          <CrosshatchLayer variant={variant ?? "project"} />
+        )}
+        {isTimeoff ? (
+          <>
+            <CalendarX2 className="shrink-0" size={16} strokeWidth={1.5} />
+            {label ? (
+              <span className="text-[13px] font-medium tracking-[0.02em] truncate">
+                {label}
+              </span>
+            ) : null}
+          </>
+        ) : (
+          <>
             <span className="text-[13px] font-medium tracking-[0.02em] truncate">
               {label}
             </span>
-          ) : null}
-        </>
-      ) : (
-        <>
-          <span className="text-[13px] font-medium tracking-[0.02em] truncate">
-            {label}
-          </span>
-          {billable === false ? (
-            <span className="block ml-1 w-1 h-1 rounded-full bg-surface-amber-3"></span>
-          ) : null}
-        </>
-      )}
-    </div>
-  );
-}
+            {billable === false ? (
+              <span className="block ml-1 w-1 h-1 rounded-full bg-surface-amber-3"></span>
+            ) : null}
+          </>
+        )}
+      </div>
+    );
+  },
+);
 
 GanttBar.displayName = "GanttBar";

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
@@ -75,7 +75,12 @@ export function GanttMemberBar({ allocation, memberInd }: GanttMemberBarProps) {
   );
 
   const handleAdd = onAddAllocation
-    ? () => onAddAllocation({ employeeId: member.id })
+    ? () =>
+        onAddAllocation({
+          employeeId: member.id,
+          startDate: allocation.startDate,
+          endDate: allocation.endDate,
+        })
     : undefined;
 
   return (

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
@@ -74,6 +74,10 @@ export function GanttMemberBar({ allocation, memberInd }: GanttMemberBarProps) {
     allocationBarToEntry(alloc, onEditAllocation, onDeleteAllocation),
   );
 
+  const handleAdd = onAddAllocation
+    ? () => onAddAllocation({ employeeId: member.id })
+    : undefined;
+
   return (
     <PreviewCard.Root>
       <PreviewCard.Trigger
@@ -95,7 +99,7 @@ export function GanttMemberBar({ allocation, memberInd }: GanttMemberBarProps) {
           <PreviewCard.Popup className="z-50 outline-none">
             <GanttAllocationPopover
               entries={entries}
-              onAdd={onAddAllocation}
+              onAdd={handleAdd}
               hasRoleAccess={hasRoleAccess}
             />
           </PreviewCard.Popup>

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
@@ -1,18 +1,36 @@
+import { PreviewCard } from "@base-ui/react/preview-card";
 import { differenceInCalendarDays } from "date-fns";
 import { FULL_DAY_HOURS } from "../constants";
 import { useGanttStore } from "../ganttStore";
 import type { MemberAllocationBar } from "../ganttStore";
+import {
+  allocationBarToEntry,
+  GanttAllocationPopover,
+} from "./allocationPopover";
 import { GanttBar } from "./ganttBar";
 
 export type MemberBarAllocation = MemberAllocationBar;
 
 interface GanttMemberBarProps {
   allocation: MemberAllocationBar;
+  memberInd: number;
 }
 
-export function GanttMemberBar({ allocation }: GanttMemberBarProps) {
-  const { headerWidth } = useGanttStore((s) => ({
+export function GanttMemberBar({ allocation, memberInd }: GanttMemberBarProps) {
+  const {
+    headerWidth,
+    members,
+    hasRoleAccess,
+    onAddAllocation,
+    onEditAllocation,
+    onDeleteAllocation,
+  } = useGanttStore((s) => ({
     headerWidth: s.headerWidth,
+    members: s.members,
+    hasRoleAccess: s.hasRoleAccess,
+    onAddAllocation: s.onAddAllocation,
+    onEditAllocation: s.onEditAllocation,
+    onDeleteAllocation: s.onDeleteAllocation,
   }));
 
   const left = allocation.barOffset + headerWidth;
@@ -45,15 +63,49 @@ export function GanttMemberBar({ allocation }: GanttMemberBarProps) {
       ? `${diff}h over`
       : `${Math.abs(diff)}h free`;
 
+  // Collect all project allocations overlapping this member bar's date range
+  const member = members[memberInd];
+  const overlapping =
+    member?.projects?.flatMap((project) =>
+      (project.allocations ?? []).filter(
+        (alloc) =>
+          alloc.startDate <= allocation.endDate &&
+          alloc.endDate >= allocation.startDate,
+      ),
+    ) ?? [];
+
+  const entries = overlapping.map((alloc) =>
+    allocationBarToEntry(alloc, onEditAllocation, onDeleteAllocation),
+  );
+
   return (
-    <GanttBar
-      variant={variant}
-      theme={allocation.tentative ? "crosshatch" : "default"}
-      label={label}
-      left={left}
-      width={width}
-      billable={allocation.billable}
-    />
+    <PreviewCard.Root>
+      <PreviewCard.Trigger
+        delay={400}
+        closeDelay={150}
+        render={
+          <GanttBar
+            variant={variant}
+            theme={allocation.tentative ? "crosshatch" : "default"}
+            label={label}
+            left={left}
+            width={width}
+            billable={allocation.billable}
+          />
+        }
+      />
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
+          <PreviewCard.Popup className="z-50 outline-none">
+            <GanttAllocationPopover
+              entries={entries}
+              onAdd={onAddAllocation}
+              hasRoleAccess={hasRoleAccess}
+            />
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberBar.tsx
@@ -3,11 +3,10 @@ import { differenceInCalendarDays } from "date-fns";
 import { FULL_DAY_HOURS } from "../constants";
 import { useGanttStore } from "../ganttStore";
 import type { MemberAllocationBar } from "../ganttStore";
-import {
-  allocationBarToEntry,
-  GanttAllocationPopover,
-} from "./allocationPopover";
+import { GanttAllocationPopover } from "./allocationPopover";
 import { GanttBar } from "./ganttBar";
+import { allocationBarToEntry } from "./utils/allocationBarToEntry";
+import { getOverlappingAllocations } from "./utils/getOverlappingAllocations";
 
 export type MemberBarAllocation = MemberAllocationBar;
 
@@ -65,14 +64,11 @@ export function GanttMemberBar({ allocation, memberInd }: GanttMemberBarProps) {
 
   // Collect all project allocations overlapping this member bar's date range
   const member = members[memberInd];
-  const overlapping =
-    member?.projects?.flatMap((project) =>
-      (project.allocations ?? []).filter(
-        (alloc) =>
-          alloc.startDate <= allocation.endDate &&
-          alloc.endDate >= allocation.startDate,
-      ),
-    ) ?? [];
+  const overlapping = getOverlappingAllocations(
+    member,
+    allocation.startDate,
+    allocation.endDate,
+  );
 
   const entries = overlapping.map((alloc) =>
     allocationBarToEntry(alloc, onEditAllocation, onDeleteAllocation),

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
@@ -1,11 +1,9 @@
 import { PreviewCard } from "@base-ui/react/preview-card";
 import { useGanttStore } from "../ganttStore";
 import type { ProjectAllocationBar } from "../ganttStore";
-import {
-  allocationBarToEntry,
-  GanttAllocationPopover,
-} from "./allocationPopover";
+import { GanttAllocationPopover } from "./allocationPopover";
 import { GanttBar } from "./ganttBar";
+import { allocationBarToEntry } from "./utils/allocationBarToEntry";
 
 interface GanttProjectBarProps {
   allocation: ProjectAllocationBar;

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
@@ -1,5 +1,10 @@
+import { PreviewCard } from "@base-ui/react/preview-card";
 import { useGanttStore } from "../ganttStore";
 import type { ProjectAllocationBar } from "../ganttStore";
+import {
+  allocationBarToEntry,
+  GanttAllocationPopover,
+} from "./allocationPopover";
 import { GanttBar } from "./ganttBar";
 
 interface GanttProjectBarProps {
@@ -7,24 +12,52 @@ interface GanttProjectBarProps {
 }
 
 export function GanttProjectBar({ allocation }: GanttProjectBarProps) {
-  const { headerWidth } = useGanttStore((s) => ({
-    headerWidth: s.headerWidth,
-  }));
+  const { headerWidth, hasRoleAccess, onEditAllocation, onDeleteAllocation } =
+    useGanttStore((s) => ({
+      headerWidth: s.headerWidth,
+      hasRoleAccess: s.hasRoleAccess,
+      onEditAllocation: s.onEditAllocation,
+      onDeleteAllocation: s.onDeleteAllocation,
+    }));
 
   const left = allocation.barOffset + headerWidth;
   const { width, fullNumDays } = allocation;
 
   const label = `${allocation.hours}h/day for ${fullNumDays} day${fullNumDays !== 1 ? "s" : ""}`;
 
+  const entry = allocationBarToEntry(
+    allocation,
+    onEditAllocation,
+    onDeleteAllocation,
+  );
+
   return (
-    <GanttBar
-      variant="project"
-      theme={allocation.tentative ? "crosshatch" : "default"}
-      label={label}
-      left={left}
-      width={width}
-      billable={allocation.billable}
-    />
+    <PreviewCard.Root>
+      <PreviewCard.Trigger
+        delay={400}
+        closeDelay={150}
+        render={
+          <GanttBar
+            variant="project"
+            theme={allocation.tentative ? "crosshatch" : "default"}
+            label={label}
+            left={left}
+            width={width}
+            billable={allocation.billable}
+          />
+        }
+      />
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
+          <PreviewCard.Popup className="z-50 outline-none">
+            <GanttAllocationPopover
+              entries={[entry]}
+              hasRoleAccess={hasRoleAccess}
+            />
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
@@ -1,13 +1,27 @@
 import { format } from "date-fns";
+import type { AllocationCallbackData } from "../../types";
 import type { ProjectAllocationBar } from "../../utils";
 import type { AllocationEntry } from "../allocationPopover";
 
 /** Convert a ProjectAllocationBar to a display-ready AllocationEntry. */
 export function allocationBarToEntry(
   alloc: ProjectAllocationBar,
-  onEdit?: () => void,
-  onDelete?: () => void,
+  onEdit?: (data: AllocationCallbackData) => void,
+  onDelete?: (data: AllocationCallbackData) => void,
 ): AllocationEntry {
+  const callbackData: AllocationCallbackData = {
+    allocationId: alloc.id,
+    employeeId: alloc.employeeId,
+    projectId: alloc.projectId,
+    projectName: alloc.projectName,
+    startDate: alloc.startDate,
+    endDate: alloc.endDate,
+    hoursPerDay: alloc.hours,
+    billable: alloc.billable,
+    tentative: alloc.tentative,
+    note: alloc.note,
+  };
+
   return {
     projectName: alloc.projectName,
     dateRange: `${format(alloc.startDate, "MMM d, yyyy")} – ${format(alloc.endDate, "MMM d, yyyy")}`,
@@ -16,8 +30,8 @@ export function allocationBarToEntry(
     billable: alloc.billable ?? true,
     updatedByName: alloc.updatedBy?.name,
     updatedByImage: alloc.updatedBy?.image,
-    onEdit,
-    onDelete,
+    onEdit: onEdit ? () => onEdit(callbackData) : undefined,
+    onDelete: onDelete ? () => onDelete(callbackData) : undefined,
     createdOn: alloc.createdOn,
     updatedOn: alloc.updatedOn,
   };

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
@@ -1,0 +1,24 @@
+import { format } from "date-fns";
+import type { ProjectAllocationBar } from "../../utils";
+import type { AllocationEntry } from "../allocationPopover";
+
+/** Convert a ProjectAllocationBar to a display-ready AllocationEntry. */
+export function allocationBarToEntry(
+  alloc: ProjectAllocationBar,
+  onEdit?: () => void,
+  onDelete?: () => void,
+): AllocationEntry {
+  return {
+    projectName: alloc.projectName,
+    dateRange: `${format(alloc.startDate, "MMM d, yyyy")} – ${format(alloc.endDate, "MMM d, yyyy")}`,
+    hoursPerDay: `${alloc.hours}h/day (${alloc.hours * alloc.fullNumDays} hours)`,
+    status: alloc.tentative ? "tentative" : "confirmed",
+    billable: alloc.billable ?? true,
+    updatedByName: alloc.updatedBy?.name,
+    updatedByImage: alloc.updatedBy?.image,
+    onEdit,
+    onDelete,
+    createdOn: alloc.createdOn,
+    updatedOn: alloc.updatedOn,
+  };
+}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getOverlappingAllocations.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getOverlappingAllocations.ts
@@ -1,0 +1,18 @@
+import type { Member, ProjectAllocationBar } from "../../utils";
+
+/**
+ * Returns all project allocations for a member that overlap the given date range.
+ */
+export function getOverlappingAllocations(
+  member: Member | undefined,
+  startDate: Date,
+  endDate: Date,
+): ProjectAllocationBar[] {
+  return (
+    member?.projects?.flatMap((project) =>
+      (project.allocations ?? []).filter(
+        (alloc) => alloc.startDate <= endDate && alloc.endDate >= startDate,
+      ),
+    ) ?? []
+  );
+}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -125,7 +125,11 @@ const GanttGridInner: React.FC<{
                     style={{ width: 0 }}
                   >
                     {member.memberAllocations.map((alloc, idx) => (
-                      <GanttMemberBar key={idx} allocation={alloc} />
+                      <GanttMemberBar
+                        key={idx}
+                        allocation={alloc}
+                        memberInd={rowIndex}
+                      />
                     ))}
                   </td>
                 </tr>
@@ -271,6 +275,9 @@ export const GanttGrid: React.FC<GanttGridProps> = (props) => {
       startDate: props.startDate,
       weekCount: props.weekCount ?? 3,
       hasRoleAccess: props.hasRoleAccess ?? false,
+      onAddAllocation: props.onAddAllocation,
+      onEditAllocation: props.onEditAllocation,
+      onDeleteAllocation: props.onDeleteAllocation,
     }),
     [
       props.hasRoleAccess,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -282,6 +282,9 @@ export const GanttGrid: React.FC<GanttGridProps> = (props) => {
     [
       props.hasRoleAccess,
       props.members,
+      props.onAddAllocation,
+      props.onDeleteAllocation,
+      props.onEditAllocation,
       props.showWeekend,
       props.startDate,
       props.weekCount,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies.
+ */
+import { Avatar } from "@rtcamp/frappe-ui-react";
+import { ArrowUpRight, Payments, People, Time, User } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import type { Member } from "./types";
+
+interface GanttMemberHoverCardProps {
+  member: Member;
+}
+
+function GanttMemberHoverCard({ member }: GanttMemberHoverCardProps) {
+  const hasDetails =
+    member.department || member.rate || member.capacity || member.manager;
+
+  return (
+    <div className="flex flex-col gap-3 p-3 w-60 rounded-xl shadow-2xl bg-surface-modal">
+      {/* Header */}
+      <div className="flex justify-between items-start">
+        <div className="flex gap-2 items-center min-w-0">
+          <div className="shrink-0">
+            <Avatar size="xl" shape="circle" image={member.image} label={member.name} />
+          </div>
+          <div className="flex flex-col gap-1 min-w-0">
+            <span className="text-base font-medium truncate text-ink-gray-7">{member.name}</span>
+            {member.designation && (
+              <span className="text-sm truncate text-ink-gray-6">{member.designation}</span>
+            )}
+          </div>
+        </div>
+        <a
+          href="#"
+          target="_blank"
+          rel="noreferrer"
+          className="ml-2 shrink-0 text-ink-gray-6 hover:text-ink-gray-9"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ArrowUpRight className="size-4" />
+        </a>
+      </div>
+
+      {/* Divider */}
+      {hasDetails && <div className="w-full h-px bg-surface-gray-3 shrink-0" />}
+
+      {/* Details */}
+      {hasDetails && (
+        <div className="flex flex-col gap-2.5">
+          {member.department && (
+            <div className="flex gap-2 items-center">
+              <People className="size-4 text-ink-gray-5 shrink-0" />
+              <span className="text-sm text-ink-gray-6">{member.department}</span>
+            </div>
+          )}
+          {member.rate && (
+            <div className="flex gap-2 items-center">
+              <Payments className="size-4 text-ink-gray-5 shrink-0" />
+              <span className="text-sm text-ink-gray-6">{member.rate}</span>
+            </div>
+          )}
+          {member.capacity && (
+            <div className="flex gap-2 items-center">
+              <Time className="size-4 text-ink-gray-5 shrink-0" />
+              <span className="text-sm text-ink-gray-6">{member.capacity}</span>
+            </div>
+          )}
+          {member.manager && (
+            <div className="flex gap-2 items-center">
+              <User className="size-4 text-ink-gray-5 shrink-0" />
+              <span className="text-sm text-ink-gray-6">{member.manager}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default GanttMemberHoverCard;

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
@@ -2,7 +2,13 @@
  * External dependencies.
  */
 import { Avatar } from "@rtcamp/frappe-ui-react";
-import { ArrowUpRight, Payments, People, Time, User } from "@rtcamp/frappe-ui-react/icons";
+import {
+  ArrowUpRight,
+  Payments,
+  People,
+  Time,
+  User,
+} from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -23,12 +29,21 @@ function GanttMemberHoverCard({ member }: GanttMemberHoverCardProps) {
       <div className="flex justify-between items-start">
         <div className="flex gap-2 items-center min-w-0">
           <div className="shrink-0">
-            <Avatar size="xl" shape="circle" image={member.image} label={member.name} />
+            <Avatar
+              size="xl"
+              shape="circle"
+              image={member.image}
+              label={member.name}
+            />
           </div>
           <div className="flex flex-col gap-1 min-w-0">
-            <span className="text-base font-medium truncate text-ink-gray-7">{member.name}</span>
+            <span className="text-base font-medium truncate text-ink-gray-7">
+              {member.name}
+            </span>
             {member.designation && (
-              <span className="text-sm truncate text-ink-gray-6">{member.designation}</span>
+              <span className="text-sm truncate text-ink-gray-6">
+                {member.designation}
+              </span>
             )}
           </div>
         </div>
@@ -52,25 +67,33 @@ function GanttMemberHoverCard({ member }: GanttMemberHoverCardProps) {
           {member.department && (
             <div className="flex gap-2 items-center">
               <People className="size-4 text-ink-gray-5 shrink-0" />
-              <span className="text-sm text-ink-gray-6">{member.department}</span>
+              <span className="text-sm text-ink-gray-6 truncate">
+                {member.department}
+              </span>
             </div>
           )}
           {member.rate && (
             <div className="flex gap-2 items-center">
               <Payments className="size-4 text-ink-gray-5 shrink-0" />
-              <span className="text-sm text-ink-gray-6">{member.rate}</span>
+              <span className="text-sm text-ink-gray-6 truncate">
+                {member.rate}
+              </span>
             </div>
           )}
           {member.capacity && (
             <div className="flex gap-2 items-center">
               <Time className="size-4 text-ink-gray-5 shrink-0" />
-              <span className="text-sm text-ink-gray-6">{member.capacity}</span>
+              <span className="text-sm text-ink-gray-6 truncate">
+                {member.capacity}
+              </span>
             </div>
           )}
           {member.manager && (
             <div className="flex gap-2 items-center">
               <User className="size-4 text-ink-gray-5 shrink-0" />
-              <span className="text-sm text-ink-gray-6">{member.manager}</span>
+              <span className="text-sm text-ink-gray-6 truncate">
+                {member.manager}
+              </span>
             </div>
           )}
         </div>

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -1,6 +1,8 @@
 import { Avatar, Badge } from "@rtcamp/frappe-ui-react";
 import { ChevronRight } from "lucide-react";
+import { PreviewCard } from "@base-ui/react/preview-card";
 import { CELL_HEIGHT } from "./constants";
+import GanttMemberHoverCard from "./ganttMemberHoverCard";
 import { useGanttStore } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
 
@@ -23,61 +25,76 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
   const canExpand = hasProjects || hasRoleAccess;
 
   return (
-    <th
-      className="sticky left-0 z-10 flex items-center w-full p-3 overflow-hidden font-normal text-left align-middle border-b border-r bg-surface-white border-outline-gray-1"
-      style={{
-        height: CELL_HEIGHT,
-        width: headerWidth,
-      }}
-    >
-      <button
-        disabled={!canExpand}
-        onClick={() => toggleRow(memberInd)}
-        className={cn("shrink-0 w-full flex items-center", {
-          "cursor-default!": !canExpand,
-        })}
-        aria-label={isExpanded ? "Collapse" : "Expand"}
+    <PreviewCard.Root>
+      <PreviewCard.Trigger
+        delay={300}
+        closeDelay={150}
+        render={
+          <th
+            className="flex overflow-hidden sticky left-0 z-10 items-center p-3 w-full font-normal text-left align-middle border-r border-b transition-colors duration-150 cursor-pointer bg-surface-white border-outline-gray-1 hover:bg-surface-gray-1"
+            style={{
+              height: CELL_HEIGHT,
+              width: headerWidth,
+            }}
+          />
+        }
       >
-        <div className="w-full flex flex-col gap-1 min-w-0">
-          <div className="flex items-center justify-between gap-1 w-full">
-            <div className="flex items-center flex-1 w-full min-w-0 overflow-hidden">
-              <ChevronRight
-                className={cn(
-                  "shrink-0 mr-1 text-ink-gray-9 transition-transform duration-150",
-                  { "opacity-0 pointer-events-none": !canExpand },
-                  { "rotate-90": isExpanded },
-                )}
-                size={16}
-              />
-              <Avatar
-                size="xs"
-                shape="circle"
-                image={member.image}
-                label={member.name}
-              />
-              <span className="ml-2 text-base font-medium leading-tight truncate text-ink-gray-9">
-                {member.name}
-              </span>
+        <button
+          disabled={!canExpand}
+          onClick={() => toggleRow(memberInd)}
+          className={cn("flex items-center w-full shrink-0", {
+            "cursor-default!": !canExpand,
+          })}
+          aria-label={isExpanded ? "Collapse" : "Expand"}
+        >
+          <div className="flex flex-col gap-1 w-full min-w-0">
+            <div className="flex gap-1 justify-between items-center w-full">
+              <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
+                <ChevronRight
+                  className={cn(
+                    "mr-1 transition-transform duration-150 shrink-0 text-ink-gray-9",
+                    { "opacity-0 pointer-events-none": !canExpand },
+                    { "rotate-90": isExpanded },
+                  )}
+                  size={16}
+                />
+                <Avatar
+                  size="xs"
+                  shape="circle"
+                  image={member.image}
+                  label={member.name}
+                />
+                <span className="ml-2 text-base font-medium leading-tight truncate text-ink-gray-9">
+                  {member.name}
+                </span>
+              </div>
+              {member.badge && (
+                <Badge
+                  className=""
+                  label={member.badge}
+                  size="sm"
+                  variant="subtle"
+                  theme="gray"
+                />
+              )}
             </div>
-            {member.badge && (
-              <Badge
-                className=""
-                label={member.badge}
-                size="sm"
-                variant="subtle"
-                theme="gray"
-              />
-            )}
+            <div className="flex overflow-hidden flex-1 items-center pl-11 w-full min-w-0">
+              {member.role && (
+                <span className="text-xs leading-tight truncate text-ink-gray-6">
+                  {member.role}
+                </span>
+              )}
+            </div>
           </div>
-          <div className="flex items-center flex-1 w-full min-w-0 overflow-hidden pl-11">
-            {member.role && (
-              <span className="text-xs leading-tight truncate text-ink-gray-6">
-                {member.role}
-              </span>
-            )}
-          </div>
-        </div>
-      </button>
-    </th>
+        </button>
+      </PreviewCard.Trigger>
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner side="right" align="center" alignOffset={20} sideOffset={-42}>
+          <PreviewCard.Popup className="outline-none">
+            <GanttMemberHoverCard member={member} />
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
   );
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -1,6 +1,6 @@
+import { PreviewCard } from "@base-ui/react/preview-card";
 import { Avatar, Badge } from "@rtcamp/frappe-ui-react";
 import { ChevronRight } from "lucide-react";
-import { PreviewCard } from "@base-ui/react/preview-card";
 import { CELL_HEIGHT } from "./constants";
 import GanttMemberHoverCard from "./ganttMemberHoverCard";
 import { useGanttStore } from "./ganttStore";
@@ -79,9 +79,9 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
               )}
             </div>
             <div className="flex overflow-hidden flex-1 items-center pl-11 w-full min-w-0">
-              {member.role && (
+              {member.designation && (
                 <span className="text-xs leading-tight truncate text-ink-gray-6">
-                  {member.role}
+                  {member.designation}
                 </span>
               )}
             </div>
@@ -89,7 +89,12 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
         </button>
       </PreviewCard.Trigger>
       <PreviewCard.Portal>
-        <PreviewCard.Positioner side="right" align="center" alignOffset={20} sideOffset={-42}>
+        <PreviewCard.Positioner
+          side="right"
+          align="center"
+          alignOffset={20}
+          sideOffset={-42}
+        >
           <PreviewCard.Popup className="outline-none">
             <GanttMemberHoverCard member={member} />
           </PreviewCard.Popup>

--- a/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
@@ -18,6 +18,9 @@ interface GanttProps {
   startDate: Date;
   weekCount: number;
   hasRoleAccess: boolean;
+  onAddAllocation?: () => void;
+  onEditAllocation?: () => void;
+  onDeleteAllocation?: () => void;
 }
 
 interface GanttState extends GanttProps {

--- a/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
@@ -85,7 +85,8 @@ function getColumnWidth(
  */
 function getMemberStableKey(member: BaseMember) {
   return (
-    member.id ?? `${member.name}::${member.role ?? ""}::${member.image ?? ""}`
+    member.id ??
+    `${member.name}::${member.designation ?? ""}::${member.image ?? ""}`
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
@@ -3,7 +3,7 @@ import { addDays, startOfWeek } from "date-fns";
 import { createStore, useStore } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import { CELL_WIDTH, ROW_HEADER_WIDTH } from "./constants";
-import type { Member as BaseMember } from "./types";
+import type { AllocationCallbackData, Member as BaseMember } from "./types";
 import { prepareMemberBars } from "./utils";
 import type { Member } from "./utils";
 export type {
@@ -18,9 +18,9 @@ interface GanttProps {
   startDate: Date;
   weekCount: number;
   hasRoleAccess: boolean;
-  onAddAllocation?: () => void;
-  onEditAllocation?: () => void;
-  onDeleteAllocation?: () => void;
+  onAddAllocation?: (data: AllocationCallbackData) => void;
+  onEditAllocation?: (data: AllocationCallbackData) => void;
+  onDeleteAllocation?: (data: AllocationCallbackData) => void;
 }
 
 interface GanttState extends GanttProps {

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -101,6 +101,6 @@ export interface GanttGridProps {
   onAddAllocation?: (data: AllocationCallbackData) => void;
   /** Called when the edit icon is clicked on an allocation entry. Receives allocation data. */
   onEditAllocation?: (data: AllocationCallbackData) => void;
-  /** Called when the delete icon is clicked on an allocation entry. Receives allocation id. */
+  /** Called when the delete icon is clicked on an allocation entry. Receives allocation data. */
   onDeleteAllocation?: (data: AllocationCallbackData) => void;
 }

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -36,6 +36,11 @@ export interface Member {
   role?: string;
   image?: string;
   badge?: string;
+  designation?: string;
+  department?: string;
+  rate?: string;
+  capacity?: string;
+  manager?: string;
   projects?: Project[];
   leaves?: LeaveAllocation[];
 }

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -15,7 +15,6 @@ export interface Allocation {
   updatedOn?: Date;
   /** Updated by user. */
   updatedBy?: {
-    employeeId: string;
     name: string;
     image?: string;
   };

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -43,7 +43,6 @@ export interface Project {
 export interface Member {
   id?: string;
   name: string;
-  role?: string;
   image?: string;
   badge?: string;
   designation?: string;

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,4 +1,10 @@
 export interface Allocation {
+  /** Unique identifier for the allocation. */
+  id?: string;
+  /** Employee identifier this allocation belongs to. */
+  employeeId?: string;
+  /** Project identifier this allocation belongs to. */
+  projectId?: string;
   /** Hours per day. */
   hours: number;
   /** First day of the allocation. */
@@ -9,6 +15,8 @@ export interface Allocation {
   billable?: boolean;
   /** Whether the allocation is tentative. */
   tentative?: boolean;
+  /** Note for the allocation. */
+  note?: string;
   /** Created on date. */
   createdOn?: Date;
   /** Updated on date. */
@@ -53,6 +61,29 @@ export interface Member {
   leaves?: LeaveAllocation[];
 }
 
+export interface AllocationCallbackData {
+  /** Allocation identifier. */
+  allocationId?: string;
+  /** Employee identifier. */
+  employeeId?: string;
+  /** Project identifier. */
+  projectId?: string;
+  /** Project name. */
+  projectName?: string;
+  /** Allocation start date. */
+  startDate?: Date;
+  /** Allocation end date. */
+  endDate?: Date;
+  /** Hours per day. */
+  hoursPerDay?: number;
+  /** Whether the allocation is billable. */
+  billable?: boolean;
+  /** Whether the allocation is tentative. */
+  tentative?: boolean;
+  /** Note for the allocation. */
+  note?: string;
+}
+
 export interface GanttGridProps {
   /** Any date within the first week to display. */
   startDate: Date;
@@ -66,10 +97,10 @@ export interface GanttGridProps {
   hasRoleAccess?: boolean;
   /** Optional custom classes for the root wrapper. */
   className?: string;
-  /** Called when "Add" is clicked in an allocation popup. */
-  onAddAllocation?: () => void;
-  /** Called when the edit icon is clicked on an allocation entry. */
-  onEditAllocation?: () => void;
-  /** Called when the delete icon is clicked on an allocation entry. */
-  onDeleteAllocation?: () => void;
+  /** Called when "Add" is clicked in an allocation popup. Receives employee data. */
+  onAddAllocation?: (data: AllocationCallbackData) => void;
+  /** Called when the edit icon is clicked on an allocation entry. Receives allocation data. */
+  onEditAllocation?: (data: AllocationCallbackData) => void;
+  /** Called when the delete icon is clicked on an allocation entry. Receives allocation id. */
+  onDeleteAllocation?: (data: AllocationCallbackData) => void;
 }

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -9,6 +9,16 @@ export interface Allocation {
   billable?: boolean;
   /** Whether the allocation is tentative. */
   tentative?: boolean;
+  /** Created on date. */
+  createdOn?: Date;
+  /** Updated on date. */
+  updatedOn?: Date;
+  /** Updated by user. */
+  updatedBy?: {
+    employeeId: string;
+    name: string;
+    image?: string;
+  };
 }
 
 export interface MemberBarAllocation extends Allocation {
@@ -58,4 +68,10 @@ export interface GanttGridProps {
   hasRoleAccess?: boolean;
   /** Optional custom classes for the root wrapper. */
   className?: string;
+  /** Called when "Add" is clicked in an allocation popup. */
+  onAddAllocation?: () => void;
+  /** Called when the edit icon is clicked on an allocation entry. */
+  onEditAllocation?: () => void;
+  /** Called when the delete icon is clicked on an allocation entry. */
+  onDeleteAllocation?: () => void;
 }

--- a/frontend/packages/design-system/src/components/gantt-view/utils.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/utils.ts
@@ -10,6 +10,7 @@ import type {
 const RIGHT_TRIM_WIDTH_REDUCTION = 3;
 
 export interface ProjectAllocationBar extends Allocation {
+  projectName: string;
   barOffset: number;
   width: number;
   fullNumDays: number;
@@ -92,6 +93,7 @@ export const prepareMemberBars = (
           acc.push({
             ...alloc,
             ...metrics,
+            projectName: project.name,
             fullNumDays:
               getNumDays(alloc.endDate, alloc.startDate, showWeekend) + 1,
           });


### PR DESCRIPTION
## Description
- Adds the member hover cards
- Adds allocation popovers

## Relevant Technical Choices
- Added mock fields assuming standard api design practices.

## Screenshot/Screencast
<img width="1058" height="569" alt="image" src="https://github.com/user-attachments/assets/6556ed12-cce0-4fac-aa90-9566ee683ca7" />

<img width="1212" height="767" alt="image" src="https://github.com/user-attachments/assets/2f1a3c48-90f5-4b45-97cc-52d10c02d558" />

<img width="1210" height="753" alt="image" src="https://github.com/user-attachments/assets/60540b8f-ae7b-4037-a107-1b070e7d18b7" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes:
- #959
- #960
- #961
- #962