### PR TITLE
feat: add extra fields for project management team view page

### DIFF
--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -86,6 +86,7 @@ def get_resource_management_team_view_data(
                 res["permissions"] = permissions
                 return res
 
+    privileged_fields = ["ctc", "salary_currency"] if permissions["write"] else []
     employees, total_count = filter_employees(
         employee_name,
         business_unit=business_unit,
@@ -96,6 +97,7 @@ def get_resource_management_team_view_data(
         status=["Active"],
         ids=ids,
         ignore_permissions=True,
+        extra_fields=["custom_work_schedule", "custom_working_hours", "reports_to", *privileged_fields],
     )
 
     resource_allocation_data = get_allocation_list_for_employee_for_given_range(

--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -53,6 +53,7 @@ def filter_employees(
     roles: list[str] | None = None,
     ignore_default_filters=False,
     ignore_permissions=False,
+    extra_fields: list[str] | None = None,
 ):
     """Apply Employee-level filters and return a paged list of matching employee doctypes and the total count."""
     import json
@@ -63,6 +64,8 @@ def filter_employees(
         ignore_permissions = set(user_roles).intersection(["Timesheet User", "Timesheet Manager"])
 
     fields = ["name", "image", "employee_name", "department", "designation"]
+    if extra_fields:
+        fields.extend(extra_fields)
     employee_ids = []
     filters = {"status": ["in", ["Active"]]}
     or_filters = {}


### PR DESCRIPTION
## Description

add the extra fields `custom_work_schedule`, `custom_working_hours`, `reports_to`, `ctc`, and `salary_currency`

## Relevant Technical Choices

- extended the filter employee function with an extra fields parameter 
- passed the extra fields through it from the main function
- passed ctc and salary currency past a permission check. you need `write` permissions to get access to this data.

## Testing Instructions

1. run the backend as a privileged user with `write` access, you will get ctc information.

```
~
❯ curl -X POST "http://erp16.localhost/api/method/next_pms.resource_management.api.team.get_resource_management_team_view_data" \
  -H "Content-Type: application/json" \
  -H "Cookie: sid=3ce0ef22d791105cad67065b2d407baf649ab87ed8ebf90653f049d9" \
  -d '{
    "date": "2026-05-05",
    "max_week": 2,
    "page_length": 1,
    "start": 0,
    "need_hours_summary": false  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22888  100 22769  100   119  33913    177 --:--:-- --:--:-- --:--:-- 34059
{
  "message": {
    "employees": [
      {
        "name": "HR-EMP-00008",
        "image": null,
        "employee_name": "Aarav Iyer",
        "department": "SEED DevOps - R",
        "designation": "SEED Tech Lead",
        "custom_work_schedule": "",
        "custom_working_hours": 0,
        "reports_to": null,
        "ctc": 2228000.0,
        "salary_currency": "INR"
      }
    ],
    "leaves": [
      {
        "employee": "HR-EMP-00008",
        "employee_name": "Aarav Iyer",
        "from_date": "2025-06-23",
        "to_date": "2025-06-23",
        "half_day": 1,
        "half_day_date": "2025-06-23",
        "total_leave_days": 0.5,
        "name": "SEED-LAP-0007217"
      },
      {
        "employee": "HR-EMP-00008",
        "employee_name": "Aarav Iyer",
        "from_date": "2022-11-07",
        "to_date": "2022-11-09",
        "half_day": 0,
        "half_day_date": null,
        "total_leave_days": 3.0,
        "name": "SEED-LAP-0015047"
      }
    ],
    "resource_allocations": [
      {
        "name": "SEED-RA-0084039",
        "employee": "HR-EMP-00008",
        "employee_name": "Aarav Iyer",
        "allocation_start_date": "2022-06-21",
        "allocation_end_date": "2022-07-12",
        "hours_allocated_per_day": 8.0,
        "project": "PROJ-0004",
        "project_name": null,
        "customer": "SEED NovaStar Solutions",
        "is_billable": 1,
        "note": null,
        "modified_by": "Administrator",
        "modified": "2026-04-16 16:51:13.764683",
        "creation": "2022-06-21 09:00:00",
        "status": "Tentative",
        "modified_by_avatar": "data:image/p..........
        .....
        .....
```


2. run the backend as an unprivileged user without `write` access, you will not get ctc information.

```
❯ curl -X POST "http://erp16.localhost/api/method/next_pms.resource_management.api.team.get_resource_management_team_view_data" \
  -H "Content-Type: application/json" \
  -H "Cookie: sid=061569046dff860464db131bfd0a96582521c562e44d2843f0b50772" \
  -d '{
    "date": "2026-05-05",
    "max_week": 2,
    "page_length": 1,
    "start": 0,
    "need_hours_summary": false,
    "employee_id": "[\"EMP-00001\"]"
  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22890  100 22732  100   158  2297k  16349 --:--:-- --:--:-- --:--:-- 2483k
{
  "message": {
    "employees": [
      {
        "name": "HR-EMP-00008",
        "image": null,
        "employee_name": "Aarav Iyer",
        "department": "SEED DevOps - R",
        "designation": "SEED Tech Lead",
        "custom_work_schedule": "",
        "custom_working_hours": 0,
        "reports_to": null
      }
    ],
    "leaves": [
      {
        "employee": "HR-EMP-00008",
        "employee_name": "Aarav Iyer",
        "from_date": "2025-06-23",
        "to_date": "2025-06-23",
        "half_day": 1,
        "half_day_date": "2025-06-23",
        "total_leave_days": 0.5,
        "name": "SEED-LAP-0007217"
      },
      {
        "employee": "HR-EMP-00008",
        "employee_name": "Aarav Iyer",
        "from_date": "2022-11-07",
        "to_date": "2022-11-09",
        "half_day": 0,
        "half_day_date": null,
        "total_leave_days": 3.0,
        "name": "SEED-LAP-0015047"
      }                                                                                                                                                                       ],                                                                                                                                                                        "resource_allocations": [                                                                                                                                                   {                                                                                                                                                                           "name": "SEED-RA-0084039",                                                                                                                                                "employee": "HR-EMP-00008",                                                                                                                                               "employee_name": "Aarav Iyer",
        "allocation_start_date": "2022-06-21",
        "allocation_end_date": "2022-07-12",
        "hours_allocated_per_day": 8.0,
        "project": "PROJ-0004",
        "project_name": null,......
        ............
        ............
```

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #974 