### PR TITLE
Fix component unmount and remount caused by data loading failure

### DIFF
--- a/frontend/packages/app/src/layout/index.tsx
+++ b/frontend/packages/app/src/layout/index.tsx
@@ -19,7 +19,7 @@ const LayoutWithSidebar = () => {
   }));
 
   const canRenderOutlet =
-    Boolean(employeeId) || (userId == "Administrator" && !hasError);
+    (Boolean(employeeId) && !hasError) || userId === "Administrator";
 
   return (
     <ErrorFallback>

--- a/frontend/packages/app/src/layout/index.tsx
+++ b/frontend/packages/app/src/layout/index.tsx
@@ -12,10 +12,14 @@ import Sidebar from "@/layout/sidebar";
 import { useUser } from "@/providers/user";
 
 const LayoutWithSidebar = () => {
-  const { employeeId, userId } = useUser(({ state }) => ({
+  const { employeeId, hasError, userId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
+    hasError: state.hasError,
     userId: state.userId,
   }));
+
+  const canRenderOutlet =
+    Boolean(employeeId) || (userId == "Administrator" && !hasError);
 
   return (
     <ErrorFallback>
@@ -24,7 +28,7 @@ const LayoutWithSidebar = () => {
           <Sidebar />
         </ErrorFallback>
         <div className="w-full overflow-hidden flex flex-col">
-          {(employeeId || userId == "Administrator") && (
+          {canRenderOutlet && (
             <>
               <Suspense fallback={<></>}>
                 <ErrorFallback>
@@ -32,6 +36,11 @@ const LayoutWithSidebar = () => {
                 </ErrorFallback>
               </Suspense>
             </>
+          )}
+          {!canRenderOutlet && hasError && (
+            <div className="flex h-full items-center justify-center px-6">
+              <p className="text-base text-ink-gray-6">Something went wrong.</p>
+            </div>
           )}
         </div>
       </div>

--- a/frontend/packages/app/src/providers/user/index.ts
+++ b/frontend/packages/app/src/providers/user/index.ts
@@ -15,6 +15,8 @@ export interface UserContextProps {
   state: {
     /** Indicates whether user/auth data is still being resolved. */
     isLoading: boolean;
+    /** Indicates whether bootstrap data required for the app failed to load. */
+    hasError: boolean;
     /** Employee record ID linked to the current user. */
     employeeId: string;
     /** Display name of the current employee. */
@@ -57,6 +59,7 @@ export interface UserContextProps {
 export const UserContext = createContext<UserContextProps>({
   state: {
     isLoading: false,
+    hasError: false,
     employeeId: "",
     employeeName: "",
     workingHours: 0,

--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -51,13 +51,13 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   >(window.frappe?.boot?.has_industry || false);
   const hasRoleAccess = roles.some((role) => ROLES.includes(role));
 
-  const isAdministrator = userId == "Administrator";
-
   const { logout, isLoading: isAuthLoading, currentUser } = useFrappeAuth();
 
-  const { isLoading: isAppDataLoading, data: appData } = useFrappeGetCall(
-    "next_pms.timesheet.api.app.get_data",
-  );
+  const {
+    isLoading: isAppDataLoading,
+    data: appData,
+    error: appDataError,
+  } = useFrappeGetCall("next_pms.timesheet.api.app.get_data");
 
   useEffect(() => {
     setRoles(appData?.message?.roles || []);
@@ -66,15 +66,16 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
     setHasIndustryField(appData?.message?.has_industry || false);
   }, [appData]);
 
-  const { isLoading: isEmployeeDataLoading, data: employeeData } =
-    useFrappeGetCall("next_pms.timesheet.api.employee.get_data");
+  const {
+    isLoading: isEmployeeDataLoading,
+    data: employeeData,
+    error: employeeDataError,
+  } = useFrappeGetCall("next_pms.timesheet.api.employee.get_data");
 
-  // Determine if there is an error in fetching necessary data for the user context.
   const hasError =
-    (!isAppDataLoading && !appData) ||
-    (!isAdministrator &&
-      !isEmployeeDataLoading &&
-      !employeeData?.message?.employee);
+    Boolean(appDataError || employeeDataError) ||
+    (!isAppDataLoading && !appData?.message) ||
+    (!isEmployeeDataLoading && !employeeData?.message?.employee);
 
   useEffect(() => {
     setEmployeeId(employeeData?.message?.employee ?? "");

--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -51,6 +51,8 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   >(window.frappe?.boot?.has_industry || false);
   const hasRoleAccess = roles.some((role) => ROLES.includes(role));
 
+  const isAdministrator = userId == "Administrator";
+
   const { logout, isLoading: isAuthLoading, currentUser } = useFrappeAuth();
 
   const { isLoading: isAppDataLoading, data: appData } = useFrappeGetCall(
@@ -66,6 +68,13 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const { isLoading: isEmployeeDataLoading, data: employeeData } =
     useFrappeGetCall("next_pms.timesheet.api.employee.get_data");
+
+  // Determine if there is an error in fetching necessary data for the user context.
+  const hasError =
+    (!isAppDataLoading && !appData) ||
+    (!isAdministrator &&
+      !isEmployeeDataLoading &&
+      !employeeData?.message?.employee);
 
   useEffect(() => {
     setEmployeeId(employeeData?.message?.employee ?? "");
@@ -103,7 +112,8 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
     <UserContext.Provider
       value={{
         state: {
-          isLoading: isAuthLoading || isAppDataLoading || isEmployeeDataLoading,
+          isLoading: isAuthLoading,
+          hasError,
           employeeId,
           employeeName,
           workingHours,


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR addresses the screen flickering issue caused by failures in `next_pms.timesheet.api.employee.get_data` or `next_pms.timesheet.api.app.get_data`.

When these requests failed, they continuously retried after a few seconds. Since the root component depended on the loading state of these requests, each retry caused the root component to unmount and remount, clearing the application state and creating the appearance that the page was repeatedly reloading.

With this change, the application no longer blocks rendering based directly on the loading state of these APIs. As a result, even if the requests fail and retry, the app state is preserved, resolving the flickering and unintended reload behavior.


## Testing Instructions

- Navigate to any Timesheet page and open a modal.
- Wait for a while, including during request failures or retries.
- Verify that the application state is preserved and the modal does not close or reset unexpectedly.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->