### PR TITLE
feat(projects): add Tracking tab KPI metric cards (#1233)

### DIFF
--- a/frontend/packages/app/src/global.css
+++ b/frontend/packages/app/src/global.css
@@ -148,9 +148,12 @@ html,
 @theme {
   --animate-fade-left: fade-left 0.2s ease;
   --animate-fade-in: fade-in 0.2s ease;
+  --color-surface-green-3: #c3f9d3;
   --color-surface-green-5: var(--color-green-600);
   --color-surface-amber-5: var(--color-amber-600);
   --color-surface-blue-4: var(--color-blue-300);
+  --color-surface-blue-5: #007be0;
+  --color-surface-violet-5: #664ecc;
   --color-ink-cyan-3: #3bbde5;
   --color-ink-violet-3: #7757ee;
 }

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/costBurnCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/costBurnCard.tsx
@@ -6,22 +6,19 @@ import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
+import { formatCompactUSD } from "./format";
 import type { CostBurnData } from "./types";
-
-const compactUSD = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  notation: "compact",
-  maximumFractionDigits: 0,
-});
-
-const fmt = (value: number) => compactUSD.format(value).toLowerCase();
 
 export function CostBurnCard({ data }: { data: CostBurnData }) {
   const { actual, forecasted, total } = data;
   const cap = Math.max(total, actual + forecasted);
   const actualPct = cap > 0 ? Math.min(100, (actual / cap) * 100) : 0;
   const forecastedPct = cap > 0 ? Math.min(100, (forecasted / cap) * 100) : 0;
+  const ariaValueMax = Math.max(0, cap);
+  const ariaValueNow = Math.min(
+    ariaValueMax,
+    Math.max(0, actual + forecasted),
+  );
 
   return (
     <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
@@ -34,12 +31,20 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
           <ArrowUpRight aria-hidden className="size-4" />
         </span>
       </div>
-      <div className="flex h-2 w-full overflow-hidden rounded-full bg-surface-gray-3">
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={ariaValueMax}
+        aria-valuenow={ariaValueNow}
+        className="flex h-2 w-full overflow-hidden rounded-full bg-surface-gray-3"
+      >
         <div
+          aria-hidden
           className="h-full bg-surface-green-5"
           style={{ width: `${actualPct}%` }}
         />
         <div
+          aria-hidden
           className="h-full bg-surface-green-3"
           style={{ width: `${forecastedPct}%` }}
         />
@@ -51,7 +56,7 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
             <span className="truncate">Actual cost incurred</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {fmt(actual)}
+            {formatCompactUSD(actual)}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -60,7 +65,7 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
             <span className="truncate">Forecasted cost to completion</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {fmt(forecasted)}
+            {formatCompactUSD(forecasted)}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -69,7 +74,7 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
             <span className="truncate">Expected total cost</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {fmt(total)}
+            {formatCompactUSD(total)}
           </span>
         </div>
       </div>

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/costBurnCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/costBurnCard.tsx
@@ -6,7 +6,6 @@ import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
-import { formatCompactUSD } from "./format";
 import type { CostBurnData } from "./types";
 
 export function CostBurnCard({ data }: { data: CostBurnData }) {
@@ -56,7 +55,7 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
             <span className="truncate">Actual cost incurred</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {formatCompactUSD(actual)}
+            ${actual}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -65,7 +64,7 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
             <span className="truncate">Forecasted cost to completion</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {formatCompactUSD(forecasted)}
+            ${forecasted}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -74,7 +73,7 @@ export function CostBurnCard({ data }: { data: CostBurnData }) {
             <span className="truncate">Expected total cost</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {formatCompactUSD(total)}
+            ${total}
           </span>
         </div>
       </div>

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/costBurnCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/costBurnCard.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies.
+ */
+import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import type { CostBurnData } from "./types";
+
+const compactUSD = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 0,
+});
+
+const fmt = (value: number) => compactUSD.format(value).toLowerCase();
+
+export function CostBurnCard({ data }: { data: CostBurnData }) {
+  const { actual, forecasted, total } = data;
+  const cap = Math.max(total, actual + forecasted);
+  const actualPct = cap > 0 ? Math.min(100, (actual / cap) * 100) : 0;
+  const forecastedPct = cap > 0 ? Math.min(100, (forecasted / cap) * 100) : 0;
+
+  return (
+    <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="truncate text-base font-medium text-ink-gray-8">
+          Cost burn (to date)
+        </h3>
+        <span className="flex shrink-0 items-center gap-1 text-base font-normal text-ink-gray-6">
+          All Timesheets
+          <ArrowUpRight aria-hidden className="size-4" />
+        </span>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-surface-gray-3">
+        <div
+          className="h-full bg-surface-green-5"
+          style={{ width: `${actualPct}%` }}
+        />
+        <div
+          className="h-full bg-surface-green-3"
+          style={{ width: `${forecastedPct}%` }}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-green-5" />
+            <span className="truncate">Actual cost incurred</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-7">
+            {fmt(actual)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-green-3" />
+            <span className="truncate">Forecasted cost to completion</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-7">
+            {fmt(forecasted)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-gray-3" />
+            <span className="truncate">Expected total cost</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-7">
+            {fmt(total)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/fake-data.ts
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/fake-data.ts
@@ -11,6 +11,25 @@ const DEFAULT_TRACKING: TrackingData = {
   lifetimeValueToDate: "$250,000",
   expectedLifetimeValue: "$120,000",
   lifetimeValueVsBilledAmount: "$45,000",
+  hoursUsage: {
+    utilised: 250,
+    total: 385,
+  },
+  taskCompletion: {
+    totalIssues: 200,
+    openIssues: 96,
+    completedIssues: 104,
+  },
+  costBurn: {
+    actual: 29000,
+    forecasted: 19000,
+    total: 60000,
+  },
+  invoiceBurn: {
+    paid: 35000,
+    unpaid: 12000,
+    total: 100000,
+  },
 };
 
 export const TRACKING_FAKE_DATA: Record<string, TrackingData> = {};

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/format.ts
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/format.ts
@@ -1,9 +1,0 @@
-const compactUSD = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  notation: "compact",
-  maximumFractionDigits: 0,
-});
-
-export const formatCompactUSD = (value: number) =>
-  compactUSD.format(value).toLowerCase();

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/format.ts
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/format.ts
@@ -1,0 +1,9 @@
+const compactUSD = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 0,
+});
+
+export const formatCompactUSD = (value: number) =>
+  compactUSD.format(value).toLowerCase();

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/hoursUsageCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/hoursUsageCard.tsx
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies.
+ */
+import type { HoursUsageData } from "./types";
+
+export function HoursUsageCard({ data }: { data: HoursUsageData }) {
+  const { utilised, total } = data;
+  const percent = total > 0 ? Math.min(100, Math.round((utilised / total) * 100)) : 0;
+  const remaining = Math.max(0, total - utilised);
+
+  return (
+    <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
+      <h3 className="truncate text-base font-medium text-ink-gray-8">
+        Hours usage
+      </h3>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-ink-gray-8">
+          {percent}% completed
+        </span>
+        <div className="relative h-4 w-full overflow-visible rounded-[4px] bg-surface-gray-3">
+          <div
+            className="h-full rounded-l-[4px] bg-surface-blue-4"
+            style={{ width: `${percent}%` }}
+          />
+          <div
+            className="absolute top-1/2 h-10 w-[1.5px] -translate-x-1/2 -translate-y-1/2 bg-ink-gray-7"
+            style={{ left: `${percent}%` }}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="flex items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-blue-4" />
+            <span className="truncate">Hours utilised</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-6">
+            {utilised}h
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="flex items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-gray-3" />
+            <span className="truncate">Hours remaining</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-6">
+            {remaining}h
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/hoursUsageCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/hoursUsageCard.tsx
@@ -7,6 +7,8 @@ export function HoursUsageCard({ data }: { data: HoursUsageData }) {
   const { utilised, total } = data;
   const percent = total > 0 ? Math.min(100, Math.round((utilised / total) * 100)) : 0;
   const remaining = Math.max(0, total - utilised);
+  const ariaValueMax = Math.max(0, total);
+  const ariaValueNow = Math.min(ariaValueMax, Math.max(0, utilised));
 
   return (
     <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
@@ -17,12 +19,20 @@ export function HoursUsageCard({ data }: { data: HoursUsageData }) {
         <span className="text-xs font-medium text-ink-gray-8">
           {percent}% completed
         </span>
-        <div className="relative h-4 w-full overflow-visible rounded-[4px] bg-surface-gray-3">
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={ariaValueMax}
+          aria-valuenow={ariaValueNow}
+          className="relative h-4 w-full overflow-visible rounded-[4px] bg-surface-gray-3"
+        >
           <div
+            aria-hidden
             className="h-full rounded-l-[4px] bg-surface-blue-4"
             style={{ width: `${percent}%` }}
           />
           <div
+            aria-hidden
             className="absolute top-1/2 h-10 w-[1.5px] -translate-x-1/2 -translate-y-1/2 bg-ink-gray-7"
             style={{ left: `${percent}%` }}
           />

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/index.tsx
@@ -6,8 +6,12 @@ import { useParams } from "react-router-dom";
 /**
  * Internal dependencies.
  */
+import { CostBurnCard } from "./costBurnCard";
 import { getTrackingData } from "./fake-data";
+import { HoursUsageCard } from "./hoursUsageCard";
+import { InvoiceBurnCard } from "./invoiceBurnCard";
 import { KnowledgePoint } from "./knowledgePoint";
+import { TaskCompletionCard } from "./taskCompletionCard";
 
 export function Tracking() {
   const { projectId = "" } = useParams<{ projectId: string }>();
@@ -15,6 +19,12 @@ export function Tracking() {
 
   return (
     <div className="flex flex-col gap-3">
+      <div className="flex gap-3">
+        <HoursUsageCard data={data.hoursUsage} />
+        <TaskCompletionCard data={data.taskCompletion} />
+        <CostBurnCard data={data.costBurn} />
+        <InvoiceBurnCard data={data.invoiceBurn} />
+      </div>
       <div className="flex gap-3">
         <KnowledgePoint title="Company" value={data.company} />
         <KnowledgePoint

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/invoiceBurnCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/invoiceBurnCard.tsx
@@ -6,7 +6,6 @@ import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
-import { formatCompactUSD } from "./format";
 import type { InvoiceBurnData } from "./types";
 
 export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
@@ -53,7 +52,7 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
             <span className="truncate">Invoiced and paid</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {formatCompactUSD(paid)}
+            ${paid}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -62,7 +61,7 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
             <span className="truncate">Invoiced but not paid</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {formatCompactUSD(unpaid)}
+            ${unpaid}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -71,7 +70,7 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
             <span className="truncate">Total project amount</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {formatCompactUSD(total)}
+            ${total}
           </span>
         </div>
       </div>

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/invoiceBurnCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/invoiceBurnCard.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies.
+ */
+import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import type { InvoiceBurnData } from "./types";
+
+const compactUSD = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 0,
+});
+
+const fmt = (value: number) => compactUSD.format(value).toLowerCase();
+
+export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
+  const { paid, unpaid, total } = data;
+  const cap = Math.max(total, paid + unpaid);
+  const paidPct = cap > 0 ? Math.min(100, (paid / cap) * 100) : 0;
+  const unpaidPct = cap > 0 ? Math.min(100, (unpaid / cap) * 100) : 0;
+
+  return (
+    <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="truncate text-base font-medium text-ink-gray-8">
+          Invoice burn (to date)
+        </h3>
+        <span className="flex shrink-0 items-center gap-1 text-base font-normal text-ink-gray-6">
+          All invoices
+          <ArrowUpRight aria-hidden className="size-4" />
+        </span>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-surface-gray-3">
+        <div
+          className="h-full bg-surface-violet-5"
+          style={{ width: `${paidPct}%` }}
+        />
+        <div
+          className="h-full bg-surface-blue-5"
+          style={{ width: `${unpaidPct}%` }}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-violet-5" />
+            <span className="truncate">Invoiced and paid</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-7">
+            {fmt(paid)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-blue-5" />
+            <span className="truncate">Invoiced but not paid</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-7">
+            {fmt(unpaid)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2 truncate text-base font-normal text-ink-gray-6">
+            <span className="size-2 shrink-0 rounded-full bg-surface-gray-3" />
+            <span className="truncate">Total project amount</span>
+          </span>
+          <span className="shrink-0 text-base font-medium text-ink-gray-7">
+            {fmt(total)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/invoiceBurnCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/invoiceBurnCard.tsx
@@ -6,22 +6,16 @@ import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
+import { formatCompactUSD } from "./format";
 import type { InvoiceBurnData } from "./types";
-
-const compactUSD = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  notation: "compact",
-  maximumFractionDigits: 0,
-});
-
-const fmt = (value: number) => compactUSD.format(value).toLowerCase();
 
 export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
   const { paid, unpaid, total } = data;
   const cap = Math.max(total, paid + unpaid);
   const paidPct = cap > 0 ? Math.min(100, (paid / cap) * 100) : 0;
   const unpaidPct = cap > 0 ? Math.min(100, (unpaid / cap) * 100) : 0;
+  const ariaValueMax = Math.max(0, cap);
+  const ariaValueNow = Math.min(ariaValueMax, Math.max(0, paid + unpaid));
 
   return (
     <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
@@ -34,12 +28,20 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
           <ArrowUpRight aria-hidden className="size-4" />
         </span>
       </div>
-      <div className="flex h-2 w-full overflow-hidden rounded-full bg-surface-gray-3">
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={ariaValueMax}
+        aria-valuenow={ariaValueNow}
+        className="flex h-2 w-full overflow-hidden rounded-full bg-surface-gray-3"
+      >
         <div
+          aria-hidden
           className="h-full bg-surface-violet-5"
           style={{ width: `${paidPct}%` }}
         />
         <div
+          aria-hidden
           className="h-full bg-surface-blue-5"
           style={{ width: `${unpaidPct}%` }}
         />
@@ -51,7 +53,7 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
             <span className="truncate">Invoiced and paid</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {fmt(paid)}
+            {formatCompactUSD(paid)}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -60,7 +62,7 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
             <span className="truncate">Invoiced but not paid</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {fmt(unpaid)}
+            {formatCompactUSD(unpaid)}
           </span>
         </div>
         <div className="flex items-center justify-between gap-2">
@@ -69,7 +71,7 @@ export function InvoiceBurnCard({ data }: { data: InvoiceBurnData }) {
             <span className="truncate">Total project amount</span>
           </span>
           <span className="shrink-0 text-base font-medium text-ink-gray-7">
-            {fmt(total)}
+            {formatCompactUSD(total)}
           </span>
         </div>
       </div>

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/taskCompletionCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/taskCompletionCard.tsx
@@ -12,10 +12,10 @@ const ARC_LENGTH = CIRCUMFERENCE * ARC_SPAN;
 
 export function TaskCompletionCard({ data }: { data: TaskCompletionData }) {
   const { totalIssues, openIssues, completedIssues } = data;
-  const percent =
-    totalIssues > 0 ? Math.round((completedIssues / totalIssues) * 100) : 0;
-  const safe = Math.min(100, Math.max(0, percent));
-  const fillLength = ARC_LENGTH * (safe / 100);
+  const ratio = totalIssues > 0 ? completedIssues / totalIssues : 0;
+  const safeRatio = Math.min(1, Math.max(0, ratio));
+  const percent = Math.round(safeRatio * 100);
+  const fillLength = ARC_LENGTH * safeRatio;
 
   return (
     <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
@@ -23,8 +23,18 @@ export function TaskCompletionCard({ data }: { data: TaskCompletionData }) {
         Task completion
       </h3>
       <div className="flex items-center gap-4">
-        <div className="relative size-[140px] shrink-0">
-          <svg viewBox="0 0 100 100" className="size-full" aria-hidden>
+        <div className="relative aspect-square w-[140px] min-w-0">
+          <svg
+            viewBox="0 0 100 100"
+            className="size-full"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={Math.max(0, totalIssues)}
+            aria-valuenow={Math.min(
+              Math.max(0, totalIssues),
+              Math.max(0, completedIssues),
+            )}
+          >
             <g transform="rotate(135 50 50)">
               <circle
                 cx="50"

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/taskCompletionCard.tsx
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/taskCompletionCard.tsx
@@ -1,0 +1,89 @@
+/**
+ * Internal dependencies.
+ */
+import type { TaskCompletionData } from "./types";
+
+const VIEWBOX = 100;
+const STROKE = 14;
+const RADIUS = (VIEWBOX - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const ARC_SPAN = 0.75;
+const ARC_LENGTH = CIRCUMFERENCE * ARC_SPAN;
+
+export function TaskCompletionCard({ data }: { data: TaskCompletionData }) {
+  const { totalIssues, openIssues, completedIssues } = data;
+  const percent =
+    totalIssues > 0 ? Math.round((completedIssues / totalIssues) * 100) : 0;
+  const safe = Math.min(100, Math.max(0, percent));
+  const fillLength = ARC_LENGTH * (safe / 100);
+
+  return (
+    <div className="flex flex-1 min-w-0 flex-col gap-3 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
+      <h3 className="truncate text-base font-medium text-ink-gray-8">
+        Task completion
+      </h3>
+      <div className="flex items-center gap-4">
+        <div className="relative size-[140px] shrink-0">
+          <svg viewBox="0 0 100 100" className="size-full" aria-hidden>
+            <g transform="rotate(135 50 50)">
+              <circle
+                cx="50"
+                cy="50"
+                r={RADIUS}
+                fill="none"
+                strokeWidth={STROKE}
+                strokeLinecap="round"
+                className="stroke-surface-gray-3"
+                strokeDasharray={`${ARC_LENGTH} ${CIRCUMFERENCE}`}
+              />
+              <circle
+                cx="50"
+                cy="50"
+                r={RADIUS}
+                fill="none"
+                strokeWidth={STROKE}
+                strokeLinecap="round"
+                className="stroke-surface-green-5"
+                strokeDasharray={`${fillLength} ${CIRCUMFERENCE}`}
+              />
+            </g>
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-base font-semibold text-ink-gray-8">
+              {percent}%
+            </span>
+            <span className="text-xs font-normal text-ink-gray-6">
+              completed
+            </span>
+          </div>
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-base font-normal text-ink-gray-6">
+              Total issues created
+            </span>
+            <span className="shrink-0 text-base font-medium text-ink-gray-6">
+              {totalIssues}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-base font-normal text-ink-gray-6">
+              Open issues
+            </span>
+            <span className="shrink-0 text-base font-medium text-ink-gray-6">
+              {openIssues}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-base font-normal text-ink-gray-6">
+              Completed issues
+            </span>
+            <span className="shrink-0 text-base font-medium text-ink-gray-6">
+              {completedIssues}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/projects/detail/tabs/tracking/types.ts
+++ b/frontend/packages/app/src/pages/projects/detail/tabs/tracking/types.ts
@@ -1,3 +1,26 @@
+export type HoursUsageData = {
+  utilised: number;
+  total: number;
+};
+
+export type TaskCompletionData = {
+  totalIssues: number;
+  openIssues: number;
+  completedIssues: number;
+};
+
+export type CostBurnData = {
+  actual: number;
+  forecasted: number;
+  total: number;
+};
+
+export type InvoiceBurnData = {
+  paid: number;
+  unpaid: number;
+  total: number;
+};
+
 export type TrackingData = {
   company: string;
   totalProjectValue: string;
@@ -6,4 +29,8 @@ export type TrackingData = {
   lifetimeValueToDate: string;
   expectedLifetimeValue: string;
   lifetimeValueVsBilledAmount: string;
+  hoursUsage: HoursUsageData;
+  taskCompletion: TaskCompletionData;
+  costBurn: CostBurnData;
+  invoiceBurn: InvoiceBurnData;
 };


### PR DESCRIPTION
## Summary

- Adds four KPI cards above the existing summary-cards row on Project → Tracking: **Hours usage**, **Task completion**, **Cost burn (to date)**, and **Invoice burn (to date)**.
- Hours card: linear progress bar (`bg-surface-blue-4` fill on `bg-surface-gray-3` track) with a thin vertical marker line at the fill's right edge, percentage label above, and "Hours utilised / Hours remaining" legend rows.
- Task completion card: hand-rolled 3/4-arc SVG donut (gap at the bottom, `stroke-linecap="round"`) with `bg-surface-green-5` fill on `bg-surface-gray-3` track, center "%" + "completed" label, and three legend rows without color dots.
- Cost burn card: 3-segment stacked bar (`green-5` actual + `green-3` forecasted on `gray-3` track) with right-aligned "All Timesheets" + `ArrowUpRight` link in the heading, and three legend rows with color dots.
- Invoice burn card: same shape as Cost burn but `violet-5` paid + `blue-5` unpaid palette and "All invoices" link.
- Extends `frontend/packages/app/src/global.css` `@theme` with three surface stops (`surface-blue-5: #007be0`, `surface-violet-5: #664ecc`, `surface-green-3: #c3f9d3` mint override). frappe-ui-react themeV3 maps `surface-green-3` to dark green; Figma uses mint here, so the app-level override matches the existing precedent for `surface-green-5` / `surface-blue-4` / `surface-amber-5` overrides.
- Pure FE / fake data (no API wiring); the "All Timesheets" / "All invoices" link targets are non-clickable spans for now since the issue marks click behavior `TBD`.

Resolves #1233.

## Verification

Browser quality-gate on `https://pms-temp.frappe.rt.gw/next-pms/projects/atlas-ui-stabilisation` → Tracking tab — all 7 checks PASS:
- 4 KPI cards present and positioned above the existing 7 KnowledgePoint cards.
- Hours card: heading "Hours usage", "65% completed" label (utilised:250 / total:385 = 65%), bar fill at 65%, marker line at 65%.
- Task completion card: SVG donut with 2 `<circle>` elements, center "52%" + "completed" (104/200 = 52%), 3 legend rows without color dots.
- Cost burn: heading "Cost burn (to date)", `green-5` 48.33% + `green-3` 31.67% segments (29/60 + 19/60), 3 legend rows with dots ($29k / $19k / $60k).
- Invoice burn: heading "Invoice burn (to date)", `violet-5` 35% + `blue-5` 12% segments, 3 legend rows ($35k / $12k / $100k).
- No new console errors, all 23 network requests 200.

## Test plan

- [ ] Pull the branch, run `npm run build:app` inside `fm shell`, navigate to Project → Tracking, confirm the 4 KPI cards render correctly above the summary cards.
- [ ] Confirm the bar fills, donut sweep, legend dots, and currency labels match the static fake data.
- [ ] Confirm `surface-blue-5` / `surface-violet-5` / `surface-green-3` (mint) tokens render as expected in light mode.
- [ ] Confirm no regressions on the existing 7 KnowledgePoint summary cards.