### PR TITLE
feat(pm-project-report): real-time status tracking with resync support

### DIFF
--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -32,9 +32,11 @@ const toLocalDateString = (date: Date): string => {
 };
 
 interface PMReportRow {
+  run_id: string;
   report_link: string;
   date_range: string;
   generated_on: string;
+  status: "Generating" | "Completed" | "Failed" | "Done" | "";
 }
 
 interface PMReportProps {
@@ -67,11 +69,13 @@ const PMReport = ({ projectId }: PMReportProps) => {
 
   const [includePreviousReport, setIncludePreviousReport] = useState(false);
 
+  const [resyncingRunId, setResyncingRunId] = useState<string | null>(null);
+
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const prevCountRef = useRef(0);
   const mutateRef = useRef(mutate);
   const isInitializedRef = useRef(false);
   const slackSlugRef = useRef(slackSlug);
+  const prevReportsRef = useRef<PMReportRow[]>([]);
 
   useEffect(() => {
     mutateRef.current = mutate;
@@ -115,32 +119,73 @@ const PMReport = ({ projectId }: PMReportProps) => {
     const handler = (data: unknown) => {
       const event = data as PMReportEvent;
       if (event.project !== projectId) return;
-      if (event.error) {
-        if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        setIsGenerating(false);
-        toast({ variant: "destructive", description: event.error });
-        return;
-      }
       mutateRef.current();
     };
 
     window.frappe?.realtime?.on("pm_report_ready", handler);
     return () => window.frappe?.realtime?.off("pm_report_ready", handler);
-  }, [projectId, toast]);
-
-  useEffect(() => {
-    if (!isGenerating) return;
-    const currentCount = projectData?.custom_project_reports?.length ?? 0;
-    if (currentCount > prevCountRef.current) {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      setIsGenerating(false);
-      toast({ variant: "success", description: "Project Report is Ready! ✅" });
-    }
-  }, [projectData?.custom_project_reports?.length, isGenerating, toast]);
+  }, [projectId]);
 
   const { updateDoc, loading: saving } = useFrappeUpdateDoc();
   const { call } = useFrappePostCall(
     "next_pms.api.generate_pm_report.generate_pm_report",
+  );
+
+  const reports = (projectData?.custom_project_reports ?? []) as PMReportRow[];
+  const completedReports = reports.filter((r) => r.status === "Done");
+  const lastReportLink =
+    completedReports.length > 0
+      ? completedReports[completedReports.length - 1].report_link
+      : null;
+  const isCustom = duration === "Custom";
+  const isAnyGenerating = reports.some((r) => r.status === "Generating");
+  const isBusy = saving || isAnyGenerating;
+
+  useEffect(() => {
+    const prev = prevReportsRef.current;
+
+    reports.forEach((r) => {
+      const prevRow = prev.find((p) => p.run_id === r.run_id);
+
+      if (prevRow?.status === "Generating" && r.status === "Done") {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setIsGenerating(false);
+        toast({
+          variant: "success",
+          description: "Project Report is Ready! ✅",
+        });
+      }
+
+      if (prevRow?.status === "Generating" && r.status === "Failed") {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setIsGenerating(false);
+        toast({
+          variant: "destructive",
+          description: "Report generation failed.",
+        });
+      }
+
+      if (prevRow?.status === "Generating" && r.status === "Completed") {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setIsGenerating(false);
+        toast({
+          variant: "destructive",
+          description: "Report completed but no document found. Click Resync.",
+        });
+      }
+    });
+
+    prevReportsRef.current = reports;
+  }, [reports, toast]);
+
+  useEffect(() => {
+    if (!isAnyGenerating) return;
+    const interval = setInterval(() => mutateRef.current(), 5000);
+    return () => clearInterval(interval);
+  }, [isAnyGenerating]);
+
+  const { call: resyncCall } = useFrappePostCall(
+    "next_pms.api.generate_pm_report.resync_report",
   );
 
   const handleDurationChange = useCallback((value: string) => {
@@ -188,7 +233,6 @@ const PMReport = ({ projectId }: PMReportProps) => {
       return;
     }
 
-    prevCountRef.current = projectData?.custom_project_reports?.length ?? 0;
     setIsGenerating(true);
 
     try {
@@ -205,6 +249,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
           ? { previous_doc_url: lastReportLink }
           : {}),
       });
+      mutateRef.current();
 
       toast({
         variant: "success",
@@ -241,11 +286,47 @@ const PMReport = ({ projectId }: PMReportProps) => {
     }
   };
 
-  const reports = (projectData?.custom_project_reports ?? []) as PMReportRow[];
-  const lastReportLink =
-    reports.length > 0 ? reports[reports.length - 1].report_link : null;
-  const isCustom = duration === "Custom";
-  const isBusy = isGenerating || saving;
+  const handleResync = async (runId: string) => {
+    setResyncingRunId(runId);
+    try {
+      const result = await resyncCall({ project: projectId, run_id: runId });
+      const status = result?.message?.status;
+
+      if (status === "success") {
+        toast({ variant: "success", description: "Report document found! ✅" });
+        mutateRef.current();
+      } else if (status === "timeout") {
+        toast({
+          variant: "destructive",
+          description: "Document still not available. Try resyncing later.",
+        });
+      } else if (status === "failed") {
+        toast({
+          variant: "destructive",
+          description: "Report failed during resync.",
+        });
+        mutateRef.current();
+      } else {
+        toast({
+          variant: "destructive",
+          description: "Document not available yet. Try again later.",
+        });
+      }
+    } catch (error) {
+      const err = error as FrappeError;
+      toast({
+        variant: "destructive",
+        description: err?.message || "Resync failed.",
+      });
+    } finally {
+      setResyncingRunId(null);
+    }
+  };
+
+  const isGeneratingRow = (r: PMReportRow) => r.status === "Generating";
+  const isFailedRow = (r: PMReportRow) => r.status === "Failed";
+  const isResyncableRow = (r: PMReportRow) => r.status === "Completed";
+  const getRowRunId = (r: PMReportRow) => r.run_id || null;
 
   return (
     <div className="flex flex-col gap-6 p-4">
@@ -513,28 +594,80 @@ const PMReport = ({ projectId }: PMReportProps) => {
                 </tr>
               </thead>
               <tbody>
-                {reports.map((report, index) => (
-                  <tr
-                    key={`${report.report_link}-${index}`}
-                    className={`border-t hover:bg-muted/50 ${index === reports.length - 1 ? "bg-primary/5 font-medium" : ""}`}
-                  >
-                    <td className="px-4 py-2">{index + 1}</td>
-                    <td className="px-4 py-2">
-                      <a
-                        href={report.report_link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline"
-                      >
-                        View Report
-                      </a>
-                    </td>
-                    <td className="px-4 py-2">{report.date_range}</td>
-                    <td className="px-4 py-2">
-                      {formatDate(report.generated_on)}
-                    </td>
-                  </tr>
-                ))}
+                {reports.map((report, index) => {
+                  const generating = isGeneratingRow(report);
+                  const failed = isFailedRow(report);
+                  const resyncable = isResyncableRow(report);
+                  const runId = getRowRunId(report);
+
+                  return (
+                    <tr
+                      key={report.run_id || `report-${index}`}
+                      className={`border-t hover:bg-muted/50 ${
+                        generating
+                          ? "bg-yellow-50"
+                          : failed || resyncable
+                            ? "bg-red-50"
+                            : ""
+                      }`}
+                    >
+                      <td className="px-4 py-2">{index + 1}</td>
+
+                      <td className="px-4 py-2">
+                        {generating && (
+                          <span className="text-yellow-600 text-sm flex items-center gap-2">
+                            <Spinner className="w-3 h-3" /> Generating...
+                          </span>
+                        )}
+                        {failed && (
+                          <span className="text-red-600 text-sm">
+                            ❌ Failed
+                          </span>
+                        )}
+                        {resyncable && runId && (
+                          <div className="flex items-center gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleResync(runId)}
+                              disabled={resyncingRunId === runId}
+                            >
+                              {resyncingRunId === runId ? (
+                                <>
+                                  <Spinner className="mr-1 w-3 h-3" />{" "}
+                                  Resyncing...
+                                </>
+                              ) : (
+                                "🔄 Resync"
+                              )}
+                            </Button>
+                            <span className="text-xs text-muted-foreground">
+                              Report completed but document not found. Click
+                              Resync to check again.
+                            </span>
+                          </div>
+                        )}
+                        {!generating && !failed && !resyncable && (
+                          <a
+                            href={report.report_link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary underline"
+                          >
+                            View Report
+                          </a>
+                        )}
+                      </td>
+
+                      <td className="px-4 py-2">{report.date_range}</td>
+
+                      <td className="px-4 py-2">
+                        {/* Always show timestamp if available */}
+                        <span>{formatDate(report.generated_on)}</span>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -33,9 +33,9 @@ const toLocalDateString = (date: Date): string => {
 
 interface PMReportRow {
   run_id: string;
-  report_link: string;
+  report_link?: string;
   date_range: string;
-  generated_on: string;
+  generated_on?: string;
   status: "Generating" | "Completed" | "Failed" | "Done" | "";
 }
 
@@ -132,10 +132,12 @@ const PMReport = ({ projectId }: PMReportProps) => {
   );
 
   const reports = (projectData?.custom_project_reports ?? []) as PMReportRow[];
-  const completedReports = reports.filter((r) => r.status === "Done");
+  const completedReports = reports.filter(
+    (r) => r.status === "Done" && !!r.report_link,
+  );
   const lastReportLink =
     completedReports.length > 0
-      ? completedReports[completedReports.length - 1].report_link
+      ? (completedReports[completedReports.length - 1].report_link ?? null)
       : null;
   const isCustom = duration === "Custom";
   const isAnyGenerating = reports.some((r) => r.status === "Generating");
@@ -492,10 +494,14 @@ const PMReport = ({ projectId }: PMReportProps) => {
           {(projectData?.custom_project_repository_connections ?? []).length >
             0 && (
             <div className="flex flex-col gap-1 col-span-2">
-              <label className="text-sm text-muted-foreground">
-                Github Repository
+              <label
+                htmlFor="github-repo"
+                className="text-sm text-muted-foreground"
+              >
+                GitHub Repository
               </label>
               <select
+                id="github-repo"
                 className="border rounded px-3 py-2 text-sm"
                 value={selectedRepo}
                 onChange={(e) => setSelectedRepo(e.target.value)}
@@ -663,7 +669,11 @@ const PMReport = ({ projectId }: PMReportProps) => {
 
                       <td className="px-4 py-2">
                         {/* Always show timestamp if available */}
-                        <span>{formatDate(report.generated_on)}</span>
+                        <span>
+                          {report.generated_on
+                            ? formatDate(report.generated_on)
+                            : ""}
+                        </span>
                       </td>
                     </tr>
                   );

--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -63,6 +63,8 @@ const PMReport = ({ projectId }: PMReportProps) => {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [isEditingSlack, setIsEditingSlack] = useState(false);
 
+  const [selectedRepo, setSelectedRepo] = useState("");
+
   const [includePreviousReport, setIncludePreviousReport] = useState(false);
 
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -97,6 +99,10 @@ const PMReport = ({ projectId }: PMReportProps) => {
     isInitializedRef.current = true;
     setDriveLink(projectData.custom_project_drive_link || "");
     setSlackSlug(projectData.custom_slack_channel_slug || "");
+    const repos = projectData.custom_project_repository_connections || [];
+    if (repos.length > 0) {
+      setSelectedRepo(repos[0].github_repository || "");
+    }
   }, [projectData]);
 
   useEffect(() => {
@@ -194,6 +200,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
         project: projectId,
         from_date: fromDate,
         to_date: toDate,
+        selected_repo: selectedRepo,
         ...(includePreviousReport && lastReportLink
           ? { previous_doc_url: lastReportLink }
           : {}),
@@ -210,6 +217,10 @@ const PMReport = ({ projectId }: PMReportProps) => {
       setFromDate("");
       setToDate("");
       setIncludePreviousReport(false);
+      setSelectedRepo(
+        projectData?.custom_project_repository_connections?.[0]
+          ?.github_repository || "",
+      );
 
       timeoutRef.current = setTimeout(() => {
         setIsGenerating(false);
@@ -395,6 +406,40 @@ const PMReport = ({ projectId }: PMReportProps) => {
               disabled={isBusy}
             />
           </div>
+
+          {/* Repository */}
+          {(projectData?.custom_project_repository_connections ?? []).length >
+            0 && (
+            <div className="flex flex-col gap-1 col-span-2">
+              <label className="text-sm text-muted-foreground">
+                Github Repository
+              </label>
+              <select
+                className="border rounded px-3 py-2 text-sm"
+                value={selectedRepo}
+                onChange={(e) => setSelectedRepo(e.target.value)}
+                disabled={isBusy}
+              >
+                {(projectData?.custom_project_repository_connections ?? []).map(
+                  (repo: { github_repository: string }) => {
+                    const repoName =
+                      (repo.github_repository || "")
+                        .replace(/\/$/, "")
+                        .split("/")
+                        .pop() || repo.github_repository;
+                    return (
+                      <option
+                        key={repo.github_repository}
+                        value={repo.github_repository}
+                      >
+                        {repoName}
+                      </option>
+                    );
+                  },
+                )}
+              </select>
+            </div>
+          )}
 
           {/* Drive Link — readonly */}
           <div className="flex flex-col gap-1 col-span-2">

--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -12,7 +12,7 @@ LLM_STATUS_URL = "https://rt-report-automation.rt.gw/api/inngest/runs"
 INITIAL_DELAY = 30
 POLL_INTERVAL = 15
 MAX_POLL_DURATION = 840
-MAX_OUTPUT_RETRIES = 10
+MAX_OUTPUT_RETRIES = 4
 COMPLETION_POLL_INTERVAL = 30
 
 
@@ -84,6 +84,12 @@ def generate_pm_report(
 
         run_id = run_ids[0]
 
+        save_report_to_child_table(
+            project=project,
+            run_id=run_id,
+            date_range=f"{from_date} to {to_date}",
+        )
+
         frappe.enqueue(
             "next_pms.api.generate_pm_report.check_and_save_report",
             project=project,
@@ -125,6 +131,7 @@ def check_and_save_report(project, run_id, user, from_date, to_date):
         # Timeout check
         if elapsed >= MAX_POLL_DURATION:
             frappe.log_error(f"run_id: {run_id} | project: {project}", "PM Report — Poll Timeout")
+            update_report_row(project, run_id, status="Failed", generated_on=frappe.utils.now())
             _notify(project, user, error="Polling timed out after 10 minutes.")
             return
 
@@ -144,21 +151,28 @@ def check_and_save_report(project, run_id, user, from_date, to_date):
 
             if status == "Completed":
                 document_url = output.get("document_url") if output else None
-
                 if document_url:
-                    save_report_to_child_table(
+                    # Update row with actual URL and datetime
+                    update_report_row(
                         project=project,
+                        run_id=run_id,
                         report_link=document_url,
-                        date_range=f"{from_date} to {to_date}",
                         generated_on=frappe.utils.now(),
+                        status="Done",
                     )
                     _notify(project, user, doc_link=document_url)
                     _send_bell_notification(project, user, document_url)
                     return
-
                 else:
                     output_retry_count += 1
                     if output_retry_count >= MAX_OUTPUT_RETRIES:
+                        # Completed but no doc_url — keep run_id for resync
+                        update_report_row(
+                            project=project,
+                            run_id=run_id,
+                            status="Completed",
+                            generated_on=frappe.utils.now(),
+                        )
                         _notify(project, user, error="Process completed but no document was generated.")
                         return
                     time.sleep(COMPLETION_POLL_INTERVAL)
@@ -166,6 +180,7 @@ def check_and_save_report(project, run_id, user, from_date, to_date):
 
             elif status in ("Failed", "Cancelled"):
                 frappe.log_error(f"run_id: {run_id} | status: {status}", "PM Report — Failed/Cancelled")
+                update_report_row(project=project, run_id=run_id, status="Failed", generated_on=frappe.utils.now())
                 _notify(project, user, error=f"Report generation {status.lower()}.")
                 return
 
@@ -177,17 +192,107 @@ def check_and_save_report(project, run_id, user, from_date, to_date):
         time.sleep(POLL_INTERVAL)
 
 
-def save_report_to_child_table(project, report_link, date_range, generated_on):
+# save_report_to_child_table — clean, no status hacks
+def save_report_to_child_table(project, run_id, date_range):
     try:
         project_doc = frappe.get_doc("Project", project)
         project_doc.append(
             "custom_project_reports",
-            {"report_link": report_link, "date_range": date_range, "generated_on": generated_on},
+            {
+                "run_id": run_id,
+                "date_range": date_range,
+                "status": "Generating",
+            },
         )
         project_doc.save(ignore_permissions=True)
         frappe.db.commit()
     except Exception:
         frappe.log_error(frappe.get_traceback(), "PM Report — Save Error")
+
+
+# update_report_row — match by run_id field now
+def update_report_row(project, run_id, report_link=None, generated_on=None, status=None):
+    try:
+        project_doc = frappe.get_doc("Project", project)
+        for row in project_doc.custom_project_reports:
+            if row.run_id == run_id:
+                if report_link is not None:
+                    row.report_link = report_link
+                if generated_on is not None:
+                    row.generated_on = generated_on
+                if status is not None:
+                    row.status = status
+                break
+        project_doc.save(ignore_permissions=True)
+        frappe.db.commit()
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "PM Report — Update Row Error")
+
+
+@frappe.whitelist()
+def resync_report(project: str, run_id: str) -> dict:
+    """Poll for document_url for a completed run"""
+    frappe.has_permission("Project", doc=project, ptype="write", throw=True)
+
+    RESYNC_POLL_INTERVAL = 10
+    RESYNC_MAX_DURATION = 120  # 2 minutes max
+
+    poll_start = time.time()
+
+    try:
+        while True:
+            elapsed = time.time() - poll_start
+
+            if elapsed >= RESYNC_MAX_DURATION:
+                return {"status": "timeout"}
+
+            response = requests.get(
+                f"{LLM_STATUS_URL}/{run_id}",
+                headers={"x-api-key": get_api_key()},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if not data or not data.get("data"):
+                time.sleep(RESYNC_POLL_INTERVAL)
+                continue
+
+            run = data["data"][0]
+            status = run.get("status")
+            output = run.get("output")
+
+            if status == "Completed":
+                document_url = output.get("document_url") if output else None
+                if document_url:
+                    update_report_row(
+                        project=project,
+                        run_id=run_id,
+                        report_link=document_url,
+                        generated_on=frappe.utils.now(),
+                        status="Done",
+                    )
+                    return {"status": "success", "document_url": document_url}
+
+                # Not ready yet — keep polling
+                time.sleep(RESYNC_POLL_INTERVAL)
+                continue
+
+            # If Failed/Cancelled during resync
+            if status in ("Failed", "Cancelled"):
+                update_report_row(
+                    project=project,
+                    run_id=run_id,
+                    status="Failed",
+                    generated_on=frappe.utils.now(),
+                )
+                return {"status": "failed"}
+
+            time.sleep(RESYNC_POLL_INTERVAL)
+
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "PM Report — Resync Error")
+        frappe.throw(_("Failed to resync report. Please try again."))
 
 
 def _notify(project, user, doc_link=None, error=None):

--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -12,7 +12,7 @@ LLM_STATUS_URL = "https://rt-report-automation.rt.gw/api/inngest/runs"
 INITIAL_DELAY = 30
 POLL_INTERVAL = 15
 MAX_POLL_DURATION = 840
-MAX_OUTPUT_RETRIES = 4
+MAX_OUTPUT_RETRIES = 5
 COMPLETION_POLL_INTERVAL = 30
 
 
@@ -192,7 +192,6 @@ def check_and_save_report(project, run_id, user, from_date, to_date):
         time.sleep(POLL_INTERVAL)
 
 
-# save_report_to_child_table — clean, no status hacks
 def save_report_to_child_table(project, run_id, date_range):
     try:
         project_doc = frappe.get_doc("Project", project)
@@ -208,9 +207,10 @@ def save_report_to_child_table(project, run_id, date_range):
         frappe.db.commit()
     except Exception:
         frappe.log_error(frappe.get_traceback(), "PM Report — Save Error")
+        raise
 
 
-# update_report_row — match by run_id field now
+# update_report_row — match by run_id field
 def update_report_row(project, run_id, report_link=None, generated_on=None, status=None):
     try:
         project_doc = frappe.get_doc("Project", project)
@@ -233,6 +233,13 @@ def update_report_row(project, run_id, report_link=None, generated_on=None, stat
 def resync_report(project: str, run_id: str) -> dict:
     """Poll for document_url for a completed run"""
     frappe.has_permission("Project", doc=project, ptype="write", throw=True)
+
+    project_doc = frappe.get_doc("Project", project)
+    matching_row = next(
+        (row for row in project_doc.custom_project_reports if row.run_id == run_id and row.status == "Completed"), None
+    )
+    if not matching_row:
+        frappe.throw(_("Invalid run ID or report is not in a resyncable state."))
 
     RESYNC_POLL_INTERVAL = 10
     RESYNC_MAX_DURATION = 120  # 2 minutes max
@@ -329,7 +336,10 @@ def _send_bell_notification(project, user, document_url):
 
 def get_github_metadata(project_doc, selected_repo: str | None = None):
     repos = project_doc.get("custom_project_repository_connections") or []
+    allowed_repos = [r.get("github_repository") for r in repos]
     if selected_repo:
+        if selected_repo not in allowed_repos:
+            frappe.throw(_("Selected repository is not linked to this project."))
         repo_url = selected_repo
     elif repos:
         repo_url = repos[0].get("github_repository") or ""

--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -31,6 +31,7 @@ def generate_pm_report(
     from_date: str | None = None,
     to_date: str | None = None,
     previous_doc_url: str | None = None,
+    selected_repo: str | None = None,
 ) -> dict:
     frappe.has_permission("Project", doc=project, ptype="write", throw=True)
 
@@ -60,7 +61,7 @@ def generate_pm_report(
         },
         **({"previous_doc_url": previous_doc_url} if previous_doc_url else {}),
         "user_metadata": {"user_name": frappe.session.user, "user_email": frappe.session.user},
-        "github_metadata": get_github_metadata(project_doc),
+        "github_metadata": get_github_metadata(project_doc, selected_repo=selected_repo),
         "slack_metadata": {"channel_slug": project_doc.get("custom_slack_channel_slug") or ""},
         "hours_breakdown": get_hours_breakdown(project, from_date, to_date),
     }
@@ -221,10 +222,16 @@ def _send_bell_notification(project, user, document_url):
         frappe.log_error(frappe.get_traceback(), "PM Report — Bell Notification Error")
 
 
-def get_github_metadata(project_doc):
+def get_github_metadata(project_doc, selected_repo: str | None = None):
     repos = project_doc.get("custom_project_repository_connections") or []
-    if repos:
+    if selected_repo:
+        repo_url = selected_repo
+    elif repos:
         repo_url = repos[0].get("github_repository") or ""
+    else:
+        repo_url = ""
+
+    if repo_url:
         parts = repo_url.rstrip("/").split("/")
         repo_name = parts[-1] if len(parts) >= 1 else project_doc.get("project_name")
         owner_name = parts[-2] if len(parts) >= 2 else "rtCamp"

--- a/next_pms/next_pms/doctype/project_report/project_report.json
+++ b/next_pms/next_pms/doctype/project_report/project_report.json
@@ -8,7 +8,10 @@
  "field_order": [
   "report_link",
   "date_range",
-  "generated_on"
+  "generated_on",
+  "column_break_mrrs",
+  "run_id",
+  "status"
  ],
  "fields": [
   {
@@ -31,13 +34,29 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Generated On"
+  },
+  {
+   "fieldname": "run_id",
+   "fieldtype": "Data",
+   "label": "Run ID"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Generating\nCompleted\nFailed\nDone"
+  },
+  {
+   "fieldname": "column_break_mrrs",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-03 17:50:08.448243",
+ "modified": "2026-05-07 15:31:17.346801",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Project Report",

--- a/next_pms/next_pms/doctype/project_report/project_report.json
+++ b/next_pms/next_pms/doctype/project_report/project_report.json
@@ -19,33 +19,38 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Report Link",
-   "options": "URL"
+   "options": "URL",
+   "read_only": 1
   },
   {
    "fieldname": "date_range",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Date Range"
+   "label": "Date Range",
+   "read_only": 1
   },
   {
    "fieldname": "generated_on",
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Generated On"
+   "label": "Generated On",
+   "read_only": 1
   },
   {
    "fieldname": "run_id",
    "fieldtype": "Data",
-   "label": "Run ID"
+   "label": "Run ID",
+   "read_only": 1
   },
   {
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Generating\nCompleted\nFailed\nDone"
+   "options": "Generating\nCompleted\nFailed\nDone",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_mrrs",
@@ -56,7 +61,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-07 15:31:17.346801",
+ "modified": "2026-05-08 14:57:39.599881",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Project Report",


### PR DESCRIPTION
## Description
Adds real-time status tracking for PM Report generation with a Resync flow for edge cases where the report completes but the document URL is not immediately available.

Adds repository selector dropdown to allow choosing which GitHub repo to use when generating the report (when project has multiple repos connected)


## Relevant Technical Choices
- Added `run_id` and `status` fields to `Project Report` child DocType to track job state cleanly without abusing datetime/URL fields
- Row is saved immediately on trigger with `status=Generating` for instant UI feedback
- Background job matches and updates the row by `run_id` across all state transitions — `Done` (completed with document), `Failed` (Inngest failed, cancelled, or polling timeout) and `Completed` (Inngest completed but document not yet available, resync eligible) — with timestamps on all terminal states.
- If report completes without `document_url`, retries for 2 min before surfacing a Resync button — new `resync_report` API polls for up to 2 min on click and persists the button if doc is still unavailable
- Button state and toasts are derived from `status` field transitions instead of local React state, keeping UI in sync after page refresh without relying solely on realtime events

## Testing Instructions
1. Go to any Project → Project Report tab
2. Select a duration and click **Generate Project Report**
3. Verify a new **Generating...** row appears immediately without refresh
4. Wait for completion — row should update to **View Report** with timestamp and success toast, button should unlock — all without refresh
5. To test Failed: cancel/kill the background job — row should show ❌ Failed with timestamp
6. To test Resync: mock the status API to return `Completed` with no `document_url` — Resync button should appear after ~2 min, clicking it should resolve to **View Report** once doc is available

## Additional Information:
<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
<img width="2052" height="912" alt="image" src="https://github.com/user-attachments/assets/662338ef-2c7f-4656-9781-57a5916ef8c1" />

<img width="2938" height="1592" alt="image" src="https://github.com/user-attachments/assets/8228c7ea-95ca-444e-8b30-7e43fc6659f5" />

<img width="2654" height="1646" alt="image" src="https://github.com/user-attachments/assets/abaf9f55-b355-4a1a-bdea-ac1764c09bcf" />


https://github.com/user-attachments/assets/76aa4c99-5d06-4ede-8ce4-1f47daea7a94




## Checklist
<!-- Check these after creating PR, use NA if something is not applicable -->
- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes [AI Internal Issue](https://github.com/rtCamp/AI-Internal/issues/9)
