### PR TITLE
Feat: Show improved error screen on failures

### DIFF
--- a/frontend/packages/app/src/app.tsx
+++ b/frontend/packages/app/src/app.tsx
@@ -30,23 +30,25 @@ const App = () => {
   });
 
   return (
-    <ToastProvider>
-      <FrappeProvider>
-        <ThemeProvider>
-          <UserProvider>
-            <Provider store={store}>
-              <TooltipProvider>
-                <Suspense fallback={<></>}>
-                  <ErrorFallback>
-                    <RouterProvider router={router} />
-                  </ErrorFallback>
-                </Suspense>
-              </TooltipProvider>
-            </Provider>
-          </UserProvider>
-        </ThemeProvider>
-      </FrappeProvider>
-    </ToastProvider>
+    <ErrorFallback>
+      <ToastProvider>
+        <FrappeProvider>
+          <ThemeProvider>
+            <UserProvider>
+              <Provider store={store}>
+                <TooltipProvider>
+                  <Suspense fallback={<></>}>
+                    <ErrorFallback>
+                      <RouterProvider router={router} />
+                    </ErrorFallback>
+                  </Suspense>
+                </TooltipProvider>
+              </Provider>
+            </UserProvider>
+          </ThemeProvider>
+        </FrappeProvider>
+      </ToastProvider>
+    </ErrorFallback>
   );
 };
 

--- a/frontend/packages/app/src/layout/index.tsx
+++ b/frontend/packages/app/src/layout/index.tsx
@@ -14,7 +14,6 @@ import { useUser } from "@/providers/user";
 const LayoutWithSidebar = () => {
   const { employeeId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
-    userId: state.userId,
   }));
 
   return (

--- a/frontend/packages/app/src/layout/index.tsx
+++ b/frontend/packages/app/src/layout/index.tsx
@@ -12,37 +12,27 @@ import Sidebar from "@/layout/sidebar";
 import { useUser } from "@/providers/user";
 
 const LayoutWithSidebar = () => {
-  const { employeeId, hasError } = useUser(({ state }) => ({
+  const { employeeId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
-    hasError: state.hasError,
     userId: state.userId,
   }));
 
-  const canRenderOutlet = Boolean(employeeId) && !hasError;
-
   return (
     <ErrorFallback>
-      <div className="flex flex-row h-screen w-full">
-        <ErrorFallback>
-          <Sidebar />
-        </ErrorFallback>
-        <div className="w-full overflow-hidden flex flex-col">
-          {canRenderOutlet && (
-            <>
-              <Suspense fallback={<></>}>
-                <ErrorFallback>
-                  <Outlet />
-                </ErrorFallback>
-              </Suspense>
-            </>
-          )}
-          {!canRenderOutlet && hasError && (
-            <div className="flex h-full items-center justify-center px-6">
-              <p className="text-base text-ink-gray-6">Something went wrong.</p>
-            </div>
-          )}
+      {Boolean(employeeId) && (
+        <div className="flex flex-row h-screen w-full">
+          <ErrorFallback>
+            <Sidebar />
+          </ErrorFallback>
+          <div className="w-full overflow-hidden flex flex-col">
+            <Suspense fallback={<></>}>
+              <ErrorFallback>
+                <Outlet />
+              </ErrorFallback>
+            </Suspense>
+          </div>
         </div>
-      </div>
+      )}
     </ErrorFallback>
   );
 };

--- a/frontend/packages/app/src/providers/user/index.ts
+++ b/frontend/packages/app/src/providers/user/index.ts
@@ -15,8 +15,6 @@ export interface UserContextProps {
   state: {
     /** Indicates whether user/auth data is still being resolved. */
     isLoading: boolean;
-    /** Indicates whether bootstrap data required for the app failed to load. */
-    hasError: boolean;
     /** Employee record ID linked to the current user. */
     employeeId: string;
     /** Display name of the current employee. */
@@ -59,7 +57,6 @@ export interface UserContextProps {
 export const UserContext = createContext<UserContextProps>({
   state: {
     isLoading: false,
-    hasError: false,
     employeeId: "",
     employeeName: "",
     workingHours: 0,

--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -69,17 +69,11 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   );
 
   if (appDataError) {
-    throw new Error(
-      appDataError ? parseFrappeErrorMsg(appDataError) : "There was an error.",
-    );
+    throw new Error(parseFrappeErrorMsg(appDataError));
   }
 
   if (employeeDataError) {
-    throw new Error(
-      employeeDataError
-        ? parseFrappeErrorMsg(employeeDataError)
-        : "There was an error.",
-    );
+    throw new Error(parseFrappeErrorMsg(employeeDataError));
   }
 
   useEffect(() => {

--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -9,7 +9,7 @@ import { useFrappeAuth, useFrappeGetCall } from "frappe-react-sdk";
  */
 import { ROLES } from "@/lib/constant";
 import { getLocalStorage, setLocalStorage } from "@/lib/storage";
-import { getCookie } from "@/lib/utils";
+import { getCookie, parseFrappeErrorMsg } from "@/lib/utils";
 import { UserContext, type UserContextProps } from ".";
 
 export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -53,11 +53,9 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const { logout, isLoading: isAuthLoading, currentUser } = useFrappeAuth();
 
-  const {
-    isLoading: isAppDataLoading,
-    data: appData,
-    error: appDataError,
-  } = useFrappeGetCall("next_pms.timesheet.api.app.get_data");
+  const { data: appData, error: appDataError } = useFrappeGetCall(
+    "next_pms.timesheet.api.app.get_data",
+  );
 
   useEffect(() => {
     setRoles(appData?.message?.roles || []);
@@ -66,16 +64,23 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
     setHasIndustryField(appData?.message?.has_industry || false);
   }, [appData]);
 
-  const {
-    isLoading: isEmployeeDataLoading,
-    data: employeeData,
-    error: employeeDataError,
-  } = useFrappeGetCall("next_pms.timesheet.api.employee.get_data");
+  const { data: employeeData, error: employeeDataError } = useFrappeGetCall(
+    "next_pms.timesheet.api.employee.get_data",
+  );
 
-  const hasError =
-    Boolean(appDataError || employeeDataError) ||
-    (!isAppDataLoading && !appData?.message) ||
-    (!isEmployeeDataLoading && !employeeData?.message?.employee);
+  if (appDataError) {
+    throw new Error(
+      appDataError ? parseFrappeErrorMsg(appDataError) : "There was an error.",
+    );
+  }
+
+  if (employeeDataError) {
+    throw new Error(
+      employeeDataError
+        ? parseFrappeErrorMsg(employeeDataError)
+        : "There was an error.",
+    );
+  }
 
   useEffect(() => {
     setEmployeeId(employeeData?.message?.employee ?? "");
@@ -114,7 +119,6 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
       value={{
         state: {
           isLoading: isAuthLoading,
-          hasError,
           employeeId,
           employeeName,
           workingHours,

--- a/frontend/packages/design-system/src/components/error-fallback/index.tsx
+++ b/frontend/packages/design-system/src/components/error-fallback/index.tsx
@@ -17,6 +17,10 @@ type ErrorFallbackState = {
   error: Error | null;
 };
 
+/**
+ * React still requires a class component for a true error boundary.
+ * Function components cannot implement getDerivedStateFromError or componentDidCatch.
+ */
 class ErrorFallback extends Component<ErrorFallbackProp, ErrorFallbackState> {
   state: ErrorFallbackState = {
     hasError: false,

--- a/frontend/packages/design-system/src/components/error-fallback/index.tsx
+++ b/frontend/packages/design-system/src/components/error-fallback/index.tsx
@@ -32,15 +32,23 @@ class ErrorFallback extends Component<ErrorFallbackProp, ErrorFallbackState> {
   }
 
   render() {
-    const { hasError } = this.state;
+    const { hasError, error } = this.state;
     const { children, fallback } = this.props;
 
     return hasError
       ? fallback || (
-          <div className="w-full h-full flex justify-center items-center">
-            <Typography variant="p" className="text-slate-600 font-medium">
+          <div className="w-full h-full flex flex-col gap-1 justify-center items-center">
+            <Typography variant="p" className="text-ink-gray-7 font-medium">
               Something went wrong
             </Typography>
+            {error?.message ? (
+              <Typography
+                variant="p"
+                className="wrap-break-word text-sm text-ink-gray-5"
+              >
+                {error.message}
+              </Typography>
+            ) : null}
           </div>
         )
       : children;


### PR DESCRIPTION
## Description

- The `ErrorFallback` component has been updated to display detailed error messages on the error screen.
- `UserProvider` now throws an error when critical API requests fail, such as when an Employee record is not found, and forwards the parsed error to `ErrorFallback`.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
-  React still requires a class component for a true error boundary. Function components cannot implement getDerivedStateFromError or componentDidCatch. 
source: https://react.dev/reference/react/Component#:~:text=There%20is%20no%20direct%20equivalent%20for%20componentDidCatch%20in%20function%20components%20yet.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
1. Log in as a user who does not have an associated Employee record.
2. Navigate to NextPMS.
3. Verify that the error screen is displayed with the appropriate error message.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

Error when a user without an Employee record tries to access NextPMS:

<img width="1664" height="736" alt="Screenshot 2026-05-08 at 7 57 07 PM" src="https://github.com/user-attachments/assets/4dfcd39c-cccd-465c-bef1-cca03d0b1725" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1206