### PR TITLE
fix(pm-report): increase poll interval from 5s to 30s

### DIFF
--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -182,7 +182,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
 
   useEffect(() => {
     if (!isAnyGenerating) return;
-    const interval = setInterval(() => mutateRef.current(), 5000);
+    const interval = setInterval(() => mutateRef.current(), 30000);
     return () => clearInterval(interval);
   }, [isAnyGenerating]);
 

--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -19,6 +19,8 @@ import {
   useFrappeUpdateDoc,
 } from "frappe-react-sdk";
 
+import { mergeClassNames } from "@/lib/utils";
+
 const formatDate = (datetime: string) => {
   if (!datetime) return "";
   return new Date(datetime.replace(" ", "T")).toLocaleDateString("en-GB", {
@@ -480,7 +482,10 @@ const PMReport = ({ projectId }: PMReportProps) => {
             </label>
             <Input
               type="date"
-              className={`${!isCustom ? "bg-muted text-muted-foreground cursor-not-allowed" : ""}`}
+              className={mergeClassNames(
+                !isCustom &&
+                  "bg-muted text-muted-foreground cursor-not-allowed",
+              )}
               value={fromDate}
               onChange={(e) => {
                 if (isCustom) setFromDate(e.target.value);
@@ -496,7 +501,10 @@ const PMReport = ({ projectId }: PMReportProps) => {
             </label>
             <Input
               type="date"
-              className={`${!isCustom ? "bg-muted text-muted-foreground cursor-not-allowed" : ""}`}
+              className={mergeClassNames(
+                !isCustom &&
+                  "bg-muted text-muted-foreground cursor-not-allowed",
+              )}
               value={toDate}
               onChange={(e) => {
                 if (isCustom) setToDate(e.target.value);
@@ -624,13 +632,11 @@ const PMReport = ({ projectId }: PMReportProps) => {
                   return (
                     <tr
                       key={report.run_id || `report-${index}`}
-                      className={`border-t hover:bg-muted/50 ${
-                        generating
-                          ? "bg-yellow-50"
-                          : failed || resyncable
-                            ? "bg-red-50"
-                            : ""
-                      }`}
+                      className={mergeClassNames(
+                        "border-t hover:bg-muted/50",
+                        generating && "bg-yellow-50",
+                        (failed || resyncable) && "bg-red-50",
+                      )}
                     >
                       <td className="px-4 py-2">{index + 1}</td>
 

--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -4,6 +4,12 @@ import {
   ComboBox,
   Spinner,
   useToast,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
 } from "@next-pms/design-system/components";
 import {
   FrappeError,
@@ -234,7 +240,13 @@ const PMReport = ({ projectId }: PMReportProps) => {
       });
       return;
     }
-
+    if (fromDate && toDate && fromDate > toDate) {
+      toast({
+        variant: "destructive",
+        description: "From Date cannot be after To Date.",
+      });
+      return;
+    }
     setIsGenerating(true);
 
     try {
@@ -341,18 +353,21 @@ const PMReport = ({ projectId }: PMReportProps) => {
             <label className="text-sm text-muted-foreground">
               Report Duration
             </label>
-            <select
-              className="border rounded px-3 py-2 text-sm"
+            <Select
               value={duration}
-              onChange={(e) => handleDurationChange(e.target.value)}
+              onValueChange={(value) => handleDurationChange(value)}
               disabled={isBusy}
             >
-              <option value="">Select...</option>
-              <option value="Last Week">Last Week</option>
-              <option value="Last 15 Days">Last 15 Days</option>
-              <option value="Last Month">Last Month</option>
-              <option value="Custom">Custom</option>
-            </select>
+              <SelectTrigger>
+                <SelectValue placeholder="Select..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Last Week">Last Week</SelectItem>
+                <SelectItem value="Last 15 Days">Last 15 Days</SelectItem>
+                <SelectItem value="Last Month">Last Month</SelectItem>
+                <SelectItem value="Custom">Custom</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           {/* Slack Channel */}
@@ -439,9 +454,9 @@ const PMReport = ({ projectId }: PMReportProps) => {
                 </>
               ) : (
                 <>
-                  <input
+                  <Input
                     type="text"
-                    className="border rounded px-3 py-2 text-sm flex-1 bg-muted text-muted-foreground cursor-not-allowed"
+                    className="flex-1 bg-muted text-muted-foreground cursor-not-allowed"
                     value={slackSlug || "Not set"}
                     readOnly
                   />
@@ -463,9 +478,9 @@ const PMReport = ({ projectId }: PMReportProps) => {
             <label className="text-sm text-muted-foreground">
               Report From Date
             </label>
-            <input
+            <Input
               type="date"
-              className={`border rounded px-3 py-2 text-sm ${!isCustom ? "bg-muted text-muted-foreground cursor-not-allowed" : ""}`}
+              className={`${!isCustom ? "bg-muted text-muted-foreground cursor-not-allowed" : ""}`}
               value={fromDate}
               onChange={(e) => {
                 if (isCustom) setFromDate(e.target.value);
@@ -479,9 +494,9 @@ const PMReport = ({ projectId }: PMReportProps) => {
             <label className="text-sm text-muted-foreground">
               Report To Date
             </label>
-            <input
+            <Input
               type="date"
-              className={`border rounded px-3 py-2 text-sm ${!isCustom ? "bg-muted text-muted-foreground cursor-not-allowed" : ""}`}
+              className={`${!isCustom ? "bg-muted text-muted-foreground cursor-not-allowed" : ""}`}
               value={toDate}
               onChange={(e) => {
                 if (isCustom) setToDate(e.target.value);
@@ -494,37 +509,37 @@ const PMReport = ({ projectId }: PMReportProps) => {
           {(projectData?.custom_project_repository_connections ?? []).length >
             0 && (
             <div className="flex flex-col gap-1 col-span-2">
-              <label
-                htmlFor="github-repo"
-                className="text-sm text-muted-foreground"
-              >
+              <label className="text-sm text-muted-foreground">
                 GitHub Repository
               </label>
-              <select
-                id="github-repo"
-                className="border rounded px-3 py-2 text-sm"
+              <Select
                 value={selectedRepo}
-                onChange={(e) => setSelectedRepo(e.target.value)}
+                onValueChange={(value) => setSelectedRepo(value)}
                 disabled={isBusy}
               >
-                {(projectData?.custom_project_repository_connections ?? []).map(
-                  (repo: { github_repository: string }) => {
+                <SelectTrigger>
+                  <SelectValue placeholder="Select repository..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {(
+                    projectData?.custom_project_repository_connections ?? []
+                  ).map((repo: { github_repository: string }) => {
                     const repoName =
                       (repo.github_repository || "")
                         .replace(/\/$/, "")
                         .split("/")
                         .pop() || repo.github_repository;
                     return (
-                      <option
+                      <SelectItem
                         key={repo.github_repository}
                         value={repo.github_repository}
                       >
                         {repoName}
-                      </option>
+                      </SelectItem>
                     );
-                  },
-                )}
-              </select>
+                  })}
+                </SelectContent>
+              </Select>
             </div>
           )}
 
@@ -533,9 +548,9 @@ const PMReport = ({ projectId }: PMReportProps) => {
             <label className="text-sm text-muted-foreground">
               Report Drive Link
             </label>
-            <input
+            <Input
               type="url"
-              className="border rounded px-3 py-2 text-sm bg-muted text-muted-foreground cursor-not-allowed"
+              className="bg-muted text-muted-foreground cursor-not-allowed"
               value={driveLink}
               readOnly
               placeholder="https://drive.google.com/..."


### PR DESCRIPTION
## Description

Increases the frontend polling interval for PM Report generation status from 5s to 30s.
Adds frontend date validation to show a clear error when From Date is after To Date.
Consistent UI


## Relevant Technical Choices

- Used `Select`, `SelectTrigger`, `SelectContent`, `SelectItem`, `SelectValue` and `Input` from `@next-pms/design-system/components`
- Date validation runs before API call — instant feedback, no network round trip needed
- Used mergeClassNames() util for cleaner conditional classes

## Testing Instructions
1. Go to any Project → Project Report tab
2. Verify Duration dropdown, date inputs, repo selector, and drive link input all use consistent styling
3. Select Custom duration, set From Date after To Date → verify toast shows "From Date cannot be after To Date."

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #