### PR TITLE
Feature: Add over allocation warning

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -195,6 +195,7 @@ function AddAllocationModal({
     toDate,
     hoursPerDay,
     includeWeekends: weekendEntriesAllowed && includeWeekendsValue,
+    repeatWeeks: recurrence === "recurring" ? repeatFor : 0,
     allocationName,
   });
 

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -31,8 +31,10 @@ import {
   addAllocationDefaultValues,
   allocationRecurrenceLabels,
 } from "./constants";
+import { OverAllocationWarning } from "./overAllocationWarning";
 import { addAllocationFormSchema } from "./schema";
 import type { AddAllocationModalProps } from "./types";
+import { useOverAllocation } from "./useOverAllocation";
 import { computeTotalHours } from "./utils";
 
 function AddAllocationModal({
@@ -185,6 +187,16 @@ function AddAllocationModal({
     form.store,
     (state) => state.values.includeWeekends,
   );
+  const employeeId = useStore(form.store, (state) => state.values.employeeId);
+
+  const overAllocatedDays = useOverAllocation({
+    employeeId,
+    fromDate,
+    toDate,
+    hoursPerDay,
+    includeWeekends: weekendEntriesAllowed && includeWeekendsValue,
+    allocationName,
+  });
 
   useEffect(() => {
     if (!open) {
@@ -432,13 +444,13 @@ function AddAllocationModal({
                   </DateRangePicker>
                   {(!fromField.state.meta.isValid ||
                     !toField.state.meta.isValid) && (
-                    <ErrorMessage
-                      message={
-                        fromField.state.meta.errors[0]?.message ??
-                        toField.state.meta.errors[0]?.message
-                      }
-                    />
-                  )}
+                      <ErrorMessage
+                        message={
+                          fromField.state.meta.errors[0]?.message ??
+                          toField.state.meta.errors[0]?.message
+                        }
+                      />
+                    )}
                 </div>
               )}
             />
@@ -504,6 +516,8 @@ function AddAllocationModal({
             />
           </div>
         </div>
+
+        <OverAllocationWarning overAllocatedDays={overAllocatedDays} />
 
         <form.Field
           name="isBillable"

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
@@ -49,7 +49,7 @@ export function OverAllocationWarning({
             <SmallDown className="size-4 shrink-0 text-ink-gray-7 transition-transform duration-200 group-data-panel-open:rotate-180" />
           </Accordion.Trigger>
         </Accordion.Header>
-        <Accordion.Panel className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8">
+        <Accordion.Panel className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8 max-h-24 overflow-y-scroll scrollbar-thin">
           {overAllocatedDays.map((day) => (
             <div key={day.date} className="flex items-center gap-2">
               <span className="text-xs text-ink-gray-7">

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
@@ -8,7 +8,7 @@ import { format, parseISO } from "date-fns";
 
 export interface OverAllocatedDay {
   date: string;
-  excess_hours: number;
+  excessHours: number;
 }
 
 interface OverAllocationWarningProps {
@@ -31,7 +31,7 @@ export function OverAllocationWarning({
 
   const dayCount = overAllocatedDays.length;
   const totalExcess = overAllocatedDays.reduce(
-    (sum, d) => sum + d.excess_hours,
+    (sum, d) => sum + d.excessHours,
     0,
   );
 
@@ -61,7 +61,7 @@ export function OverAllocationWarning({
                   "text-xs font-medium px-1.5 py-0.5 rounded-md",
                 )}
               >
-                {formatHours(day.excess_hours)} over
+                {formatHours(day.excessHours)} over
               </span>
             </div>
           ))}

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies.
+ */
+import { Accordion } from "@base-ui/react/accordion";
+import { mergeClassNames as cn } from "@next-pms/design-system";
+import { AlertTriangle, SmallDown } from "@rtcamp/frappe-ui-react/icons";
+import { format, parseISO } from "date-fns";
+
+export interface OverAllocatedDay {
+  date: string;
+  excess_hours: number;
+}
+
+interface OverAllocationWarningProps {
+  overAllocatedDays: OverAllocatedDay[];
+}
+
+function formatHours(hours: number): string {
+  const rounded = Math.round(hours * 100) / 100;
+  return `${rounded}h`;
+}
+
+function formatDate(dateStr: string): string {
+  return format(parseISO(dateStr), "MMM d, yyyy");
+}
+
+export function OverAllocationWarning({
+  overAllocatedDays,
+}: OverAllocationWarningProps) {
+  if (overAllocatedDays.length === 0) return null;
+
+  const dayCount = overAllocatedDays.length;
+  const totalExcess = overAllocatedDays.reduce(
+    (sum, d) => sum + d.excess_hours,
+    0,
+  );
+
+  return (
+    <Accordion.Root className="bg-(--color-violet-50) rounded-lg overflow-hidden">
+      <Accordion.Item value="details">
+        <Accordion.Header render={<div />}>
+          <Accordion.Trigger className="w-full flex items-center gap-2 px-2.5 py-2 group">
+            <AlertTriangle className="size-4 shrink-0 text-(--color-violet-700)" />
+            <p className="flex-1 min-w-0 text-xs text-ink-gray-9 text-left">
+              This allocation causes over-allocation on {dayCount}{" "}
+              {dayCount === 1 ? "day" : "days"} (+{formatHours(totalExcess)}{" "}
+              total)
+            </p>
+            <SmallDown className="size-4 shrink-0 text-ink-gray-7 transition-transform duration-200 group-data-panel-open:rotate-180" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8">
+          {overAllocatedDays.map((day) => (
+            <div key={day.date} className="flex items-center gap-2">
+              <span className="text-xs text-ink-gray-7">
+                {formatDate(day.date)}
+              </span>
+              <span
+                className={cn(
+                  "bg-surface-violet-1 text-(--color-violet-700)",
+                  "text-xs font-medium px-1.5 py-0.5 rounded-md",
+                )}
+              >
+                {formatHours(day.excess_hours)} over
+              </span>
+            </div>
+          ))}
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
@@ -49,22 +49,24 @@ export function OverAllocationWarning({
             <SmallDown className="size-4 shrink-0 text-ink-gray-7 transition-transform duration-200 group-data-panel-open:rotate-180" />
           </Accordion.Trigger>
         </Accordion.Header>
-        <Accordion.Panel className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8 max-h-24 overflow-y-scroll scrollbar-thin">
-          {overAllocatedDays.map((day) => (
-            <div key={day.date} className="flex items-center gap-2">
-              <span className="text-xs text-ink-gray-7">
-                {formatDate(day.date)}
-              </span>
-              <span
-                className={cn(
-                  "bg-surface-violet-1 text-(--color-violet-700)",
-                  "text-xs font-medium px-1.5 py-0.5 rounded-md",
-                )}
-              >
-                {formatHours(day.excessHours)} over
-              </span>
-            </div>
-          ))}
+        <Accordion.Panel className="accordion-panel">
+          <div className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8 max-h-24 overflow-y-scroll scrollbar-thin [scrollbar-gutter:stable]">
+            {overAllocatedDays.map((day) => (
+              <div key={day.date} className="flex items-center gap-2">
+                <span className="text-xs text-ink-gray-7">
+                  {formatDate(day.date)}
+                </span>
+                <span
+                  className={cn(
+                    "bg-surface-violet-1 text-(--color-violet-700)",
+                    "text-xs font-medium px-1.5 py-0.5 rounded-md",
+                  )}
+                >
+                  {formatHours(day.excessHours)} over
+                </span>
+              </div>
+            ))}
+          </div>
         </Accordion.Panel>
       </Accordion.Item>
     </Accordion.Root>

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
@@ -1,0 +1,119 @@
+/**
+ * External dependencies.
+ */
+import { useMemo } from "react";
+import { eachDayOfInterval, format, isWeekend, parseISO } from "date-fns";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal dependencies.
+ */
+import { useDebounce } from "@/hooks/useDebounce";
+import { OverAllocatedDay } from "./overAllocationWarning";
+
+const STANDARD_WORKING_HOURS = 8;
+
+interface UseOverAllocationOptions {
+  employeeId: string;
+  fromDate: string;
+  toDate: string;
+  hoursPerDay: number;
+  includeWeekends: boolean;
+  /** Name of the allocation being edited - excluded from the existing-hours sum. */
+  allocationName?: string;
+}
+
+interface ExistingAllocation {
+  name: string;
+  allocation_start_date: string;
+  allocation_end_date: string;
+  hours_allocated_per_day: number;
+}
+
+export function useOverAllocation({
+  employeeId,
+  fromDate,
+  toDate,
+  hoursPerDay,
+  includeWeekends,
+  allocationName,
+}: UseOverAllocationOptions): OverAllocatedDay[] {
+  const debouncedHoursPerDay = useDebounce(hoursPerDay, 500);
+  const debouncedFromDate = useDebounce(fromDate, 500);
+  const debouncedToDate = useDebounce(toDate, 500);
+
+  const enabled =
+    Boolean(employeeId) &&
+    Boolean(debouncedFromDate) &&
+    Boolean(debouncedToDate) &&
+    debouncedFromDate <= debouncedToDate &&
+    debouncedHoursPerDay > 0;
+
+  const { data } = useFrappeGetCall(
+    "frappe.client.get_list",
+    {
+      doctype: "Resource Allocation",
+      fields: [
+        "name",
+        "allocation_start_date",
+        "allocation_end_date",
+        "hours_allocated_per_day",
+      ],
+      filters: JSON.stringify([
+        ["employee", "=", employeeId],
+        ["allocation_start_date", "<=", debouncedToDate],
+        ["allocation_end_date", ">=", debouncedFromDate],
+      ]),
+      limit_page_length: "null",
+    },
+    enabled ? undefined : false,
+  );
+
+  return useMemo(() => {
+    if (!enabled || !data?.message) return [];
+
+    const existing = (data.message as ExistingAllocation[]).filter(
+      (a) => a.name !== allocationName,
+    );
+
+    const result: OverAllocatedDay[] = [];
+    const days = eachDayOfInterval({
+      start: parseISO(debouncedFromDate),
+      end: parseISO(debouncedToDate),
+    });
+
+    for (const d of days) {
+      if (!includeWeekends && isWeekend(d)) {
+        continue;
+      }
+
+      const dateStr = format(d, "yyyy-MM-dd");
+      const existingHours = existing
+        .filter(
+          (a) =>
+            a.allocation_start_date <= dateStr &&
+            a.allocation_end_date >= dateStr,
+        )
+        .reduce((sum, a) => sum + (a.hours_allocated_per_day ?? 0), 0);
+
+      const total = existingHours + debouncedHoursPerDay;
+      if (total > STANDARD_WORKING_HOURS) {
+        result.push({
+          date: dateStr,
+          excess_hours:
+            Math.round((total - STANDARD_WORKING_HOURS) * 100) / 100,
+        });
+      }
+    }
+
+    return result;
+  }, [
+    enabled,
+    data,
+    allocationName,
+    debouncedFromDate,
+    debouncedToDate,
+    debouncedHoursPerDay,
+    includeWeekends,
+  ]);
+}

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
@@ -2,7 +2,13 @@
  * External dependencies.
  */
 import { useMemo } from "react";
-import { eachDayOfInterval, format, isWeekend, parseISO } from "date-fns";
+import {
+  addDays,
+  eachDayOfInterval,
+  format,
+  isWeekend,
+  parseISO,
+} from "date-fns";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
@@ -19,7 +25,12 @@ interface UseOverAllocationOptions {
   toDate: string;
   hoursPerDay: number;
   includeWeekends: boolean;
-  /** Name of the allocation being edited - excluded from the existing-hours sum. */
+  /**
+   * Number of additional weekly copies that will be created on save.
+   * Pass 0 for one-time or edit.
+   */
+  repeatWeeks: number;
+  /** Name of the allocation being edited — excluded from the existing-hours sum. */
   allocationName?: string;
 }
 
@@ -36,11 +47,13 @@ export function useOverAllocation({
   toDate,
   hoursPerDay,
   includeWeekends,
+  repeatWeeks,
   allocationName,
 }: UseOverAllocationOptions): OverAllocatedDay[] {
   const debouncedHoursPerDay = useDebounce(hoursPerDay, 500);
   const debouncedFromDate = useDebounce(fromDate, 500);
   const debouncedToDate = useDebounce(toDate, 500);
+  const debouncedRepeatWeeks = useDebounce(repeatWeeks, 500);
 
   const enabled =
     Boolean(employeeId) &&
@@ -48,6 +61,15 @@ export function useOverAllocation({
     Boolean(debouncedToDate) &&
     debouncedFromDate <= debouncedToDate &&
     debouncedHoursPerDay > 0;
+
+  // Extend the fetch range to cover all recurring copies.
+  const fetchEndDate = useMemo(() => {
+    if (!debouncedToDate || debouncedRepeatWeeks <= 0) return debouncedToDate;
+    return format(
+      addDays(parseISO(debouncedToDate), debouncedRepeatWeeks * 7),
+      "yyyy-MM-dd",
+    );
+  }, [debouncedToDate, debouncedRepeatWeeks]);
 
   const { data } = useFrappeGetCall(
     "frappe.client.get_list",
@@ -61,7 +83,7 @@ export function useOverAllocation({
       ],
       filters: JSON.stringify([
         ["employee", "=", employeeId],
-        ["allocation_start_date", "<=", debouncedToDate],
+        ["allocation_start_date", "<=", fetchEndDate],
         ["allocation_end_date", ">=", debouncedFromDate],
       ]),
       limit_page_length: "null",
@@ -77,32 +99,36 @@ export function useOverAllocation({
     );
 
     const result: OverAllocatedDay[] = [];
-    const days = eachDayOfInterval({
-      start: parseISO(debouncedFromDate),
-      end: parseISO(debouncedToDate),
-    });
+    const baseStart = parseISO(debouncedFromDate);
+    const baseEnd = parseISO(debouncedToDate);
 
-    for (const d of days) {
-      if (!includeWeekends && isWeekend(d)) {
-        continue;
-      }
+    // Iterate each weekly copy (week 0 = base range, week 1..N = recurring copies).
+    for (let week = 0; week <= debouncedRepeatWeeks; week++) {
+      const weekStart = addDays(baseStart, week * 7);
+      const weekEnd = addDays(baseEnd, week * 7);
 
-      const dateStr = format(d, "yyyy-MM-dd");
-      const existingHours = existing
-        .filter(
-          (a) =>
-            a.allocation_start_date <= dateStr &&
-            a.allocation_end_date >= dateStr,
-        )
-        .reduce((sum, a) => sum + (a.hours_allocated_per_day ?? 0), 0);
+      for (const d of eachDayOfInterval({ start: weekStart, end: weekEnd })) {
+        if (!includeWeekends && isWeekend(d)) {
+          continue;
+        }
 
-      const total = existingHours + debouncedHoursPerDay;
-      if (total > STANDARD_WORKING_HOURS) {
-        result.push({
-          date: dateStr,
-          excess_hours:
-            Math.round((total - STANDARD_WORKING_HOURS) * 100) / 100,
-        });
+        const dateStr = format(d, "yyyy-MM-dd");
+        const existingHours = existing
+          .filter(
+            (a) =>
+              a.allocation_start_date <= dateStr &&
+              a.allocation_end_date >= dateStr,
+          )
+          .reduce((sum, a) => sum + (a.hours_allocated_per_day ?? 0), 0);
+
+        const total = existingHours + debouncedHoursPerDay;
+        if (total > STANDARD_WORKING_HOURS) {
+          result.push({
+            date: dateStr,
+            excess_hours:
+              Math.round((total - STANDARD_WORKING_HOURS) * 100) / 100,
+          });
+        }
       }
     }
 
@@ -113,6 +139,7 @@ export function useOverAllocation({
     allocationName,
     debouncedFromDate,
     debouncedToDate,
+    debouncedRepeatWeeks,
     debouncedHoursPerDay,
     includeWeekends,
   ]);

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
@@ -125,7 +125,7 @@ export function useOverAllocation({
         if (total > STANDARD_WORKING_HOURS) {
           result.push({
             date: dateStr,
-            excess_hours:
+            excessHours:
               Math.round((total - STANDARD_WORKING_HOURS) * 100) / 100,
           });
         }


### PR DESCRIPTION
## Description
- Add over allocation warning when adding a new allocation or editing an existing one

## Relevant Technical Choices
- I have used `--color-violet-50` and `--color-violet-700` directly as we don't have `surface` or `text` css variables for these, I tried adding new variables for these but the current configuration has

`
  --color-ink-violet-1: var(--color-violet-500);
`

which means to add other colors I will have to modify this - which will affect the whole project, it would be better if we tackle this in a separate PR. As this can cause regression in unknown places.

## Screenshot/Screencast
<img width="640" height="759" alt="image" src="https://github.com/user-attachments/assets/2f63cc50-8f8a-4c4f-bff9-4da9729b15fb" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #950