### PR TITLE
Add allocation popover overflow scroll

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -148,7 +148,7 @@ export function GanttAllocationPopover({
   hasRoleAccess = false,
 }: GanttAllocationPopoverProps) {
   return (
-    <div className="flex flex-col gap-4 p-3 rounded-xl shadow-2xl w-70 bg-surface-modal">
+    <div className="flex flex-col gap-4 p-3 rounded-xl shadow-2xl w-70 bg-surface-modal animate-fade-in max-h-[min(550px,90dvh)] overflow-y-auto scrollbar-thin">
       <div className="flex flex-col">
         {entries.map((entry, index) => (
           <div key={index}>
@@ -164,10 +164,11 @@ export function GanttAllocationPopover({
         <Button
           variant="solid"
           theme="gray"
-          className="justify-center w-full"
+          className="justify-center w-full h-7 shrink-0"
           iconLeft={() => <AddMd className="size-4" />}
           label="Add"
           onClick={onAdd}
+          size="sm"
         />
       )}
     </div>


### PR DESCRIPTION
## Description
- Adds scroll on overflow for allocation popover

## Relevant Technical Choices
- Ref: https://github.com/rtCamp/next-pms/blob/ab8588501a0d4c0a190d3eb08a816df08931e8e0/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx#L259

## Screenshot/Screencast
<img width="1015" height="707" alt="image" src="https://github.com/user-attachments/assets/bdf9cd46-13d9-417e-a098-9cf9a2d950ca" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)