### PR TITLE
Allow multiple draft allocations and add tooltip

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -169,7 +169,7 @@ export function DraftBar({
   );
 
   return (
-    <Tooltip text="Click to Add allocation" disabled={!onOpenAllocation}>
+    <Tooltip text="Click to save the allocation" disabled={!onOpenAllocation}>
       <GanttBar
         ref={draftBarRef}
         variant="draft"

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { format } from "date-fns";
 
 /**
@@ -26,7 +27,7 @@ interface DraftBarProps {
   projectName?: string;
   customerName?: string;
   onOpenAllocation?: (data: AllocationCallbackData) => void;
-  onRemove?: (rowKey: string) => void;
+  onRemove?: (rowKey: string, seedLeft: number) => void;
 }
 
 export function DraftBar({
@@ -126,7 +127,7 @@ export function DraftBar({
       showWeekend,
     });
 
-    onRemove?.(rowKey);
+    onRemove?.(rowKey, left);
     onOpenAllocation({
       employeeId,
       projectId,
@@ -142,6 +143,7 @@ export function DraftBar({
     customerName,
     employeeId,
     headerWidth,
+    left,
     onOpenAllocation,
     onRemove,
     previewGeometry.left,
@@ -161,30 +163,32 @@ export function DraftBar({
 
       event.preventDefault();
       event.stopPropagation();
-      onRemove?.(rowKey);
+      onRemove?.(rowKey, left);
     },
-    [onRemove, rowKey],
+    [onRemove, rowKey, left],
   );
 
   return (
-    <GanttBar
-      ref={draftBarRef}
-      variant="draft"
-      label={`${FULL_DAY_HOURS}h`}
-      renderLabel={renderLabel}
-      renderFloatingLabel={renderFloatingLabel}
-      left={previewGeometry.left}
-      width={previewGeometry.width}
-      className="outline-none"
-      minLeft={bounds.minLeft}
-      maxRight={bounds.maxRight}
-      resizable={Boolean(onOpenAllocation)}
-      snapUnitPx={columnWidth}
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      onResizeEnd={handleResizeEnd}
-    />
+    <Tooltip text="Click to Add allocation" disabled={!onOpenAllocation}>
+      <GanttBar
+        ref={draftBarRef}
+        variant="draft"
+        label={`${FULL_DAY_HOURS}h`}
+        renderLabel={renderLabel}
+        renderFloatingLabel={renderFloatingLabel}
+        left={previewGeometry.left}
+        width={previewGeometry.width}
+        className="outline-none"
+        minLeft={bounds.minLeft}
+        maxRight={bounds.maxRight}
+        resizable={Boolean(onOpenAllocation)}
+        snapUnitPx={columnWidth}
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onResizeEnd={handleResizeEnd}
+      />
+    </Tooltip>
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
@@ -208,7 +208,7 @@ export function GanttProjectBar({
         delay={400}
         closeDelay={150}
         render={
-          <Tooltip text="Click to save changes" disabled={!isModified}>
+          <Tooltip text="Click to save the allocation" disabled={!isModified}>
             <GanttBar
               ref={projectBarRef}
               variant="project"

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PreviewCard } from "@base-ui/react/preview-card";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { useGanttStore } from "../ganttStore";
 import type { ProjectAllocationBar } from "../ganttStore";
 import { getBarDateRange, getBarDaySpan, getBarTimelineBounds } from "../utils";
@@ -207,28 +208,30 @@ export function GanttProjectBar({
         delay={400}
         closeDelay={150}
         render={
-          <GanttBar
-            ref={projectBarRef}
-            variant="project"
-            theme={allocation.tentative ? "crosshatch" : "default"}
-            label={label}
-            renderLabel={renderLabel}
-            left={previewGeometry.left}
-            width={previewGeometry.width}
-            className={cn(
-              "outline-none",
-              isModified && "ring-1 ring-inset ring-surface-amber-3",
-            )}
-            billable={allocation.billable}
-            resizable={resizable}
-            snapUnitPx={columnWidth}
-            tabIndex={0}
-            minLeft={bounds.minLeft}
-            maxRight={bounds.maxRight}
-            onClick={isModified ? handleClick : undefined}
-            onKeyDown={handleKeyDown}
-            onResizeEnd={handleResizeEnd}
-          />
+          <Tooltip text="Click to save changes" disabled={!isModified}>
+            <GanttBar
+              ref={projectBarRef}
+              variant="project"
+              theme={allocation.tentative ? "crosshatch" : "default"}
+              label={label}
+              renderLabel={renderLabel}
+              left={previewGeometry.left}
+              width={previewGeometry.width}
+              className={cn(
+                "outline-none",
+                isModified && "ring-1 ring-inset ring-surface-amber-3",
+              )}
+              billable={allocation.billable}
+              resizable={resizable}
+              snapUnitPx={columnWidth}
+              tabIndex={0}
+              minLeft={bounds.minLeft}
+              maxRight={bounds.maxRight}
+              onClick={isModified ? handleClick : undefined}
+              onKeyDown={handleKeyDown}
+              onResizeEnd={handleResizeEnd}
+            />
+          </Tooltip>
         }
       />
       <PreviewCard.Portal>

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/rowAllocationOverlay.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/rowAllocationOverlay.tsx
@@ -56,33 +56,28 @@ export const RowAllocationOverlay = forwardRef<
   },
   ref,
 ) {
-  const [draft, setDraft] = useState<DraftBarSeed | null>(null);
+  const [drafts, setDrafts] = useState<DraftBarSeed[]>([]);
   const [hoveredSlotLeft, setHoveredSlotLeft] = useState<number | null>(null);
-  const hasDraft = Boolean(draft);
 
   const clearHoveredSlot = useCallback(() => {
     setHoveredSlotLeft(null);
   }, []);
 
-  const removeDraft = useCallback((nextRowKey: string) => {
-    setDraft((currentDraft) => {
-      if (!currentDraft || currentDraft.rowKey !== nextRowKey) {
-        return currentDraft;
-      }
-
-      return null;
-    });
+  const removeDraft = useCallback((nextRowKey: string, seedLeft: number) => {
+    setDrafts((prev) =>
+      prev.filter((d) => !(d.rowKey === nextRowKey && d.left === seedLeft)),
+    );
   }, []);
 
   useEffect(() => {
-    if (!enabled || hasDraft) {
+    if (!enabled) {
       setHoveredSlotLeft(null);
     }
-  }, [enabled, hasDraft]);
+  }, [enabled]);
 
   const updateHoveredSlotFromPointer = useCallback(
     (event: React.PointerEvent<HTMLTableRowElement>) => {
-      if (!enabled || hasDraft) {
+      if (!enabled) {
         setHoveredSlotLeft(null);
         return;
       }
@@ -109,10 +104,19 @@ export const RowAllocationOverlay = forwardRef<
       const relativeX = event.clientX - rect.left - headerWidth;
       const dayIndex = Math.floor(relativeX / columnWidth);
 
+      const draftOccupancies = drafts.map((d) => ({
+        barOffset: d.left - headerWidth,
+        width: d.width,
+      }));
+
       if (
         dayIndex < 0 ||
         dayIndex >= columnCount ||
-        isColumnOccupied(allocations, dayIndex, columnWidth)
+        isColumnOccupied(
+          [...allocations, ...draftOccupancies],
+          dayIndex,
+          columnWidth,
+        )
       ) {
         setHoveredSlotLeft(null);
         return;
@@ -121,7 +125,7 @@ export const RowAllocationOverlay = forwardRef<
       const snappedLeft = headerWidth + dayIndex * columnWidth;
       setHoveredSlotLeft((prev) => (prev === snappedLeft ? prev : snappedLeft));
     },
-    [allocations, columnCount, columnWidth, enabled, hasDraft, headerWidth],
+    [allocations, columnCount, columnWidth, drafts, enabled, headerWidth],
   );
 
   const handleRowPointerDown = useCallback(
@@ -152,21 +156,21 @@ export const RowAllocationOverlay = forwardRef<
 
   return (
     <>
-      {draft ? (
+      {drafts.map((d) => (
         <DraftBar
-          key={draft.rowKey}
-          rowKey={draft.rowKey}
-          left={draft.left}
-          width={draft.width}
-          employeeId={draft.employeeId}
-          projectId={draft.projectId}
-          projectName={draft.projectName}
-          customerName={draft.customerName}
+          key={`${d.rowKey}-${d.left}`}
+          rowKey={d.rowKey}
+          left={d.left}
+          width={d.width}
+          employeeId={d.employeeId}
+          projectId={d.projectId}
+          projectName={d.projectName}
+          customerName={d.customerName}
           onOpenAllocation={onOpenAllocation}
           onRemove={removeDraft}
         />
-      ) : null}
-      {!enabled || hasDraft || hoveredSlotLeft === null ? null : (
+      ))}
+      {!enabled || hoveredSlotLeft === null ? null : (
         <Button
           type="button"
           variant="subtle"
@@ -181,7 +185,9 @@ export const RowAllocationOverlay = forwardRef<
             height: BAR_HEIGHT,
             top: (CELL_HEIGHT - BAR_HEIGHT) / 2,
           }}
-          onClick={() => setDraft(createDraftBar(hoveredSlotLeft))}
+          onClick={() =>
+            setDrafts((prev) => [...prev, createDraftBar(hoveredSlotLeft)])
+          }
           icon={() => <AddMd className="size-4" />}
           key={rowKey}
         />

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/rowAllocationOverlay.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/rowAllocationOverlay.tsx
@@ -156,16 +156,16 @@ export const RowAllocationOverlay = forwardRef<
 
   return (
     <>
-      {drafts.map((d) => (
+      {drafts.map((draft) => (
         <DraftBar
-          key={`${d.rowKey}-${d.left}`}
-          rowKey={d.rowKey}
-          left={d.left}
-          width={d.width}
-          employeeId={d.employeeId}
-          projectId={d.projectId}
-          projectName={d.projectName}
-          customerName={d.customerName}
+          key={`${draft.rowKey}-${draft.left}`}
+          rowKey={draft.rowKey}
+          left={draft.left}
+          width={draft.width}
+          employeeId={draft.employeeId}
+          projectId={draft.projectId}
+          projectName={draft.projectName}
+          customerName={draft.customerName}
           onOpenAllocation={onOpenAllocation}
           onRemove={removeDraft}
         />


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This pull request enhances the Gantt chart's draft allocation experience by supporting multiple draft bars at once and improving user interaction with tooltips.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/46a40462-4a60-4004-96a4-b6bf397e4fc5



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes [comment](https://github.com/rtCamp/next-pms/issues/964#issuecomment-4477140350) on #964
