### PR TITLE
Add composite filters to timesheet project page

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/constants.ts
+++ b/frontend/packages/app/src/pages/timesheet/constants.ts
@@ -135,3 +135,23 @@ export const teamTimesheetFilters: FilterField[] = [
     type: "string",
   },
 ];
+
+export const projectTimesheetFilters: FilterField[] = [
+  {
+    fieldCategory: "Timesheet Detail",
+    name: "project_name",
+    label: "Project",
+    type: "string",
+  },
+  {
+    name: "date",
+    label: "Date",
+    type: "daterange",
+  },
+  {
+    fieldCategory: "Timesheet",
+    name: "employee_name",
+    label: "Member",
+    type: "string",
+  },
+];

--- a/frontend/packages/app/src/pages/timesheet/project/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/context.ts
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import type { ApprovalStatusLabelType } from "@next-pms/design-system/components";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 import { createContext, useContextSelector } from "use-context-selector";
 
 /**
@@ -44,24 +45,34 @@ export type WeekGroup = {
 
 export interface ProjectTimesheetContextProps {
   state: {
-    hasMoreWeeks: boolean;
+    hasMore: boolean;
     isLoadingProjectData: boolean;
+    isFilterRequest: boolean;
     weekGroups: WeekGroup[];
+    searchInput: string;
+    compositeFilters: FilterCondition[];
   };
   actions: {
     loadData: () => void;
+    handleSearchChange: (value: string) => void;
+    handleCompositeFilterChange: (value: FilterCondition[]) => void;
   };
 }
 
 export const ProjectTimesheetContext =
   createContext<ProjectTimesheetContextProps>({
     state: {
-      hasMoreWeeks: false,
+      hasMore: false,
       isLoadingProjectData: false,
+      isFilterRequest: false,
       weekGroups: [],
+      searchInput: "",
+      compositeFilters: [],
     },
     actions: {
       loadData: () => null,
+      handleSearchChange: () => null,
+      handleCompositeFilterChange: () => null,
     },
   });
 

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -1,14 +1,10 @@
 /**
  * External dependencies.
  */
-import { Fragment, useCallback, useState } from "react";
+import { Fragment } from "react";
+import { mergeClassNames as cn } from "@next-pms/design-system";
 import { Spinner, Typography } from "@next-pms/design-system/components";
-import {
-  Button,
-  Filter,
-  FilterCondition,
-  TextInput,
-} from "@rtcamp/frappe-ui-react";
+import { Button, Filter, TextInput } from "@rtcamp/frappe-ui-react";
 import { Ellipsis } from "lucide-react";
 
 /**
@@ -18,47 +14,47 @@ import { InfiniteScroll } from "@/components/infiniteScroll";
 import { ProjectTimesheetRow } from "@/components/timesheet-row";
 import { HeaderRow } from "@/components/timesheet-row/components/row/headerRow";
 import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
-import { TimesheetFilters } from "@/types/timesheet";
 import { useProjectTimesheet } from "./context";
-import { sampleFields } from "../constants";
+import { projectTimesheetFilters } from "../constants";
 
 export const ProjectTimesheetTable = () => {
-  const hasMoreWeeks = useProjectTimesheet(({ state }) => state.hasMoreWeeks);
+  const hasMore = useProjectTimesheet(({ state }) => state.hasMore);
   const isLoadingProjectData = useProjectTimesheet(
     ({ state }) => state.isLoadingProjectData,
   );
-  const weekGroups = useProjectTimesheet(({ state }) => state.weekGroups);
-  const loadData = useProjectTimesheet(({ actions }) => actions.loadData);
-
-  const [compositeFilters, setCompositeFilters] = useState<FilterCondition[]>(
-    [],
+  const isFilterRequest = useProjectTimesheet(
+    ({ state }) => state.isFilterRequest,
   );
-  const [filters, setFilters] = useState<TimesheetFilters>({
-    search: "",
-    reportsTo: undefined,
-  });
+  const weekGroups = useProjectTimesheet(({ state }) => state.weekGroups);
+  const searchInput = useProjectTimesheet(({ state }) => state.searchInput);
+  const compositeFilters = useProjectTimesheet(
+    ({ state }) => state.compositeFilters,
+  );
+  const loadData = useProjectTimesheet(({ actions }) => actions.loadData);
+  const handleSearchChange = useProjectTimesheet(
+    ({ actions }) => actions.handleSearchChange,
+  );
+  const handleCompositeFilterChange = useProjectTimesheet(
+    ({ actions }) => actions.handleCompositeFilterChange,
+  );
 
-  const handleSearchChange = useCallback((value: string) => {
-    setFilters((prev) => ({ ...prev, search: value }));
-  }, []);
+  const isFilteredDataLoading = isFilterRequest && isLoadingProjectData;
 
   return (
-    <div className="w-full h-full py-3.5 px-3">
+    <div className="w-full flex-1 min-h-0 py-3.5 px-3 relative">
       <div className="flex flex-wrap gap-2 justify-between mb-3.5">
         <div className="flex gap-2">
           <TextInput
             placeholder="Search Tasks"
-            value={filters.search}
+            value={searchInput}
             onChange={(e) => handleSearchChange(e.target.value)}
           />
         </div>
         <div className="flex gap-2">
           <Filter
-            fields={sampleFields}
+            fields={projectTimesheetFilters}
             value={compositeFilters}
-            onChange={(newFilters) => {
-              setCompositeFilters(newFilters);
-            }}
+            onChange={handleCompositeFilterChange}
           />
           <Button icon={() => <Ellipsis size={16} />} />
         </div>
@@ -73,9 +69,15 @@ export const ProjectTimesheetTable = () => {
       ) : (
         <InfiniteScroll
           isLoading={isLoadingProjectData}
-          hasMore={hasMoreWeeks}
+          hasMore={hasMore}
           verticalLodMore={loadData}
-          className="w-full h-full overflow-auto scrollbar [scrollbar-gutter:stable]"
+          className={cn(
+            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable] opacity-100",
+            {
+              "opacity-50 transition-opacity duration-150":
+                isFilteredDataLoading,
+            },
+          )}
           count={NUMBER_OF_WEEKS_TO_FETCH}
         >
           <div className="min-w-225">
@@ -117,6 +119,13 @@ export const ProjectTimesheetTable = () => {
           </div>
         </InfiniteScroll>
       )}
+
+      {isFilteredDataLoading ? (
+        <Spinner
+          isFull
+          className="absolute top-0 left-0 w-full h-full cursor-wait"
+        />
+      ) : null}
     </div>
   );
 };

--- a/frontend/packages/app/src/pages/timesheet/project/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/provider.tsx
@@ -1,35 +1,124 @@
 /**
  * External dependencies.
  */
-import { FC, PropsWithChildren, useMemo } from "react";
+import {
+  FC,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from "react";
+import { type FilterCondition, useToasts } from "@rtcamp/frappe-ui-react";
+import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
 
 /**
  * Internal dependencies.
  */
+import { useDebounce } from "@/hooks/useDebounce";
+import { isCompleteFilterCondition, parseFrappeErrorMsg } from "@/lib/utils";
 import {
   ProjectTimesheetContext,
   type ProjectTimesheetContextProps,
 } from "./context";
+import {
+  createInitialProjectTimesheetState,
+  projectTimesheetReducer,
+} from "./reducer";
 import { useProjectTimesheetData } from "./useProjectTimesheetData";
 
 export const ProjectTimesheetProvider: FC<PropsWithChildren> = ({
   children,
 }) => {
-  const { hasMoreWeeks, isLoadingProjectData, weekGroups, loadData } =
-    useProjectTimesheetData();
+  const toast = useToasts();
+
+  const [state, dispatch] = useReducer(
+    projectTimesheetReducer,
+    undefined,
+    createInitialProjectTimesheetState,
+  );
+
+  const debouncedSearch = useDebounce(state.searchInput, 400);
+
+  // Only pass complete filter conditions to the data hook so that selecting a
+  // field (without an operator/value) does not trigger a reset + network request.
+  const effectiveCompositeFilters = useMemo(
+    () => state.compositeFilters.filter(isCompleteFilterCondition),
+    [state.compositeFilters],
+  );
+
+  const {
+    hasMore,
+    isLoadingProjectData,
+    weekGroups: freshWeekGroups,
+    loadData,
+    error,
+  } = useProjectTimesheetData({
+    search: debouncedSearch,
+    compositeFilters: effectiveCompositeFilters,
+  });
+
+  // Keep the last non-empty result so that during a filter-triggered reload the
+  // table stays visible (faded) instead of blinking through an empty state and
+  // triggering the full-page spinner.
+  const staleWeekGroupsRef = useRef(freshWeekGroups);
+  if (freshWeekGroups.length > 0) {
+    staleWeekGroupsRef.current = freshWeekGroups;
+  }
+  const weekGroups =
+    freshWeekGroups.length > 0 || !isLoadingProjectData
+      ? freshWeekGroups
+      : staleWeekGroupsRef.current;
+
+  useEffect(() => {
+    if (isLoadingProjectData) return;
+    dispatch({ type: "FILTER_REQUEST_COMPLETE" });
+
+    if (error) {
+      toast.error(parseFrappeErrorMsg(error as FrappeError));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadingProjectData, error]);
+
+  const handleSearchChange = useCallback((value: string) => {
+    dispatch({ type: "SEARCH_CHANGED", payload: value });
+  }, []);
+
+  const handleCompositeFilterChange = useCallback(
+    (value: FilterCondition[]) => {
+      dispatch({ type: "COMPOSITE_FILTERS_CHANGED", payload: value });
+    },
+    [],
+  );
 
   const value: ProjectTimesheetContextProps = useMemo(
     () => ({
       state: {
-        hasMoreWeeks,
+        hasMore,
         isLoadingProjectData,
+        isFilterRequest: state.isFilterRequest,
         weekGroups,
+        searchInput: state.searchInput,
+        compositeFilters: state.compositeFilters,
       },
       actions: {
         loadData,
+        handleSearchChange,
+        handleCompositeFilterChange,
       },
     }),
-    [hasMoreWeeks, isLoadingProjectData, loadData, weekGroups],
+    [
+      hasMore,
+      isLoadingProjectData,
+      state.isFilterRequest,
+      loadData,
+      weekGroups,
+      state.searchInput,
+      state.compositeFilters,
+      handleSearchChange,
+      handleCompositeFilterChange,
+    ],
   );
 
   return (

--- a/frontend/packages/app/src/pages/timesheet/project/reducer.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/reducer.ts
@@ -1,29 +1,24 @@
 /**
  * External dependencies.
  */
-import { getTodayDate } from "@next-pms/design-system/date";
-
-/**
- * Internal dependencies.
- */
-import type { ApiPayload } from "./types";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 
 export type ProjectTimesheetState = {
-  weekDate: string;
-  employeeStart: number;
-  pages: ApiPayload[];
+  searchInput: string;
+  compositeFilters: FilterCondition[];
+  isFilterRequest: boolean;
 };
 
 export type ProjectTimesheetAction =
-  | { type: "APPEND_PAGE"; payload: ApiPayload }
-  | { type: "SET_WEEK_DATE"; payload: string }
-  | { type: "LOAD_MORE_EMPLOYEES"; payload: { pageLength: number } };
+  | { type: "SEARCH_CHANGED"; payload: string }
+  | { type: "COMPOSITE_FILTERS_CHANGED"; payload: FilterCondition[] }
+  | { type: "FILTER_REQUEST_COMPLETE" };
 
 export const createInitialProjectTimesheetState =
   (): ProjectTimesheetState => ({
-    weekDate: getTodayDate(),
-    employeeStart: 0,
-    pages: [],
+    searchInput: "",
+    compositeFilters: [],
+    isFilterRequest: false,
   });
 
 export function projectTimesheetReducer(
@@ -31,24 +26,18 @@ export function projectTimesheetReducer(
   action: ProjectTimesheetAction,
 ): ProjectTimesheetState {
   switch (action.type) {
-    case "APPEND_PAGE":
+    case "SEARCH_CHANGED":
+      return { ...state, searchInput: action.payload, isFilterRequest: true };
+
+    case "COMPOSITE_FILTERS_CHANGED":
       return {
         ...state,
-        pages: [...state.pages, action.payload],
+        compositeFilters: action.payload,
+        isFilterRequest: true,
       };
 
-    case "SET_WEEK_DATE":
-      return {
-        ...state,
-        weekDate: action.payload,
-        employeeStart: 0,
-      };
-
-    case "LOAD_MORE_EMPLOYEES":
-      return {
-        ...state,
-        employeeStart: state.employeeStart + action.payload.pageLength,
-      };
+    case "FILTER_REQUEST_COMPLETE":
+      return { ...state, isFilterRequest: false };
 
     default:
       return state;

--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -84,7 +84,7 @@ export function useProjectTimesheetData({
     "next_pms.timesheet.api.project.get_project_timesheet_data",
     {
       date: weekDate,
-      max_week: maxWeek,
+      max_week: NUMBER_OF_WEEKS_TO_FETCH,
       page_length: PROJECT_PAGE_LENGTH,
       start: projectStart,
       search: search || null,

--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -177,12 +177,14 @@ export function useProjectTimesheetData({
     const weekGroups = Array.from(weekMap.values())
       .sort(
         (a, b) =>
-          new Date(b.start_date).getTime() - new Date(a.start_date).getTime(),
+          parseISO(b.start_date).getTime() - parseISO(a.start_date).getTime(),
       )
       .map((week) => ({
         ...week,
         projects: [...week.projects].sort((a, b) =>
-          (a.projectName ?? "").localeCompare(b.projectName ?? ""),
+          (a.projectName || a.project).localeCompare(
+            b.projectName || b.project,
+          ),
         ),
       }));
 
@@ -214,7 +216,7 @@ export function useProjectTimesheetData({
     if (!hasMoreWeeks) return;
 
     setWeekDate((prev) =>
-      getFormatedDate(addDays(prev, -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
+      getFormatedDate(addDays(parseISO(prev), -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
     );
     setProjectStart(0);
   }, [
@@ -240,7 +242,9 @@ export function useProjectTimesheetData({
     // produce a new date value.
     if (hasMoreWeeks) {
       setWeekDate((prev) =>
-        getFormatedDate(addDays(prev, -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
+        getFormatedDate(
+          addDays(parseISO(prev), -(NUMBER_OF_WEEKS_TO_FETCH * 7)),
+        ),
       );
       setProjectStart(0);
     }

--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -1,53 +1,95 @@
 /**
  * External dependencies.
  */
-import { useCallback, useEffect, useMemo, useReducer } from "react";
-import { getFormatedDate } from "@next-pms/design-system/date";
-import { useToasts } from "@rtcamp/frappe-ui-react";
-import { addDays } from "date-fns";
-import { useFrappeGetCall, type FrappeError } from "frappe-react-sdk";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getFormatedDate, getTodayDate } from "@next-pms/design-system/date";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+import { addDays, parseISO } from "date-fns";
+import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
+import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
 import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
-import { parseFrappeErrorMsg } from "@/lib/utils";
+import { buildCompositeFilters } from "@/lib/utils";
 import type { ProjectMemberData, WeekGroup } from "./context";
-import {
-  createInitialProjectTimesheetState,
-  projectTimesheetReducer,
-} from "./reducer";
-import type { ProjectTimesheetApiResponse } from "./types";
+import type { ApiPayload, ProjectTimesheetApiResponse } from "./types";
 
 type UseProjectTimesheetDataResult = {
-  hasMoreWeeks: boolean;
+  hasMore: boolean;
   isLoadingProjectData: boolean;
   weekGroups: WeekGroup[];
   loadData: () => void;
+  error: FrappeError | undefined;
+  resetData: () => void;
 };
 
-const EMPLOYEE_PAGE_LENGTH = 10;
+type UseProjectTimesheetOptions = {
+  search: string;
+  compositeFilters: FilterCondition[];
+};
 
-export function useProjectTimesheetData(): UseProjectTimesheetDataResult {
-  const toast = useToasts();
+const PROJECT_PAGE_LENGTH = 10;
 
-  const [state, dispatch] = useReducer(
-    projectTimesheetReducer,
-    undefined,
-    createInitialProjectTimesheetState,
+export function useProjectTimesheetData({
+  search,
+  compositeFilters,
+}: UseProjectTimesheetOptions): UseProjectTimesheetDataResult {
+  const [weekDate, setWeekDate] = useState(getTodayDate());
+  const [projectStart, setProjectStart] = useState(0);
+
+  // Each entry represents one paginated fetch.
+  // All derived data (weeks, projects, members) is computed from this.
+  const [pages, setPages] = useState<ApiPayload[]>([]);
+
+  // Track filter changes to reset pagination
+  const prevFiltersRef = useRef({ search, compositeFilters });
+
+  // Build Frappe-compatible filters from composite filters
+  const { startDate, maxWeek, frappeFilters } = useMemo(
+    () => buildCompositeFilters(compositeFilters),
+    [compositeFilters],
   );
+
+  const resetData = useCallback(() => {
+    setPages([]);
+    // When a date-range filter is active, start the sliding window at the
+    // filter's end date (startDate) so week pagination walks backward through
+    // the filtered range instead of from today.
+    setWeekDate(startDate ?? getTodayDate());
+    setProjectStart(0);
+  }, [startDate]);
+
+  // Reset pagination when filters change
+  useEffect(() => {
+    const filtersChanged =
+      prevFiltersRef.current.search !== search ||
+      JSON.stringify(prevFiltersRef.current.compositeFilters) !==
+        JSON.stringify(compositeFilters);
+
+    if (filtersChanged) {
+      resetData();
+      prevFiltersRef.current = { search, compositeFilters };
+    }
+  }, [search, compositeFilters, resetData]);
+
+  const hasActiveFilter = !!search || compositeFilters.length > 0;
 
   const {
     data: projectTimesheetData,
     error: projectTimesheetError,
-    isLoading: isLoadingProjectData,
+    isLoading: isLoadingProjectApiData,
   } = useFrappeGetCall<ProjectTimesheetApiResponse>(
     "next_pms.timesheet.api.project.get_project_timesheet_data",
     {
-      date: state.weekDate,
-      max_week: String(NUMBER_OF_WEEKS_TO_FETCH),
-      page_length: String(EMPLOYEE_PAGE_LENGTH),
-      start: String(state.employeeStart),
+      date: weekDate,
+      max_week: maxWeek,
+      page_length: PROJECT_PAGE_LENGTH,
+      start: projectStart,
+      search: search || null,
+      filters: frappeFilters.length > 0 ? JSON.stringify(frappeFilters) : null,
+      skip_empty_weeks: hasActiveFilter || null,
     },
   );
 
@@ -55,33 +97,26 @@ export function useProjectTimesheetData(): UseProjectTimesheetDataResult {
     if (!projectTimesheetData?.message) {
       return;
     }
-    dispatch({
-      type: "APPEND_PAGE",
-      payload: projectTimesheetData.message,
-    });
+    setPages((prev) => [...prev, projectTimesheetData.message as ApiPayload]);
   }, [projectTimesheetData]);
 
-  useEffect(() => {
-    if (!projectTimesheetError) {
-      return;
-    }
+  // All transformation lives here. Because this is pure data derivation (no side effects).
+  const { hasMoreProjects, hasMoreWeeks, hasMore, weekGroups } = useMemo(() => {
+    const oneYearAgo = addDays(parseISO(getTodayDate()), -365);
+    // When a date-range filter is active, limit week pagination to the actual
+    // filter range (startDate − maxWeek weeks). Without a filter, fall back
+    // to the 1-year rolling limit.
+    const hasMoreWeeks = startDate
+      ? parseISO(weekDate) > addDays(parseISO(startDate), -(maxWeek * 7))
+      : parseISO(weekDate) > oneYearAgo;
 
-    const message = parseFrappeErrorMsg(projectTimesheetError as FrappeError);
-    toast.error(message || "Failed to load project timesheets.");
-  }, [projectTimesheetError, toast]);
-
-  const { hasMoreEmployees, hasMoreWeeks, weekGroups } = useMemo(() => {
-    const hasMoreEmployees =
-      state.pages.length > 0
-        ? (state.pages[state.pages.length - 1].has_more ?? false)
-        : true;
-
-    const hasMoreWeeks = true;
+    const hasMoreProjects =
+      pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
 
     const weekMap = new Map<string, WeekGroup>();
     const projectMemberDedup = new Map<string, Set<string>>();
 
-    state.pages.forEach((page) => {
+    pages.forEach((page) => {
       (page.week_groups ?? []).forEach((week) => {
         if (!weekMap.has(week.start_date)) {
           weekMap.set(week.start_date, {
@@ -146,44 +181,78 @@ export function useProjectTimesheetData(): UseProjectTimesheetDataResult {
       )
       .map((week) => ({
         ...week,
-        projects: week.projects.sort((a, b) =>
-          (a.projectName || a.project).localeCompare(
-            b.projectName || b.project,
-          ),
+        projects: [...week.projects].sort((a, b) =>
+          (a.projectName ?? "").localeCompare(b.projectName ?? ""),
         ),
       }));
 
-    return { hasMoreEmployees, hasMoreWeeks, weekGroups };
-  }, [state.pages]);
+    const hasMore = hasMoreProjects || hasMoreWeeks;
 
+    return { hasMoreProjects, hasMoreWeeks, hasMore, weekGroups };
+  }, [pages, weekDate, startDate, maxWeek]);
+
+  // When the current window is fully loaded but yields no visible weeks, we are
+  // about to auto-advance. Expose this as "still loading" to prevent a flicker
+  // where the consumer briefly sees an empty / "No Data" state before the next
+  // fetch starts.
+  const isAutoAdvancing =
+    !isLoadingProjectApiData &&
+    pages.length > 0 &&
+    !hasMoreProjects &&
+    weekGroups.length === 0 &&
+    hasMoreWeeks;
+
+  // Auto-advance the week window when a fully-loaded window yields no visible
+  // weeks (all employees have "Not Submitted" timesheets for that range).
+  // This prevents a "No Data" screen when data exists in older date ranges,
+  // which happens frequently when skip_empty_weeks is active with a filter.
+  useEffect(() => {
+    if (isLoadingProjectApiData) return;
+    if (pages.length === 0) return;
+    if (hasMoreProjects) return; // current window not fully loaded yet
+    if (weekGroups.length > 0) return; // we have visible data
+    if (!hasMoreWeeks) return;
+
+    setWeekDate((prev) =>
+      getFormatedDate(addDays(prev, -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
+    );
+    setProjectStart(0);
+  }, [
+    isLoadingProjectApiData,
+    hasMoreProjects,
+    hasMoreWeeks,
+    weekGroups.length,
+    pages.length,
+  ]);
+
+  // Unified loadData: prioritizes project pagination, then week pagination.
   const loadData = useCallback(() => {
-    if (isLoadingProjectData) {
+    if (isLoadingProjectApiData) return;
+
+    // Priority 1: Load more projects for current date range
+    if (hasMoreProjects) {
+      setProjectStart((prev) => prev + PROJECT_PAGE_LENGTH);
       return;
     }
 
-    if (hasMoreEmployees) {
-      dispatch({
-        type: "LOAD_MORE_EMPLOYEES",
-        payload: { pageLength: EMPLOYEE_PAGE_LENGTH },
-      });
-      return;
+    // Priority 2: Load more weeks (with project pagination reset).
+    // Advance by the fixed batch window from the current weekDate so we always
+    // produce a new date value.
+    if (hasMoreWeeks) {
+      setWeekDate((prev) =>
+        getFormatedDate(addDays(prev, -(NUMBER_OF_WEEKS_TO_FETCH * 7))),
+      );
+      setProjectStart(0);
     }
-
-    if (!hasMoreWeeks || weekGroups.length === 0) {
-      return;
-    }
-
-    const oldestWeek = weekGroups[weekGroups.length - 1];
-    dispatch({
-      type: "SET_WEEK_DATE",
-      payload: getFormatedDate(addDays(oldestWeek.start_date, -1)),
-    });
-  }, [hasMoreEmployees, hasMoreWeeks, isLoadingProjectData, weekGroups]);
+  }, [hasMoreProjects, hasMoreWeeks, isLoadingProjectApiData]);
 
   return {
-    hasMoreWeeks,
-    isLoadingProjectData,
+    hasMore,
+    isLoadingProjectData:
+      isLoadingProjectApiData || isAutoAdvancing || pages.length === 0,
     weekGroups,
     loadData,
+    error: projectTimesheetError,
+    resetData,
   };
 }


### PR DESCRIPTION
## Description
- Introduces composite filters for project page
- Adds double pagination

## Relevant Technical Choices
- Follows the same pattern I used for the useTeamTimesheetData hook.
- Similar loading state as on team page

## Screenshot/Screencast
<img width="713" height="572" alt="image" src="https://github.com/user-attachments/assets/41333395-2558-4561-91a3-b9c5a9dfd7ba" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #827