### PR TITLE
Fix: Click event handling on Kanban Card

### DIFF
--- a/frontend/packages/app/src/pages/projects/kanban/constants.ts
+++ b/frontend/packages/app/src/pages/projects/kanban/constants.ts
@@ -2,3 +2,4 @@
  * Internal dependencies.
  */
 export const KANBAN_COLUMN_WIDTH = 284;
+export const CLICK_DRAG_THRESHOLD_PX = 5;

--- a/frontend/packages/app/src/pages/projects/kanban/projectCard.tsx
+++ b/frontend/packages/app/src/pages/projects/kanban/projectCard.tsx
@@ -1,26 +1,56 @@
 /**
  * External dependencies.
  */
+import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { Avatar } from "@rtcamp/frappe-ui-react";
 import { AgentAlt, Apps, Calendar, Code } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
  */
+import { ROUTES } from "@/lib/constant";
 import { formatProjectDate, toKebabCase } from "@/lib/utils";
 
 import { Dot } from "../list/cells/dot";
 import type { RagStatus } from "../types";
+import { CLICK_DRAG_THRESHOLD_PX } from "./constants";
 import type { Employee, KanbanProjectItem } from "./types";
 
 export function ProjectCard({ project }: { project: KanbanProjectItem }) {
+  const navigate = useNavigate();
+  const pointerStart = useRef<{ x: number; y: number } | null>(null);
+
   const dateRange = [project.start_date, project.end_date]
     .map((d) => (d ? formatProjectDate(d) : null))
     .filter(Boolean)
     .join(" - ");
 
   return (
-    <div className="flex w-full cursor-pointer flex-col gap-2.5 rounded-2xl border border-outline-gray-modals bg-surface-white pb-3 shadow-sm">
+    <div
+      role="link"
+      tabIndex={0}
+      onPointerDown={(e) => {
+        pointerStart.current = { x: e.clientX, y: e.clientY };
+      }}
+      onPointerUp={(e) => {
+        const start = pointerStart.current;
+        pointerStart.current = null;
+        if (!start) return;
+        const dx = e.clientX - start.x;
+        const dy = e.clientY - start.y;
+        if (Math.hypot(dx, dy) <= CLICK_DRAG_THRESHOLD_PX) {
+          navigate(`${ROUTES.project}/${project.name}`);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          navigate(`${ROUTES.project}/${project.name}`);
+        }
+      }}
+      className="flex w-full cursor-pointer flex-col gap-2.5 rounded-2xl border border-outline-gray-modals bg-surface-white pb-3 shadow-sm hover:bg-surface-gray-2 focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
+    >
       <div className="flex w-full items-center gap-2 rounded-t-2xl border-b border-outline-gray-1 px-3.5 py-3">
         <Dot risk={toKebabCase(project.rag_status) as RagStatus} />
         <span className="min-w-0 flex-1 truncate text-base font-medium text-ink-gray-7">


### PR DESCRIPTION
## Description

Clicking a project card in kanban view now redirects to project details page.

## Relevant Technical Choices

-Uses pointer up and drag offset to differentiate b/w click and a drag.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


https://github.com/user-attachments/assets/d79f6f25-0189-4d8b-973e-cd95a4ce6b58


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes [Comment](https://github.com/rtCamp/next-pms/issues/1026#issuecomment-4469694960) in #1026