### PR TITLE
Fix Team Allocations Popover Visibility

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectBar.tsx
@@ -204,11 +204,11 @@ export function GanttProjectBar({
 
   return (
     <PreviewCard.Root>
-      <PreviewCard.Trigger
-        delay={400}
-        closeDelay={150}
-        render={
-          <Tooltip text="Click to save the allocation" disabled={!isModified}>
+      <Tooltip text="Click to save the allocation" disabled={!isModified}>
+        <PreviewCard.Trigger
+          delay={400}
+          closeDelay={150}
+          render={
             <GanttBar
               ref={projectBarRef}
               variant="project"
@@ -231,9 +231,9 @@ export function GanttProjectBar({
               onKeyDown={handleKeyDown}
               onResizeEnd={handleResizeEnd}
             />
-          </Tooltip>
-        }
-      />
+          }
+        />
+      </Tooltip>
       <PreviewCard.Portal>
         <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
           <PreviewCard.Popup className="z-50 outline-none">


### PR DESCRIPTION
## Description

This PR fixes a regression caused by PR #1329, which added tooltips for the project allocation and draft bar.

The project allocation bar uses a BaseUI component with a render function to render the trigger. The tooltip component was placed inside that render function, and the tooltip interaction was stopping proper event propagation. Because of this, hovering over the project allocation bar was not triggering the popover correctly.

This issue was fixed by moving the tooltip outside of the trigger component.


## Testing Instructions

* Navigate to the Team Allocation page.
* Open any member and hover over an allocation.
* Verify that the popover is shown correctly.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

<img width="528" height="320" alt="Screenshot 2026-05-18 at 4 53 20 PM" src="https://github.com/user-attachments/assets/a264fceb-92d1-48dc-b5d7-90b72966d720" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes [comment](https://github.com/rtCamp/next-pms/pull/1329#issuecomment-4477156517) on #1329