### PR TITLE
fix: update mention notification email subject and remove open document link

### DIFF
--- a/next_pms/templates/emails/new_notification.html
+++ b/next_pms/templates/emails/new_notification.html
@@ -1,0 +1,13 @@
+<p>
+    <p class="text-color">{{ body_content }}</p>
+</p>
+{% if description %}
+<blockquote>
+    {{ description | markdown }}
+</blockquote>
+{% endif %}
+{% if doc_link and "tab=Project+Updates" not in doc_link %}
+<div class="more-info">
+    <a href="{{ doc_link }}">{{ _("Open Document") }}</a>
+</div>
+{% endif %}

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -413,7 +413,9 @@ def notify_mentions(
     if project_status_update and frappe.db.exists("Project Status Update", project_status_update):
         status_update_doc = frappe.get_doc("Project Status Update", project_status_update)
         project_name = status_update_doc.project
-        notification_context = f"project status update for: {project_name}"
+        update_title = status_update_doc.title
+        project_title = frappe.db.get_value("Project", project_name, "project_name")
+        notification_context = f"project status '{update_title}' for project '{project_title}'"
     else:
         return {"message": "No project status update found"}
 

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -413,8 +413,7 @@ def notify_mentions(
     if project_status_update and frappe.db.exists("Project Status Update", project_status_update):
         status_update_doc = frappe.get_doc("Project Status Update", project_status_update)
         project_name = status_update_doc.project
-        update_title = status_update_doc.title
-        notification_context = f"project status update '{update_title}'"
+        notification_context = f"project status update for: {project_name}"
     else:
         return {"message": "No project status update found"}
 
@@ -435,6 +434,7 @@ def notify_mentions(
                 "document_type": doc_type,
                 "document_name": doc_name,
                 "from_user": current_user,
+                "link": project_url,
                 "email_content": frappe.render_template(  # nosemgrep - trusted template file
                     "next_pms/timesheet/templates/project_status_update/mention_notification.html",
                     {


### PR DESCRIPTION
## Description

Fixes mention notification email to include project name in subject line and remove the "Open Document" link.

## Relevant Technical Choices

- Updated `notification_context` to use `project_name`, so the email subject reads `"You were mentioned in project status update for: <project_name>"`
- Overrode Frappe's `new_notification.html` at `next_pms/templates/emails/` to conditionally hide the "Open Document" link when the notification is triggered from a project status update (detected via `tab=Project+Updates` in `doc_link`)

## Testing Instructions

1. Go to a project in Next PMS and open the Project Updates tab
2. Add a status update and mention a user
3. Verify subject line reads `"You were mentioned in project status update for: <project_name>"`
4. Verify "Open Document" link is not present in the email body
5. Trigger any other notification type (assignment, share, etc.) and verify "Open Document" still appears normally


## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1108" height="784" alt="image" src="https://github.com/user-attachments/assets/cf59ea5d-b204-43b1-acab-a73b9dc01860" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes [#2627 ](https://github.com/rtCamp/erp-rtcamp/issues/2627)