### PR TITLE
fix(customer): auto-disambiguate colliding custom_abbr

### DIFF
--- a/next_pms/api/customer.py
+++ b/next_pms/api/customer.py
@@ -1,0 +1,60 @@
+import re
+
+import frappe
+
+
+@frappe.whitelist()
+def generate_unique_abbr(customer_name: str, exclude_name: str | None = None) -> str:
+    """Build a unique custom_abbr from customer_name initials.
+
+    On collision, extend the abbr by pulling the next character from the
+    leftmost word that still has unused characters. Example:
+        "Acme Web Co"      -> AWC
+        "Apex Widget Corp" -> APWC   (first word extended to AP)
+        "AP Web Company"   -> APWEC  (first word exhausted, second extended to WE)
+
+    Every candidate abbr we could generate starts with the first letter of
+    each word in order, so we prefetch all existing customer abbrs matching
+    that shape (e.g. ``A%W%C%``) in one query and check collisions in memory.
+    """
+    words = (customer_name or "").split()
+    if not words:
+        frappe.throw(frappe._("Abbreviation is mandatory"))
+
+    # Strip SQL LIKE wildcards (and other non-alphanumerics) from the leading
+    # char of each word so a customer name like "%Foo Bar" can't leak `%`/`_`
+    # into the prefetch pattern. The inner loop below still uses the raw
+    # word chars for the generated abbr itself — only the prefetch shape is
+    # sanitized.
+    initial_chars = [re.sub(r"[^A-Za-z0-9]", "", w[:1]) for w in words]
+    initial_chars = [c for c in initial_chars if c]
+
+    if not initial_chars:
+        # Customer name has no usable alphanumeric leading chars — fall back
+        # to no prefetch; the in-memory collision check will just see an
+        # empty set and the first candidate abbr will be returned.
+        taken = set()
+    else:
+        abbr_like_pattern = "%".join(initial_chars).upper() + "%"
+        filters = {"custom_abbr": ["like", abbr_like_pattern]}
+        if exclude_name:
+            filters["name"] = ["!=", exclude_name]
+        # Case-normalize: DB collation may be case-insensitive and return
+        # lowercase values like "awc" for the pattern "A%W%C%". Our generated
+        # candidate is uppercase, so we upper-case the taken set too.
+        taken = {v.upper() for v in frappe.get_all("Customer", filters=filters, pluck="custom_abbr")}
+
+    # In-memory disambiguation loop — `taken` was prefetched above so this
+    # does no DB I/O regardless of how many iterations it takes.
+    slice_lens = [1] * len(words)
+    while True:
+        abbr = "".join(words[i][: slice_lens[i]] for i in range(len(words))).upper()
+        if abbr not in taken:
+            return abbr
+
+        for i in range(len(words)):
+            if slice_lens[i] < len(words[i]):
+                slice_lens[i] += 1
+                break
+        else:
+            frappe.throw(frappe._("Unable to generate unique abbreviation from customer name"))

--- a/next_pms/public/js/customer.js
+++ b/next_pms/public/js/customer.js
@@ -2,8 +2,7 @@ frappe.ui.form.on("Customer", {
   customer_name: async function (frm) {
     if (!frm.doc.customer_name) return;
     const { message } = await frappe.call({
-      method:
-        "next_pms.resource_management.doc_events.customer._generate_unique_abbr",
+      method: "next_pms.api.customer.generate_unique_abbr",
       args: {
         customer_name: frm.doc.customer_name,
         exclude_name: frm.doc.name || null,

--- a/next_pms/public/js/customer.js
+++ b/next_pms/public/js/customer.js
@@ -1,13 +1,14 @@
 frappe.ui.form.on("Customer", {
   customer_name: async function (frm) {
-    if (frm.doc.customer_name) {
-      const abbr = frm.doc.customer_name
-        .split(" ")
-        .filter(Boolean)
-        .map((w) => w[0])
-        .join("")
-        .toUpperCase();
-      frm.set_value("custom_abbr", abbr);
-    }
+    if (!frm.doc.customer_name) return;
+    const { message } = await frappe.call({
+      method:
+        "next_pms.resource_management.doc_events.customer._generate_unique_abbr",
+      args: {
+        customer_name: frm.doc.customer_name,
+        exclude_name: frm.doc.name || null,
+      },
+    });
+    if (message) frm.set_value("custom_abbr", message);
   },
 });

--- a/next_pms/public/js/customer_quickentry.js
+++ b/next_pms/public/js/customer_quickentry.js
@@ -9,17 +9,16 @@ class CustomerQuickEntryForm extends frappe.ui.form.CustomerQuickEntryForm {
     };
   }
 
-  set_abbr() {
+  async set_abbr() {
     const name = this.dialog.doc.customer_name || "";
+    if (!name) return;
 
-    const abbr = name
-      .split(" ")
-      .filter(Boolean)
-      .map((w) => w[0])
-      .join("")
-      .toUpperCase();
-
-    this.dialog.set_value("custom_abbr", abbr);
+    const { message } = await frappe.call({
+      method:
+        "next_pms.resource_management.doc_events.customer._generate_unique_abbr",
+      args: { customer_name: name },
+    });
+    if (message) this.dialog.set_value("custom_abbr", message);
   }
 }
 frappe.ui.form.CustomerQuickEntryForm = CustomerQuickEntryForm;

--- a/next_pms/public/js/customer_quickentry.js
+++ b/next_pms/public/js/customer_quickentry.js
@@ -14,8 +14,7 @@ class CustomerQuickEntryForm extends frappe.ui.form.CustomerQuickEntryForm {
     if (!name) return;
 
     const { message } = await frappe.call({
-      method:
-        "next_pms.resource_management.doc_events.customer._generate_unique_abbr",
+      method: "next_pms.api.customer.generate_unique_abbr",
       args: { customer_name: name },
     });
     if (message) this.dialog.set_value("custom_abbr", message);

--- a/next_pms/resource_management/doc_events/customer.py
+++ b/next_pms/resource_management/doc_events/customer.py
@@ -1,3 +1,5 @@
+import re
+
 import frappe
 
 
@@ -15,6 +17,7 @@ def validate_abbr(doc, method=None):
         frappe.throw(frappe._("Abbreviation already used for another customer"))
 
 
+@frappe.whitelist()
 def _generate_unique_abbr(customer_name, exclude_name=None):
     """Build a unique custom_abbr from customer_name initials.
 
@@ -32,11 +35,28 @@ def _generate_unique_abbr(customer_name, exclude_name=None):
     if not words:
         frappe.throw(frappe._("Abbreviation is mandatory"))
 
-    shape_pattern = "%".join(w[0] for w in words).upper() + "%"
-    filters = {"custom_abbr": ["like", shape_pattern]}
-    if exclude_name:
-        filters["name"] = ["!=", exclude_name]
-    taken = set(frappe.get_all("Customer", filters=filters, pluck="custom_abbr"))
+    # Strip SQL LIKE wildcards (and other non-alphanumerics) from the leading
+    # char of each word so a customer name like "%Foo Bar" can't leak `%`/`_`
+    # into the prefetch pattern. The inner loop below still uses the raw
+    # word chars for the generated abbr itself — only the prefetch shape is
+    # sanitized.
+    shape_chars = [re.sub(r"[^A-Za-z0-9]", "", w[:1]) for w in words]
+    shape_chars = [c for c in shape_chars if c]
+
+    if not shape_chars:
+        # Customer name has no usable alphanumeric leading chars — fall back
+        # to no prefetch; the in-memory collision check will just see an
+        # empty set and the first candidate abbr will be returned.
+        taken = set()
+    else:
+        shape_pattern = "%".join(shape_chars).upper() + "%"
+        filters = {"custom_abbr": ["like", shape_pattern]}
+        if exclude_name:
+            filters["name"] = ["!=", exclude_name]
+        # Case-normalize: DB collation may be case-insensitive and return
+        # lowercase values like "awc" for the pattern "A%W%C%". Our generated
+        # candidate is uppercase, so we upper-case the taken set too.
+        taken = {v.upper() for v in frappe.get_all("Customer", filters=filters, pluck="custom_abbr")}
 
     slice_lens = [1] * len(words)
     while True:

--- a/next_pms/resource_management/doc_events/customer.py
+++ b/next_pms/resource_management/doc_events/customer.py
@@ -1,11 +1,11 @@
-import re
-
 import frappe
+
+from next_pms.api.customer import generate_unique_abbr
 
 
 def validate_abbr(doc, method=None):
     if not doc.custom_abbr:
-        doc.custom_abbr = _generate_unique_abbr(doc.customer_name, exclude_name=doc.name)
+        doc.custom_abbr = generate_unique_abbr(doc.customer_name, exclude_name=doc.name)
         return
 
     doc.custom_abbr = doc.custom_abbr.strip()
@@ -15,58 +15,3 @@ def validate_abbr(doc, method=None):
 
     if frappe.db.get_value("Customer", {"custom_abbr": doc.custom_abbr, "name": ["!=", doc.name]}):
         frappe.throw(frappe._("Abbreviation already used for another customer"))
-
-
-@frappe.whitelist()
-def _generate_unique_abbr(customer_name: str, exclude_name: str | None = None) -> str:
-    """Build a unique custom_abbr from customer_name initials.
-
-    On collision, extend the abbr by pulling the next character from the
-    leftmost word that still has unused characters. Example:
-        "Acme Web Co"      -> AWC
-        "Apex Widget Corp" -> APWC   (first word extended to AP)
-        "AP Web Company"   -> APWEC  (first word exhausted, second extended to WE)
-
-    Every candidate abbr we could generate starts with the first letter of
-    each word in order, so we prefetch all existing customer abbrs matching
-    that shape (e.g. ``A%W%C%``) in one query and check collisions in memory.
-    """
-    words = (customer_name or "").split()
-    if not words:
-        frappe.throw(frappe._("Abbreviation is mandatory"))
-
-    # Strip SQL LIKE wildcards (and other non-alphanumerics) from the leading
-    # char of each word so a customer name like "%Foo Bar" can't leak `%`/`_`
-    # into the prefetch pattern. The inner loop below still uses the raw
-    # word chars for the generated abbr itself — only the prefetch shape is
-    # sanitized.
-    shape_chars = [re.sub(r"[^A-Za-z0-9]", "", w[:1]) for w in words]
-    shape_chars = [c for c in shape_chars if c]
-
-    if not shape_chars:
-        # Customer name has no usable alphanumeric leading chars — fall back
-        # to no prefetch; the in-memory collision check will just see an
-        # empty set and the first candidate abbr will be returned.
-        taken = set()
-    else:
-        shape_pattern = "%".join(shape_chars).upper() + "%"
-        filters = {"custom_abbr": ["like", shape_pattern]}
-        if exclude_name:
-            filters["name"] = ["!=", exclude_name]
-        # Case-normalize: DB collation may be case-insensitive and return
-        # lowercase values like "awc" for the pattern "A%W%C%". Our generated
-        # candidate is uppercase, so we upper-case the taken set too.
-        taken = {v.upper() for v in frappe.get_all("Customer", filters=filters, pluck="custom_abbr")}
-
-    slice_lens = [1] * len(words)
-    while True:
-        abbr = "".join(words[i][: slice_lens[i]] for i in range(len(words))).upper()
-        if abbr not in taken:
-            return abbr
-
-        for i in range(len(words)):
-            if slice_lens[i] < len(words[i]):
-                slice_lens[i] += 1
-                break
-        else:
-            frappe.throw(frappe._("Unable to generate unique abbreviation from customer name"))

--- a/next_pms/resource_management/doc_events/customer.py
+++ b/next_pms/resource_management/doc_events/customer.py
@@ -3,12 +3,50 @@ import frappe
 
 def validate_abbr(doc, method=None):
     if not doc.custom_abbr:
-        doc.custom_abbr = "".join(c[0] for c in doc.customer_name.split()).upper()
+        doc.custom_abbr = _generate_unique_abbr(doc.customer_name, exclude_name=doc.name)
+        return
 
     doc.custom_abbr = doc.custom_abbr.strip()
 
-    if not doc.custom_abbr.strip():
+    if not doc.custom_abbr:
         frappe.throw(frappe._("Abbreviation is mandatory"))
 
     if frappe.db.get_value("Customer", {"custom_abbr": doc.custom_abbr, "name": ["!=", doc.name]}):
         frappe.throw(frappe._("Abbreviation already used for another customer"))
+
+
+def _generate_unique_abbr(customer_name, exclude_name=None):
+    """Build a unique custom_abbr from customer_name initials.
+
+    On collision, extend the abbr by pulling the next character from the
+    leftmost word that still has unused characters. Example:
+        "Acme Web Co"      -> AWC
+        "Apex Widget Corp" -> APWC   (first word extended to AP)
+        "AP Web Company"   -> APWEC  (first word exhausted, second extended to WE)
+
+    Every candidate abbr we could generate starts with the first letter of
+    each word in order, so we prefetch all existing customer abbrs matching
+    that shape (e.g. ``A%W%C%``) in one query and check collisions in memory.
+    """
+    words = (customer_name or "").split()
+    if not words:
+        frappe.throw(frappe._("Abbreviation is mandatory"))
+
+    shape_pattern = "%".join(w[0] for w in words).upper() + "%"
+    filters = {"custom_abbr": ["like", shape_pattern]}
+    if exclude_name:
+        filters["name"] = ["!=", exclude_name]
+    taken = set(frappe.get_all("Customer", filters=filters, pluck="custom_abbr"))
+
+    slice_lens = [1] * len(words)
+    while True:
+        abbr = "".join(words[i][: slice_lens[i]] for i in range(len(words))).upper()
+        if abbr not in taken:
+            return abbr
+
+        for i in range(len(words)):
+            if slice_lens[i] < len(words[i]):
+                slice_lens[i] += 1
+                break
+        else:
+            frappe.throw(frappe._("Unable to generate unique abbreviation from customer name"))

--- a/next_pms/resource_management/doc_events/customer.py
+++ b/next_pms/resource_management/doc_events/customer.py
@@ -18,7 +18,7 @@ def validate_abbr(doc, method=None):
 
 
 @frappe.whitelist()
-def _generate_unique_abbr(customer_name, exclude_name=None):
+def _generate_unique_abbr(customer_name: str, exclude_name: str | None = None) -> str:
     """Build a unique custom_abbr from customer_name initials.
 
     On collision, extend the abbr by pulling the next character from the

--- a/next_pms/tests/test_customer_abbr.py
+++ b/next_pms/tests/test_customer_abbr.py
@@ -1,5 +1,3 @@
-import unittest
-
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -97,7 +95,3 @@ class TestCustomerAbbr(IntegrationTestCase):
         # collation). With the fix it should disambiguate to APWC.
         self.assertNotEqual(c2.custom_abbr, "AWC")
         self.assertEqual(c2.custom_abbr, "APWC")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/next_pms/tests/test_customer_abbr.py
+++ b/next_pms/tests/test_customer_abbr.py
@@ -1,0 +1,103 @@
+import unittest
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class TestCustomerAbbr(IntegrationTestCase):
+    """Regression tests for the Customer custom_abbr auto-generation logic in
+    ``next_pms.resource_management.doc_events.customer``.
+
+    Each test rolls back its DB writes in tearDown so customers created here
+    don't pollute the site (and don't collide across test runs).
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Track customers created during the test so we can clean them up if
+        # the rollback strategy isn't sufficient.
+        self._created_customer_names: list[str] = []
+
+    def tearDown(self):
+        # Roll back any uncommitted DB writes from this test. ``insert()`` in
+        # Frappe doesn't auto-commit, so this is normally enough to keep the
+        # site clean.
+        frappe.db.rollback()
+        super().tearDown()
+
+    def _make_customer(self, customer_name, custom_abbr=None):
+        """Create a Customer doc; let the validate hook auto-fill custom_abbr
+        unless one is explicitly passed in.
+        """
+        data = {
+            "doctype": "Customer",
+            "customer_name": customer_name,
+            "customer_type": "Company",
+            "default_currency": "INR",
+        }
+        if custom_abbr is not None:
+            data["custom_abbr"] = custom_abbr
+        doc = frappe.get_doc(data)
+        doc.insert(ignore_if_duplicate=False)
+        self._created_customer_names.append(doc.name)
+        return doc
+
+    def test_two_colliding_customers_extends_first_word(self):
+        """`Acme Web Co` -> AWC; `Apex Widget Corp` collides and extends to APWC."""
+        c1 = self._make_customer("Acme Web Co")
+        self.assertEqual(c1.custom_abbr, "AWC")
+
+        c2 = self._make_customer("Apex Widget Corp")
+        self.assertEqual(c2.custom_abbr, "APWC")
+
+    def test_three_way_collision_walks_into_next_word(self):
+        """With AWC and APWC taken, `AP Web Company` should become APWEC."""
+        self._make_customer("Acme Web Co")  # AWC
+        self._make_customer("Apex Widget Corp")  # APWC
+
+        c3 = self._make_customer("AP Web Company")
+        self.assertEqual(c3.custom_abbr, "APWEC")
+
+    def test_resave_existing_customer_preserves_abbr(self):
+        """Re-saving an existing customer without changing custom_abbr must not
+        throw and must keep the existing value (verifies the ``exclude_name``
+        filter on the uniqueness check)."""
+        c = self._make_customer("Acme Web Co")
+        self.assertEqual(c.custom_abbr, "AWC")
+
+        # Reload and save without changing anything.
+        c.reload()
+        c.save()
+        self.assertEqual(c.custom_abbr, "AWC")
+
+        # And changing some unrelated field shouldn't throw either.
+        c.customer_type = "Company"
+        c.save()
+        self.assertEqual(c.custom_abbr, "AWC")
+
+    def test_user_typed_colliding_abbr_throws(self):
+        """When the user supplies a custom_abbr that collides with an existing
+        customer's, validate_abbr must raise."""
+        self._make_customer("Acme Web Co")  # AWC
+
+        with self.assertRaises(frappe.ValidationError):
+            self._make_customer("Other Name", custom_abbr="AWC")
+
+    def test_case_insensitive_existing_row_is_detected(self):
+        """If an existing customer has a lowercase ``custom_abbr`` (e.g. ``awc``)
+        the auto-generator must still detect the collision and disambiguate.
+        Regression for the case-normalization fix on the ``taken`` set."""
+        c1 = self._make_customer("Acme Web Co")
+        # Sneak a lowercase abbr past the validator so we can verify the
+        # generator handles a case-insensitive DB collation correctly.
+        frappe.db.set_value("Customer", c1.name, "custom_abbr", "awc")
+
+        c2 = self._make_customer("Apex Widget Corp")
+        # Must not equal "AWC" (would be a collision under case-insensitive
+        # collation). With the fix it should disambiguate to APWC.
+        self.assertNotEqual(c2.custom_abbr, "AWC")
+        self.assertEqual(c2.custom_abbr, "APWC")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1341 — Customer creation fails when two customers share the same auto-generated `custom_abbr`.

The `validate_abbr` hook on Customer auto-generates `custom_abbr` from the initials of `customer_name`, then enforces uniqueness on that value. Real-world initials collide often (`Acme Web Co` vs `Apex Widget Corp` both → `AWC`), so the second Customer save fails with *"Abbreviation already used for another customer"* — for a field the user never typed and may not even see. This breaks Frappe CRM's built-in ERPNext integration whenever a Won deal's customer initials collide with an existing customer.

## Fix

Replace the one-shot initials join with a disambiguation loop in `next_pms/resource_management/doc_events/customer.py`:

- Start with the first letter of each word in `customer_name`.
- On collision, extend the abbr by pulling the **next character** from the leftmost word that still has unused characters.
- Once a word is exhausted, the next word starts getting extended.

| Customer name      | First-letter abbr | Collision? | Final abbr |
| ------------------ | ----------------- | ---------- | ---------- |
| `Acme Web Co`      | `AWC`             | —          | `AWC`      |
| `Apex Widget Corp` | `AWC`             | yes        | `APWC` (word 1: `A` → `AP`) |
| `AP Web Company`   | `AWC`             | yes        | `APWEC` (word 1 exhausted, word 2: `W` → `WE`) |

The result is always derived from the customer name, so the abbr stays human-meaningful — no `AWC2` / `AWC3` style numeric suffixes.

### Performance

Every candidate abbr we could generate starts with the first letter of each word in order, so all possible colliding abbrs match a shape pattern like `A%W%C%`. The fix prefetches that set in **a single LIKE query**, then resolves collisions against an in-memory `set` — O(1) DB queries regardless of how many collisions get walked through.

### User-typed abbrs

Unchanged. If the user types a value into `custom_abbr`, the original uniqueness check still throws on collision — disambiguation only runs on the auto-generated path.

## Test plan

- [ ] Create Customer `Acme Web Co` → abbr is `AWC`.
- [ ] Create Customer `Apex Widget Corp` → abbr is `APWC` (not an error).
- [ ] Create Customer `AP Web Company` → abbr is `APWEC`.
- [ ] Manually type a colliding abbr in the form → still throws "Abbreviation already used for another customer".
- [ ] Re-save an existing customer without changing `custom_abbr` → no error, value preserved (handled by `exclude_name` filter).
- [ ] Trigger Frappe CRM's ERPNext integration on a Won deal whose customer initials collide → Customer is created successfully.

Closes #1341