### PR TITLE
feat: add PM report API key in Timesheet Settings

### DIFF
--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -5,6 +5,7 @@ import frappe
 import requests
 from frappe import _
 from frappe.utils import getdate
+from frappe.utils.password import get_decrypted_password
 
 LLM_SUMMARIZE_URL = "https://rt-report-automation.rt.gw/api/llm/summarize"
 LLM_STATUS_URL = "https://rt-report-automation.rt.gw/api/inngest/runs"
@@ -17,11 +18,11 @@ COMPLETION_POLL_INTERVAL = 30
 
 
 def get_api_key() -> str:
-    api_key = frappe.conf.get("pm_report_api_key")
+    api_key = get_decrypted_password("Timesheet Settings", "Timesheet Settings", "pm_report_api_key")
     if isinstance(api_key, str):
         api_key = api_key.strip()
     if not api_key:
-        frappe.throw(_("PM Report API key is not configured. Please set `pm_report_api_key` in site config."))
+        frappe.throw(_("PM Report API key is not configured. Please set it in Timesheet Settings."))
     return api_key
 
 

--- a/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.json
+++ b/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.json
@@ -23,6 +23,8 @@
   "day_to_send_reminder",
   "weekly_approval_reminder_template",
   "allowed_departments",
+  "report_configuration_section",
+  "pm_report_api_key",
   "tab_break_34k6",
   "notifications_section",
   "send_missing_allocation_reminder",
@@ -208,12 +210,22 @@
    "fieldtype": "Table MultiSelect",
    "label": "Ignored Role",
    "options": "Timesheet Role"
+  },
+  {
+   "fieldname": "report_configuration_section",
+   "fieldtype": "Section Break",
+   "label": "Report Configuration"
+  },
+  {
+   "fieldname": "pm_report_api_key",
+   "fieldtype": "Password",
+   "label": "PM Report API Key"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-27 17:38:39.008638",
+ "modified": "2026-05-18 18:46:23.443800",
  "modified_by": "Administrator",
  "module": "Timesheet",
  "name": "Timesheet Settings",


### PR DESCRIPTION
## Description

Add a `PM Report API Key` Password field in Timesheet Settings under a new "Report Configuration" section, and update `get_api_key()` to read and decrypt the key from there instead of site config.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

1. Go to Timesheet Settings
2. Enter the PM Report API key in the "PM Report API Key" field under Report Configuration
3. Trigger a PM Report generation from any project
4. Verify the report generates successfully without Unauthorized error

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
