### PR TITLE
Feature: Add project allocations sidebar

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/fakeData.ts
+++ b/frontend/packages/app/src/pages/allocations/project/fakeData.ts
@@ -11,15 +11,18 @@ const weekCountByDuration: Record<AllocationsDuration, number> = {
   "this-quarter": 13,
 };
 
-export const projectAllocationShellProjects: ProjectGroup[] = [
+const PROJECT_SHELL_COUNT = 10;
+
+const projectAllocationShellTemplates: ProjectGroup[] = [
   {
-    id: "project-atlas",
-    name: "Project Atlas",
-    client: "Acme Corp",
+    id: "atlas-mobile-app-checkout-flow-stabilisation",
+    name: "Atlas Mobile App Checkout Flow Stabilisation",
+    dateRange: "Jan 11 - Jan 31",
+    client: "Atlas Corporation",
     members: [
       {
-        id: "member-ada",
-        name: "Ada Lovelace",
+        id: "member-samantha",
+        name: "Samantha Robbins",
         designation: "Product Designer",
         allocations: [
           {
@@ -31,9 +34,82 @@ export const projectAllocationShellProjects: ProjectGroup[] = [
         ],
       },
       {
-        id: "member-grace",
-        name: "Grace Hopper",
+        id: "member-julian",
+        name: "Julian Andrews",
         designation: "Frontend Engineer",
+        allocations: [
+          {
+            hours: 4,
+            startDate: addDays(shellBaseDate, 4),
+            endDate: addDays(shellBaseDate, 8),
+            billable: true,
+          },
+        ],
+      },
+      {
+        id: "member-christina",
+        name: "Christina Chung",
+        designation: "QA Engineer",
+        allocations: [
+          {
+            hours: 5,
+            startDate: addDays(shellBaseDate, 2),
+            endDate: addDays(shellBaseDate, 6),
+            billable: true,
+          },
+        ],
+      },
+      {
+        id: "member-ananya",
+        name: "Ananya Bharadwaj",
+        designation: "Project Manager",
+        allocations: [
+          {
+            hours: 3,
+            startDate: addDays(shellBaseDate, 1),
+            endDate: addDays(shellBaseDate, 5),
+            billable: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "northstar-onboarding-portal-refresh",
+    name: "Northstar Onboarding Portal Refresh",
+    dateRange: "Feb 03 - Mar 14",
+    client: "Northstar Health",
+    members: [
+      {
+        id: "member-maya",
+        name: "Maya Rodriguez",
+        designation: "Design Lead",
+        allocations: [
+          {
+            hours: 5,
+            startDate: addDays(shellBaseDate, 2),
+            endDate: addDays(shellBaseDate, 7),
+            billable: true,
+          },
+        ],
+      },
+      {
+        id: "member-nikhil",
+        name: "Nikhil Sharma",
+        designation: "Backend Engineer",
+        allocations: [
+          {
+            hours: 6,
+            startDate: addDays(shellBaseDate, 6),
+            endDate: addDays(shellBaseDate, 10),
+            billable: true,
+          },
+        ],
+      },
+      {
+        id: "member-priya",
+        name: "Priya Nair",
+        designation: "QA Engineer",
         allocations: [
           {
             hours: 4,
@@ -45,7 +121,62 @@ export const projectAllocationShellProjects: ProjectGroup[] = [
       },
     ],
   },
+  {
+    id: "atlas-ui-stabilisation",
+    name: "Atlas UI Stabilisation",
+    dateRange: "Nov 23 - Feb 28",
+    client: "Atlas Corporation",
+    members: [
+      {
+        id: "member-ali",
+        name: "Ali Smith",
+        designation: "Project Manager",
+        allocations: [
+          {
+            hours: 4,
+            startDate: addDays(shellBaseDate, 3),
+            endDate: addDays(shellBaseDate, 9),
+            billable: true,
+          },
+        ],
+      },
+      {
+        id: "member-evelyn",
+        name: "Evelyn Carter",
+        designation: "Design Lead",
+        allocations: [
+          {
+            hours: 5,
+            startDate: addDays(shellBaseDate, 5),
+            endDate: addDays(shellBaseDate, 10),
+            billable: true,
+          },
+        ],
+      },
+    ],
+  },
 ];
+
+export const projectAllocationShellProjects: ProjectGroup[] = Array.from(
+  { length: PROJECT_SHELL_COUNT },
+  (_, index) => {
+    const template =
+      projectAllocationShellTemplates[
+        index % projectAllocationShellTemplates.length
+      ];
+    const projectNumber = index + 1;
+
+    return {
+      ...template,
+      id: `${template.id}-${projectNumber}`,
+      name: `${template.name} ${projectNumber}`,
+      members: template.members?.map((member) => ({
+        ...member,
+        id: member.id ? `${member.id}-${projectNumber}` : undefined,
+      })),
+    };
+  },
+);
 
 export function getProjectAllocationShellStartDate() {
   return startOfWeek(shellBaseDate, { weekStartsOn: 1 });

--- a/frontend/packages/app/src/pages/allocations/project/fakeData.ts
+++ b/frontend/packages/app/src/pages/allocations/project/fakeData.ts
@@ -165,12 +165,13 @@ export const projectAllocationShellProjects: ProjectGroup[] = Array.from(
         index % projectAllocationShellTemplates.length
       ];
     const projectNumber = index + 1;
+    const project = structuredClone(template);
 
     return {
-      ...template,
-      id: `${template.id}-${projectNumber}`,
-      name: `${template.name} ${projectNumber}`,
-      members: template.members?.map((member) => ({
+      ...project,
+      id: `${project.id}-${projectNumber}`,
+      name: `${project.name} ${projectNumber}`,
+      members: project.members?.map((member) => ({
         ...member,
         id: member.id ? `${member.id}-${projectNumber}` : undefined,
       })),

--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -15,6 +15,7 @@ import React, {
 import { HEADER_HEIGHT } from "./constants";
 import { DeleteAllocationDialog } from "./deleteAllocationDialog";
 import { GanttMemberRows } from "./ganttMemberRows";
+import { GanttProjectRows } from "./ganttProjectRows";
 import { createGanttStore, GanttContext, useGanttStore } from "./ganttStore";
 import { GanttWeekHeader } from "./ganttWeekHeader";
 import { useContainerResize } from "./hooks/useContainerResize";
@@ -28,6 +29,7 @@ const GanttGridInner: React.FC<{
   const {
     variant,
     members,
+    projects,
     rowHeaderLabel,
     headerWidth,
     columnWidth,
@@ -42,6 +44,7 @@ const GanttGridInner: React.FC<{
   } = useGanttStore((s) => ({
     variant: s.variant,
     members: s.members,
+    projects: s.projects,
     rowHeaderLabel: s.rowHeaderLabel,
     headerWidth: s.headerWidth,
     columnWidth: s.columnWidth,
@@ -111,7 +114,9 @@ const GanttGridInner: React.FC<{
             ? members.map((_, rowIndex) => (
                 <GanttMemberRows key={rowIndex} memberInd={rowIndex} />
               ))
-            : null}
+            : projects.map((_, rowIndex) => (
+                <GanttProjectRows key={rowIndex} projectInd={rowIndex} />
+              ))}
         </tbody>
       </table>
 

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
@@ -13,10 +13,10 @@ import {
 /**
  * Internal dependencies.
  */
-import type { Member } from "./types";
+import type { Member, ProjectMember } from "./types";
 
 interface GanttMemberHoverCardProps {
-  member: Member;
+  member: Member | ProjectMember;
 }
 
 function GanttMemberHoverCard({ member }: GanttMemberHoverCardProps) {

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -59,7 +59,7 @@ export function GanttMemberItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               className,
             )}
             style={{
@@ -71,12 +71,13 @@ export function GanttMemberItem({
         }
       >
         <button
+          type="button"
           disabled={!canExpand}
           onClick={() => handleToggle?.()}
           className={cn("flex items-center w-full shrink-0", {
             "cursor-default!": !canExpand,
           })}
-          aria-label={isExpanded ? "Collapse" : "Expand"}
+          aria-expanded={canExpand ? isExpanded : undefined}
         >
           <div className="flex flex-col gap-1 w-full min-w-0">
             <div className="flex gap-1 justify-between items-center w-full">

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -1,16 +1,34 @@
+import type { CSSProperties } from "react";
 import { PreviewCard } from "@base-ui/react/preview-card";
 import { Avatar, Badge } from "@rtcamp/frappe-ui-react";
 import { RightChevron } from "@rtcamp/frappe-ui-react/icons";
 import { CELL_HEIGHT } from "./constants";
 import GanttMemberHoverCard from "./ganttMemberHoverCard";
 import { useGanttStore } from "./ganttStore";
+import type { Member, ProjectMember } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
 
 export interface GanttMemberItemProps {
-  memberInd: number;
+  memberInd?: number;
+  member?: Member | ProjectMember;
+  isExpanded?: boolean;
+  canExpand?: boolean;
+  showChevron?: boolean;
+  onToggle?: () => void;
+  className?: string;
+  style?: CSSProperties;
 }
 
-export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
+export function GanttMemberItem({
+  memberInd,
+  member: memberProp,
+  isExpanded: isExpandedProp,
+  canExpand: canExpandProp,
+  showChevron = true,
+  onToggle,
+  className,
+  style,
+}: GanttMemberItemProps) {
   const { members, expandedRows, toggleRow, headerWidth, hasRoleAccess } =
     useGanttStore((s) => ({
       members: s.members,
@@ -19,10 +37,19 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
       toggleRow: s.toggleRow,
       hasRoleAccess: s.hasRoleAccess,
     }));
-  const member = members[memberInd];
-  const isExpanded = expandedRows.has(memberInd);
-  const hasProjects = Boolean(member.projects?.length);
-  const canExpand = hasProjects || hasRoleAccess;
+
+  const hasMemberIndex = memberInd !== undefined;
+  const storeMember = hasMemberIndex ? members[memberInd] : undefined;
+  const member = memberProp ?? storeMember;
+
+  if (!member) return null;
+
+  const isExpanded =
+    isExpandedProp ?? (hasMemberIndex && expandedRows.has(memberInd));
+  const hasProjects = "projects" in member && Boolean(member.projects?.length);
+  const canExpand = canExpandProp ?? (hasProjects || hasRoleAccess);
+  const handleToggle =
+    onToggle ?? (hasMemberIndex ? () => toggleRow(memberInd) : undefined);
 
   return (
     <PreviewCard.Root>
@@ -31,17 +58,21 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
         closeDelay={150}
         render={
           <th
-            className="flex overflow-hidden sticky left-0 z-10 items-center p-3 w-full font-normal text-left align-middle border-r border-b transition-colors duration-150 cursor-pointer bg-surface-white border-outline-gray-1 hover:bg-surface-gray-1"
+            className={cn(
+              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out cursor-pointer hover:bg-surface-gray-1",
+              className,
+            )}
             style={{
               height: CELL_HEIGHT,
               width: headerWidth,
+              ...style,
             }}
           />
         }
       >
         <button
           disabled={!canExpand}
-          onClick={() => toggleRow(memberInd)}
+          onClick={() => handleToggle?.()}
           className={cn("flex items-center w-full shrink-0", {
             "cursor-default!": !canExpand,
           })}
@@ -50,13 +81,15 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
           <div className="flex flex-col gap-1 w-full min-w-0">
             <div className="flex gap-1 justify-between items-center w-full">
               <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
-                <RightChevron
-                  className={cn(
-                    "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-9",
-                    { "opacity-0 pointer-events-none": !canExpand },
-                    { "rotate-90": isExpanded },
-                  )}
-                />
+                {showChevron ? (
+                  <RightChevron
+                    className={cn(
+                      "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-9",
+                      { "opacity-0 pointer-events-none": !canExpand },
+                      { "rotate-90": isExpanded },
+                    )}
+                  />
+                ) : null}
                 <Avatar
                   size="xs"
                   shape="circle"
@@ -77,7 +110,12 @@ export function GanttMemberItem({ memberInd }: GanttMemberItemProps) {
                 />
               )}
             </div>
-            <div className="flex overflow-hidden flex-1 items-center pl-11 w-full min-w-0">
+            <div
+              className={cn(
+                "flex overflow-hidden flex-1 items-center w-full min-w-0",
+                showChevron ? "pl-11" : "pl-6",
+              )}
+            >
               {member.designation && (
                 <span className="text-xs leading-tight truncate text-ink-gray-6">
                   {member.designation}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -132,7 +132,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
           aria-hidden={!isExpanded}
         >
           <th
-            className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out"
+            className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -1,9 +1,16 @@
 import type { CSSProperties } from "react";
+import { PreviewCard } from "@base-ui/react/preview-card";
 import { Badge } from "@rtcamp/frappe-ui-react";
-import { Folder } from "@rtcamp/frappe-ui-react/icons";
+import { Folder, RightChevron } from "@rtcamp/frappe-ui-react/icons";
 import type { Project } from "./types";
+import { mergeClassNames as cn } from "../../utils";
 
 export interface GanttProjectItemProps extends Project {
+  isExpanded?: boolean;
+  canExpand?: boolean;
+  showChevron?: boolean;
+  onToggle?: () => void;
+  className?: string;
   style?: CSSProperties;
 }
 
@@ -12,34 +19,89 @@ export function GanttProjectItem({
   dateRange,
   client,
   badge,
+  isExpanded = false,
+  canExpand = false,
+  showChevron = true,
+  onToggle,
+  className,
   style,
 }: GanttProjectItemProps) {
   const subtext = [dateRange, client].filter(Boolean).join(" · ");
+
   return (
-    <th
-      className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out"
-      style={style}
-    >
-      <div className="w-full flex flex-col gap-1 min-w-0">
-        <div className="flex items-center justify-between gap-1 w-full">
-          <div className="flex items-center w-full min-w-0 overflow-hidden">
-            <Folder className="size-4 shrink-0" />
-            <span className="ml-2 text-base font-medium leading-tight truncate text-ink-gray-9">
-              {name}
-            </span>
+    <PreviewCard.Root>
+      <PreviewCard.Trigger
+        delay={300}
+        closeDelay={150}
+        render={
+          <th
+            className={cn(
+              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out cursor-pointer hover:bg-surface-gray-1",
+              showChevron ? "pl-3" : "pl-8",
+              className,
+            )}
+            style={style}
+          />
+        }
+      >
+        <button
+          disabled={!canExpand}
+          onClick={() => onToggle?.()}
+          className={cn("flex items-center w-full shrink-0", {
+            "cursor-default!": !canExpand,
+          })}
+          aria-label={isExpanded ? "Collapse" : "Expand"}
+        >
+          <div className="flex flex-col gap-1 w-full min-w-0">
+            <div className="flex gap-1 justify-between items-center w-full">
+              <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
+                {showChevron ? (
+                  <RightChevron
+                    className={cn(
+                      "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-9",
+                      { "opacity-0 pointer-events-none": !canExpand },
+                      { "rotate-90": isExpanded },
+                    )}
+                  />
+                ) : null}
+                <Folder className="size-4 shrink-0" />
+                <span className="ml-2 text-base font-medium leading-tight truncate text-ink-gray-9">
+                  {name}
+                </span>
+              </div>
+              {badge && (
+                <Badge label={badge} size="sm" variant="subtle" theme="gray" />
+              )}
+            </div>
+            <div
+              className={cn(
+                "flex overflow-hidden flex-1 items-center w-full min-w-0",
+                showChevron ? "pl-11" : "pl-6",
+              )}
+            >
+              {subtext && (
+                <span className="text-xs leading-tight truncate text-ink-gray-6">
+                  {subtext}
+                </span>
+              )}
+            </div>
           </div>
-          {badge && (
-            <Badge label={badge} size="sm" variant="subtle" theme="gray" />
-          )}
-        </div>
-        {subtext && (
-          <div className="flex items-center flex-1 w-full min-w-0 overflow-hidden pl-6">
-            <span className="text-xs leading-tight truncate text-ink-gray-6">
-              {subtext}
-            </span>
-          </div>
-        )}
-      </div>
-    </th>
+        </button>
+      </PreviewCard.Trigger>
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner
+          side="right"
+          align="center"
+          alignOffset={20}
+          sideOffset={-42}
+        >
+          <PreviewCard.Popup className="outline-none">
+            <div className="w-60 rounded-xl bg-surface-modal p-3 text-sm text-ink-gray-6 shadow-2xl">
+              Project hover card placeholder
+            </div>
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
   );
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -36,7 +36,7 @@ export function GanttProjectItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               showChevron ? "pl-3" : "pl-8",
               className,
             )}
@@ -45,12 +45,13 @@ export function GanttProjectItem({
         }
       >
         <button
+          type="button"
           disabled={!canExpand}
           onClick={() => onToggle?.()}
           className={cn("flex items-center w-full shrink-0", {
             "cursor-default!": !canExpand,
           })}
-          aria-label={isExpanded ? "Collapse" : "Expand"}
+          aria-expanded={canExpand ? isExpanded : undefined}
         >
           <div className="flex flex-col gap-1 w-full min-w-0">
             <div className="flex gap-1 justify-between items-center w-full">

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
@@ -68,6 +68,9 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
     >
       <GanttProjectItem
         {...project}
+        isExpanded={false}
+        canExpand={false}
+        showChevron={false}
         style={{
           height: animatedRowHeight,
           width: headerWidth,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -1,0 +1,165 @@
+/**
+ * External dependencies.
+ */
+import React from "react";
+import { AddMd } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { ADD_PROJECT_ROW_HEIGHT, CELL_HEIGHT } from "./constants";
+import { GanttMemberItem } from "./ganttMemberItem";
+import { GanttProjectItem } from "./ganttProjectItem";
+import { useGanttStore } from "./ganttStore";
+import { mergeClassNames as cn } from "../../utils";
+
+interface GanttProjectRowsProps {
+  projectInd: number;
+}
+
+export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
+  projectInd,
+}) => {
+  const {
+    project,
+    isExpanded,
+    isNextExpanded,
+    weeks,
+    daysPerWeek,
+    headerWidth,
+    toggleRow,
+  } = useGanttStore((s) => ({
+    project: s.projects[projectInd],
+    isExpanded: s.expandedRows.has(projectInd),
+    isNextExpanded:
+      !s.expandedRows.has(projectInd) && s.expandedRows.has(projectInd + 1),
+    weeks: s.weeks,
+    daysPerWeek: s.daysPerWeek,
+    headerWidth: s.headerWidth,
+    toggleRow: s.toggleRow,
+  }));
+
+  if (!project) return null;
+
+  const hasMembers = Boolean(project.members?.length);
+  const addMemberRowHeight = isExpanded ? ADD_PROJECT_ROW_HEIGHT : 0;
+
+  return (
+    <React.Fragment>
+      <tr className="relative last:border-b border-outline-gray-1">
+        <GanttProjectItem
+          {...project}
+          canExpand={hasMembers}
+          isExpanded={isExpanded}
+          showChevron={true}
+          onToggle={() => {
+            if (hasMembers) {
+              toggleRow(projectInd);
+            }
+          }}
+          style={{
+            height: CELL_HEIGHT,
+            width: headerWidth,
+            minWidth: headerWidth,
+          }}
+        />
+        {weeks.map((week, index) => (
+          <td
+            key={`${week}-${index}`}
+            colSpan={daysPerWeek}
+            className={cn("border-r border-outline-gray-1", {
+              "border-b": isNextExpanded,
+            })}
+            style={{ height: CELL_HEIGHT }}
+          />
+        ))}
+        <td
+          aria-hidden="true"
+          className="p-0 border-0 w-0 min-w-0 max-w-0"
+          style={{ width: 0 }}
+        />
+      </tr>
+
+      {project.members?.map((member) => (
+        <tr
+          key={member.id ?? member.name}
+          className={cn("relative", { "pointer-events-none": !isExpanded })}
+          aria-hidden={!isExpanded}
+        >
+          <GanttMemberItem
+            member={member}
+            isExpanded={false}
+            canExpand={false}
+            showChevron={false}
+            className="pl-8 pr-3"
+            style={{
+              height: isExpanded ? CELL_HEIGHT : 0,
+              width: headerWidth,
+              minWidth: headerWidth,
+              borderBottomWidth: isExpanded ? undefined : 0,
+              borderRightWidth: isExpanded ? undefined : 0,
+            }}
+          />
+          {weeks.map((week, index) => (
+            <td
+              key={`${week}-${index}`}
+              colSpan={daysPerWeek}
+              className={cn(
+                "overflow-hidden transition-[height] duration-200 ease-in-out",
+                { "border-r border-outline-gray-1": isExpanded },
+              )}
+              style={{ height: isExpanded ? CELL_HEIGHT : 0 }}
+            />
+          ))}
+          <td
+            aria-hidden="true"
+            className="p-0 border-0 w-0 min-w-0 max-w-0"
+            style={{ width: 0 }}
+          />
+        </tr>
+      ))}
+
+      <tr
+        className={cn("relative", { "pointer-events-none": !isExpanded })}
+        aria-hidden={!isExpanded}
+      >
+        <th
+          className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out"
+          style={{
+            width: headerWidth,
+            minWidth: headerWidth,
+            height: addMemberRowHeight,
+            borderBottomWidth: isExpanded ? undefined : 0,
+            borderRightWidth: isExpanded ? undefined : 0,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => {}}
+            tabIndex={isExpanded ? undefined : -1}
+            className="w-full h-full flex items-center gap-2 text-base font-medium text-ink-gray-9 overflow-hidden"
+          >
+            <AddMd className="size-4 shrink-0" />
+            <span className="truncate">Add member</span>
+          </button>
+        </th>
+        {weeks.map((week, index) => (
+          <td
+            key={`${week}-${index}`}
+            colSpan={daysPerWeek}
+            className={cn(
+              "overflow-hidden transition-[height] duration-200 ease-in-out",
+              { "border-r border-b border-outline-gray-1": isExpanded },
+            )}
+            style={{ height: addMemberRowHeight }}
+          />
+        ))}
+        <td
+          aria-hidden="true"
+          className="p-0 border-0 w-0 min-w-0 max-w-0"
+          style={{ width: 0 }}
+        />
+      </tr>
+    </React.Fragment>
+  );
+};

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -124,7 +124,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
         aria-hidden={!isExpanded}
       >
         <th
-          className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height] duration-200 ease-in-out"
+          className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
           style={{
             width: headerWidth,
             minWidth: headerWidth,

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -102,6 +102,10 @@ export interface GanttGridProps {
   startDate: Date;
   /** Number of weeks to display. */
   weekCount?: number;
+  /** Member row data. */
+  members?: Member[];
+  /** Project row data. */
+  projects?: ProjectGroup[];
   /** Label shown in the sticky row header cell. */
   rowHeaderLabel: string;
   /** Layout and transformation mode for the grid. */
@@ -118,8 +122,4 @@ export interface GanttGridProps {
   onEditAllocation?: (data: AllocationCallbackData) => void;
   /** Called when the delete icon is clicked on an allocation entry. Receives allocation data. */
   onDeleteAllocation?: (data: AllocationCallbackData) => void;
-  /** Member row data. */
-  members?: Member[];
-  /** Project row data. */
-  projects?: ProjectGroup[];
 }


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR enhances the Gantt view in the design system by introducing project-level rows and improving the flexibility and reusability of member and project item components. The changes allow the Gantt grid to display both members and projects.

## Relevant Technical Choices

- The Gantt view components have been refactored to make them more configurable so the existing components can be reused for Project Allocation with minimal duplication.
- Uses fake data for now.
- This PR depends on change from #1343 


<!-- For Code Reviewers: Please describe your changes. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/a8d01eba-9f76-44be-9f24-d7d9962c2afa



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #979 #982 #983