### PR TITLE
Add date range filters and improve item display logic

### DIFF
--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -240,9 +240,11 @@ def mark_timeline_item_complete(name: str, is_complete: int = 1):
 
     doc = frappe.get_doc("Project Timeline Item", name)
     doc.is_complete = cint(is_complete)
+    doc.actual_end_date = getdate() if cint(is_complete) else None
     doc.save(ignore_permissions=False)
 
     return {
         "name": doc.name,
         "is_complete": cint(doc.is_complete),
+        "actual_end_date": doc.actual_end_date,
     }

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -96,7 +96,7 @@ def get_project_timeline_items(
     start: int = 0,
     limit: int = 20,
     start_date: str | None = None,
-    max_week: int = 0,
+    max_week: int = 4,
     is_calendar: bool = False,
 ):
     """
@@ -128,7 +128,7 @@ def get_project_timeline_items(
 
     if start_date and max_week:
         end_date = add_to_date(getdate(start_date), weeks=cint(max_week))
-        filters["start_date"] = ["between", [getdate(start_date), end_date]]
+        filters["planned_end_date"] = ["between", [getdate(start_date), end_date]]
 
     items = frappe.get_all(
         "Project Timeline Item",

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -5,12 +5,11 @@ from typing import Literal
 
 import frappe
 from frappe import only_for, whitelist
-from frappe.utils import cint, getdate, today
+from frappe.utils import add_to_date, cint, getdate, today
 
 from next_pms.api.utils import error_logger
 from next_pms.next_projects.api.constant import ALLOWED_ROLES, TIMELINE_ITEM_FIELDS
 from next_pms.next_projects.api.utils import get_user_image_map
-from next_pms.timesheet.api import get_count
 
 
 def get_watchers_map(item_names: list[str]) -> dict[str, list[dict]]:
@@ -96,6 +95,8 @@ def get_project_timeline_items(
     type: Literal["Milestone", "Touchpoint"] | None = None,
     start: int = 0,
     limit: int = 20,
+    start_date: str | None = None,
+    max_week: int = 0,
 ):
     """
     Get active (not completed) Project Timeline Items for a project.
@@ -105,6 +106,8 @@ def get_project_timeline_items(
         type: "Milestone" or "Touchpoint" — omit to fetch both
         start: Pagination offset
         limit: Page size
+        start_date: ISO date string (e.g. "2026-05-05"); used as the range start
+        max_week: Number of weeks from start_date to use as the range end
 
     Returns:
         {"data": [...], "total_count": int, "has_more": bool}
@@ -122,6 +125,10 @@ def get_project_timeline_items(
     if type:
         filters["type"] = type
 
+    if start_date and max_week:
+        end_date = add_to_date(getdate(start_date), weeks=cint(max_week))
+        filters["start_date"] = ["between", [getdate(start_date), end_date]]
+
     items = frappe.get_all(
         "Project Timeline Item",
         filters=filters,
@@ -131,7 +138,7 @@ def get_project_timeline_items(
         order_by="start_date asc, planned_end_date asc",
     )
 
-    total_count = get_count("Project Timeline Item", filters=filters)
+    total_count = frappe.db.count("Project Timeline Item", filters=filters)
     has_more = cint(start) + cint(limit) < total_count
 
     item_names = [item.get("name") for item in items if item.get("name")]

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -100,7 +100,10 @@ def get_project_timeline_items(
     is_calendar: bool = False,
 ):
     """
-    Get active (not completed) Project Timeline Items for a project.
+    Get all Project Timeline Items (complete and incomplete) for a project.
+
+    Touchpoints do not have a start_date, so ordering and range filtering use
+    planned_end_date as the authoritative date field.
 
     Args:
         project: Project name to filter by
@@ -108,8 +111,12 @@ def get_project_timeline_items(
         start: Pagination offset
         limit: Page size
         start_date: ISO date string (e.g. "2026-05-05"); used as the range start
+            for planned_end_date filtering
         max_week: Number of weeks from start_date to use as the range end
-        is_calendar: When True, skips fetching owner images and watchers
+        is_calendar: Pass "1"/1/True to skip the bulk-fetch of owner images and
+            watchers (e.g. for calendar views where those fields are not rendered).
+            Accepts "0"/"1" string values from HTTP query params — coerced via
+            cint() before use so "0" is correctly treated as falsy.
 
     Returns:
         {"data": [...], "total_count": int, "has_more": bool}
@@ -118,6 +125,8 @@ def get_project_timeline_items(
 
     if not project:
         frappe.throw(frappe._("project is required"))
+
+    is_calendar = bool(cint(is_calendar))
 
     filters = {
         "project": project,
@@ -226,12 +235,16 @@ def mark_timeline_item_complete(name: str, is_complete: int = 1):
     """
     Mark a Project Timeline Item as complete or incomplete.
 
+    Setting is_complete=1 also records today's date as actual_end_date.
+    Reverting (is_complete=0) clears actual_end_date back to None.
+
     Args:
         name: Document name of the Project Timeline Item
-        is_complete: 1 to mark complete, 0 to revert
+        is_complete: 1 to mark complete, 0 to revert — accepts "0"/"1" string
+            values from HTTP form params (coerced via cint())
 
     Returns:
-        {"name": str, "is_complete": int}
+        {"name": str, "is_complete": int, "actual_end_date": str | None}
     """
     only_for(ALLOWED_ROLES, message=True)
 

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -121,7 +121,6 @@ def get_project_timeline_items(
 
     filters = {
         "project": project,
-        "is_complete": 0,
     }
 
     if type:

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -97,6 +97,7 @@ def get_project_timeline_items(
     limit: int = 20,
     start_date: str | None = None,
     max_week: int = 0,
+    is_calendar: bool = False,
 ):
     """
     Get active (not completed) Project Timeline Items for a project.
@@ -108,6 +109,7 @@ def get_project_timeline_items(
         limit: Page size
         start_date: ISO date string (e.g. "2026-05-05"); used as the range start
         max_week: Number of weeks from start_date to use as the range end
+        is_calendar: When True, skips fetching owner images and watchers
 
     Returns:
         {"data": [...], "total_count": int, "has_more": bool}
@@ -143,11 +145,14 @@ def get_project_timeline_items(
 
     item_names = [item.get("name") for item in items if item.get("name")]
 
-    # Bulk-fetch owner images; item_owner is a Link → User
-    owner_users = list({item.get("item_owner") for item in items if item.get("item_owner")})
-    user_image_map = get_user_image_map(owner_users)
-
-    watchers_map = get_watchers_map(item_names)
+    if is_calendar:
+        user_image_map = {}
+        watchers_map = {}
+    else:
+        # Bulk-fetch owner images; item_owner is a Link → User
+        owner_users = list({item.get("item_owner") for item in items if item.get("item_owner")})
+        user_image_map = get_user_image_map(owner_users)
+        watchers_map = get_watchers_map(item_names)
 
     data = [enrich_timeline_item(item, user_image_map, watchers_map) for item in items]
 


### PR DESCRIPTION
## Description


* Added support for date range filtering in `get_project_timeline_items` by introducing `start_date` and `max_week` parameters, allowing clients to fetch items within a specific date range.
* Introduced the `is_calendar` parameter to optimize calendar views by skipping unnecessary fetching of owner images and watchers when not needed. 
* Updated `mark_timeline_item_complete` to set or clear the `actual_end_date` field based on the completion status, and return it in the response for better tracking of item completion. 
## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

1. get endpoint with "start_date" field:
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/593c9bf4-2d44-48b8-bb84-3bf50dc04664" />

2. mark milestone complete endpoint setting the actual_end_date field  
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/5ba5b37a-081e-4094-83f7-359c544eb1e4" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1073 
Addresses https://github.com/rtCamp/next-pms/issues/1050#issuecomment-4488308183