### PR TITLE
Add milestone and touchpoint creation modal

### DIFF
--- a/frontend/packages/app/src/hooks/useUserLookup.ts
+++ b/frontend/packages/app/src/hooks/useUserLookup.ts
@@ -1,0 +1,62 @@
+/**
+ * Internal Dependencies.
+ */
+import { useRemoteLookup, type LookupOption } from "@/hooks/useRemoteLookup";
+
+type UserRecord = {
+  name: string;
+  full_name: string;
+  user_image?: string;
+};
+
+export type UserLookupOption = LookupOption & {
+  image?: string;
+};
+
+interface UseUserLookupOptions {
+  /** Controls whether the user lookup should fetch for the current UI state. */
+  shouldFetch?: boolean;
+  /** Caps the number of user rows fetched per request. */
+  pageSize?: number;
+  /** Filters users by partial full name on the backend. */
+  query: string;
+  /** Revalidates the lookup when the window regains focus. */
+  revalidateOnFocus?: boolean;
+  /** Keeps the current selection visible when it is not in the latest results. */
+  selectedOption?: UserLookupOption | null;
+}
+
+/**
+ * Fetches Frappe User records for lookup fields that expect a User email (name).
+ * Uses frappe.client.get_list to query the User doctype directly.
+ */
+export const useUserLookup = ({
+  shouldFetch = true,
+  pageSize = 20,
+  query,
+  revalidateOnFocus,
+  selectedOption,
+}: UseUserLookupOptions) => {
+  return useRemoteLookup<UserRecord[], UserRecord, UserLookupOption>({
+    shouldFetch,
+    query,
+    pageSize,
+    revalidateOnFocus,
+    method: "frappe.client.get_list",
+    params: ({ query: searchQuery, pageSize: limit }) => ({
+      doctype: "User",
+      fields: ["name", "full_name", "user_image"],
+      filters: searchQuery
+        ? [["full_name", "like", `%${searchQuery}%`]]
+        : [["user_type", "=", "System User"]],
+      limit,
+    }),
+    getItems: (message) => message ?? [],
+    mapOption: (user) => ({
+      label: user.full_name || user.name,
+      value: user.name,
+      image: user.user_image,
+    }),
+    selectedOption,
+  });
+};

--- a/frontend/packages/app/src/hooks/useUserLookup.ts
+++ b/frontend/packages/app/src/hooks/useUserLookup.ts
@@ -28,7 +28,6 @@ interface UseUserLookupOptions {
 
 /**
  * Fetches Frappe User records for lookup fields that expect a User email (name).
- * Uses frappe.client.get_list to query the User doctype directly.
  */
 export const useUserLookup = ({
   shouldFetch = true,
@@ -46,9 +45,11 @@ export const useUserLookup = ({
     params: ({ query: searchQuery, pageSize: limit }) => ({
       doctype: "User",
       fields: ["name", "full_name", "user_image"],
-      filters: searchQuery
-        ? [["full_name", "like", `%${searchQuery}%`]]
-        : [["user_type", "=", "System User"]],
+      filters: [
+        ["user_type", "=", "System User"],
+        ["enabled", "=", 1],
+        ...(searchQuery ? [["full_name", "like", `%${searchQuery}%`]] : []),
+      ],
       limit,
     }),
     getItems: (message) => message ?? [],

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/index.tsx
@@ -128,16 +128,14 @@ export function CreateMilestoneModal({
       onOpenChange={handleOpenChange}
       options={{ title: "Create milestone" }}
       actions={
-        <div className="flex w-full justify-end gap-2">
-          <Button variant="ghost" label="Cancel" onClick={closeModal} />
-          <Button
-            variant="solid"
-            label="Create"
-            onClick={() => form.handleSubmit()}
-            disabled={submitting}
-            loading={submitting}
-          />
-        </div>
+        <Button
+          className="w-full h-7"
+          variant="solid"
+          label="Create"
+          onClick={() => form.handleSubmit()}
+          disabled={submitting}
+          loading={submitting}
+        />
       }
     >
       <div className="-mt-2 space-y-4">

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/index.tsx
@@ -1,0 +1,259 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getTodayDate } from "@next-pms/design-system/date";
+import {
+  Avatar,
+  Button,
+  Combobox,
+  DatePicker,
+  Dialog,
+  ErrorMessage,
+  TextInput,
+  useToasts,
+} from "@rtcamp/frappe-ui-react";
+import { useForm } from "@tanstack/react-form";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
+import { Calendar } from "lucide-react";
+
+/**
+ * Internal dependencies.
+ */
+import { useUserLookup } from "@/hooks/useUserLookup";
+import { parseFrappeErrorMsg } from "@/lib/utils";
+import { createMilestoneSchema } from "./schema";
+import type { CreateMilestoneModalProps } from "./types";
+
+const defaultValues = {
+  title: "",
+  startDate: getTodayDate(),
+  completionDate: getTodayDate(),
+  owner: "",
+};
+
+export function CreateMilestoneModal({
+  open,
+  onOpenChange,
+  projectId,
+  onSuccess,
+}: CreateMilestoneModalProps) {
+  const toast = useToasts();
+  const [ownerSearch, setOwnerSearch] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const { call: createMilestone } = useFrappePostCall(
+    "next_pms.next_projects.api.project_timeline_item.create_project_timeline_item",
+  );
+
+  const { options: ownerOptions, isLoading: isOwnerLookupLoading } =
+    useUserLookup({
+      shouldFetch: open,
+      pageSize: 20,
+      query: ownerSearch,
+    });
+
+  const ownerOptionsWithAvatars = useMemo(
+    () =>
+      ownerOptions.map((opt) => ({
+        ...opt,
+        icon: (
+          <Avatar
+            size="xs"
+            shape="circle"
+            image={opt.image}
+            label={opt.label}
+          />
+        ),
+      })),
+    [ownerOptions],
+  );
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onSubmit: createMilestoneSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setSubmitting(true);
+      try {
+        await createMilestone({
+          project: projectId,
+          type: "Milestone",
+          title: value.title,
+          item_owner: value.owner,
+          start_date: value.startDate,
+          planned_end_date: value.completionDate,
+        });
+        toast.success("Milestone created successfully");
+        closeModal();
+        await onSuccess?.();
+      } catch (err) {
+        const error = parseFrappeErrorMsg(err as FrappeError);
+        toast.error(error);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  });
+
+  const closeModal = useCallback(() => {
+    onOpenChange(false);
+    form.reset(defaultValues);
+  }, [form, onOpenChange]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        onOpenChange(true);
+        return;
+      }
+      closeModal();
+    },
+    [closeModal, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    form.reset(defaultValues);
+  }, [form, open]);
+
+  useEffect(() => {
+    setOwnerSearch("");
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      options={{ title: "Create milestone" }}
+      actions={
+        <div className="flex w-full justify-end gap-2">
+          <Button variant="ghost" label="Cancel" onClick={closeModal} />
+          <Button
+            variant="solid"
+            label="Create"
+            onClick={() => form.handleSubmit()}
+            disabled={submitting}
+            loading={submitting}
+          />
+        </div>
+      }
+    >
+      <div className="-mt-2 space-y-4">
+        <form.Field
+          name="title"
+          children={(field) => (
+            <div className="flex flex-col gap-1.5">
+              <label className="block text-base text-ink-gray-5">
+                Milestone name
+              </label>
+              <TextInput
+                size="md"
+                variant="outline"
+                placeholder="Enter milestone name"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                className="bg-white border-outline-gray-2"
+              />
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+
+        <div className="flex gap-4">
+          <form.Field
+            name="startDate"
+            children={(field) => (
+              <div className="flex-1 flex flex-col gap-1.5">
+                <label className="block text-base text-ink-gray-5">
+                  Start date
+                </label>
+                <DatePicker
+                  label="Start date"
+                  value={field.state.value}
+                  onChange={(val) => field.handleChange(val as string)}
+                  placeholder="Start date"
+                >
+                  {({ displayValue }) => (
+                    <div className="flex relative items-center py-1 w-full rounded-lg border border-outline-gray-2 px-2.5">
+                      <input
+                        readOnly
+                        type="text"
+                        value={displayValue}
+                        className="flex-1"
+                      />
+                      <Calendar className="size-4" />
+                    </div>
+                  )}
+                </DatePicker>
+                {!field.state.meta.isValid && (
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                )}
+              </div>
+            )}
+          />
+
+          <form.Field
+            name="completionDate"
+            children={(field) => (
+              <div className="flex-1 flex flex-col gap-1.5">
+                <label className="block text-base text-ink-gray-5">
+                  Completion date
+                </label>
+                <DatePicker
+                  label="Completion date"
+                  value={field.state.value}
+                  onChange={(val) => field.handleChange(val as string)}
+                  placeholder="Completion date"
+                >
+                  {({ displayValue }) => (
+                    <div className="flex relative items-center py-1 w-full rounded-lg border border-outline-gray-2 px-2.5">
+                      <input
+                        readOnly
+                        type="text"
+                        value={displayValue}
+                        className="flex-1"
+                      />
+                      <Calendar className="size-4" />
+                    </div>
+                  )}
+                </DatePicker>
+                {!field.state.meta.isValid && (
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                )}
+              </div>
+            )}
+          />
+        </div>
+
+        <form.Field
+          name="owner"
+          children={(field) => (
+            <div className="flex flex-col gap-1.5">
+              <label className="block text-base text-ink-gray-5">Owner</label>
+              <Combobox
+                inputClassName="bg-white h-8 border-outline-gray-2"
+                loading={isOwnerLookupLoading}
+                options={ownerOptionsWithAvatars}
+                searchValue={ownerSearch}
+                placeholder="Select owner"
+                value={field.state.value}
+                onChange={(value) => field.handleChange(value as string)}
+                onSearchChange={setOwnerSearch}
+                openOnFocus
+              />
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+      </div>
+    </Dialog>
+  );
+}
+
+export default CreateMilestoneModal;

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/schema.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/schema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const createMilestoneSchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, { message: "Please enter a milestone name." }),
+    startDate: z
+      .string()
+      .trim()
+      .min(1, { message: "Please select a start date." }),
+    completionDate: z
+      .string()
+      .trim()
+      .min(1, { message: "Please select a completion date." }),
+    owner: z.string().trim().min(1, { message: "Please select an owner." }),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.startDate &&
+      value.completionDate &&
+      value.startDate > value.completionDate
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["completionDate"],
+        message: "Completion date must be on or after start date.",
+      });
+    }
+  });

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-milestone/types.ts
@@ -1,0 +1,6 @@
+export interface CreateMilestoneModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  onSuccess?: () => void | Promise<void>;
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/index.tsx
@@ -1,0 +1,223 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getTodayDate } from "@next-pms/design-system/date";
+import {
+  Avatar,
+  Button,
+  Combobox,
+  DatePicker,
+  Dialog,
+  ErrorMessage,
+  TextInput,
+  useToasts,
+} from "@rtcamp/frappe-ui-react";
+import { useForm } from "@tanstack/react-form";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
+import { Calendar } from "lucide-react";
+
+/**
+ * Internal dependencies.
+ */
+import { useUserLookup } from "@/hooks/useUserLookup";
+import { parseFrappeErrorMsg } from "@/lib/utils";
+import { createTouchpointSchema } from "./schema";
+import type { CreateTouchpointModalProps } from "./types";
+
+const defaultValues = {
+  title: "",
+  scheduledDate: getTodayDate(),
+  owner: "",
+};
+
+export function CreateTouchpointModal({
+  open,
+  onOpenChange,
+  projectId,
+  onSuccess,
+}: CreateTouchpointModalProps) {
+  const toast = useToasts();
+  const [ownerSearch, setOwnerSearch] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const { call: createTouchpoint } = useFrappePostCall(
+    "next_pms.next_projects.api.project_timeline_item.create_project_timeline_item",
+  );
+
+  const { options: ownerOptions, isLoading: isOwnerLookupLoading } =
+    useUserLookup({
+      shouldFetch: open,
+      pageSize: 20,
+      query: ownerSearch,
+    });
+
+  const ownerOptionsWithAvatars = useMemo(
+    () =>
+      ownerOptions.map((opt) => ({
+        ...opt,
+        icon: (
+          <Avatar
+            size="xs"
+            shape="circle"
+            image={opt.image}
+            label={opt.label}
+          />
+        ),
+      })),
+    [ownerOptions],
+  );
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onSubmit: createTouchpointSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setSubmitting(true);
+      try {
+        await createTouchpoint({
+          project: projectId,
+          type: "Touchpoint",
+          title: value.title,
+          item_owner: value.owner,
+          planned_end_date: value.scheduledDate,
+        });
+        toast.success("Touchpoint created successfully");
+        closeModal();
+        await onSuccess?.();
+      } catch (err) {
+        const error = parseFrappeErrorMsg(err as FrappeError);
+        toast.error(error);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  });
+
+  const closeModal = useCallback(() => {
+    onOpenChange(false);
+    form.reset(defaultValues);
+  }, [form, onOpenChange]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        onOpenChange(true);
+        return;
+      }
+      closeModal();
+    },
+    [closeModal, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    form.reset(defaultValues);
+  }, [form, open]);
+
+  useEffect(() => {
+    setOwnerSearch("");
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      options={{ title: "Create touchpoint" }}
+      actions={
+        <div className="flex w-full justify-end gap-2">
+          <Button variant="ghost" label="Cancel" onClick={closeModal} />
+          <Button
+            variant="solid"
+            label="Create"
+            onClick={() => form.handleSubmit()}
+            disabled={submitting}
+            loading={submitting}
+          />
+        </div>
+      }
+    >
+      <div className="-mt-2 space-y-4">
+        <form.Field
+          name="title"
+          children={(field) => (
+            <div className="flex flex-col gap-1.5">
+              <label className="block text-base text-ink-gray-5">
+                Touchpoint name
+              </label>
+              <TextInput
+                size="md"
+                variant="outline"
+                placeholder="Enter touchpoint name"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                className="bg-white border-outline-gray-2"
+              />
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+
+        <form.Field
+          name="scheduledDate"
+          children={(field) => (
+            <div className="flex flex-col gap-1.5">
+              <label className="block text-base text-ink-gray-5">
+                Scheduled date
+              </label>
+              <DatePicker
+                label="Scheduled date"
+                value={field.state.value}
+                onChange={(val) => field.handleChange(val as string)}
+                placeholder="Scheduled date"
+              >
+                {({ displayValue }) => (
+                  <div className="flex relative items-center py-1 w-full rounded-lg border border-outline-gray-2 px-2.5">
+                    <input
+                      readOnly
+                      type="text"
+                      value={displayValue}
+                      className="flex-1"
+                    />
+                    <Calendar className="size-4" />
+                  </div>
+                )}
+              </DatePicker>
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+
+        <form.Field
+          name="owner"
+          children={(field) => (
+            <div className="flex flex-col gap-1.5">
+              <label className="block text-base text-ink-gray-5">Owner</label>
+              <Combobox
+                inputClassName="bg-white h-8 border-outline-gray-2"
+                loading={isOwnerLookupLoading}
+                options={ownerOptionsWithAvatars}
+                searchValue={ownerSearch}
+                placeholder="Select owner"
+                value={field.state.value}
+                onChange={(value) => field.handleChange(value as string)}
+                onSearchChange={setOwnerSearch}
+                openOnFocus
+              />
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+      </div>
+    </Dialog>
+  );
+}
+
+export default CreateTouchpointModal;

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/index.tsx
@@ -126,16 +126,14 @@ export function CreateTouchpointModal({
       onOpenChange={handleOpenChange}
       options={{ title: "Create touchpoint" }}
       actions={
-        <div className="flex w-full justify-end gap-2">
-          <Button variant="ghost" label="Cancel" onClick={closeModal} />
-          <Button
-            variant="solid"
-            label="Create"
-            onClick={() => form.handleSubmit()}
-            disabled={submitting}
-            loading={submitting}
-          />
-        </div>
+        <Button
+          className="w-full h-7"
+          variant="solid"
+          label="Create"
+          onClick={() => form.handleSubmit()}
+          disabled={submitting}
+          loading={submitting}
+        />
       }
     >
       <div className="-mt-2 space-y-4">

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/schema.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const createTouchpointSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, { message: "Please enter a touchpoint name." }),
+  scheduledDate: z
+    .string()
+    .trim()
+    .min(1, { message: "Please select a scheduled date." }),
+  owner: z.string().trim().min(1, { message: "Please select an owner." }),
+});

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/types.ts
@@ -1,0 +1,6 @@
+export interface CreateTouchpointModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  onSuccess?: () => void | Promise<void>;
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
@@ -12,6 +12,8 @@ import { Plus } from "lucide-react";
  */
 import { CalendarGrid } from "./calendarGrid";
 import { CalendarToolbar, type CalendarView } from "./calendarToolbar";
+import { CreateMilestoneModal } from "./create-milestone";
+import { CreateTouchpointModal } from "./create-touchpoint";
 import { getTimelineItems } from "./fake-data";
 import { GanttView } from "./ganttView";
 import { MilestonesTable } from "./milestonesTable";
@@ -31,6 +33,8 @@ export function CalendarTab() {
   const [activeView, setActiveView] = useState<CalendarView>("calendar");
   const [filterType, setFilterType] = useState("all");
   const [tableTab, setTableTab] = useState<TableTab>("milestones");
+  const [createMilestoneOpen, setCreateMilestoneOpen] = useState(false);
+  const [createTouchpointOpen, setCreateTouchpointOpen] = useState(false);
 
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
@@ -113,7 +117,13 @@ export function CalendarTab() {
             variant="solid"
             label="Create"
             iconLeft={() => <Plus className="size-3.5" />}
-            onClick={() => {}}
+            onClick={() => {
+              if (tableTab === "milestones") {
+                setCreateMilestoneOpen(true);
+              } else {
+                setCreateTouchpointOpen(true);
+              }
+            }}
           />
         </div>
 
@@ -126,6 +136,18 @@ export function CalendarTab() {
           )}
         </div>
       </div>
+
+      <CreateMilestoneModal
+        open={createMilestoneOpen}
+        onOpenChange={setCreateMilestoneOpen}
+        projectId={projectId}
+      />
+
+      <CreateTouchpointModal
+        open={createTouchpointOpen}
+        onOpenChange={setCreateTouchpointOpen}
+        projectId={projectId}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description
- Adds functional create modals for milestones and touchpoints

## Testing Instructions
1) Open the project calendar page
2) Click on the +Create button
3) Fill the required details (start, end date, owner etc)
4) Click "Create" a toast should appear on success.
5) The frontend still uses mock data, so to confirm the change - go to desk -> go to "[Project Timeline Item](http://next-pms.localhost/desk/project-timeline-item)" -> and confirm the items were created.

## Screenshot/Screencast
<img width="869" height="670" alt="image" src="https://github.com/user-attachments/assets/1b86e127-b193-45aa-aa3b-c5250f89a0fa" />

<img width="895" height="632" alt="image" src="https://github.com/user-attachments/assets/7ad325bb-faf7-42dc-a03f-9a840551abdc" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1230