### PR TITLE
Feature: API integration for project calendar view

### DIFF
--- a/frontend/packages/app/src/hooks/useThrottledCallback.ts
+++ b/frontend/packages/app/src/hooks/useThrottledCallback.ts
@@ -1,0 +1,47 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Returns a throttled version of the given callback. Calls are coalesced using
+ * `requestAnimationFrame`, so the callback fires at most once per paint frame
+ * regardless of how rapidly the returned function is invoked. Any invocations
+ * while a frame is already pending are dropped.
+ *
+ * The latest version of `callback` is always used (no stale-closure issues),
+ * and any pending frame is cancelled automatically on unmount.
+ *
+ * @example
+ * const onScroll = useThrottledCallback(() => { ... });
+ * el.addEventListener("scroll", onScroll);
+ */
+export function useThrottledCallback<T extends unknown[]>(
+  callback: (...args: T) => void,
+): (...args: T) => void {
+  const rafRef = useRef<number | null>(null);
+  const callbackRef = useRef(callback);
+
+  // Keep callbackRef current without resetting the throttle.
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // Cancel any pending frame on unmount.
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, []);
+
+  return useCallback((...args: T) => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      callbackRef.current(...args);
+    });
+  }, []);
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/eventPill.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/eventPill.tsx
@@ -34,6 +34,7 @@ export function EventPill({ item, truncate = false }: EventPillProps) {
         className={mergeClassNames(
           "min-w-0 leading-tight",
           truncate ? "truncate" : "wrap-break-word",
+          item.isComplete && "line-through opacity-60",
         )}
       >
         {item.title}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
@@ -25,7 +25,11 @@ export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
         title={item.title}
       >
         <Diamond className="size-3.5 shrink-0" />
-        <span className="truncate text-sm">{item.title}</span>
+        <span
+          className={`truncate text-sm${item.isComplete ? " line-through opacity-60" : ""}`}
+        >
+          {item.title}
+        </span>
       </div>
     );
   }
@@ -53,7 +57,9 @@ export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
       >
         <Zap className="size-3.5" />
       </div>
-      <span className="text-sm text-violet-700 whitespace-nowrap">
+      <span
+        className={`text-sm text-violet-700 whitespace-nowrap${item.isComplete ? " line-through opacity-60" : ""}`}
+      >
         {item.title}
       </span>
     </div>

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttView.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttView.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useEffect, useRef, useState } from "react";
 import {
   format,
   getDay,
@@ -9,9 +10,11 @@ import {
   parseISO,
   startOfMonth,
 } from "date-fns";
+import { ArrowDown } from "lucide-react";
 /**
  * Internal dependencies.
  */
+import { useThrottledCallback } from "@/hooks/useThrottledCallback";
 import { mergeClassNames as cn } from "@/lib/utils";
 import {
   COLUMN_WIDTH,
@@ -41,6 +44,29 @@ export function GanttView({
   items,
   showWeekend = true,
 }: GanttViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [hasMoreBelow, setHasMoreBelow] = useState(false);
+
+  const checkScroll = useThrottledCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
+    setHasMoreBelow(!atBottom && el.scrollHeight > el.clientHeight);
+  });
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    checkScroll();
+    el.addEventListener("scroll", checkScroll);
+    const ro = new ResizeObserver(checkScroll);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", checkScroll);
+      ro.disconnect();
+    };
+  }, [checkScroll, items]);
+
   const monthStart = startOfMonth(new Date(year, month, 1));
   const dayColumns = buildDayColumns(year, month, showWeekend);
   const colIndexMap = buildColIndexMap(dayColumns);
@@ -69,117 +95,129 @@ export function GanttView({
   }
 
   return (
-    <div className="overflow-auto no-scrollbar max-h-112.5">
-      <div style={{ minWidth: totalWidth }}>
-        {/* Week range labels */}
-        <div
-          className="sticky z-20 flex bg-surface-white border-t border-outline-gray-1"
-          style={{ top: 0, height: WEEK_LABEL_HEIGHT }}
-        >
-          {weekGroups.map((group, i) => {
-            const start = group[0];
-            const end = group[group.length - 1];
-            const endFmt = end.getMonth() !== start.getMonth() ? "MMM d" : "d";
-            const label = `${format(start, "MMM d")} - ${format(end, endFmt)}`;
-            return (
-              <div
-                key={i}
-                className={cn(
-                  "flex items-center justify-center px-2 text-xs text-ink-gray-4",
-                  i < weekGroups.length - 1 && "border-r border-outline-gray-1",
-                )}
-                style={{ width: group.length * COLUMN_WIDTH }}
-              >
-                <span className="truncate">{label}</span>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Day numbers */}
-        <div
-          className="sticky z-20 flex bg-surface-white border-b border-outline-gray-1"
-          style={{ top: WEEK_LABEL_HEIGHT, height: DAY_HEADER_HEIGHT }}
-        >
-          {dayColumns.map((day, i) => {
-            const todayDay = isToday(day);
-            const dow = getDay(day); // 0 Sun … 6 Sat
-            const isWeekend = dow === 0 || dow === 6;
-            // Mark last column of each week (Sun when showing weekends, Fri when not)
-            const isLastInWeek = showWeekend ? dow === 0 : dow === 5;
-            const isOutsideMonth = !isSameMonth(day, monthStart);
-            return (
-              <div
-                key={i}
-                className={cn(
-                  "relative flex items-center justify-center shrink-0",
-                  isWeekend && showWeekend && "bg-surface-gray-1/50",
-                  isLastInWeek && "border-r border-outline-gray-1",
-                )}
-                style={{ width: COLUMN_WIDTH, height: DAY_HEADER_HEIGHT }}
-              >
-                <span
-                  className={cn(
-                    "text-xs px-1.5 py-0.5",
-                    isOutsideMonth ? "text-ink-gray-3" : "text-ink-gray-4",
-                    todayDay &&
-                      "bg-surface-gray-7 text-ink-white rounded-[6px]",
-                  )}
-                >
-                  {format(day, "d")}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Timeline body */}
-        <div className="relative">
-          {/* Weekend column backgrounds */}
-          {showWeekend &&
-            dayColumns.map((day, i) => {
-              const dow = getDay(day);
-              const isWeekend = dow === 0 || dow === 6;
-              return isWeekend ? (
+    <div className="relative">
+      <div ref={scrollRef} className="overflow-auto no-scrollbar max-h-112.5">
+        <div style={{ minWidth: totalWidth }}>
+          {/* Week range labels */}
+          <div
+            className="sticky z-20 flex bg-surface-white border-t border-outline-gray-1"
+            style={{ top: 0, height: WEEK_LABEL_HEIGHT }}
+          >
+            {weekGroups.map((group, i) => {
+              const start = group[0];
+              const end = group[group.length - 1];
+              const endFmt =
+                end.getMonth() !== start.getMonth() ? "MMM d" : "d";
+              const label = `${format(start, "MMM d")} - ${format(end, endFmt)}`;
+              return (
                 <div
                   key={i}
-                  className="absolute top-0 bottom-0 bg-surface-gray-1/50 pointer-events-none"
-                  style={{ left: i * COLUMN_WIDTH, width: COLUMN_WIDTH }}
-                />
-              ) : null;
+                  className={cn(
+                    "flex items-center justify-center px-2 text-xs text-ink-gray-4",
+                    i < weekGroups.length - 1 &&
+                      "border-r border-outline-gray-1",
+                  )}
+                  style={{ width: group.length * COLUMN_WIDTH }}
+                >
+                  <span className="truncate">{label}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Day numbers */}
+          <div
+            className="sticky z-20 flex bg-surface-white border-b border-outline-gray-1"
+            style={{ top: WEEK_LABEL_HEIGHT, height: DAY_HEADER_HEIGHT }}
+          >
+            {dayColumns.map((day, i) => {
+              const todayDay = isToday(day);
+              const dow = getDay(day); // 0 Sun … 6 Sat
+              const isWeekend = dow === 0 || dow === 6;
+              // Mark last column of each week (Sun when showing weekends, Fri when not)
+              const isLastInWeek = showWeekend ? dow === 0 : dow === 5;
+              const isOutsideMonth = !isSameMonth(day, monthStart);
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    "relative flex items-center justify-center shrink-0",
+                    isWeekend && showWeekend && "bg-surface-gray-1/50",
+                    isLastInWeek && "border-r border-outline-gray-1",
+                  )}
+                  style={{ width: COLUMN_WIDTH, height: DAY_HEADER_HEIGHT }}
+                >
+                  <span
+                    className={cn(
+                      "text-xs px-1.5 py-0.5",
+                      isOutsideMonth ? "text-ink-gray-3" : "text-ink-gray-4",
+                      todayDay &&
+                        "bg-surface-gray-7 text-ink-white rounded-[6px]",
+                    )}
+                  >
+                    {format(day, "d")}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Timeline body */}
+          <div className="relative">
+            {/* Weekend column backgrounds */}
+            {showWeekend &&
+              dayColumns.map((day, i) => {
+                const dow = getDay(day);
+                const isWeekend = dow === 0 || dow === 6;
+                return isWeekend ? (
+                  <div
+                    key={i}
+                    className="absolute top-0 bottom-0 bg-surface-gray-1/50 pointer-events-none"
+                    style={{ left: i * COLUMN_WIDTH, width: COLUMN_WIDTH }}
+                  />
+                ) : null;
+              })}
+
+            {/* Week separator lines */}
+            {separatorXs.map((x) => (
+              <div
+                key={x}
+                className="absolute top-0 bottom-0 w-px bg-outline-gray-1 pointer-events-none"
+                style={{ left: x - 1 }}
+              />
+            ))}
+
+            {/* Item rows */}
+            {visibleItems.map((item) => {
+              const pos = resolvePosition(item, dayColumns, colIndexMap);
+              if (!pos) return null;
+              return (
+                <div
+                  key={item.id}
+                  className="relative"
+                  style={{ height: ROW_HEIGHT }}
+                >
+                  <GanttBar item={item} pos={pos} totalWidth={totalWidth} />
+                </div>
+              );
             })}
 
-          {/* Week separator lines */}
-          {separatorXs.map((x) => (
-            <div
-              key={x}
-              className="absolute top-0 bottom-0 w-px bg-outline-gray-1 pointer-events-none"
-              style={{ left: x - 1 }}
-            />
-          ))}
-
-          {/* Item rows */}
-          {visibleItems.map((item) => {
-            const pos = resolvePosition(item, dayColumns, colIndexMap);
-            if (!pos) return null;
-            return (
-              <div
-                key={item.id}
-                className="relative"
-                style={{ height: ROW_HEIGHT }}
-              >
-                <GanttBar item={item} pos={pos} totalWidth={totalWidth} />
+            {visibleItems.length === 0 && (
+              <div className="py-10 text-center text-sm text-ink-gray-4 relative z-10">
+                No items for this period
               </div>
-            );
-          })}
-
-          {visibleItems.length === 0 && (
-            <div className="py-10 text-center text-sm text-ink-gray-4 relative z-10">
-              No items for this period
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
+      {hasMoreBelow && (
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 flex justify-center pb-2 pt-6 bg-linear-to-t from-surface-white to-transparent z-10">
+          <span className="flex items-center gap-1 text-base text-ink-gray-4">
+            <ArrowDown className="size-4" />
+            More
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
@@ -52,7 +52,11 @@ export function CalendarTab() {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
-  const { items, mutate } = useProjectTimelineItems(projectId, year, month);
+  const { items, monthItems, mutate } = useProjectTimelineItems(
+    projectId,
+    year,
+    month,
+  );
 
   const filteredItems =
     filterType === "all"
@@ -176,14 +180,14 @@ export function CalendarTab() {
         <div className="overflow-x-auto">
           {tableTab === "milestones" ? (
             <MilestonesTable
-              items={items}
+              items={monthItems}
               userId={userId}
               onMarkAsCompleted={handleMarkAsCompleted}
               onFollowDocument={handleFollowDocument}
             />
           ) : (
             <TouchpointsTable
-              items={items}
+              items={monthItems}
               userId={userId}
               onMarkAsCompleted={handleMarkAsCompleted}
               onFollowDocument={handleFollowDocument}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
@@ -3,27 +3,40 @@
  */
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import { Button, TabButtons } from "@rtcamp/frappe-ui-react";
+import { Button, TabButtons, useToasts } from "@rtcamp/frappe-ui-react";
 import { format, parseISO } from "date-fns";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 import { Plus } from "lucide-react";
 
 /**
  * Internal dependencies.
  */
+import { parseFrappeErrorMsg } from "@/lib/utils";
+import { useUser } from "@/providers/user";
 import { CalendarGrid } from "./calendarGrid";
 import { CalendarToolbar, type CalendarView } from "./calendarToolbar";
 import { CreateMilestoneModal } from "./create-milestone";
 import { CreateTouchpointModal } from "./create-touchpoint";
-import { getTimelineItems } from "./fake-data";
 import { GanttView } from "./ganttView";
 import { MilestonesTable } from "./milestonesTable";
 import { TouchpointsTable } from "./touchpointsTable";
+import type { ProjectTimelineItem } from "./types";
+import { useProjectTimelineItems } from "./useProjectTimelineItems";
 
 type TableTab = "milestones" | "touchpoints";
 
 export function CalendarTab() {
   const { projectId = "" } = useParams<{ projectId: string }>();
-  const items = getTimelineItems(projectId);
+  const toast = useToasts();
+  const { userId } = useUser(({ state }) => ({ userId: state.userId }));
+
+  const { call: markComplete } = useFrappePostCall(
+    "next_pms.next_projects.api.project_timeline_item.mark_timeline_item_complete",
+  );
+
+  const { call: updateFollow } = useFrappePostCall(
+    "frappe.desk.form.document_follow.update_follow",
+  );
 
   const [currentDate, setCurrentDate] = useState(() => {
     const n = new Date();
@@ -38,6 +51,8 @@ export function CalendarTab() {
 
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
+
+  const { items, mutate } = useProjectTimelineItems(projectId, year, month);
 
   const filteredItems =
     filterType === "all"
@@ -68,6 +83,36 @@ export function CalendarTab() {
     const n = new Date();
     setCurrentDate(new Date(n.getFullYear(), n.getMonth(), 1));
     setSelectedDate(null);
+  }
+
+  async function handleMarkAsCompleted(item: ProjectTimelineItem) {
+    try {
+      await markComplete({
+        name: item.id,
+        is_complete: item.isComplete ? 0 : 1,
+      });
+      toast.success(
+        item.isComplete ? "Marked as incomplete" : "Marked as completed",
+      );
+      void mutate();
+    } catch (err) {
+      toast.error(parseFrappeErrorMsg(err as FrappeError));
+    }
+  }
+
+  async function handleFollowDocument(item: ProjectTimelineItem) {
+    const isFollowing = item.watchers.some((w) => w.name === userId);
+    try {
+      await updateFollow({
+        doctype: "Project Timeline Item",
+        doc_name: item.id,
+        following: !isFollowing,
+      });
+      toast.success(isFollowing ? "Unfollowed document" : "Following document");
+      void mutate();
+    } catch (err) {
+      toast.error(parseFrappeErrorMsg(err as FrappeError));
+    }
   }
 
   return (
@@ -130,9 +175,19 @@ export function CalendarTab() {
         {/* Table */}
         <div className="overflow-x-auto">
           {tableTab === "milestones" ? (
-            <MilestonesTable items={items} />
+            <MilestonesTable
+              items={items}
+              userId={userId}
+              onMarkAsCompleted={handleMarkAsCompleted}
+              onFollowDocument={handleFollowDocument}
+            />
           ) : (
-            <TouchpointsTable items={items} />
+            <TouchpointsTable
+              items={items}
+              userId={userId}
+              onMarkAsCompleted={handleMarkAsCompleted}
+              onFollowDocument={handleFollowDocument}
+            />
           )}
         </div>
       </div>
@@ -141,12 +196,18 @@ export function CalendarTab() {
         open={createMilestoneOpen}
         onOpenChange={setCreateMilestoneOpen}
         projectId={projectId}
+        onSuccess={() => {
+          void mutate();
+        }}
       />
 
       <CreateTouchpointModal
         open={createTouchpointOpen}
         onOpenChange={setCreateTouchpointOpen}
         projectId={projectId}
+        onSuccess={() => {
+          void mutate();
+        }}
       />
     </div>
   );

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/milestonesTable.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/milestonesTable.tsx
@@ -7,6 +7,7 @@ import type { ProjectTimelineItem } from "./types";
 
 type MilestonesTableProps = {
   items: ProjectTimelineItem[];
+  userId?: string;
   onEdit?: (item: ProjectTimelineItem) => void;
   onMarkAsCompleted?: (item: ProjectTimelineItem) => void;
   onFollowDocument?: (item: ProjectTimelineItem) => void;
@@ -14,6 +15,7 @@ type MilestonesTableProps = {
 
 export function MilestonesTable({
   items,
+  userId,
   onEdit,
   onMarkAsCompleted,
   onFollowDocument,
@@ -53,6 +55,7 @@ export function MilestonesTable({
                 <TimelineCell
                   item={item}
                   column={column}
+                  userId={userId}
                   onEdit={onEdit}
                   onMarkAsCompleted={onMarkAsCompleted}
                   onFollowDocument={onFollowDocument}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/table/cells/actionsCell.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/table/cells/actionsCell.tsx
@@ -6,8 +6,9 @@ import {
   Check,
   EditAlt,
   NotificationBell,
+  NotificationOff,
 } from "@rtcamp/frappe-ui-react/icons";
-import { Ellipsis } from "lucide-react";
+import { Ellipsis, RotateCcw } from "lucide-react";
 
 /**
  * Internal dependencies.
@@ -16,6 +17,7 @@ import type { ProjectTimelineItem } from "../../types";
 
 type ActionsCellProps = {
   item: ProjectTimelineItem;
+  userId?: string;
   onEdit?: (item: ProjectTimelineItem) => void;
   onMarkAsCompleted?: (item: ProjectTimelineItem) => void;
   onFollowDocument?: (item: ProjectTimelineItem) => void;
@@ -23,10 +25,15 @@ type ActionsCellProps = {
 
 export function ActionsCell({
   item,
+  userId,
   onEdit,
   onMarkAsCompleted,
   onFollowDocument,
 }: ActionsCellProps) {
+  const isFollowing = userId
+    ? item.watchers.some((w) => w.name === userId)
+    : false;
+
   return (
     <Dropdown
       dropdownClassName="border-none"
@@ -43,15 +50,23 @@ export function ActionsCell({
           onClick: () => onEdit?.(item),
         },
         {
-          label: "Mark as completed",
+          label: item.isComplete ? "Mark as incomplete" : "Mark as completed",
           key: "mark-as-completed",
-          icon: <Check className="size-4 mr-2" />,
+          icon: item.isComplete ? (
+            <RotateCcw className="size-4 mr-2" />
+          ) : (
+            <Check className="size-4 mr-2" />
+          ),
           onClick: () => onMarkAsCompleted?.(item),
         },
         {
-          label: "Follow Document",
+          label: isFollowing ? "Unfollow Document" : "Follow Document",
           key: "follow-document",
-          icon: <NotificationBell className="size-4 mr-2" />,
+          icon: isFollowing ? (
+            <NotificationOff className="size-4 mr-2" />
+          ) : (
+            <NotificationBell className="size-4 mr-2" />
+          ),
           onClick: () => onFollowDocument?.(item),
         },
       ]}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/table/cells/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/table/cells/index.tsx
@@ -13,6 +13,7 @@ import { isDateOverdue } from "../../utils";
 type TimelineCellProps = {
   item: ProjectTimelineItem;
   column: TableColumn;
+  userId?: string;
   onEdit?: (item: ProjectTimelineItem) => void;
   onMarkAsCompleted?: (item: ProjectTimelineItem) => void;
   onFollowDocument?: (item: ProjectTimelineItem) => void;
@@ -21,6 +22,7 @@ type TimelineCellProps = {
 export function TimelineCell({
   item,
   column,
+  userId,
   onEdit,
   onMarkAsCompleted,
   onFollowDocument,
@@ -47,6 +49,7 @@ export function TimelineCell({
       return (
         <ActionsCell
           item={item}
+          userId={userId}
           onEdit={onEdit}
           onMarkAsCompleted={onMarkAsCompleted}
           onFollowDocument={onFollowDocument}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/touchpointsTable.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/touchpointsTable.tsx
@@ -7,6 +7,7 @@ import type { ProjectTimelineItem } from "./types";
 
 type TouchpointsTableProps = {
   items: ProjectTimelineItem[];
+  userId?: string;
   onEdit?: (item: ProjectTimelineItem) => void;
   onMarkAsCompleted?: (item: ProjectTimelineItem) => void;
   onFollowDocument?: (item: ProjectTimelineItem) => void;
@@ -14,6 +15,7 @@ type TouchpointsTableProps = {
 
 export function TouchpointsTable({
   items,
+  userId,
   onEdit,
   onMarkAsCompleted,
   onFollowDocument,
@@ -53,6 +55,7 @@ export function TouchpointsTable({
                 <TimelineCell
                   item={item}
                   column={column}
+                  userId={userId}
                   onEdit={onEdit}
                   onMarkAsCompleted={onMarkAsCompleted}
                   onFollowDocument={onFollowDocument}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
@@ -1,0 +1,101 @@
+/**
+ * External dependencies.
+ */
+import { useMemo } from "react";
+import { format, startOfISOWeek } from "date-fns";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal dependencies.
+ */
+import type { ProjectTimelineItem, UserRef } from "./types";
+
+// 6 ISO weeks always covers any calendar month's full view range
+const WEEKS_PER_FETCH = 6;
+// Generous upper limit - avoids multiple round-trips for a single month
+const ITEMS_LIMIT = 200;
+
+interface ApiUserRef {
+  user: string;
+  full_name: string;
+  image: string | null;
+}
+
+interface ApiTimelineItem {
+  name: string;
+  title: string;
+  project: string;
+  type: "Milestone" | "Touchpoint";
+  is_complete: 0 | 1;
+  start_date: string | null;
+  planned_end_date: string;
+  actual_end_date: string | null;
+  owner: ApiUserRef | null;
+  watchers: ApiUserRef[];
+}
+
+interface ApiResponse {
+  data: ApiTimelineItem[];
+  total_count: number;
+  has_more: boolean;
+}
+
+function mapUserRef(raw: ApiUserRef): UserRef {
+  return {
+    name: raw.user,
+    fullName: raw.full_name,
+    avatar: raw.image ?? undefined,
+  };
+}
+
+function mapItem(raw: ApiTimelineItem): ProjectTimelineItem {
+  return {
+    id: raw.name,
+    title: raw.title,
+    project: raw.project,
+    type: raw.type,
+    isComplete: Boolean(raw.is_complete),
+    startDate: raw.start_date ?? undefined,
+    plannedEndDate: raw.planned_end_date,
+    actualEndDate: raw.actual_end_date ?? undefined,
+    owner: raw.owner ? mapUserRef(raw.owner) : { name: "", fullName: "" },
+    watchers: (raw.watchers ?? []).map(mapUserRef),
+  };
+}
+
+export function useProjectTimelineItems(
+  projectId: string,
+  year: number,
+  month: number,
+) {
+  // Extend to the ISO week boundary so Gantt's extended view is covered
+  const viewStart = startOfISOWeek(new Date(year, month, 1));
+  const startDate = format(viewStart, "yyyy-MM-dd");
+
+  const { data, isLoading, error, mutate } = useFrappeGetCall<{
+    message: ApiResponse;
+  }>(
+    "next_pms.next_projects.api.project_timeline_item.get_project_timeline_items",
+    {
+      project: projectId,
+      start_date: startDate,
+      max_week: WEEKS_PER_FETCH,
+      limit: ITEMS_LIMIT,
+      start: 0,
+    },
+    // Disable when no project is provided
+    projectId ? undefined : null,
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  // console.log({ timelineItemsData: data, timelineItemsError: error });
+
+  const items = useMemo<ProjectTimelineItem[]>(
+    () => (data?.message?.data ?? []).map(mapItem),
+    [data],
+  );
+
+  return { items, isLoading, error, mutate };
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
@@ -28,7 +28,7 @@ interface ApiTimelineItem {
   type: "Milestone" | "Touchpoint";
   is_complete: 0 | 1;
   start_date: string | null;
-  planned_end_date: string;
+  planned_end_date: string | null;
   actual_end_date: string | null;
   owner: ApiUserRef | null;
   watchers: ApiUserRef[];
@@ -56,7 +56,7 @@ function mapItem(raw: ApiTimelineItem): ProjectTimelineItem {
     type: raw.type,
     isComplete: Boolean(raw.is_complete),
     startDate: raw.start_date ?? undefined,
-    plannedEndDate: raw.planned_end_date,
+    plannedEndDate: raw.planned_end_date as string,
     actualEndDate: raw.actual_end_date ?? undefined,
     owner: raw.owner ? mapUserRef(raw.owner) : { name: "", fullName: "" },
     watchers: (raw.watchers ?? []).map(mapUserRef),
@@ -68,9 +68,13 @@ export function useProjectTimelineItems(
   year: number,
   month: number,
 ) {
-  // Extend to the ISO week boundary so Gantt's extended view is covered
+  // Fetch window: start at the ISO week containing the 1st (covers grid overflow days)
   const viewStart = startOfISOWeek(new Date(year, month, 1));
   const startDate = format(viewStart, "yyyy-MM-dd");
+
+  // Month boundaries used to scope the table view
+  const monthStart = format(new Date(year, month, 1), "yyyy-MM-dd");
+  const monthEnd = format(new Date(year, month + 1, 0), "yyyy-MM-dd");
 
   const { data, isLoading, error, mutate } = useFrappeGetCall<{
     message: ApiResponse;
@@ -90,12 +94,18 @@ export function useProjectTimelineItems(
     },
   );
 
-  // console.log({ timelineItemsData: data, timelineItemsError: error });
+  const { items, monthItems } = useMemo(() => {
+    const allItems = (data?.message?.data ?? [])
+      .filter((item) => item.planned_end_date !== null)
+      .map(mapItem);
 
-  const items = useMemo<ProjectTimelineItem[]>(
-    () => (data?.message?.data ?? []).map(mapItem),
-    [data],
-  );
+    const monthOnlyItems = allItems.filter(
+      (item) =>
+        item.plannedEndDate >= monthStart && item.plannedEndDate <= monthEnd,
+    );
 
-  return { items, isLoading, error, mutate };
+    return { items: allItems, monthItems: monthOnlyItems };
+  }, [data, monthStart, monthEnd]);
+
+  return { items, monthItems, isLoading, error, mutate };
 }


### PR DESCRIPTION
## Description

1. Real API data, useProjectTimelineItems replaces fake data
2. Gantt scroll indicator, GanttView shows a sticky ↓ More badge when rows overflow
3. Completed item styling, isComplete items show line-through opacity-60 in Gantt bars and calendar event pills
4. Working toggle actions menu, "Mark as completed/incomplete" and "Follow/Unfollow Document" toggle dynamically

## Testing Instructions
1. Go to project calendar view page
2. Everything should work now, all actions.
3. EXCEPT: Edit milestone/touchpoint as the API is not present.

NOTE: The date selector at the top filters both the calendar and table. But calendars will show items from the previous or next month if the data is present in the view, but the table will strictly show only that months items. An event's date is decided by the planned_end_date.

## Screenshot/Screencast

<img width="889" height="764" alt="image" src="https://github.com/user-attachments/assets/7f163187-70be-4c13-b5e9-99c52f2d5a3f" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1049 #1050 #1051 #1052 #1053 #1054
Partially Fixed #1055