### PR TITLE
feat: Edit project timeline item API endpoint

### DIFF
--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -198,6 +198,9 @@ def create_project_timeline_item(
     """
     only_for(ALLOWED_ROLES, message=True)
 
+    title = (title or "").strip()
+    item_owner = (item_owner or "").strip()
+
     if not project:
         frappe.throw(frappe._("Project is required"))
     if not title:
@@ -206,14 +209,24 @@ def create_project_timeline_item(
         frappe.throw(frappe._("Item Owner is required"))
     if type not in ("Milestone", "Touchpoint"):
         frappe.throw(frappe._("Type must be Milestone or Touchpoint"))
+    if not frappe.db.exists("User", item_owner):
+        frappe.throw(frappe._("User {0} does not exist").format(item_owner))
+    if type == "Touchpoint" and start_date:
+        frappe.throw(frappe._("start_date cannot be set for a Touchpoint"))
+
+    start_date_val = getdate(start_date) if start_date else None
+    planned_end_date_val = getdate(planned_end_date) if planned_end_date else None
+
+    if start_date_val and planned_end_date_val and start_date_val > planned_end_date_val:
+        frappe.throw(frappe._("start_date must not be later than planned_end_date"))
 
     doc = frappe.new_doc("Project Timeline Item")
     doc.project = project
     doc.type = type
     doc.title = title
     doc.item_owner = item_owner
-    doc.start_date = start_date or None
-    doc.planned_end_date = planned_end_date or None
+    doc.start_date = start_date_val
+    doc.planned_end_date = planned_end_date_val
     doc.is_complete = 0
     doc.insert()
 
@@ -255,19 +268,24 @@ def edit_project_timeline_item(
 
     if not name:
         frappe.throw(frappe._("Name is required"))
+
     doc = frappe.get_doc("Project Timeline Item", name)
 
     if start_date is not None and doc.type == "Touchpoint":
         frappe.throw(frappe._("start_date cannot be set for a Touchpoint"))
 
     if title is not None:
+        title = title.strip()
         if not title:
             frappe.throw(frappe._("Title cannot be empty"))
         doc.title = title
 
     if item_owner is not None:
-        if not item_owner:  ##guarad against empty string
+        item_owner = item_owner.strip()
+        if not item_owner:
             frappe.throw(frappe._("Item Owner cannot be empty"))
+        if not frappe.db.exists("User", item_owner):
+            frappe.throw(frappe._("User {0} does not exist").format(item_owner))
         doc.item_owner = item_owner
 
     if start_date is not None:
@@ -276,7 +294,12 @@ def edit_project_timeline_item(
     if planned_end_date is not None:
         doc.planned_end_date = getdate(planned_end_date) if planned_end_date else None
 
-    doc.save()
+    effective_start = doc.start_date
+    effective_end = doc.planned_end_date
+    if effective_start and effective_end and getdate(effective_start) > getdate(effective_end):
+        frappe.throw(frappe._("start_date must not be later than planned_end_date"))
+
+    doc.save(ignore_permissions=False)
 
     return {
         "name": doc.name,

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -231,6 +231,67 @@ def create_project_timeline_item(
 
 @whitelist(methods=["POST"])
 @error_logger
+def edit_project_timeline_item(
+    name: str,
+    title: str | None = None,
+    item_owner: str | None = None,
+    start_date: str | None = None,
+    planned_end_date: str | None = None,
+):
+    """
+    Edit an existing Project Timeline Item.
+
+    Args:
+        name: Document name of the Project Timeline Item
+        title: New title — must be non-empty if provided
+        item_owner: New owner (User email) — must be non-empty if provided
+        start_date: New start date (Milestone only); "" to clear
+        planned_end_date: New planned end date; "" to clear
+
+    Returns:
+        Dict : The updated item's key fields.
+    """
+    only_for(ALLOWED_ROLES, message=True)
+
+    if not name:
+        frappe.throw(frappe._("Name is required"))
+    doc = frappe.get_doc("Project Timeline Item", name)
+
+    if start_date is not None and doc.type == "Touchpoint":
+        frappe.throw(frappe._("start_date cannot be set for a Touchpoint"))
+
+    if title is not None:
+        if not title:
+            frappe.throw(frappe._("Title cannot be empty"))
+        doc.title = title
+
+    if item_owner is not None:
+        if not item_owner:  ##guarad against empty string
+            frappe.throw(frappe._("Item Owner cannot be empty"))
+        doc.item_owner = item_owner
+
+    if start_date is not None:
+        doc.start_date = getdate(start_date) if start_date else None
+
+    if planned_end_date is not None:
+        doc.planned_end_date = getdate(planned_end_date) if planned_end_date else None
+
+    doc.save()
+
+    return {
+        "name": doc.name,
+        "title": doc.title,
+        "project": doc.project,
+        "type": doc.type,
+        "item_owner": doc.item_owner,
+        "start_date": doc.start_date,
+        "planned_end_date": doc.planned_end_date,
+        "is_complete": cint(doc.is_complete),
+    }
+
+
+@whitelist(methods=["POST"])
+@error_logger
 def mark_timeline_item_complete(name: str, is_complete: int = 1):
     """
     Mark a Project Timeline Item as complete or incomplete.

--- a/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.json
+++ b/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.json
@@ -60,6 +60,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "depends_on": "eval:doc.type==\"Milestone\"",
    "fieldname": "start_date",
    "fieldtype": "Date",
    "label": "Start Date"
@@ -97,7 +98,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-18 18:42:03.761148",
+ "modified": "2026-05-22 13:18:17.086117",
  "modified_by": "Administrator",
  "module": "Next Projects",
  "name": "Project Timeline Item",


### PR DESCRIPTION
## Description
* Added the `edit_project_timeline_item` function to `project_timeline_item.py`, enabling updates to the title, owner, start date, and planned end date of a Project Timeline Item, with input validation and error handling.
* added validation for item_owner being a correct link and end_date > start_date in both create and edit API
* added display depends on property for start_date as its not used in touchpoint

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/d7050c56-6dd4-4208-a275-f14d490cb1fc" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #1075 , #1078 