### PR TITLE
Fix: Missing weeks issue on project and team timesheets page

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -556,7 +556,7 @@ export const buildFrappeFilters = (compositeFilters: FilterCondition[]) => {
  * and native Frappe filters.
  *
  * @param compositeFilters Array of FilterCondition objects.
- * @returns Object containing startDate, maxWeek, and frappeFilters derived from the composite filters.
+ * @returns Object containing startDate, endDate, maxWeek, and frappeFilters derived from the composite filters.
  */
 export const buildCompositeFilters = (compositeFilters: FilterCondition[]) => {
   if (compositeFilters.length === 0) {
@@ -617,7 +617,7 @@ export const buildCompositeFilters = (compositeFilters: FilterCondition[]) => {
     }
   }
 
-  // Note: We are return end date as start date because API expects end date and fetches backwards from there.
+  // Note: We are returning end date as start date because API expects end date and fetches backwards from there.
   return {
     startDate: endDate,
     endDate: startDate,

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -620,6 +620,7 @@ export const buildCompositeFilters = (compositeFilters: FilterCondition[]) => {
   // Note: We are return end date as start date because API expects end date and fetches backwards from there.
   return {
     startDate: endDate,
+    endDate: startDate,
     maxWeek: maxWeek,
     frappeFilters,
   };

--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -47,7 +47,7 @@ export function useProjectTimesheetData({
   const prevFiltersRef = useRef({ search, compositeFilters });
 
   // Build Frappe-compatible filters from composite filters
-  const { startDate, endDate, maxWeek, frappeFilters } = useMemo(
+  const { startDate, endDate, frappeFilters } = useMemo(
     () => buildCompositeFilters(compositeFilters),
     [compositeFilters],
   );
@@ -195,7 +195,7 @@ export function useProjectTimesheetData({
     const hasMore = hasMoreProjects || hasMoreWeeks;
 
     return { hasMoreProjects, hasMoreWeeks, hasMore, weekGroups };
-  }, [pages, weekDate, startDate, endDate, maxWeek]);
+  }, [pages, weekDate, startDate, endDate]);
 
   // When the current window is fully loaded but yields no visible weeks, we are
   // about to auto-advance. Expose this as "still loading" to prevent a flicker

--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -47,7 +47,7 @@ export function useProjectTimesheetData({
   const prevFiltersRef = useRef({ search, compositeFilters });
 
   // Build Frappe-compatible filters from composite filters
-  const { startDate, maxWeek, frappeFilters } = useMemo(
+  const { startDate, endDate, maxWeek, frappeFilters } = useMemo(
     () => buildCompositeFilters(compositeFilters),
     [compositeFilters],
   );
@@ -74,6 +74,7 @@ export function useProjectTimesheetData({
     }
   }, [search, compositeFilters, resetData]);
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- will eventually use filters in the API call, just not yet.
   const hasActiveFilter = !!search || compositeFilters.length > 0;
 
   const {
@@ -89,7 +90,8 @@ export function useProjectTimesheetData({
       start: projectStart,
       search: search || null,
       filters: frappeFilters.length > 0 ? JSON.stringify(frappeFilters) : null,
-      skip_empty_weeks: hasActiveFilter || null,
+      // skip_empty_weeks: hasActiveFilter || null,
+      // TODO: Re-enable skip_empty_weeks once the API properly supports it.
     },
   );
 
@@ -104,11 +106,13 @@ export function useProjectTimesheetData({
   const { hasMoreProjects, hasMoreWeeks, hasMore, weekGroups } = useMemo(() => {
     const oneYearAgo = addDays(parseISO(getTodayDate()), -365);
     // When a date-range filter is active, limit week pagination to the actual
-    // filter range (startDate − maxWeek weeks). Without a filter, fall back
+    // filter range. Without a filter, fall back
     // to the 1-year rolling limit.
-    const hasMoreWeeks = startDate
-      ? parseISO(weekDate) > addDays(parseISO(startDate), -(maxWeek * 7))
-      : parseISO(weekDate) > oneYearAgo;
+    const hasMoreWeeks =
+      startDate && endDate
+        ? addDays(parseISO(weekDate), -(NUMBER_OF_WEEKS_TO_FETCH * 7)) >
+          parseISO(endDate)
+        : parseISO(weekDate) > oneYearAgo;
 
     const hasMoreProjects =
       pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
@@ -191,7 +195,7 @@ export function useProjectTimesheetData({
     const hasMore = hasMoreProjects || hasMoreWeeks;
 
     return { hasMoreProjects, hasMoreWeeks, hasMore, weekGroups };
-  }, [pages, weekDate, startDate, maxWeek]);
+  }, [pages, weekDate, startDate, endDate, maxWeek]);
 
   // When the current window is fully loaded but yields no visible weeks, we are
   // about to auto-advance. Expose this as "still loading" to prevent a flicker

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ApprovalStatusLabelMap } from "@next-pms/design-system/components";
 import { getFormatedDate, getTodayDate } from "@next-pms/design-system/date";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
-import { addDays } from "date-fns";
+import { addDays, parseISO } from "date-fns";
 import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
@@ -74,7 +74,7 @@ export function useTeamTimesheetData({
   const prevFiltersRef = useRef({ filters, compositeFilters });
 
   // Build Frappe-compatible filters from composite filters
-  const { startDate, maxWeek, frappeFilters } = useMemo(
+  const { startDate, endDate, maxWeek, frappeFilters } = useMemo(
     () => buildCompositeFilters(compositeFilters),
     [compositeFilters],
   );
@@ -102,6 +102,7 @@ export function useTeamTimesheetData({
     }
   }, [filters, compositeFilters, resetData]);
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- will eventually use filters in the API call, just not yet.
   const hasActiveFilter =
     !!filters.reportsTo ||
     !!filters.search ||
@@ -123,7 +124,7 @@ export function useTeamTimesheetData({
       ? JSON.stringify([ApprovalStatusLabelMap[filters.approvalStatus]])
       : null,
     filters: frappeFilters.length > 0 ? JSON.stringify(frappeFilters) : null,
-    skip_empty_weeks: hasActiveFilter || null,
+    // skip_empty_weeks: hasActiveFilter || null,
   });
 
   useEffect(() => {
@@ -140,9 +141,11 @@ export function useTeamTimesheetData({
       // When a date-range filter is active, limit week pagination to the actual
       // filter range (startDate − maxWeek weeks). Without a filter, fall back
       // to the 1-year rolling limit.
-      const hasMoreWeeks = startDate
-        ? new Date(weekDate) > addDays(new Date(startDate), -(maxWeek * 7))
-        : new Date(weekDate) > oneYearAgo;
+      const hasMoreWeeks =
+        startDate && endDate
+          ? addDays(parseISO(weekDate), -(NUMBER_OF_WEEKS_TO_FETCH * 7)) >
+            parseISO(endDate)
+          : parseISO(weekDate) > oneYearAgo;
       const hasMoreEmployees =
         pages.length > 0 ? (pages[pages.length - 1].has_more ?? false) : true;
 
@@ -216,6 +219,24 @@ export function useTeamTimesheetData({
 
       const weekMap = new Map<string, WeekGroup>();
 
+      // Seed week skeletons from the API-declared date ranges so that weeks
+      // are always present in the output even when every employee's timesheet
+      // for that week has status "Not Submitted" (and was filtered above).
+      pages.forEach((payload) => {
+        (payload.dates ?? []).forEach((weekEntry) => {
+          if (!weekMap.has(weekEntry.start_date)) {
+            weekMap.set(weekEntry.start_date, {
+              key: weekEntry.key,
+              start_date: weekEntry.start_date,
+              end_date: weekEntry.end_date,
+              dates: weekEntry.dates,
+              members: [],
+              approvalPendingCount: 0,
+            });
+          }
+        });
+      });
+
       Object.values(employeeMap).forEach(
         ({
           member,
@@ -264,7 +285,7 @@ export function useTeamTimesheetData({
       const hasMore = hasMoreEmployees || hasMoreWeeks;
 
       return { hasMoreWeeks, hasMoreEmployees, hasMore, weekGroups };
-    }, [pages, weekDate, startDate, maxWeek]);
+    }, [pages, weekDate, startDate, endDate, maxWeek]);
 
   // When the current window is fully loaded but yields no visible weeks, we are
   // about to auto-advance. Expose this as "still loading" to prevent a flicker

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -74,7 +74,7 @@ export function useTeamTimesheetData({
   const prevFiltersRef = useRef({ filters, compositeFilters });
 
   // Build Frappe-compatible filters from composite filters
-  const { startDate, endDate, maxWeek, frappeFilters } = useMemo(
+  const { startDate, endDate, frappeFilters } = useMemo(
     () => buildCompositeFilters(compositeFilters),
     [compositeFilters],
   );
@@ -139,7 +139,7 @@ export function useTeamTimesheetData({
     useMemo(() => {
       const oneYearAgo = addDays(new Date(getTodayDate()), -365);
       // When a date-range filter is active, limit week pagination to the actual
-      // filter range (startDate − maxWeek weeks). Without a filter, fall back
+      // filter range. Without a filter, fall back
       // to the 1-year rolling limit.
       const hasMoreWeeks =
         startDate && endDate
@@ -285,7 +285,7 @@ export function useTeamTimesheetData({
       const hasMore = hasMoreEmployees || hasMoreWeeks;
 
       return { hasMoreWeeks, hasMoreEmployees, hasMore, weekGroups };
-    }, [pages, weekDate, startDate, endDate, maxWeek]);
+    }, [pages, weekDate, startDate, endDate]);
 
   // When the current window is fully loaded but yields no visible weeks, we are
   // about to auto-advance. Expose this as "still loading" to prevent a flicker


### PR DESCRIPTION
## Description
- Fixed missing weeks on project and team page by removing skip empty weeks.
- Fixed composite date range filter to only fetch the minimum required weeks.

## Relevant Technical Choices
- Made update to teams page to also include weeks with no time entries, previously we were filtering out any weeks that had not submitted time entries.

## Screenshot/Screencast
<img width="1225" height="578" alt="image" src="https://github.com/user-attachments/assets/0589f5d1-d586-49cc-9775-79d2c3d435d8" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #821