### PR TITLE
feat(project-details): Notes tab grid view (#1241)

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -10,6 +10,12 @@ import {
 import { FilterCondition } from "@rtcamp/frappe-ui-react";
 import { type ClassValue, clsx } from "clsx";
 import {
+  differenceInDays,
+  differenceInHours,
+  differenceInMinutes,
+  differenceInMonths,
+  differenceInWeeks,
+  differenceInYears,
   format,
   getISOWeek,
   getISOWeekYear,
@@ -58,6 +64,42 @@ export function formatProjectDate(isoDate: string): string {
   const pattern =
     date.getFullYear() === new Date().getFullYear() ? "MMM d" : "MMM d, yyyy";
   return format(date, pattern);
+}
+
+export function formatRelativeTimeShort(
+  value: string | Date,
+  now = new Date(),
+) {
+  const date = typeof value === "string" ? parseISO(value) : value;
+  const minutes = Math.max(differenceInMinutes(now, date), 0);
+
+  if (minutes < 1) {
+    return "now";
+  }
+
+  if (minutes < 60) {
+    return `${minutes}min ago`;
+  }
+
+  const hours = differenceInHours(now, date);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  const days = differenceInDays(now, date);
+  if (days < 7) {
+    return `${days}d ago`;
+  }
+
+  if (days < 30) {
+    return `${differenceInWeeks(now, date)}w ago`;
+  }
+
+  if (days < 365) {
+    return `${Math.max(differenceInMonths(now, date), 1)}m ago`;
+  }
+
+  return `${Math.max(differenceInYears(now, date), 1)}y ago`;
 }
 
 export function toKebabCase(value?: string | null): string | undefined {

--- a/frontend/packages/app/src/pages/project-details/tabs/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/index.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from "react";
 import { Tabs } from "@rtcamp/frappe-ui-react";
 import { UnderConstruction } from "@/components/under-construction";
 import { CalendarTab } from "./calendar";
+import { Notes } from "./notes";
 import { Overview } from "./overview";
 import { Tracking } from "./tracking";
 
@@ -23,7 +24,7 @@ export const TABS: ComponentProps<typeof Tabs>["tabs"] = [
   { label: "Calendar", content: <CalendarTab /> },
   { label: "Tracking", content: <Tracking /> },
   { label: "Risks", content: <UnderConstruction /> },
-  { label: "Notes", content: <UnderConstruction /> },
+  { label: "Notes", content: <Notes /> },
   { label: "Email", content: <UnderConstruction /> },
   { label: "To-do", content: <UnderConstruction /> },
   { label: "Feedback", content: <UnderConstruction /> },

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/constants.ts
@@ -1,0 +1,21 @@
+import type { FilterField } from "@rtcamp/frappe-ui-react";
+import { NOTE_AUTHORS } from "./fake-data";
+
+export const FILTER_FIELDS: FilterField[] = [
+  {
+    name: "author",
+    label: "Author",
+    type: "select",
+    options: NOTE_AUTHORS.map((a) => ({ label: a.name, value: a.email })),
+  },
+  {
+    name: "createdAt",
+    label: "Creation date",
+    type: "daterange",
+  },
+];
+
+export const CREATE_OPTIONS = {
+  newFromTemplate: "new-from-template",
+  newBlankNote: "new-blank-note",
+} as const;

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/fake-data.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/fake-data.ts
@@ -1,0 +1,86 @@
+import type { Note, NoteAuthor } from "./types";
+
+const AUTHORS: Record<string, NoteAuthor> = {
+  ayush: { name: "Ayush Nirwal", email: "ayush.nirwal@rtcamp.com" },
+  akash: { name: "Akash Chandgude", email: "akash.chandgude@rtcamp.com" },
+  aditya: { name: "Aditya Dhade", email: "aditya.dhade@rtcamp.com" },
+  girish: { name: "Girish Raghav", email: "girish.raghav@rtcamp.com" },
+  nitun: { name: "Nitun Lanjewar", email: "nitun.lanjewar@rtcamp.com" },
+};
+
+export const NOTE_AUTHORS = Object.values(AUTHORS);
+
+export const INITIAL_NOTES: Note[] = [
+  {
+    id: "kickoff-recap",
+    title: "Atlas UI stabilisation — kickoff recap",
+    excerpt:
+      "Kickoff went well on Monday. The client is aligned on the Q3 milestones and accepted the proposed cadence of bi-weekly demos.\n\nNext steps:\n• Confirm RBAC sign-off by Friday\n• Land the design tokens migration before the next demo\n• Wire up the analytics dashboards to the new ingestion pipeline\n\nKey risk surfaced: the QA bench is still on the older Atlas build, which makes regression testing slower than it should be. We agreed to prioritise upgrading the QA bench this sprint.",
+    createdAt: "2026-05-22",
+    author: AUTHORS.ayush,
+  },
+  {
+    id: "design-tokens-migration",
+    title: "Design tokens migration — phase 2 notes",
+    excerpt:
+      "Phase 2 covers the long tail of one-off colour values still in the codebase. We swept the tabs/* tree and replaced ~120 hex literals with design-system tokens.\n\nRemaining work:\n• Replace inline shadow values in 4 dashboard cards\n• Migrate the legacy spacing scale in the Reports surface\n• Audit the print stylesheet for residual hex usage\n\nThe surface-amber-5 stop landed this morning so we can finally drop the bg-[#fff3e0] override on the warning banner.",
+    createdAt: "2026-05-18",
+    author: AUTHORS.akash,
+  },
+  {
+    id: "qa-bench-upgrade",
+    title: "QA bench upgrade plan",
+    excerpt:
+      "We need to upgrade the QA bench to Atlas 2.1 before the next demo cycle. Estimated downtime: 2 hours.\n\nMitigation:\n• Schedule for Friday 18:00 IST when no demos are planned\n• Spin up a temporary mirror on staging-2 for any urgent regressions\n• Capture a fresh database snapshot before kickoff for rollback\n\nNeed to coordinate with the SRE team for the supervisor restart and the post-upgrade cache rebuild. Loop @nitun in on the calendar invite.",
+    createdAt: "2026-05-12",
+    author: AUTHORS.aditya,
+  },
+  {
+    id: "rbac-sign-off",
+    title: "RBAC sign-off blockers",
+    excerpt:
+      "Two outstanding blockers for the RBAC sign-off:\n\n1. Permission inheritance for nested project folders is not yet exposed in the UI — the policy lives in the BE but the UI only shows direct grants.\n2. The audit log doesn't yet record permission *changes*, only resource access. Legal flagged this last week.\n\nProposing we fix #1 in this sprint (frontend-only) and schedule #2 for the next milestone since it touches the audit pipeline.",
+    createdAt: "2026-04-29",
+    author: AUTHORS.girish,
+  },
+  {
+    id: "analytics-ingestion",
+    title: "Analytics ingestion pipeline cutover",
+    excerpt:
+      "The new ingestion pipeline is ready for cutover. It runs ~3x faster on the bench and the schema is backward-compatible with the existing dashboards.\n\nCutover plan:\n• Run both pipelines in parallel for 7 days\n• Diff the daily aggregates between old + new outputs\n• If diff < 0.1%, flip the feature flag and decommission the old pipeline\n\nDoc owner: @akash. Cutover owner: @nitun. ETA for flip: 3 weeks if no diffs surface.",
+    createdAt: "2026-04-14",
+    author: AUTHORS.nitun,
+  },
+  {
+    id: "client-feedback-q1",
+    title: "Client feedback — Q1 retrospective",
+    excerpt:
+      "Notes from the Q1 retro with the client product team:\n\nWhat went well:\n• Faster turnaround on bug fixes (median 1.8 days vs 4.2 last quarter)\n• Visible improvement in dashboard load times\n• Better cross-team comms on RBAC scope\n\nWhat to improve:\n• PR review SLA still varies by reviewer — push for shared on-call rotation\n• Designs sometimes land mid-sprint, blocking implementation — formalise the 1-sprint design-lead-time rule",
+    createdAt: "2026-03-30",
+    author: AUTHORS.ayush,
+  },
+  {
+    id: "ssr-experiment",
+    title: "SSR experiment results",
+    excerpt:
+      "We ran the SSR experiment for 4 weeks on 5% of traffic. Headline numbers:\n\n• TTFB improved by 280ms (median) and 410ms (p95)\n• Bundle size unchanged (we serve the same bundle, just pre-render the shell)\n• No regressions in error rate or user-reported issues\n\nRecommendation: ship to 25% this week, then 100% next sprint if metrics hold. Risk: the SSR edge cache invalidation logic is still untested under traffic spikes — need a load test before 100%.",
+    createdAt: "2026-03-11",
+    author: AUTHORS.akash,
+  },
+  {
+    id: "permissions-audit",
+    title: "Permissions audit — outstanding items",
+    excerpt:
+      "Internal permissions audit surfaced 4 outstanding items, all medium severity:\n\n1. Stale service-account tokens for the legacy ingestion pipeline (rotate before cutover)\n2. Two engineers retain admin grants from a finished engagement — revoke\n3. Permission inheritance gap in the UI (see RBAC sign-off note)\n4. Missing 2FA enforcement on the staging environment\n\nETA: items 1, 2, 4 this sprint. Item 3 tracked separately.",
+    createdAt: "2026-02-19",
+    author: AUTHORS.aditya,
+  },
+  {
+    id: "onboarding-revamp",
+    title: "Onboarding revamp — initial scoping",
+    excerpt:
+      "Scoping notes for the new-engineer onboarding revamp. Current path takes ~3 weeks to first meaningful PR, which is too slow.\n\nProposed changes:\n• Pre-provisioned bench environments per new hire (no more day-1 setup)\n• Codified \"first PR\" curriculum (10 small tasks of increasing complexity)\n• Dedicated buddy rotation with a shared on-call channel for questions\n\nKickoff with @girish next week to validate the proposal against last cohort's feedback before formalising.",
+    createdAt: "2026-01-22",
+    author: AUTHORS.girish,
+  },
+];

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useMemo, useState } from "react";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import { INITIAL_NOTES } from "./fake-data";
+import { NoteCard } from "./noteCard";
+import { NotesSubHeader } from "./sub-header";
+import type { Note } from "./types";
+import { useNotesFilters } from "./useNotesFilters";
+
+const applyFilters = (notes: Note[], filters: FilterCondition[]): Note[] => {
+  if (!filters.length) return notes;
+  return notes.filter((note) =>
+    filters.every((f) => {
+      if (!f.field || !f.operator) return true;
+      if (f.field === "author") {
+        const email = String(f.value ?? "");
+        if (!email) return true;
+        return f.operator === "is_not"
+          ? note.author.email !== email
+          : note.author.email === email;
+      }
+      if (f.field === "createdAt" && Array.isArray(f.value)) {
+        const [from, to] = f.value as string[];
+        if (from && note.createdAt < from) return false;
+        if (to && note.createdAt > to) return false;
+      }
+      return true;
+    }),
+  );
+};
+
+export function Notes() {
+  const [notes, setNotes] = useState<Note[]>(INITIAL_NOTES);
+  const { filters, setAdvanced } = useNotesFilters();
+
+  const visible = useMemo(() => {
+    const filtered = applyFilters(notes, filters.advanced);
+    return [...filtered].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }, [notes, filters.advanced]);
+
+  const handleDelete = useCallback(
+    (id: string) => setNotes((prev) => prev.filter((n) => n.id !== id)),
+    [],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <NotesSubHeader
+        advanced={filters.advanced}
+        onAdvancedChange={setAdvanced}
+      />
+      {visible.length === 0 ? (
+        <div className="py-10 text-center text-sm text-ink-gray-4">
+          No notes match the current filters
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-5">
+          {visible.map((note) => (
+            <NoteCard key={note.id} note={note} onDelete={handleDelete} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
@@ -60,7 +60,7 @@ export function Notes() {
           No notes match the current filters
         </div>
       ) : (
-        <div className="grid grid-cols-3 gap-5">
+        <div className="flex flex-wrap gap-5">
           {visible.map((note) => (
             <NoteCard key={note.id} note={note} onDelete={handleDelete} />
           ))}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { Avatar, Button, Dropdown } from "@rtcamp/frappe-ui-react";
+import { Avatar, Dropdown } from "@rtcamp/frappe-ui-react";
 import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
 import { formatDistanceToNow, parseISO } from "date-fns";
 import { Trash2 } from "lucide-react";
@@ -9,7 +9,6 @@ import { Trash2 } from "lucide-react";
 /**
  * Internal dependencies.
  */
-import { getSiteName } from "@/lib/utils";
 import type { Note } from "./types";
 
 type NoteCardProps = {
@@ -21,7 +20,7 @@ export function NoteCard({ note, onDelete }: NoteCardProps) {
   const relativeDate = formatDistanceToNow(parseISO(note.createdAt), {
     addSuffix: true,
   });
-  const authorHref = `/${getSiteName()}/desk/user/${note.author.email}`;
+  const authorHref = `/desk/user/${encodeURIComponent(note.author.email)}`;
 
   return (
     <div className="flex h-64 flex-col rounded-[12px] border border-outline-gray-1 bg-surface-white overflow-clip">

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies.
+ */
+import { Avatar, Button, Dropdown } from "@rtcamp/frappe-ui-react";
+import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
+import { formatDistanceToNow, parseISO } from "date-fns";
+import { Trash2 } from "lucide-react";
+
+/**
+ * Internal dependencies.
+ */
+import { getSiteName } from "@/lib/utils";
+import type { Note } from "./types";
+
+type NoteCardProps = {
+  note: Note;
+  onDelete: (id: string) => void;
+};
+
+export function NoteCard({ note, onDelete }: NoteCardProps) {
+  const relativeDate = formatDistanceToNow(parseISO(note.createdAt), {
+    addSuffix: true,
+  });
+  const authorHref = `/${getSiteName()}/desk/user/${note.author.email}`;
+
+  return (
+    <div className="flex h-64 flex-col rounded-[12px] border border-outline-gray-1 bg-surface-white overflow-clip">
+      <div className="flex items-center gap-3 px-[14px] pt-[14px]">
+        <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">
+          {note.title}
+        </h3>
+        <Dropdown
+          placement="right"
+          button={{
+            variant: "ghost",
+            size: "sm",
+            icon: DotHorizontal,
+            "aria-label": "Note actions",
+          }}
+          options={[
+            {
+              label: "Delete",
+              key: "delete",
+              theme: "red",
+              icon: <Trash2 className="size-4 mr-2" />,
+              onClick: () => onDelete(note.id),
+            },
+          ]}
+        />
+      </div>
+      <p className="flex-1 line-clamp-[7] whitespace-pre-wrap px-[14px] pt-1 text-base leading-relaxed text-ink-gray-5">
+        {note.excerpt}
+      </p>
+      <div className="flex items-center gap-2 px-[14px] pb-[14px] pt-3">
+        <a href={authorHref} className="shrink-0">
+          <Avatar size="xs" label={note.author.name} />
+        </a>
+        <span className="flex-1 truncate text-sm text-ink-gray-5">
+          {note.author.name}
+        </span>
+        <span className="shrink-0 text-base text-ink-gray-5">
+          {relativeDate}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -21,7 +21,7 @@ export function NoteCard({ note, onDelete }: NoteCardProps) {
   const authorHref = `/desk/user/${encodeURIComponent(note.author.email)}`;
 
   return (
-    <div className="flex h-64 flex-col rounded-[12px] border border-outline-gray-1 bg-surface-white overflow-clip">
+    <div className="flex h-64 min-w-[263px] max-w-[526px] flex-1 flex-col rounded-[12px] border border-outline-gray-1 bg-surface-white overflow-clip">
       <div className="flex items-center gap-3 px-3.5 pt-3.5">
         <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">
           {note.title}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -3,12 +3,12 @@
  */
 import { Avatar, Dropdown } from "@rtcamp/frappe-ui-react";
 import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
-import { formatDistanceToNow, parseISO } from "date-fns";
 import { Trash2 } from "lucide-react";
 
 /**
  * Internal dependencies.
  */
+import { formatRelativeTimeShort } from "@/lib/utils";
 import type { Note } from "./types";
 
 type NoteCardProps = {
@@ -17,14 +17,12 @@ type NoteCardProps = {
 };
 
 export function NoteCard({ note, onDelete }: NoteCardProps) {
-  const relativeDate = formatDistanceToNow(parseISO(note.createdAt), {
-    addSuffix: true,
-  });
+  const relativeDate = formatRelativeTimeShort(note.createdAt);
   const authorHref = `/desk/user/${encodeURIComponent(note.author.email)}`;
 
   return (
     <div className="flex h-64 flex-col rounded-[12px] border border-outline-gray-1 bg-surface-white overflow-clip">
-      <div className="flex items-center gap-3 px-[14px] pt-[14px]">
+      <div className="flex items-center gap-3 px-3.5 pt-3.5">
         <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">
           {note.title}
         </h3>
@@ -47,10 +45,10 @@ export function NoteCard({ note, onDelete }: NoteCardProps) {
           ]}
         />
       </div>
-      <p className="flex-1 line-clamp-[7] whitespace-pre-wrap px-[14px] pt-1 text-base leading-relaxed text-ink-gray-5">
+      <p className="flex-1 line-clamp-7 whitespace-pre-wrap px-3.5 pt-1 text-base leading-relaxed text-ink-gray-5">
         {note.excerpt}
       </p>
-      <div className="flex items-center gap-2 px-[14px] pb-[14px] pt-3">
+      <div className="flex items-center gap-2 px-3.5 pb-3.5 pt-3">
         <a href={authorHref} className="shrink-0">
           <Avatar size="xs" label={note.author.name} />
         </a>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/sub-header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/sub-header.tsx
@@ -3,7 +3,7 @@
  */
 import { useNavigate, useParams } from "react-router-dom";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
-import { Button, Dropdown, Filter } from "@rtcamp/frappe-ui-react";
+import { Dropdown, Filter } from "@rtcamp/frappe-ui-react";
 import { AddSm, SmallDown } from "@rtcamp/frappe-ui-react/icons";
 
 /**

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/sub-header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/sub-header.tsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies.
+ */
+import { useNavigate, useParams } from "react-router-dom";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+import { Button, Dropdown, Filter } from "@rtcamp/frappe-ui-react";
+import { AddSm, SmallDown } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { ROUTES } from "@/lib/constant";
+import { CREATE_OPTIONS, FILTER_FIELDS } from "./constants";
+
+type NotesSubHeaderProps = {
+  advanced: FilterCondition[];
+  onAdvancedChange: (v: FilterCondition[]) => void;
+};
+
+export function NotesSubHeader({
+  advanced,
+  onAdvancedChange,
+}: NotesSubHeaderProps) {
+  const { projectId = "" } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex items-center justify-between gap-8">
+      <h2 className="text-xl font-semibold text-ink-gray-7">Notes</h2>
+      <div className="flex items-center gap-2">
+        <Filter
+          align="end"
+          value={advanced}
+          onChange={onAdvancedChange}
+          fields={FILTER_FIELDS}
+        />
+        <Dropdown
+          placement="right"
+          button={{
+            variant: "solid",
+            size: "sm",
+            iconLeft: AddSm,
+            iconRight: SmallDown,
+            label: "Create",
+          }}
+          options={[
+            {
+              label: "New from template",
+              key: CREATE_OPTIONS.newFromTemplate,
+              onClick: () =>
+                console.info("[notes] New from template — coming soon"),
+            },
+            {
+              label: "New blank note",
+              key: CREATE_OPTIONS.newBlankNote,
+              onClick: () =>
+                navigate(`${ROUTES.project}/${projectId}/notes/new`),
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/types.ts
@@ -1,0 +1,19 @@
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+
+export type NoteAuthor = {
+  name: string;
+  email: string;
+  avatar?: string;
+};
+
+export type Note = {
+  id: string;
+  title: string;
+  excerpt: string;
+  createdAt: string;
+  author: NoteAuthor;
+};
+
+export type NotesFilters = {
+  advanced: FilterCondition[];
+};

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/useNotesFilters.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/useNotesFilters.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+
+import type { NotesFilters } from "./types";
+
+const parseAdvanced = (raw: string | null): FilterCondition[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as FilterCondition[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+export function useNotesFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters: NotesFilters = useMemo(
+    () => ({ advanced: parseAdvanced(searchParams.get("notesAdvanced")) }),
+    [searchParams],
+  );
+
+  const setAdvanced = useCallback(
+    (v: FilterCondition[]) =>
+      setSearchParams(
+        (prev) => {
+          if (v.length) prev.set("notesAdvanced", JSON.stringify(v));
+          else prev.delete("notesAdvanced");
+          return prev;
+        },
+        { replace: true },
+      ),
+    [setSearchParams],
+  );
+
+  return { filters, setAdvanced };
+}

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -6,6 +6,7 @@ import { Route, Outlet } from "react-router-dom";
 /**
  * Internal dependencies.
  */
+import { UnderConstruction } from "@/components/under-construction";
 import { ROUTES } from "@/lib/constant";
 import LayoutWithSidebar from "./layout";
 import { useUser } from "./providers/user";
@@ -51,6 +52,10 @@ export function Router() {
           <Route
             path={`${ROUTES.project}/:projectId`}
             element={<ProjectDetail />}
+          />
+          <Route
+            path={`${ROUTES.project}/:projectId/notes/new`}
+            element={<UnderConstruction />}
           />
           <Route element={<PersonalTimesheetLayout />}>
             <Route


### PR DESCRIPTION
## Summary

Implements Epic 12 CUJ1 — the **Notes** tab on the project-details page (issue #1241).

- New folder `pages/project-details/tabs/notes/` with `index.tsx`, `noteCard.tsx`, `sub-header.tsx`, `useNotesFilters.ts`, `types.ts`, `constants.ts`, `fake-data.ts`.
- Replaced the `Notes: <UnderConstruction />` placeholder in `tabs/index.tsx` with the new `<Notes />` component.
- Added `/projects/:projectId/notes/new` route under `<LayoutWithSidebar />` rendering `<UnderConstruction />` — single-PR rule for the Create > "New blank note" navigation target.

## Screenshot

<img width="1660" height="792" alt="Screenshot 2026-05-27 at 3 05 10 PM" src="https://github.com/user-attachments/assets/289da91b-b89d-4699-be1c-aa99c9b02514" />
