### PR TITLE
fix: use start_date to sort the items

### DIFF
--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -102,9 +102,6 @@ def get_project_timeline_items(
     """
     Get all Project Timeline Items (complete and incomplete) for a project.
 
-    Touchpoints do not have a start_date, so ordering and range filtering use
-    planned_end_date as the authoritative date field.
-
     Args:
         project: Project name to filter by
         type: "Milestone" or "Touchpoint" — omit to fetch both

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -137,7 +137,7 @@ def get_project_timeline_items(
 
     if start_date and max_week:
         end_date = add_to_date(getdate(start_date), weeks=cint(max_week))
-        filters["planned_end_date"] = ["between", [getdate(start_date), end_date]]
+        filters["start_date"] = ["between", [getdate(start_date), end_date]]
 
     items = frappe.get_all(
         "Project Timeline Item",

--- a/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.json
+++ b/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.json
@@ -68,7 +68,8 @@
   {
    "fieldname": "planned_end_date",
    "fieldtype": "Date",
-   "label": "Planned End Date"
+   "label": "Planned End Date",
+   "reqd": 1
   },
   {
    "fieldname": "actual_end_date",
@@ -98,7 +99,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-22 13:18:17.086117",
+ "modified": "2026-05-26 08:46:49.740907",
  "modified_by": "Administrator",
  "module": "Next Projects",
  "name": "Project Timeline Item",

--- a/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.py
+++ b/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026, rtCamp and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 
@@ -18,11 +17,13 @@ class ProjectTimelineItem(Document):
         is_complete: DF.Check
         item_owner: DF.Link
         item_owner_name: DF.Data | None
-        planned_end_date: DF.Date | None
+        planned_end_date: DF.Date
         project: DF.Link
         start_date: DF.Date | None
         title: DF.Data
         type: DF.Literal["Milestone", "Touchpoint"]
     # end: auto-generated types
 
-    pass
+    def validate(self):
+        if self.type == "Touchpoint":
+            self.start_date = self.planned_end_date

--- a/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.py
+++ b/next_pms/next_projects/doctype/project_timeline_item/project_timeline_item.py
@@ -25,5 +25,5 @@ class ProjectTimelineItem(Document):
     # end: auto-generated types
 
     def validate(self):
-        if self.type == "Touchpoint":
+        if self.type == "Touchpoint" and not self.start_date:
             self.start_date = self.planned_end_date


### PR DESCRIPTION
## Description


* Made the `planned_end_date` field required in the doctype schema to enforce data integrity.
* Added a `validate` method to the `ProjectTimelineItem` class to automatically set `start_date` to `planned_end_date` when the item type is "Touchpoint", ensuring consistency for these items.
* Changed the timeline items API to filter by `start_date` between the start and calculated end date, instead of `planned_end_date`, aligning the filter with the intended logic.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

