### PR TITLE
fix: make the get api support intervals for gantt view

### DIFF
--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -5,7 +5,8 @@ from typing import Literal
 
 import frappe
 from frappe import only_for, whitelist
-from frappe.utils import add_to_date, cint, getdate, today
+from frappe.query_builder.functions import Count
+from frappe.utils import cint, getdate, today
 
 from next_pms.api.utils import error_logger
 from next_pms.next_projects.api.constant import ALLOWED_ROLES, TIMELINE_ITEM_FIELDS
@@ -96,24 +97,32 @@ def get_project_timeline_items(
     start: int = 0,
     limit: int = 20,
     start_date: str | None = None,
-    max_week: int = 4,
+    end_date: str | None = None,
     is_calendar: bool = False,
 ):
     """
     Get all Project Timeline Items (complete and incomplete) for a project.
+
+    When start_date and end_date are provided, items are filtered using interval
+    overlap so that any item whose date range intersects [start_date, end_date)
+    is returned:
+
+        item.start_date < end_date AND item.planned_end_date > start_date
+
+    This ensures items spanning multiple months appear in every month/week view
+    they overlap — not only the view that contains their start or end date.
 
     Args:
         project: Project name to filter by
         type: "Milestone" or "Touchpoint" — omit to fetch both
         start: Pagination offset
         limit: Page size
-        start_date: ISO date string (e.g. "2026-05-05"); used as the range start
-            for planned_end_date filtering
-        max_week: Number of weeks from start_date to use as the range end
-        is_calendar: Pass "1"/1/True to skip the bulk-fetch of owner images and
-            watchers (e.g. for calendar views where those fields are not rendered).
-            Accepts "0"/"1" string values from HTTP query params — coerced via
-            cint() before use so "0" is correctly treated as falsy.
+        start_date: ISO date string (e.g. "2026-01-01"); range start for
+            interval-overlap date filtering
+        end_date: ISO date string (e.g. "2026-02-01"); range end for
+            interval-overlap date filtering
+        is_calendar: Pass "1"/1/True to skip owner images and watchers (used for
+            calendar/gantt views). Accepts "0"/"1" strings — coerced via cint().
 
     Returns:
         {"data": [...], "total_count": int, "has_more": bool}
@@ -125,27 +134,28 @@ def get_project_timeline_items(
 
     is_calendar = bool(cint(is_calendar))
 
-    filters = {
-        "project": project,
-    }
+    PTI = frappe.qb.DocType("Project Timeline Item")
+    query_base = frappe.qb.from_(PTI).where(PTI.project == project)
 
     if type:
-        filters["type"] = type
+        query_base = query_base.where(PTI.type == type)
 
-    if start_date and max_week:
-        end_date = add_to_date(getdate(start_date), weeks=cint(max_week))
-        filters["start_date"] = ["between", [getdate(start_date), end_date]]
+    if start_date and end_date:
+        range_start = getdate(start_date)
+        range_end = getdate(end_date)
+        # Interval overlap: item overlaps with [range_start, range_end) when
+        # start_date < range_end AND planned_end_date > range_start
+        query_base = query_base.where((PTI.start_date < range_end) & (PTI.planned_end_date > range_start))
 
-    items = frappe.get_all(
-        "Project Timeline Item",
-        filters=filters,
-        fields=TIMELINE_ITEM_FIELDS,
-        limit_start=cint(start),
-        limit_page_length=cint(limit),
-        order_by="start_date asc, planned_end_date asc",
-    )
+    items = (
+        query_base.select(*[PTI[field] for field in TIMELINE_ITEM_FIELDS])
+        .orderby(PTI.start_date)
+        .orderby(PTI.planned_end_date)
+        .offset(cint(start))
+        .limit(cint(limit))
+    ).run(as_dict=True)
 
-    total_count = frappe.db.count("Project Timeline Item", filters=filters)
+    total_count = (query_base.select(Count("*"))).run()[0][0]
     has_more = cint(start) + cint(limit) < total_count
 
     item_names = [item.get("name") for item in items if item.get("name")]


### PR DESCRIPTION
## Description

This pull request refactors the `get_project_timeline_items` API to support more flexible date range filtering and improves query performance by switching to Query Builder. The most important changes are:

* Replaces the `max_week` parameter with an explicit `end_date` parameter, allowing callers to specify any date range for filtering timeline items. The function now uses interval overlap logic to include any item whose date range intersects the `[start_date, end_date)` interval. This ensures items spanning multiple months/weeks are included in all relevant views, not just those starting or ending within the range.

* Refactors the main query to use Frappe's Query Builder instead of `frappe.get_all`, enabling more complex filtering (including interval overlap) and improving performance. The query now applies filters for `project`, `type`, and the new interval overlap logic, and supports pagination and ordering.
* Updates the calculation of `total_count` to use Query Builder's `Count` function, ensuring the count matches the filtered result set.

* Removes unused imports (`add_to_date`) and cleans up parameter documentation to reflect the new filtering logic and parameters. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="830" height="775" alt="image" src="https://github.com/user-attachments/assets/11a882e2-c8fa-4c3b-86aa-ead9917129d3" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1382 