### PR TITLE
fix: inherit Timesheet controller from HRMS EmployeeTimesheet and correct naming overrides

### DIFF
--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -180,9 +180,9 @@ fixtures = [
 # Override standard doctype classes
 
 override_doctype_class = {
-    "Project": "next_pms.project_currency.overrides.project.ProjectOverwrite",
+    "Project": "next_pms.project_currency.overrides.project.ProjectOverride",
     "Customize Form": "next_pms.project_currency.overrides.customize_form.CustomizeFormOverride",
-    "Timesheet": "next_pms.project_currency.overrides.timesheet.TimesheetOverwrite",
+    "Timesheet": "next_pms.project_currency.overrides.timesheet.TimesheetOverride",
     "Task": "next_pms.project_currency.overrides.task.TaskOverride",
 }
 

--- a/next_pms/project_currency/overrides/project.py
+++ b/next_pms/project_currency/overrides/project.py
@@ -85,7 +85,7 @@ class ProjectOverride(EmployeeProject):
             self.name,
         )
 
-        self.total_sales_amount = total_sales_amount and total_sales_amount[0][0] or 0
+        self.total_sales_amount = (total_sales_amount and total_sales_amount[0][0]) or 0
 
     def update_billed_amount(self):
         # nosemgrep
@@ -95,7 +95,7 @@ class ProjectOverride(EmployeeProject):
             self.name,
         )
 
-        self.total_billed_amount = total_billed_amount and total_billed_amount[0][0] or 0
+        self.total_billed_amount = (total_billed_amount and total_billed_amount[0][0]) or 0
 
     def update_purchase_costing(self):
         total_purchase_cost = frappe.db.get_all(

--- a/next_pms/project_currency/overrides/project.py
+++ b/next_pms/project_currency/overrides/project.py
@@ -7,7 +7,7 @@ from frappe.utils import flt
 from hrms.overrides.employee_project import EmployeeProject
 
 
-class ProjectOverwrite(EmployeeProject):
+class ProjectOverride(EmployeeProject):
     def validate(self):
         super().validate()
         self.update_project_currency()

--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -1,29 +1,15 @@
 import frappe
 from erpnext import get_company_currency
-from hrms.overrides.employee_timesheet import EmployeeTimesheet
 from erpnext.setup.utils import get_exchange_rate
 from frappe.utils.data import flt, nowdate
+from hrms.overrides.employee_timesheet import EmployeeTimesheet
 
 from next_pms.utils.employee import get_employee_salary
 
 
+# Inheritance: erpnext.Timesheet -> hrms.EmployeeTimesheet -> TimesheetOverride
+# It inherits from HRMS EmployeeTimesheet to support custom project billing and costing.
 class TimesheetOverride(EmployeeTimesheet):
-    """
-    TimesheetOverride customizes the Timesheet controller for the Next PMS app.
-
-    Inheritance Hierarchy:
-        erpnext.projects.doctype.timesheet.timesheet.Timesheet (Core)
-        └── hrms.overrides.employee_timesheet.EmployeeTimesheet (HRMS status & payroll mappings)
-            └── next_pms.project_currency.overrides.timesheet.TimesheetOverride (This Class)
-
-    Purpose of Override:
-        - Implements custom project-currency conversion rules for time log costing.
-        - Calculates activity costing rates based on historical employee CTC / promotion records.
-        - Calculates custom project billing team and material hourly billing rates.
-        - Adds specific validation checks for billing hours and mandatory field inputs.
-        - Overrides `calculate_hours` to bypass standard datetime duration calculations, 
-          preserving custom client-side daily log entries.
-    """
     ignore_backdated_validation = False
 
     def calculate_hours(self):

--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -1,13 +1,29 @@
 import frappe
 from erpnext import get_company_currency
-from erpnext.projects.doctype.timesheet.timesheet import Timesheet
+from hrms.overrides.employee_timesheet import EmployeeTimesheet
 from erpnext.setup.utils import get_exchange_rate
 from frappe.utils.data import flt, nowdate
 
 from next_pms.utils.employee import get_employee_salary
 
 
-class TimesheetOverwrite(Timesheet):
+class TimesheetOverride(EmployeeTimesheet):
+    """
+    TimesheetOverride customizes the Timesheet controller for the Next PMS app.
+
+    Inheritance Hierarchy:
+        erpnext.projects.doctype.timesheet.timesheet.Timesheet (Core)
+        └── hrms.overrides.employee_timesheet.EmployeeTimesheet (HRMS status & payroll mappings)
+            └── next_pms.project_currency.overrides.timesheet.TimesheetOverride (This Class)
+
+    Purpose of Override:
+        - Implements custom project-currency conversion rules for time log costing.
+        - Calculates activity costing rates based on historical employee CTC / promotion records.
+        - Calculates custom project billing team and material hourly billing rates.
+        - Adds specific validation checks for billing hours and mandatory field inputs.
+        - Overrides `calculate_hours` to bypass standard datetime duration calculations, 
+          preserving custom client-side daily log entries.
+    """
     ignore_backdated_validation = False
 
     def calculate_hours(self):


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

Inherit Timesheet Controller from HRMS EmployeeTimesheet and correct naming overrides

*  **Controller**: Changed base class of `TimesheetOverride` in `timesheet.py` from core ERPNext `Timesheet` to `hrms.overrides.employee_timesheet.EmployeeTimesheet`.
*   **Rename Overrides**: Cleaned up class name references in `hooks.py`, `project.py`, and `timesheet.py` from `Overwrite` to `Override` to ensure correct resolution by Frappe framework.

## Testing Instructions

1. Ensure the selected Employee has a CTC and Salary Currency set in their record.
2. Ensure the selected Project has Project Currency, Billing Type, and Default Hourly Billing Rate configured.
3. Create a Timesheet, select the Employee, add a row in the table, select the Project, and log hours.
4. Save the Timesheet and verify that Costing Rate, Costing Amount, Billing Rate, and Billing Amount are populated and converted correctly.
5. Submit the Timesheet and verify it submits successfully.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #