### PR TITLE
feat: integrate project board selection into PM Report UI and API

### DIFF
--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -13,6 +13,7 @@ import {
 } from "@next-pms/design-system/components";
 import {
   FrappeError,
+  useFrappeGetCall,
   useFrappeGetDoc,
   useFrappeGetDocList,
   useFrappePostCall,
@@ -78,6 +79,25 @@ const PMReport = ({ projectId }: PMReportProps) => {
   const [includePreviousReport, setIncludePreviousReport] = useState(false);
 
   const [resyncingRunId, setResyncingRunId] = useState<string | null>(null);
+
+  const [selectedBoard, setSelectedBoard] = useState("");
+
+  const { data: boardsData } = useFrappeGetCall(
+    "next_pms.api.generate_pm_report.get_repository_project_boards",
+    selectedRepo ? { repository: selectedRepo } : null,
+  );
+
+  const boards = boardsData?.message || [];
+
+  useEffect(() => {
+    if (boards.length > 0) {
+      if (!boards.includes(selectedBoard)) {
+        setSelectedBoard(boards[0]);
+      }
+    } else {
+      setSelectedBoard("");
+    }
+  }, [boards, selectedBoard]);
 
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mutateRef = useRef(mutate);
@@ -263,6 +283,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
         from_date: fromDate,
         to_date: toDate,
         selected_repo: selectedRepo,
+        selected_board: selectedBoard,
         ...(includePreviousReport && lastReportLink
           ? { previous_doc_url: lastReportLink }
           : {}),
@@ -295,6 +316,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
         projectData?.custom_project_repository_connections?.[0]
           ?.github_repository || "",
       );
+      setSelectedBoard("");
 
       timeoutRef.current = setTimeout(() => {
         setIsGenerating(false);
@@ -560,6 +582,31 @@ const PMReport = ({ projectId }: PMReportProps) => {
                       </SelectItem>
                     );
                   })}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Project Board */}
+          {boards.length > 0 && (
+            <div className="flex flex-col gap-1 col-span-2">
+              <label className="text-sm text-muted-foreground">
+                Project Board
+              </label>
+              <Select
+                value={selectedBoard}
+                onValueChange={(value) => setSelectedBoard(value)}
+                disabled={isBusy}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select project board..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {boards.map((board) => (
+                    <SelectItem key={board} value={board}>
+                      {board}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -46,6 +46,7 @@ def generate_pm_report(
     to_date: str | None = None,
     previous_doc_url: str | None = None,
     selected_repo: str | None = None,
+    selected_board: str | None = None,
 ) -> dict:
     frappe.has_permission("Project", doc=project, ptype="write", throw=True)
 
@@ -86,7 +87,7 @@ def generate_pm_report(
         },
         **({"previous_doc_url": previous_doc_url} if previous_doc_url else {}),
         "user_metadata": {"user_name": frappe.session.user, "user_email": frappe.session.user},
-        "github_metadata": get_github_metadata(project_doc, selected_repo=selected_repo),
+        "github_metadata": get_github_metadata(project_doc, selected_repo=selected_repo, selected_board=selected_board),
         "slack_metadata": {"channel_slug": project_doc.get("custom_slack_channel_slug") or ""},
         "hours_breakdown": get_hours_breakdown(project, from_date, to_date),
     }
@@ -381,7 +382,7 @@ def _send_bell_notification(project, user, document_url):
         frappe.log_error(frappe.get_traceback(), "PM Report — Bell Notification Error")
 
 
-def get_github_metadata(project_doc, selected_repo: str | None = None):
+def get_github_metadata(project_doc, selected_repo: str | None = None, selected_board: str | None = None):
     repos = project_doc.get("custom_project_repository_connections") or []
     allowed_repos = [r.get("github_repository") for r in repos]
     if selected_repo:
@@ -401,7 +402,22 @@ def get_github_metadata(project_doc, selected_repo: str | None = None):
         repo_name = project_doc.get("project_name") or ""
         owner_name = "rtCamp"
 
-    return {"repo_name": repo_name, "owner_name": owner_name, "project_board": project_doc.get("project_name") or ""}
+    project_board = ""
+    if selected_board:
+        project_board = selected_board
+    elif repo_url:
+        try:
+            repo_doc = frappe.get_doc("GitHub Repository", repo_url)
+            boards = repo_doc.get("project_boards") or []
+            if boards:
+                project_board = boards[0].board_name
+        except Exception:
+            pass
+
+    if not project_board:
+        project_board = project_doc.get("project_name") or ""
+
+    return {"repo_name": repo_name, "owner_name": owner_name, "project_board": project_board}
 
 
 def get_hours_breakdown(project, from_date, to_date):
@@ -473,3 +489,12 @@ def _is_valid_document_url(url: str) -> bool:
         )
     except Exception:
         return False
+
+
+@frappe.whitelist()
+def get_repository_project_boards(repository: str) -> list[str]:
+    try:
+        repo_doc = frappe.get_doc("GitHub Repository", repository)
+        return [b.board_name for b in repo_doc.get("project_boards") or [] if b.board_name]
+    except Exception:
+        return []


### PR DESCRIPTION
## Description

This PR integrates Project Board selection into the PM Reporting feature.

## Relevant Technical Choices

- Backend API Updates: accept the selected_board parameter
- Frontend UI Updates: Added a dropdown select component for Project Report Tab. The dropdown dynamically fetches the board names associated with the selected repository and handles selections seamlessly.

## Testing Instructions

1. Link a repository that has synced project boards to an ERPNext Project (under repository connections).
2. Go to the project details page and open the Project Report section in Next PMS frontend.
3. Select the linked repository.
4. Verify that the Project Board dropdown successfully renders and lists the synced board names.
5. Select a board and click Generate Project Report; check that the report is triggered successfully.

## Additional Information:

Github Connector PR: [PR#100](https://github.com/rtCamp/frappe-github-connector/pull/100)

## Screenshot/Screencast


https://github.com/user-attachments/assets/69427c38-c7bd-49c8-a56f-c33b7764b5ba




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #