### PR TITLE
Syncing develop to main for report order

### DIFF
--- a/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
+++ b/frontend/packages/app/src/app/pages/project/project-detail/components/pm-report.tsx
@@ -140,6 +140,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
   );
 
   const reports = (projectData?.custom_project_reports ?? []) as PMReportRow[];
+  const sortedReports = [...reports].reverse();
   const completedReports = reports.filter(
     (r) => r.status === "Done" && !!r.report_link,
   );
@@ -640,7 +641,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
                 </tr>
               </thead>
               <tbody>
-                {reports.map((report, index) => {
+                {sortedReports.map((report, index) => {
                   const generating = isGeneratingRow(report);
                   const failed = isFailedRow(report);
                   const resyncable = isResyncableRow(report);
@@ -655,7 +656,7 @@ const PMReport = ({ projectId }: PMReportProps) => {
                         (failed || resyncable) && "bg-red-50",
                       )}
                     >
-                      <td className="px-4 py-2">{index + 1}</td>
+                      <td className="px-4 py-2">{reports.length - index}</td>
 
                       <td className="px-4 py-2">
                         {generating && (


### PR DESCRIPTION
## Description

Generated reports in the Project Management (PM) Report history table to display the latest reports first (newest at the top).

## Relevant Technical Choices

Created a copy of the reports array (const sortedReports = [...reports].reverse()) specifically for the table rendering.

## Testing Instructions

1. Verify that the table lists the reports in descending order (the most recently generated report should be at the very top of the table).
2. Verify that checking Include previous report as reference correctly references and uses the latest completed report link.


## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1154" height="772" alt="image" src="https://github.com/user-attachments/assets/4eb711c5-6421-4403-935e-424f7d41ed96" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #