### PR TITLE
Feature: Add unsaved changes modal to allocation pages

### DIFF
--- a/frontend/packages/app/src/pages/allocations/components/unsavedChangesDialog.tsx
+++ b/frontend/packages/app/src/pages/allocations/components/unsavedChangesDialog.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies.
+ */
+import { Button, Dialog } from "@rtcamp/frappe-ui-react";
+
+interface UnsavedChangesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDiscardChanges: () => void;
+  onKeepEditing: () => void;
+  onSaveChanges: () => void;
+}
+
+export function UnsavedChangesDialog({
+  open,
+  onOpenChange,
+  onDiscardChanges,
+  onKeepEditing,
+  onSaveChanges,
+}: UnsavedChangesDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      options={{
+        title: () => <span className="text-lg font-medium">Save Changes</span>,
+      }}
+      actions={
+        <div className="flex items-center justify-end w-full gap-2 -mt-5">
+          <Button
+            variant="ghost"
+            label="Discard Changes"
+            onClick={onDiscardChanges}
+          />
+          <Button
+            variant="subtle"
+            label="Keep Editing"
+            onClick={onKeepEditing}
+          />
+          <Button
+            variant="solid"
+            label="Save Changes"
+            onClick={onSaveChanges}
+          />
+        </div>
+      }
+    >
+      <div className="-mt-2">
+        <p className="text-base text-ink-gray-6">
+          You have unsaved changes. Would you like to save them before leaving?
+        </p>
+      </div>
+    </Dialog>
+  );
+}
+
+UnsavedChangesDialog.displayName = "UnsavedChangesDialog";

--- a/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
@@ -97,7 +97,7 @@ export const AllocationsProjectTable = () => {
           <TextInput
             className="w-xs"
             placeholder="Search project"
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => guard(() => setSearch(e.target.value))}
             value={searchInput}
           />
           <Select

--- a/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
@@ -27,6 +27,10 @@ import {
 import { InfiniteScroll } from "@/components/infiniteScroll";
 import { isWeekendEntryAllowed } from "@/lib/utils";
 import { useAllocationOutletContext } from "@/pages/allocations/allocationOutletContext";
+import {
+  useGuardedAction,
+  useUnsavedChangesSource,
+} from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { useUser } from "@/providers/user";
 import { useAllocationsProject } from "./context";
 import {
@@ -68,6 +72,9 @@ export const AllocationsProjectTable = () => {
   );
   const handleNext = useAllocationsProject(({ actions }) => actions.handleNext);
 
+  const guard = useGuardedAction();
+  const ganttRef = useUnsavedChangesSource();
+
   const { hasRoleAccess } = useUser(({ state }) => ({
     hasRoleAccess: state.hasRoleAccess,
   }));
@@ -99,7 +106,9 @@ export const AllocationsProjectTable = () => {
             options={durationOptions}
             value={duration}
             onChange={(value) =>
-              setDuration((value || "this-quarter") as typeof duration)
+              guard(() =>
+                setDuration((value || "this-quarter") as typeof duration),
+              )
             }
           />
           <Select
@@ -117,16 +126,20 @@ export const AllocationsProjectTable = () => {
               icon={() => (
                 <SmallLeftChevron className="size-4 text-ink-gray-9" />
               )}
-              onClick={handlePrevious}
+              onClick={() => guard(handlePrevious)}
               aria-label={navigationButtonAriaLabels["previous"][duration]}
             />
-            <Button variant="ghost" label="Today" onClick={handleToday} />
+            <Button
+              variant="ghost"
+              label="Today"
+              onClick={() => guard(handleToday)}
+            />
             <Button
               variant="ghost"
               icon={() => (
                 <SmallRightChevron className="size-4 text-ink-gray-9" />
               )}
-              onClick={handleNext}
+              onClick={() => guard(handleNext)}
               aria-label={navigationButtonAriaLabels["next"][duration]}
             />
           </div>
@@ -158,6 +171,7 @@ export const AllocationsProjectTable = () => {
             count={ALLOCATIONS_PAGE_SIZE}
           >
             <GanttGrid
+              ref={ganttRef}
               variant="project"
               startDate={anchorDate}
               projects={projects}

--- a/frontend/packages/app/src/pages/allocations/project/layout.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/layout.tsx
@@ -11,6 +11,7 @@ import { Plus } from "lucide-react";
 import { Header } from "@/layout/header";
 import { AllocationsBreadcrumbs } from "@/pages/allocations/components/allocationsBreadcrumbs";
 import AddAllocationModal from "@/pages/allocations/team/add-allocation";
+import { UnsavedChangesProvider } from "@/pages/allocations/unsavedChanges/UnsavedChangesProvider";
 import { useAllocationModal } from "@/pages/allocations/useAllocationModal";
 import { useUser } from "@/providers/user";
 import { useAllocationsProject } from "./context";
@@ -48,9 +49,11 @@ function ProjectAllocationsLayoutContent() {
 
 function ProjectAllocationsLayout() {
   return (
-    <AllocationsProjectProvider>
-      <ProjectAllocationsLayoutContent />
-    </AllocationsProjectProvider>
+    <UnsavedChangesProvider>
+      <AllocationsProjectProvider>
+        <ProjectAllocationsLayoutContent />
+      </AllocationsProjectProvider>
+    </UnsavedChangesProvider>
   );
 }
 

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -93,7 +93,7 @@ export const AllocationsTeamTable = () => {
           <TextInput
             className="w-xs"
             placeholder="Search members or designation"
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => guard(() => setSearch(e.target.value))}
             value={searchInput}
           />
           <Select

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -27,6 +27,10 @@ import {
 import { InfiniteScroll } from "@/components/infiniteScroll";
 import { isWeekendEntryAllowed } from "@/lib/utils";
 import { useAllocationOutletContext } from "@/pages/allocations/allocationOutletContext";
+import {
+  useGuardedAction,
+  useUnsavedChangesSource,
+} from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { useUser } from "@/providers/user";
 import { useAllocationsTeam } from "./context";
 import {
@@ -64,6 +68,9 @@ export const AllocationsTeamTable = () => {
   const handleToday = useAllocationsTeam(({ actions }) => actions.handleToday);
   const handleNext = useAllocationsTeam(({ actions }) => actions.handleNext);
 
+  const guard = useGuardedAction();
+  const ganttRef = useUnsavedChangesSource();
+
   const { hasRoleAccess } = useUser(({ state }) => ({
     hasRoleAccess: state.hasRoleAccess,
   }));
@@ -95,7 +102,9 @@ export const AllocationsTeamTable = () => {
             options={durationOptions}
             value={duration}
             onChange={(value) =>
-              setDuration((value || "this-quarter") as typeof duration)
+              guard(() =>
+                setDuration((value || "this-quarter") as typeof duration),
+              )
             }
           />
           <Select
@@ -113,16 +122,20 @@ export const AllocationsTeamTable = () => {
               icon={() => (
                 <SmallLeftChevron className="size-4 text-ink-gray-9" />
               )}
-              onClick={handlePrevious}
+              onClick={() => guard(handlePrevious)}
               aria-label={navigationButtonAriaLabels["previous"][duration]}
             />
-            <Button variant="ghost" label="Today" onClick={handleToday} />
+            <Button
+              variant="ghost"
+              label="Today"
+              onClick={() => guard(handleToday)}
+            />
             <Button
               variant="ghost"
               icon={() => (
                 <SmallRightChevron className="size-4 text-ink-gray-9" />
               )}
-              onClick={handleNext}
+              onClick={() => guard(handleNext)}
               aria-label={navigationButtonAriaLabels["next"][duration]}
             />
           </div>
@@ -155,6 +168,7 @@ export const AllocationsTeamTable = () => {
             count={ALLOCATIONS_PAGE_SIZE}
           >
             <GanttGrid
+              ref={ganttRef}
               variant="team"
               startDate={anchorDate}
               members={members}

--- a/frontend/packages/app/src/pages/allocations/team/layout.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/layout.tsx
@@ -12,6 +12,7 @@ import { Header } from "@/layout/header";
 import { AllocationsBreadcrumbs } from "@/pages/allocations/components/allocationsBreadcrumbs";
 import AddAllocationModal from "@/pages/allocations/team/add-allocation";
 import { AllocationsTeamProvider } from "@/pages/allocations/team/provider";
+import { UnsavedChangesProvider } from "@/pages/allocations/unsavedChanges/UnsavedChangesProvider";
 import { useAllocationModal } from "@/pages/allocations/useAllocationModal";
 import { useUser } from "@/providers/user";
 import { useAllocationsTeam } from "./context";
@@ -48,9 +49,11 @@ function AllocationsTeamLayoutContent() {
 
 function AllocationsTeamLayout() {
   return (
-    <AllocationsTeamProvider>
-      <AllocationsTeamLayoutContent />
-    </AllocationsTeamProvider>
+    <UnsavedChangesProvider>
+      <AllocationsTeamProvider>
+        <AllocationsTeamLayoutContent />
+      </AllocationsTeamProvider>
+    </UnsavedChangesProvider>
   );
 }
 

--- a/frontend/packages/app/src/pages/allocations/unsavedChanges/UnsavedChangesProvider.tsx
+++ b/frontend/packages/app/src/pages/allocations/unsavedChanges/UnsavedChangesProvider.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { useBeforeUnload, useBlocker } from "react-router-dom";
+
+/**
+ * Internal dependencies.
+ */
+import { UnsavedChangesDialog } from "@/pages/allocations/components/unsavedChangesDialog";
+import {
+  UnsavedChangesContext,
+  type UnsavedChangesContextValue,
+  type UnsavedChangesSource,
+} from "./context";
+
+export type { UnsavedChangesSource };
+
+export function UnsavedChangesProvider({ children }: { children: ReactNode }) {
+  const sourceRef = useRef<UnsavedChangesSource | null>(null);
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
+
+  const hasDirty = useCallback(
+    () => sourceRef.current?.hasUnsavedChanges() ?? false,
+    [],
+  );
+
+  const blocker = useBlocker(useCallback(() => hasDirty(), [hasDirty]));
+
+  useBeforeUnload(
+    useCallback(
+      (event: BeforeUnloadEvent) => {
+        if (!hasDirty()) return;
+        event.preventDefault();
+        event.returnValue = "";
+      },
+      [hasDirty],
+    ),
+  );
+
+  const requestGuardedAction = useCallback(
+    (action: () => void) => {
+      if (!hasDirty()) {
+        action();
+        return;
+      }
+      setPendingAction(() => action);
+    },
+    [hasDirty],
+  );
+
+  // Stable identity `requestGuardedAction` never changes, so consumers
+  // don't re-render when the dialog opens/closes.
+  const contextValue = useMemo<UnsavedChangesContextValue>(
+    () => ({ sourceRef, requestGuardedAction }),
+    [requestGuardedAction],
+  );
+
+  const isOpen = blocker.state === "blocked" || pendingAction !== null;
+
+  const handleKeepEditing = useCallback(() => {
+    setPendingAction(null);
+    if (blocker.state === "blocked") blocker.reset();
+  }, [blocker]);
+
+  // Ref so handleDiscardChanges doesn't change identity on every render.
+  const queuedActionRef = useRef<(() => void) | null>(null);
+  queuedActionRef.current = pendingAction;
+
+  const handleDiscardChanges = useCallback(() => {
+    sourceRef.current?.discardChanges();
+    const queued = queuedActionRef.current;
+    setPendingAction(null);
+    if (blocker.state === "blocked") {
+      blocker.proceed();
+      return;
+    }
+    queued?.();
+  }, [blocker]);
+
+  const handleSaveChanges = useCallback(() => {
+    // Hands off to the feature's own save flow don't auto-proceed navigation.
+    sourceRef.current?.saveChanges();
+    setPendingAction(null);
+    if (blocker.state === "blocked") blocker.reset();
+  }, [blocker]);
+
+  return (
+    <UnsavedChangesContext.Provider value={contextValue}>
+      {children}
+      <UnsavedChangesDialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) handleKeepEditing();
+        }}
+        onDiscardChanges={handleDiscardChanges}
+        onKeepEditing={handleKeepEditing}
+        onSaveChanges={handleSaveChanges}
+      />
+    </UnsavedChangesContext.Provider>
+  );
+}

--- a/frontend/packages/app/src/pages/allocations/unsavedChanges/context.ts
+++ b/frontend/packages/app/src/pages/allocations/unsavedChanges/context.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies.
+ */
+import { createContext, type RefObject } from "react";
+
+export interface UnsavedChangesSource {
+  hasUnsavedChanges: () => boolean;
+  saveChanges: () => void;
+  discardChanges: () => void;
+}
+
+export interface UnsavedChangesContextValue {
+  sourceRef: RefObject<UnsavedChangesSource | null>;
+  requestGuardedAction: (action: () => void) => void;
+}
+
+export const UnsavedChangesContext =
+  createContext<UnsavedChangesContextValue | null>(null);

--- a/frontend/packages/app/src/pages/allocations/unsavedChanges/useUnsavedChanges.ts
+++ b/frontend/packages/app/src/pages/allocations/unsavedChanges/useUnsavedChanges.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies.
+ */
+import { useContext } from "react";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  UnsavedChangesContext,
+  type UnsavedChangesContextValue,
+} from "./context";
+
+function useUnsavedChangesContext(): UnsavedChangesContextValue {
+  const ctx = useContext(UnsavedChangesContext);
+  if (!ctx) {
+    throw new Error(
+      "useUnsavedChangesContext must be used inside <UnsavedChangesProvider>",
+    );
+  }
+  return ctx;
+}
+
+export function useUnsavedChangesSource() {
+  return useUnsavedChangesContext().sourceRef;
+}
+
+export function useGuardedAction() {
+  return useUnsavedChangesContext().requestGuardedAction;
+}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -238,7 +238,11 @@ export function GanttAllocationBar({
   const renderFloatingLabel = useCallback(() => {
     return (
       <div className="pointer-events-none absolute inset-x-0 top-full mt-1 flex cursor-default">
-        <div className="pointer-events-auto ml-auto flex w-max gap-1 items-center whitespace-nowrap text-[13px] font-medium text-ink-gray-6">
+        <div
+          className="pointer-events-auto ml-auto flex w-max gap-1 items-center whitespace-nowrap text-[13px] font-medium text-ink-gray-6"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
           <Button onClick={handleResetPreview} variant="ghost">
             Cancel
           </Button>

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -3,7 +3,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PreviewCard } from "@base-ui/react/preview-card";
-import { Tooltip } from "@rtcamp/frappe-ui-react";
+import { Button } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
@@ -46,6 +46,7 @@ export function GanttAllocationBar({
     onEditAllocation,
     onDeleteAllocation,
     setPendingDeleteEntry,
+    setHasActiveAllocationEdit,
   } = useGanttStore((s) => ({
     headerWidth: s.headerWidth,
     columnWidth: s.columnWidth,
@@ -56,17 +57,27 @@ export function GanttAllocationBar({
     onEditAllocation: s.onEditAllocation,
     onDeleteAllocation: s.onDeleteAllocation,
     setPendingDeleteEntry: s.setPendingDeleteEntry,
+    setHasActiveAllocationEdit: s.setHasActiveAllocationEdit,
   }));
 
   const left = allocation.barOffset + headerWidth;
   const { width, fullNumDays } = allocation;
   const [previewGeometry, setPreviewGeometry] = useState({ left, width });
+  const [previewOpen, setPreviewOpen] = useState(false);
   const isModified =
     previewGeometry.left !== left || previewGeometry.width !== width;
 
   useEffect(() => {
     setPreviewGeometry({ left, width });
   }, [allocation, left, width]);
+
+  useEffect(() => {
+    setHasActiveAllocationEdit(isModified);
+
+    return () => {
+      setHasActiveAllocationEdit(false);
+    };
+  }, [isModified, setHasActiveAllocationEdit]);
 
   const currentDates = useMemo(
     () =>
@@ -192,6 +203,12 @@ export function GanttAllocationBar({
     allocationBarRef.current?.focus();
   }, []);
 
+  const handleResetPreview = useCallback(() => {
+    setPreviewGeometry({ left, width });
+    setPreviewOpen(false);
+    allocationBarRef.current?.focus();
+  }, [left, width]);
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key !== "Escape") {
@@ -200,9 +217,9 @@ export function GanttAllocationBar({
 
       event.preventDefault();
       event.stopPropagation();
-      setPreviewGeometry({ left, width });
+      handleResetPreview();
     },
-    [left, width],
+    [handleResetPreview],
   );
 
   const handleClick = useCallback(() => {
@@ -218,46 +235,60 @@ export function GanttAllocationBar({
     previewGeometry.width,
   ]);
 
+  const renderFloatingLabel = useCallback(() => {
+    return (
+      <div className="pointer-events-none absolute inset-x-0 top-full mt-1 flex cursor-default">
+        <div className="pointer-events-auto ml-auto flex w-max gap-1 items-center whitespace-nowrap text-[13px] font-medium text-ink-gray-6">
+          <Button onClick={handleResetPreview} variant="ghost">
+            Cancel
+          </Button>
+          <Button onClick={handleClick} variant="solid">
+            Save
+          </Button>
+        </div>
+      </div>
+    );
+  }, [handleClick, handleResetPreview]);
+
   return (
-    <PreviewCard.Root>
-      <Tooltip text="Click to save the allocation" disabled={!isModified}>
-        <PreviewCard.Trigger
-          delay={400}
-          closeDelay={150}
-          render={
-            <GanttBar
-              ref={allocationBarRef}
-              variant="allocation"
-              theme={allocation.tentative ? "crosshatch" : "default"}
-              label={dayCountLabel}
-              renderLabel={renderLabel}
-              trailingLabel={
-                showCapacityStatus ? capacityStatus.trailingLabel : undefined
-              }
-              trailingLabelVariant={
-                showCapacityStatus
-                  ? capacityStatus.trailingLabelVariant
-                  : undefined
-              }
-              left={previewGeometry.left}
-              width={previewGeometry.width}
-              className={cn(
-                "outline-none",
-                isModified && "ring-1 ring-inset ring-surface-amber-3",
-              )}
-              billable={allocation.billable}
-              resizable={resizable}
-              snapUnitPx={columnWidth}
-              tabIndex={0}
-              minLeft={bounds.minLeft}
-              maxRight={bounds.maxRight}
-              onClick={isModified ? handleClick : undefined}
-              onKeyDown={handleKeyDown}
-              onResizeEnd={handleResizeEnd}
-            />
-          }
-        />
-      </Tooltip>
+    <PreviewCard.Root
+      open={isModified ? false : previewOpen}
+      onOpenChange={setPreviewOpen}
+    >
+      <PreviewCard.Trigger
+        delay={400}
+        closeDelay={150}
+        render={
+          <GanttBar
+            ref={allocationBarRef}
+            variant="allocation"
+            theme={allocation.tentative ? "crosshatch" : "default"}
+            label={dayCountLabel}
+            renderLabel={renderLabel}
+            trailingLabel={
+              showCapacityStatus ? capacityStatus.trailingLabel : undefined
+            }
+            trailingLabelVariant={
+              showCapacityStatus
+                ? capacityStatus.trailingLabelVariant
+                : undefined
+            }
+            left={previewGeometry.left}
+            width={previewGeometry.width}
+            className={cn("outline-none", isModified && "z-20")}
+            billable={allocation.billable}
+            showOutline={isModified}
+            renderFloatingLabel={isModified ? renderFloatingLabel : undefined}
+            resizable={resizable}
+            snapUnitPx={columnWidth}
+            tabIndex={0}
+            minLeft={bounds.minLeft}
+            maxRight={bounds.maxRight}
+            onKeyDown={handleKeyDown}
+            onResizeEnd={handleResizeEnd}
+          />
+        }
+      />
       <PreviewCard.Portal>
         <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
           <PreviewCard.Popup className="z-50 outline-none">

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -46,7 +46,8 @@ export function GanttAllocationBar({
     onEditAllocation,
     onDeleteAllocation,
     setPendingDeleteEntry,
-    setHasActiveAllocationEdit,
+    setActiveEdit,
+    clearActiveEdit,
   } = useGanttStore((s) => ({
     headerWidth: s.headerWidth,
     columnWidth: s.columnWidth,
@@ -57,7 +58,8 @@ export function GanttAllocationBar({
     onEditAllocation: s.onEditAllocation,
     onDeleteAllocation: s.onDeleteAllocation,
     setPendingDeleteEntry: s.setPendingDeleteEntry,
-    setHasActiveAllocationEdit: s.setHasActiveAllocationEdit,
+    setActiveEdit: s.setActiveEdit,
+    clearActiveEdit: s.clearActiveEdit,
   }));
 
   const left = allocation.barOffset + headerWidth;
@@ -69,15 +71,7 @@ export function GanttAllocationBar({
 
   useEffect(() => {
     setPreviewGeometry({ left, width });
-  }, [allocation, left, width]);
-
-  useEffect(() => {
-    setHasActiveAllocationEdit(isModified);
-
-    return () => {
-      setHasActiveAllocationEdit(false);
-    };
-  }, [isModified, setHasActiveAllocationEdit]);
+  }, [left, width]);
 
   const currentDates = useMemo(
     () =>
@@ -233,6 +227,25 @@ export function GanttAllocationBar({
     openEditAllocation,
     previewGeometry.left,
     previewGeometry.width,
+  ]);
+
+  useEffect(() => {
+    if (!isModified) {
+      return;
+    }
+
+    const actions = { save: handleClick, discard: handleResetPreview };
+    setActiveEdit(actions);
+
+    return () => {
+      clearActiveEdit(actions);
+    };
+  }, [
+    isModified,
+    handleClick,
+    handleResetPreview,
+    setActiveEdit,
+    clearActiveEdit,
   ]);
 
   const renderFloatingLabel = useCallback(() => {

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -8,6 +8,7 @@ import { format } from "date-fns";
 /**
  * Internal dependencies.
  */
+import { mergeClassNames as cn } from "../../../utils";
 import { FULL_DAY_HOURS } from "../constants";
 import { useGanttStore } from "../ganttStore";
 import type { AllocationCallbackData } from "../types";
@@ -42,14 +43,21 @@ export function DraftBar({
   onRemove,
 }: DraftBarProps) {
   const draftBarRef = useRef<HTMLDivElement>(null);
-  const { headerWidth, columnWidth, columnCount, weekStart, showWeekend } =
-    useGanttStore((s) => ({
-      headerWidth: s.headerWidth,
-      columnWidth: s.columnWidth,
-      columnCount: s.columnCount,
-      weekStart: s.weekStart,
-      showWeekend: s.showWeekend,
-    }));
+  const {
+    headerWidth,
+    columnWidth,
+    columnCount,
+    weekStart,
+    showWeekend,
+    setHasActiveAllocationEdit,
+  } = useGanttStore((s) => ({
+    headerWidth: s.headerWidth,
+    columnWidth: s.columnWidth,
+    columnCount: s.columnCount,
+    weekStart: s.weekStart,
+    showWeekend: s.showWeekend,
+    setHasActiveAllocationEdit: s.setHasActiveAllocationEdit,
+  }));
 
   const [previewGeometry, setPreviewGeometry] = useState({ left, width });
 
@@ -60,6 +68,14 @@ export function DraftBar({
   useEffect(() => {
     draftBarRef.current?.focus();
   }, [rowKey]);
+
+  useEffect(() => {
+    setHasActiveAllocationEdit(true);
+
+    return () => {
+      setHasActiveAllocationEdit(false);
+    };
+  }, [setHasActiveAllocationEdit]);
 
   const bounds = useMemo(
     () =>
@@ -92,19 +108,24 @@ export function DraftBar({
   );
 
   const renderFloatingLabel = useCallback(
-    ({ liveLeft, liveWidth }: GanttBarRenderState) =>
-      format(
-        getBarDateRange({
-          left: liveLeft,
-          width: liveWidth,
-          headerWidth,
-          columnWidth,
-          columnCount,
-          weekStart,
-          showWeekend,
-        }).endDate,
-        "MMM d",
-      ),
+    ({ liveLeft, liveWidth }: GanttBarRenderState) => (
+      <span className="pointer-events-none absolute inset-x-0 top-full mt-1 flex">
+        <span className="ml-auto w-max whitespace-nowrap pr-2 text-[13px] font-medium text-ink-gray-6">
+          {format(
+            getBarDateRange({
+              left: liveLeft,
+              width: liveWidth,
+              headerWidth,
+              columnWidth,
+              columnCount,
+              weekStart,
+              showWeekend,
+            }).endDate,
+            "MMM d",
+          )}
+        </span>
+      </span>
+    ),
     [headerWidth, columnWidth, columnCount, weekStart, showWeekend],
   );
 
@@ -178,7 +199,7 @@ export function DraftBar({
         renderFloatingLabel={renderFloatingLabel}
         left={previewGeometry.left}
         width={previewGeometry.width}
-        className="outline-none"
+        className={cn("outline-none", "z-20")}
         minLeft={bounds.minLeft}
         maxRight={bounds.maxRight}
         resizable={Boolean(onOpenAllocation)}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -2,7 +2,8 @@
  * External dependencies.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tooltip } from "@rtcamp/frappe-ui-react";
+import { Button, Tooltip } from "@rtcamp/frappe-ui-react";
+import { Close } from "@rtcamp/frappe-ui-react/icons";
 import { format } from "date-fns";
 
 /**
@@ -107,31 +108,13 @@ export function DraftBar({
     [columnWidth],
   );
 
-  const renderFloatingLabel = useCallback(
-    ({ liveLeft, liveWidth }: GanttBarRenderState) => (
-      <span className="pointer-events-none absolute inset-x-0 top-full mt-1 flex">
-        <span className="ml-auto w-max whitespace-nowrap pr-2 text-[13px] font-medium text-ink-gray-6">
-          {format(
-            getBarDateRange({
-              left: liveLeft,
-              width: liveWidth,
-              headerWidth,
-              columnWidth,
-              columnCount,
-              weekStart,
-              showWeekend,
-            }).endDate,
-            "MMM d",
-          )}
-        </span>
-      </span>
-    ),
-    [headerWidth, columnWidth, columnCount, weekStart, showWeekend],
-  );
-
   const handleResizeEnd = useCallback((geometry: GanttBarGeometry) => {
     setPreviewGeometry(geometry);
   }, []);
+
+  const handleResetDraft = useCallback(() => {
+    onRemove?.(rowKey, left);
+  }, [left, onRemove, rowKey]);
 
   const handleClick = useCallback(() => {
     if (!onOpenAllocation) {
@@ -176,6 +159,48 @@ export function DraftBar({
     weekStart,
   ]);
 
+  const renderFloatingLabel = useCallback(
+    ({ liveLeft, liveWidth }: GanttBarRenderState) => (
+      <span className="pointer-events-none absolute inset-x-0 top-full mt-1 flex cursor-default">
+        <span
+          className="pointer-events-auto ml-auto flex w-max items-center gap-2 whitespace-nowrap pr-2 text-[13px] font-medium text-ink-gray-6"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <span className="flex items-center gap-1">
+            <Button
+              onClick={handleResetDraft}
+              variant="ghost"
+              icon={() => <Close className="size-4" />}
+            />
+            <span>
+              {format(
+                getBarDateRange({
+                  left: liveLeft,
+                  width: liveWidth,
+                  headerWidth,
+                  columnWidth,
+                  columnCount,
+                  weekStart,
+                  showWeekend,
+                }).endDate,
+                "MMM d",
+              )}
+            </span>
+          </span>
+        </span>
+      </span>
+    ),
+    [
+      columnCount,
+      columnWidth,
+      handleResetDraft,
+      headerWidth,
+      showWeekend,
+      weekStart,
+    ],
+  );
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key !== "Escape") {
@@ -184,9 +209,9 @@ export function DraftBar({
 
       event.preventDefault();
       event.stopPropagation();
-      onRemove?.(rowKey, left);
+      handleResetDraft();
     },
-    [onRemove, rowKey, left],
+    [handleResetDraft],
   );
 
   return (

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -9,7 +9,6 @@ import { format } from "date-fns";
 /**
  * Internal dependencies.
  */
-import { mergeClassNames as cn } from "../../../utils";
 import { FULL_DAY_HOURS } from "../constants";
 import { useGanttStore } from "../ganttStore";
 import type { AllocationCallbackData } from "../types";
@@ -227,7 +226,7 @@ export function DraftBar({
         renderFloatingLabel={renderFloatingLabel}
         left={previewGeometry.left}
         width={previewGeometry.width}
-        className={cn("outline-none", "z-20")}
+        className="outline-none z-20"
         minLeft={bounds.minLeft}
         maxRight={bounds.maxRight}
         resizable={Boolean(onOpenAllocation)}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -50,14 +50,16 @@ export function DraftBar({
     columnCount,
     weekStart,
     showWeekend,
-    setHasActiveAllocationEdit,
+    setActiveEdit,
+    clearActiveEdit,
   } = useGanttStore((s) => ({
     headerWidth: s.headerWidth,
     columnWidth: s.columnWidth,
     columnCount: s.columnCount,
     weekStart: s.weekStart,
     showWeekend: s.showWeekend,
-    setHasActiveAllocationEdit: s.setHasActiveAllocationEdit,
+    setActiveEdit: s.setActiveEdit,
+    clearActiveEdit: s.clearActiveEdit,
   }));
 
   const [previewGeometry, setPreviewGeometry] = useState({ left, width });
@@ -69,14 +71,6 @@ export function DraftBar({
   useEffect(() => {
     draftBarRef.current?.focus();
   }, [rowKey]);
-
-  useEffect(() => {
-    setHasActiveAllocationEdit(true);
-
-    return () => {
-      setHasActiveAllocationEdit(false);
-    };
-  }, [setHasActiveAllocationEdit]);
 
   const bounds = useMemo(
     () =>
@@ -158,6 +152,15 @@ export function DraftBar({
     showWeekend,
     weekStart,
   ]);
+
+  useEffect(() => {
+    const actions = { save: handleClick, discard: handleResetDraft };
+    setActiveEdit(actions);
+
+    return () => {
+      clearActiveEdit(actions);
+    };
+  }, [handleClick, handleResetDraft, setActiveEdit, clearActiveEdit]);
 
   const renderFloatingLabel = useCallback(
     ({ liveLeft, liveWidth }: GanttBarRenderState) => (

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -68,6 +68,7 @@ interface GanttBarProps
   theme?: "default" | "crosshatch";
   billable?: boolean;
   className?: string;
+  showOutline?: boolean;
   resizable?: boolean;
   snapUnitPx?: number;
   minLeft?: number;
@@ -89,6 +90,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
       theme = "default",
       billable,
       className,
+      showOutline = false,
       resizable = false,
       snapUnitPx,
       minLeft,
@@ -132,6 +134,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
         data-gantt-bar="true"
         className={cn(
           ganttBarVariants({ variant }),
+          isInteracting && "z-5",
           showPointerCursor && "cursor-pointer",
           className,
         )}
@@ -143,7 +146,6 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
           width: Math.max(liveWidth - BAR_MARGIN, 0),
           height: BAR_HEIGHT,
           top: (CELL_HEIGHT - BAR_HEIGHT) / 2,
-          zIndex: isInteracting ? 5 : style?.zIndex,
         }}
       >
         {!isTimeoff && variant !== "draft" && isCrosshatch && (
@@ -203,17 +205,18 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
                 </span>
               </>
             ) : null}
-            {renderFloatingLabel ? (
-              <span className="pointer-events-none absolute right-0 top-full mt-1 pr-2 whitespace-nowrap text-[13px] font-medium text-ink-gray-6">
-                {renderFloatingLabel({
+            {renderFloatingLabel
+              ? renderFloatingLabel({
                   isInteracting,
                   liveLeft,
                   liveWidth,
-                })}
-              </span>
-            ) : null}
+                })
+              : null}
           </>
         )}
+        {showOutline ? (
+          <span className="inline-flex pointer-events-none absolute inset-0 rounded-[9px] border border-dashed border-surface-amber-3"></span>
+        ) : null}
       </div>
     );
   },

--- a/frontend/packages/design-system/src/components/gantt-view/ganttEditingOverlay.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttEditingOverlay.tsx
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies.
+ */
+import { HEADER_HEIGHT } from "./constants";
+import { useGanttStore } from "./ganttStore";
+
+export function GanttEditingOverlay() {
+  const { hasActiveAllocationEdit, headerWidth } = useGanttStore((s) => ({
+    hasActiveAllocationEdit: s.hasActiveAllocationEdit,
+    headerWidth: s.headerWidth,
+  }));
+
+  if (!hasActiveAllocationEdit) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-auto absolute right-0 bottom-0 z-15 bg-surface-white/50"
+      style={{ top: HEADER_HEIGHT, left: headerWidth }}
+    />
+  );
+}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttEditingOverlay.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttEditingOverlay.tsx
@@ -3,6 +3,7 @@
  */
 import { HEADER_HEIGHT } from "./constants";
 import { useGanttStore } from "./ganttStore";
+import { mergeClassNames as cn } from "../../utils";
 
 export function GanttEditingOverlay() {
   const { hasActiveAllocationEdit, headerWidth } = useGanttStore((s) => ({
@@ -10,14 +11,15 @@ export function GanttEditingOverlay() {
     headerWidth: s.headerWidth,
   }));
 
-  if (!hasActiveAllocationEdit) {
-    return null;
-  }
-
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-auto absolute right-0 bottom-0 z-15 bg-surface-white/50"
+      className={cn(
+        "absolute right-0 bottom-0 z-15 bg-surface-white/50 transition-opacity duration-150 ease-out",
+        hasActiveAllocationEdit
+          ? "pointer-events-auto opacity-100"
+          : "pointer-events-none opacity-0",
+      )}
       style={{ top: HEADER_HEIGHT, left: headerWidth }}
     />
   );

--- a/frontend/packages/design-system/src/components/gantt-view/ganttEditingOverlay.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttEditingOverlay.tsx
@@ -6,8 +6,8 @@ import { useGanttStore } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
 
 export function GanttEditingOverlay() {
-  const { hasActiveAllocationEdit, headerWidth } = useGanttStore((s) => ({
-    hasActiveAllocationEdit: s.hasActiveAllocationEdit,
+  const { hasActiveEdit, headerWidth } = useGanttStore((s) => ({
+    hasActiveEdit: s.activeEdit !== null,
     headerWidth: s.headerWidth,
   }));
 
@@ -16,7 +16,7 @@ export function GanttEditingOverlay() {
       aria-hidden="true"
       className={cn(
         "absolute right-0 bottom-0 z-15 bg-surface-white/50 transition-opacity duration-150 ease-out",
-        hasActiveAllocationEdit
+        hasActiveEdit
           ? "pointer-events-auto opacity-100"
           : "pointer-events-none opacity-0",
       )}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -2,8 +2,10 @@
  * External dependencies.
  */
 import React, {
+  forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -20,7 +22,7 @@ import { GanttProjectRows } from "./ganttProjectRows";
 import { createGanttStore, GanttContext, useGanttStore } from "./ganttStore";
 import { GanttWeekHeader } from "./ganttWeekHeader";
 import { useContainerResize } from "./hooks/useContainerResize";
-import type { GanttGridProps } from "./types";
+import type { GanttGridHandle, GanttGridProps } from "./types";
 import { mergeClassNames as cn } from "../../utils";
 
 const GanttGridInner: React.FC<{
@@ -161,56 +163,68 @@ const GanttGridInner: React.FC<{
   );
 };
 
-export const GanttGrid: React.FC<GanttGridProps> = (props) => {
-  const rootRef = useRef<HTMLDivElement>(null);
+export const GanttGrid = forwardRef<GanttGridHandle, GanttGridProps>(
+  function GanttGrid(props, ref) {
+    const rootRef = useRef<HTMLDivElement>(null);
 
-  const resolvedProps = useMemo(
-    () => ({
-      variant: props.variant,
-      members: props.members,
-      projects: props.projects,
-      rowHeaderLabel: props.rowHeaderLabel,
-      showWeekend: props.showWeekend ?? true,
-      startDate: props.startDate,
-      weekCount: props.weekCount ?? 3,
-      hasRoleAccess: props.hasRoleAccess ?? false,
-      onAddAllocation: props.onAddAllocation,
-      onEditAllocation: props.onEditAllocation,
-      onDeleteAllocation: props.onDeleteAllocation,
-    }),
-    [
-      props.hasRoleAccess,
-      props.onAddAllocation,
-      props.onDeleteAllocation,
-      props.onEditAllocation,
-      props.members,
-      props.projects,
-      props.rowHeaderLabel,
-      props.showWeekend,
-      props.startDate,
-      props.variant,
-      props.weekCount,
-    ],
-  );
+    const resolvedProps = useMemo(
+      () => ({
+        variant: props.variant,
+        members: props.members,
+        projects: props.projects,
+        rowHeaderLabel: props.rowHeaderLabel,
+        showWeekend: props.showWeekend ?? true,
+        startDate: props.startDate,
+        weekCount: props.weekCount ?? 3,
+        hasRoleAccess: props.hasRoleAccess ?? false,
+        onAddAllocation: props.onAddAllocation,
+        onEditAllocation: props.onEditAllocation,
+        onDeleteAllocation: props.onDeleteAllocation,
+      }),
+      [
+        props.hasRoleAccess,
+        props.onAddAllocation,
+        props.onDeleteAllocation,
+        props.onEditAllocation,
+        props.members,
+        props.projects,
+        props.rowHeaderLabel,
+        props.showWeekend,
+        props.startDate,
+        props.variant,
+        props.weekCount,
+      ],
+    );
 
-  const [store] = useState(() => createGanttStore(resolvedProps));
+    const [store] = useState(() => createGanttStore(resolvedProps));
 
-  useEffect(() => {
-    store.getState().syncProps(resolvedProps);
-  }, [resolvedProps, store]);
+    useEffect(() => {
+      store.getState().syncProps(resolvedProps);
+    }, [resolvedProps, store]);
 
-  useContainerResize({
-    rootRef,
-    onWidthChange: (width) => {
-      store.getState().setContainerWidth(width);
-    },
-  });
+    useContainerResize({
+      rootRef,
+      onWidthChange: (width) => {
+        store.getState().setContainerWidth(width);
+      },
+    });
 
-  return (
-    <GanttContext.Provider value={store}>
-      <GanttGridInner rootRef={rootRef} className={props.className} />
-    </GanttContext.Provider>
-  );
-};
+    useImperativeHandle(
+      ref,
+      () => ({
+        hasUnsavedChanges: () => store.getState().activeEdit !== null,
+        saveChanges: () => store.getState().activeEdit?.save(),
+        discardChanges: () => store.getState().activeEdit?.discard(),
+      }),
+      [store],
+    );
+
+    return (
+      <GanttContext.Provider value={store}>
+        <GanttGridInner rootRef={rootRef} className={props.className} />
+      </GanttContext.Provider>
+    );
+  },
+);
 
 GanttGrid.displayName = "GanttGrid";

--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -14,6 +14,7 @@ import React, {
  */
 import { HEADER_HEIGHT } from "./constants";
 import { DeleteAllocationDialog } from "./deleteAllocationDialog";
+import { GanttEditingOverlay } from "./ganttEditingOverlay";
 import { GanttMemberRows } from "./ganttMemberRows";
 import { GanttProjectRows } from "./ganttProjectRows";
 import { createGanttStore, GanttContext, useGanttStore } from "./ganttStore";
@@ -89,15 +90,15 @@ const GanttGridInner: React.FC<{
       )}
 
       <table
-        className="relative z-10 border-separate border-spacing-0"
+        className="relative border-separate border-spacing-0"
         style={{ width: headerWidth + columnCount * columnWidth }}
       >
-        <thead className="sticky top-0 z-20">
+        <thead className="sticky top-0 z-30">
           {/* Row 1: corner + week range labels */}
           <tr>
             <th
               rowSpan={2}
-              className="sticky left-0 z-20 bg-surface-white text-ink-gray-8 border border-l-0 border-outline-gray-1 font-medium text-start p-3 pl-4.25"
+              className="sticky left-0 z-35 bg-surface-white text-ink-gray-8 border border-l-0 border-outline-gray-1 font-medium text-start p-3 pl-4.25"
               style={{ width: headerWidth, height: HEADER_HEIGHT }}
             >
               {rowHeaderLabel}
@@ -120,7 +121,9 @@ const GanttGridInner: React.FC<{
         </tbody>
       </table>
 
-      <div className="pointer-events-none absolute inset-0 z-30">
+      <GanttEditingOverlay />
+
+      <div className="pointer-events-none absolute inset-0 z-40">
         <div className="sticky left-0 top-0 h-full w-0">
           <div
             className={cn(

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -59,7 +59,7 @@ export function GanttMemberItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               className,
             )}
             style={{

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -128,7 +128,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
           aria-hidden={!isExpanded}
         >
           <th
-            className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
+            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -37,7 +37,7 @@ export function GanttProjectItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               showChevron ? "pl-3" : "pl-8",
               className,
             )}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -146,7 +146,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
           aria-hidden={!isExpanded}
         >
           <th
-            className="sticky left-0 z-10 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
+            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
@@ -29,6 +29,11 @@ export interface PendingDeleteEntry {
   onDelete: () => void;
 }
 
+export interface GanttActiveEdit {
+  save: () => void;
+  discard: () => void;
+}
+
 interface GanttProps {
   variant: GanttGridVariant;
   members?: BaseMember[];
@@ -62,12 +67,13 @@ interface GanttState extends GanttProps {
   containerWidth: number;
   resizeHandleActive: boolean;
   pendingDeleteEntry: PendingDeleteEntry | null;
-  hasActiveAllocationEdit: boolean;
+  activeEdit: GanttActiveEdit | null;
 
   toggleRow: (index: number) => void;
   setPendingDeleteEntry: (entry: PendingDeleteEntry) => void;
   clearPendingDeleteEntry: () => void;
-  setHasActiveAllocationEdit: (active: boolean) => void;
+  setActiveEdit: (actions: GanttActiveEdit) => void;
+  clearActiveEdit: (actions: GanttActiveEdit) => void;
   setHeaderWidth: (width: number) => void;
   setContainerWidth: (width: number) => void;
   setResizeHandleActive: (active: boolean) => void;
@@ -287,7 +293,7 @@ export const createGanttStore = (initProps: GanttProps) => {
     containerWidth,
     resizeHandleActive: false,
     pendingDeleteEntry: null,
-    hasActiveAllocationEdit: false,
+    activeEdit: null,
 
     toggleRow: (index) =>
       set((state) => {
@@ -311,11 +317,14 @@ export const createGanttStore = (initProps: GanttProps) => {
     setPendingDeleteEntry: (entry) => set({ pendingDeleteEntry: entry }),
     clearPendingDeleteEntry: () => set({ pendingDeleteEntry: null }),
 
-    setHasActiveAllocationEdit: (active) =>
+    setActiveEdit: (actions) =>
       set((state) =>
-        state.hasActiveAllocationEdit === active
-          ? state
-          : { hasActiveAllocationEdit: active },
+        state.activeEdit === actions ? state : { activeEdit: actions },
+      ),
+
+    clearActiveEdit: (actions) =>
+      set((state) =>
+        state.activeEdit === actions ? { activeEdit: null } : state,
       ),
 
     startResize: (startX) => {

--- a/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
@@ -62,10 +62,12 @@ interface GanttState extends GanttProps {
   containerWidth: number;
   resizeHandleActive: boolean;
   pendingDeleteEntry: PendingDeleteEntry | null;
+  hasActiveAllocationEdit: boolean;
 
   toggleRow: (index: number) => void;
   setPendingDeleteEntry: (entry: PendingDeleteEntry) => void;
   clearPendingDeleteEntry: () => void;
+  setHasActiveAllocationEdit: (active: boolean) => void;
   setHeaderWidth: (width: number) => void;
   setContainerWidth: (width: number) => void;
   setResizeHandleActive: (active: boolean) => void;
@@ -285,6 +287,7 @@ export const createGanttStore = (initProps: GanttProps) => {
     containerWidth,
     resizeHandleActive: false,
     pendingDeleteEntry: null,
+    hasActiveAllocationEdit: false,
 
     toggleRow: (index) =>
       set((state) => {
@@ -307,6 +310,13 @@ export const createGanttStore = (initProps: GanttProps) => {
 
     setPendingDeleteEntry: (entry) => set({ pendingDeleteEntry: entry }),
     clearPendingDeleteEntry: () => set({ pendingDeleteEntry: null }),
+
+    setHasActiveAllocationEdit: (active) =>
+      set((state) =>
+        state.hasActiveAllocationEdit === active
+          ? state
+          : { hasActiveAllocationEdit: active },
+      ),
 
     startResize: (startX) => {
       const startWidth = get().headerWidth;

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -98,6 +98,15 @@ export interface AllocationCallbackData {
   note?: string;
 }
 
+export interface GanttGridHandle {
+  /** True when there is an in-progress, unsaved allocation edit or draft bar. */
+  hasUnsavedChanges: () => boolean;
+  /** Trigger the currently-active edit's save path. */
+  saveChanges: () => void;
+  /** Trigger the currently-active edit's discard path. */
+  discardChanges: () => void;
+}
+
 export interface GanttGridProps {
   /** Any date within the first week to display. */
   startDate: Date;


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This pull request introduces a unsaved changes guard for the allocations feature, ensuring users are prompted to save, discard, or keep editing when navigating away with unsaved changes. It does so by implementing a context-based provider and hooks, integrating them into both the project and team allocations flows, and updating the Gantt allocation bar to support in-place edit actions with Save/Cancel controls.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Added an imperative `GanttGridHandle` on `GanttGrid` (`hasUnsavedChanges`, `saveChanges`, `discardChanges`) so the parent can query dirty state on demand so there are no re-renders.
- Introduced `UnsavedChangesProvider` which uses React Router's built-in `useBlocker` for in-app navigation and `useBeforeUnload` for tab close. The context value is stable so consumers never re-render when the dialog opens or closes.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

**Unsaved allocation edit**

1. Navigate to Team or Project Allocations.
2. Edit an existing allocation bar. The Save / Cancel inline controls should appear below the bar.
`or`
4. Click on "+" button to create a new draft allocation bar. The "X" cancel button should appear beside the floating date.
2. Without confirming, click a sidebar nav item. The dialog should appear.
5. Without saving, click any item in the sidebar. The "Save Changes" dialog should appear.
6. Click **Keep Editing** the dialog closes and the bar remains in the dragged position.
7. Repeat step 3, then click **Discard Changes** the bar snaps back to its original position and navigation proceeds.
8. Repeat steps 2–3, then click **Save Changes** the edit-allocation modal should open pre-filled with the data.

**Duration / date range controls**

1. Edit an existing allocation bar or add draft bar (do not save).
2. Change the duration selector (e.g. Quarter → Month). The dialog should appear.
3. Verify the same three dialog actions work as described above.
3. Repeat for the **Prev**, **Next**, and **Today** toolbar buttons.

**Tab / browser close**

1. With any unsaved edit or draft active, attempt to close the tab or reload the page. The browser's native "Leave site?" prompt should appear.
2. With no unsaved changes, close or reload the tab no prompt should appear.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/83695f6e-8b64-4244-adcf-0212667dc4a3



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1326


