### PR TITLE
feat: Add child table for allocation override and improve API handling

### DIFF
--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -7,8 +7,10 @@ from frappe.automation.doctype.auto_repeat.auto_repeat import add_days
 from frappe.utils import cint, getdate
 
 from next_pms.resource_management.api.utils.helpers import resource_api_permissions_check
+from next_pms.resource_management.doctype.resource_allocation.resource_allocation import clear_cache
 
 NON_DATE_FIELDS = frozenset({"project", "customer", "is_billable", "status", "note", "hours_allocated_per_day"})
+VALID_DELETE_MODES = frozenset({"only_this", "this_and_future", "all_in_series"})
 
 
 @dataclass
@@ -270,6 +272,7 @@ def upsert_day_override(doc_name: str, override_date: str, override_fields: dict
     )
     if existing_row:
         frappe.db.set_value("Resource Allocation Extra Entry", existing_row, override_fields)
+        clear_cache()  # set_value bypasses on_update, so invalidate manually
     else:
         doc = frappe.get_doc("Resource Allocation", doc_name)
         doc.append("override", {"date": override_date, **override_fields})
@@ -369,6 +372,14 @@ def delete_allocation(name: str, delete_mode: str):
     permission = resource_api_permissions_check()
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    if delete_mode not in VALID_DELETE_MODES:
+        frappe.throw(
+            frappe._("Invalid delete_mode '{0}'. Allowed values: {1}.").format(
+                delete_mode, ", ".join(sorted(VALID_DELETE_MODES))
+            ),
+            exc=frappe.ValidationError,
+        )
 
     if not frappe.db.exists("Resource Allocation", name):
         frappe.throw(

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import asdict, dataclass
 from datetime import date, timedelta
 
@@ -6,6 +7,8 @@ from frappe.automation.doctype.auto_repeat.auto_repeat import add_days
 from frappe.utils import cint, getdate
 
 from next_pms.resource_management.api.utils.helpers import resource_api_permissions_check
+
+NON_DATE_FIELDS = frozenset({"project", "customer", "is_billable", "status", "note", "hours_allocated_per_day"})
 
 
 @dataclass
@@ -136,6 +139,7 @@ def add_allocation(allocation: AllocationPayload, repeat_till_week_count: int = 
     """Create a new resource allocation document."""
 
     doc_data = _to_doc_dict(allocation, include_name=False)
+    recurrence_id = str(uuid.uuid4()) if repeat_till_week_count else None
 
     if not allocation.include_weekends:
         chunks = get_weekday_chunks(allocation.allocation_start_date, allocation.allocation_end_date)
@@ -164,6 +168,7 @@ def add_allocation(allocation: AllocationPayload, repeat_till_week_count: int = 
                         "allocation_start_date": chunk_start + week_delta,
                         "allocation_end_date": chunk_end + week_delta,
                         "total_allocated_hours": weekday_count * allocation.hours_allocated_per_day,
+                        **({"recurrence_id": recurrence_id} if recurrence_id else {}),
                     }
                 )
                 doc.save()
@@ -171,7 +176,7 @@ def add_allocation(allocation: AllocationPayload, repeat_till_week_count: int = 
                     first_doc = doc
         return first_doc
 
-    new_allocation = frappe.get_doc(doc_data)
+    new_allocation = frappe.get_doc({**doc_data, **({"recurrence_id": recurrence_id} if recurrence_id else {})})
     new_allocation.save()
 
     if repeat_till_week_count:
@@ -187,7 +192,7 @@ def add_allocation(allocation: AllocationPayload, repeat_till_week_count: int = 
         for _ in range(repeat_till_week_count):
             doc_data["allocation_start_date"] = add_days(doc_data["allocation_start_date"], 7)
             doc_data["allocation_end_date"] = add_days(doc_data["allocation_end_date"], 7)
-            frappe.get_doc(dict(doc_data)).save()
+            frappe.get_doc({**doc_data, "recurrence_id": recurrence_id}).save()
 
     return new_allocation
 
@@ -241,3 +246,82 @@ def update_allocation(allocation: AllocationPayload):
     allocation_doc.update(doc_data)
     allocation_doc.save()
     return allocation_doc
+
+
+@frappe.whitelist(methods=["POST"])
+def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload):
+    """Edit a Resource Allocation, optionally propagating changes to all docs in the series.
+
+    Args:
+        name (str): Name of the allocation being edited.
+        edit_mode (str): ``"only_this"`` — update just this doc.
+                         ``"whole_series"`` — update all docs sharing the same ``recurrence_id``.
+        allocation (AllocationPayload): New field values.
+    """
+    permission = resource_api_permissions_check()
+    if not permission["write"]:
+        frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    allocation.name = name
+
+    if edit_mode == "whole_series":
+        recurrence_id = frappe.db.get_value("Resource Allocation", name, "recurrence_id")
+        if recurrence_id:
+            series = frappe.get_all(
+                "Resource Allocation",
+                filters={"recurrence_id": recurrence_id},
+                fields=["name", "allocation_start_date", "allocation_end_date"],
+            )
+            update_fields = {k: v for k, v in asdict(allocation).items() if k in NON_DATE_FIELDS and v is not None}
+            for series_doc_meta in series:
+                series_doc = frappe.get_doc("Resource Allocation", series_doc_meta.name)
+                day_count = (
+                    getdate(series_doc_meta.allocation_end_date) - getdate(series_doc_meta.allocation_start_date)
+                ).days + 1
+                series_doc.update(
+                    {
+                        **update_fields,
+                        "total_allocated_hours": update_fields.get(
+                            "hours_allocated_per_day", series_doc.hours_allocated_per_day
+                        )
+                        * day_count,
+                    }
+                )
+                series_doc.save()
+            return frappe.get_doc("Resource Allocation", name)
+
+    return update_allocation(allocation)
+
+
+@frappe.whitelist(methods=["POST"])
+def delete_allocation(name: str, delete_mode: str):
+    """Delete a Resource Allocation, optionally deleting all or future docs in the series.
+
+    Args:
+        name (str): Name of the allocation to delete.
+        delete_mode (str): ``"only_this"`` — delete just this doc.
+                           ``"this_and_future"`` — delete this doc and all later docs in the series.
+                           ``"all_in_series"`` — delete every doc sharing the same ``recurrence_id``.
+    """
+    permission = resource_api_permissions_check()
+    if not permission["write"]:
+        frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    if delete_mode == "only_this":
+        frappe.delete_doc("Resource Allocation", name)
+        return {"success": True}
+
+    recurrence_id = frappe.db.get_value("Resource Allocation", name, "recurrence_id")
+    if not recurrence_id:
+        frappe.delete_doc("Resource Allocation", name)
+        return {"success": True}
+
+    filters = {"recurrence_id": recurrence_id}
+    if delete_mode == "this_and_future":
+        this_start = frappe.db.get_value("Resource Allocation", name, "allocation_start_date")
+        filters["allocation_start_date"] = [">=", this_start]
+
+    names = frappe.db.get_all("Resource Allocation", filters=filters, pluck="name")
+    for doc_name in names:
+        frappe.delete_doc("Resource Allocation", doc_name)
+    return {"success": True}

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -119,6 +119,12 @@ def handle_allocation(allocation: AllocationPayload, repeat_till_week_count: int
     if not permission["write"]:
         return frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
 
+    if allocation.name:
+        frappe.throw(
+            frappe._("Use edit_allocation to update an existing allocation."),
+            exc=frappe.ValidationError,
+        )
+
     if allocation.include_weekends and not cint(
         frappe.db.get_single_value("Timesheet Settings", "allow_weekend_entries")
     ):
@@ -128,9 +134,6 @@ def handle_allocation(allocation: AllocationPayload, repeat_till_week_count: int
             ),
             exc=frappe.ValidationError,
         )
-
-    if allocation.name:
-        return update_allocation(allocation)
 
     return add_allocation(allocation, repeat_till_week_count)
 
@@ -248,19 +251,79 @@ def update_allocation(allocation: AllocationPayload):
     return allocation_doc
 
 
+def upsert_day_override(doc_name: str, override_date: str, override_fields: dict):
+    """Add or update a single day override row on a Resource Allocation doc.
+
+    If a row already exists for the given date it is updated in-place; otherwise
+    a new row is appended and the parent doc is saved.
+
+    Args:
+        doc_name (str): Name of the Resource Allocation document.
+        override_date (str): The specific date to override (``"YYYY-MM-DD"``).
+        override_fields (dict): Fields to set on the row, e.g. ``{"cancelled": 1}``
+                                or ``{"hours": 4.0}``.
+    """
+    existing_row = frappe.db.get_value(
+        "Resource Allocation Extra Entry",
+        {"parent": doc_name, "parenttype": "Resource Allocation", "date": override_date},
+        "name",
+    )
+    if existing_row:
+        frappe.db.set_value("Resource Allocation Extra Entry", existing_row, override_fields)
+    else:
+        doc = frappe.get_doc("Resource Allocation", doc_name)
+        doc.append("override", {"date": override_date, **override_fields})
+        doc.save()
+
+
 @frappe.whitelist(methods=["POST"])
-def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload):
+def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, day_override: dict | None = None):
     """Edit a Resource Allocation, optionally propagating changes to all docs in the series.
 
     Args:
         name (str): Name of the allocation being edited.
         edit_mode (str): ``"only_this"`` — update just this doc.
                          ``"whole_series"`` — update all docs sharing the same ``recurrence_id``.
-        allocation (AllocationPayload): New field values.
+                         ``"this_and_future"`` — used with ``day_override`` to apply a per-day
+                         change to this doc and all later docs in the series.
+        allocation (AllocationPayload): New field values (ignored when ``day_override`` is provided).
+        day_override (dict | None): Optional per-day override, e.g. ``{"date": "2025-06-05", "cancelled": 1}``
+                                    or ``{"date": "2025-06-05", "hours": 4.0}``.
+                                    When provided, ``edit_mode`` controls scope:
+                                    ``"only_this"`` — apply to this doc only.
+                                    ``"this_and_future"`` — apply to this and all later docs in the series,
+                                    targeting the same weekday in each doc's range.
     """
     permission = resource_api_permissions_check()
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    if day_override:
+        override_date = getdate(day_override.get("date"))
+        override_fields = {k: v for k, v in day_override.items() if k != "date"}
+
+        if edit_mode == "this_and_future":
+            recurrence_id, this_start = frappe.db.get_value(
+                "Resource Allocation", name, ["recurrence_id", "allocation_start_date"]
+            )
+            if recurrence_id:
+                series = frappe.get_all(
+                    "Resource Allocation",
+                    filters={"recurrence_id": recurrence_id, "allocation_start_date": [">=", this_start]},
+                    fields=["name", "allocation_start_date", "allocation_end_date"],
+                )
+                target_weekday = override_date.weekday()
+                for series_doc in series:
+                    doc_start = getdate(series_doc.allocation_start_date)
+                    doc_end = getdate(series_doc.allocation_end_date)
+                    offset = (target_weekday - doc_start.weekday()) % 7
+                    target_date = doc_start + timedelta(days=offset)
+                    if target_date <= doc_end:
+                        upsert_day_override(series_doc.name, str(target_date), override_fields)
+                return {"success": True}
+
+        upsert_day_override(name, str(override_date), override_fields)
+        return {"success": True}
 
     allocation.name = name
 
@@ -306,6 +369,12 @@ def delete_allocation(name: str, delete_mode: str):
     permission = resource_api_permissions_check()
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    if not frappe.db.exists("Resource Allocation", name):
+        frappe.throw(
+            frappe._("Resource Allocation {0} does not exist.").format(name),
+            exc=frappe.DoesNotExistError,
+        )
 
     if delete_mode == "only_this":
         frappe.delete_doc("Resource Allocation", name)

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -13,6 +13,7 @@ from next_pms.resource_management.api.utils.helpers import (
     resource_api_permissions_check,
 )
 from next_pms.resource_management.api.utils.query import (
+    attach_extra_entries,
     get_allocation_list_for_employee_for_given_range,
     get_allocation_worked_hours_for_given_employee,
     get_allocation_worked_hours_for_given_projects,
@@ -91,6 +92,7 @@ def get_resource_management_project_view_data(
             "modified_by",
             "modified",
             "creation",
+            "recurrence_id",
         ],
         "project",
         [project.name for project in projects],
@@ -98,6 +100,7 @@ def get_resource_management_project_view_data(
         weeks[-1].get("end_date"),
         is_billable,
     )
+    resource_allocation_data = attach_extra_entries(resource_allocation_data)
 
     resource_allocation_map = {}
     user_info_cache = {}
@@ -252,6 +255,7 @@ def get_employees_resrouce_data_for_given_project(project: str, start_date: str,
             "modified_by",
             "modified",
             "creation",
+            "recurrence_id",
         ],
         "project",
         [project],
@@ -259,6 +263,7 @@ def get_employees_resrouce_data_for_given_project(project: str, start_date: str,
         end_date,
         is_billable,
     )
+    resource_allocation_data = attach_extra_entries(resource_allocation_data)
 
     resource_allocation_map = {}
     user_info_cache = {}

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -13,6 +13,7 @@ from next_pms.resource_management.api.utils.helpers import (
     resource_api_permissions_check,
 )
 from next_pms.resource_management.api.utils.query import (
+    attach_extra_entries,
     get_allocation_list_for_employee_for_given_range,
     get_employee_leaves,
 )
@@ -306,6 +307,7 @@ def get_resource_management_team_view_data(
             "modified",
             "creation",
             "status",
+            "recurrence_id",
         ],
         "employee",
         [employee.name for employee in employees],
@@ -315,6 +317,7 @@ def get_resource_management_team_view_data(
         allocation_status=allocation_status,
         is_need_fetch_all_weeks=not need_hours_summary,
     )
+    resource_allocation_data = attach_extra_entries(resource_allocation_data)
 
     # Make the map of resource allocation data for given employee
     resource_allocation_map = {}

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -135,6 +135,39 @@ def _normalize_is_billable_filter(is_billable: list | int | None) -> list[int]:
     return [int(v) for v in is_billable]
 
 
+def attach_extra_entries(allocations: list[dict]) -> list[dict]:
+    """Batch-fetch all Resource Allocation Extra Entry rows for a list of allocations and attach them in-place.
+
+    Issues one query regardless of how many allocations are on the page, avoiding N+1.
+
+    Args:
+        allocations: List of Resource Allocation dicts — each must have a ``"name"`` key.
+
+    Returns:
+        The same list, each dict now containing an ``"override"`` key with a
+        (possibly empty) list of extra entry row dicts.
+    """
+    if not allocations:
+        return allocations
+
+    parent_names = [a["name"] for a in allocations]
+    rows = frappe.db.get_all(
+        "Resource Allocation Extra Entry",
+        filters={"parent": ["in", parent_names], "parenttype": "Resource Allocation"},
+        fields=["name", "parent", "date", "hours", "cancelled"],
+        order_by="parent, date",
+    )
+
+    by_parent: dict[str, list] = {}
+    for row in rows:
+        by_parent.setdefault(row["parent"], []).append(row)
+
+    for alloc in allocations:
+        alloc["override"] = by_parent.get(alloc["name"], [])
+
+    return allocations
+
+
 def get_allocation_worked_hours_for_given_projects(project: str, start_date: str, end_date: str):
     """Get the total hours spend for given projects for given time range.
 

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.json
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.json
@@ -10,6 +10,7 @@
   "employee_name",
   "status",
   "is_billable",
+  "reccurence_id",
   "column_break_wngn",
   "project",
   "project_name",
@@ -27,7 +28,9 @@
   "column_break_zhca",
   "total_cost",
   "section_break_dysk",
-  "note"
+  "note",
+  "section_break_muzg",
+  "override"
  ],
  "fields": [
   {
@@ -165,12 +168,29 @@
    "options": "currency",
    "permlevel": 2,
    "read_only": 1
+  },
+  {
+   "fieldname": "reccurence_id",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Reccurence ID",
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_muzg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "override",
+   "fieldtype": "Table",
+   "label": "Override",
+   "options": "Resource Allocation Extra Entry"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-29 15:07:08.787165",
+ "modified": "2026-05-28 16:06:07.436328",
  "modified_by": "Administrator",
  "module": "Resource Management",
  "name": "Resource Allocation",

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.json
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.json
@@ -10,7 +10,7 @@
   "employee_name",
   "status",
   "is_billable",
-  "reccurence_id",
+  "recurrence_id",
   "column_break_wngn",
   "project",
   "project_name",
@@ -170,13 +170,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "reccurence_id",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Reccurence ID",
-   "search_index": 1
-  },
-  {
    "fieldname": "section_break_muzg",
    "fieldtype": "Section Break"
   },
@@ -185,12 +178,19 @@
    "fieldtype": "Table",
    "label": "Override",
    "options": "Resource Allocation Extra Entry"
+  },
+  {
+   "fieldname": "recurrence_id",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Recurrence ID",
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-28 16:06:07.436328",
+ "modified": "2026-05-28 16:18:35.637846",
  "modified_by": "Administrator",
  "module": "Resource Management",
  "name": "Resource Allocation",

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
@@ -40,7 +40,7 @@ class ResourceAllocation(Document):
         override: DF.Table[ResourceAllocationExtraEntry]
         project: DF.Link | None
         project_name: DF.Data | None
-        reccurence_id: DF.Data | None
+        recurrence_id: DF.Data | None
         status: DF.Literal["Tentative", "Confirmed"]
         total_allocated_hours: DF.Float
         total_cost: DF.Currency

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
@@ -14,6 +14,38 @@ from next_pms.resource_management.api.team import get_resource_management_team_v
 
 
 class ResourceAllocation(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from next_pms.resource_management.doctype.resource_allocation_extra_entry.resource_allocation_extra_entry import (
+            ResourceAllocationExtraEntry,
+        )
+
+        allocation_end_date: DF.Date
+        allocation_start_date: DF.Date
+        currency: DF.Link | None
+        customer: DF.Link
+        employee: DF.Link
+        employee_name: DF.Data | None
+        hourly_cost_rate: DF.Currency
+        hours_allocated_per_day: DF.Float
+        is_billable: DF.Check
+        naming_series: DF.Literal["RA-.{employee}.-.YYYY.-.####."]
+        note: DF.Text | None
+        override: DF.Table[ResourceAllocationExtraEntry]
+        project: DF.Link | None
+        project_name: DF.Data | None
+        reccurence_id: DF.Data | None
+        status: DF.Literal["Tentative", "Confirmed"]
+        total_allocated_hours: DF.Float
+        total_cost: DF.Currency
+    # end: auto-generated types
+
     def validate(self):
         if self.allocation_end_date < self.allocation_start_date:
             frappe.throw(frappe._("End date should be greater than or equal to start date"))

--- a/next_pms/resource_management/doctype/resource_allocation_extra_entry/resource_allocation_extra_entry.json
+++ b/next_pms/resource_management/doctype/resource_allocation_extra_entry/resource_allocation_extra_entry.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-05-28 16:01:09.817816",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "hours",
+  "cancelled"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "hours",
+   "fieldtype": "Float",
+   "label": "Hours",
+   "read_only_depends_on": "eval:doc.cancelled"
+  },
+  {
+   "default": "0",
+   "fieldname": "cancelled",
+   "fieldtype": "Check",
+   "label": "Cancelled",
+   "read_only_depends_on": "eval:doc.hours>0"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-05-28 16:10:27.593873",
+ "modified_by": "Administrator",
+ "module": "Resource Management",
+ "name": "Resource Allocation Extra Entry",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/next_pms/resource_management/doctype/resource_allocation_extra_entry/resource_allocation_extra_entry.py
+++ b/next_pms/resource_management/doctype/resource_allocation_extra_entry/resource_allocation_extra_entry.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ResourceAllocationExtraEntry(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        cancelled: DF.Check
+        date: DF.Date
+        hours: DF.Float
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+    # end: auto-generated types
+
+    pass


### PR DESCRIPTION
## Description 

* Added a new child DocType, `Resource Allocation Extra Entry`, and related table field `override` to `Resource Allocation` for storing per-day overrides such as adjusted hours or cancellations. 
* Introduced the `recurrence_id` field to `Resource Allocation` to group allocations in a recurring series. 
* Added new API endpoints: `edit_allocation` and `delete_allocation`, allowing edits and deletions to apply to a single allocation, all future allocations, or the entire series, utilizing the `recurrence_id`.
* Implemented `upsert_day_override` to efficiently add or update per-day override entries for allocations.
* Updated `handle_allocation` and `add_allocation` to generate and propagate `recurrence_id` for recurring allocations, ensuring all series members are linked. 
* Added `attach_extra_entries` utility to batch-fetch all extra entry rows for allocations, avoiding N+1 queries and attaching override data to each allocation dict.
* Integrated `attach_extra_entries` into project and team view API endpoints to ensure override data is available in responses.
* Improved validation and error handling for series operations, including checks for permissions, valid modes, and existence of allocations.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
1. Create recurring allocation 
<img width="1213" height="564" alt="Screenshot 2026-06-01 at 2 04 13 PM" src="https://github.com/user-attachments/assets/b7dfc676-8ff3-41b3-8a7f-d9590b344153" />

2. Edit singular allocation to override a singular day 
<img width="1217" height="664" alt="Screenshot 2026-06-01 at 2 06 42 PM" src="https://github.com/user-attachments/assets/c9ee0965-11c1-43ec-a10f-d6cfaf599794" />

3. Edit recurring allocation to override a singular day
<img width="1201" height="628" alt="Screenshot 2026-06-01 at 2 09 36 PM" src="https://github.com/user-attachments/assets/4ce456f0-018c-481d-88a4-d3f4de7e4880" />

4. Delete recurring allocation 
<img width="1222" height="334" alt="Screenshot 2026-06-01 at 2 10 04 PM" src="https://github.com/user-attachments/assets/555a2daf-ff7e-4ba9-8637-45ead08b92f5" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #973 