### PR TITLE
Refactor: Update frontend to consume new project timeline api

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
@@ -53,11 +53,7 @@ export function CalendarTab() {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
-  const { items, monthItems, mutate } = useProjectTimelineItems(
-    projectId,
-    year,
-    month,
-  );
+  const { items, mutate } = useProjectTimelineItems(projectId, year, month);
 
   const filteredItems =
     filterType === "all"
@@ -185,7 +181,7 @@ export function CalendarTab() {
         <div className="overflow-x-auto">
           {tableTab === "milestones" ? (
             <MilestonesTable
-              items={monthItems}
+              items={items}
               userId={userId}
               onEdit={handleEdit}
               onMarkAsCompleted={handleMarkAsCompleted}
@@ -193,7 +189,7 @@ export function CalendarTab() {
             />
           ) : (
             <TouchpointsTable
-              items={monthItems}
+              items={items}
               userId={userId}
               onEdit={handleEdit}
               onMarkAsCompleted={handleMarkAsCompleted}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
@@ -1,14 +1,7 @@
 /**
  * External dependencies.
  */
-import { useMemo } from "react";
-import {
-  differenceInDays,
-  endOfISOWeek,
-  endOfMonth,
-  format,
-  startOfISOWeek,
-} from "date-fns";
+import { endOfISOWeek, endOfMonth, format, startOfISOWeek } from "date-fns";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
@@ -75,7 +68,6 @@ export function useProjectTimelineItems(
   // Fetch window: ISO week containing the 1st → ISO week containing the last day of the month
   const viewStart = startOfISOWeek(new Date(year, month, 1));
   const viewEnd = endOfISOWeek(endOfMonth(new Date(year, month, 1)));
-  const weeksCount = Math.round((differenceInDays(viewEnd, viewStart) + 1) / 7);
   const startDate = format(viewStart, "yyyy-MM-dd");
   const endDate = format(viewEnd, "yyyy-MM-dd");
 
@@ -86,7 +78,7 @@ export function useProjectTimelineItems(
     {
       project: projectId,
       start_date: startDate,
-      max_week: weeksCount,
+      end_date: endDate,
       limit: ITEMS_LIMIT,
       start: 0,
     },
@@ -97,28 +89,11 @@ export function useProjectTimelineItems(
     },
   );
 
-  const { items, monthItems } = useMemo(() => {
-    const allItems = (data?.message?.data ?? [])
-      .filter((item) =>
-        item.type === "Milestone"
-          ? item.start_date !== null
-          : item.planned_end_date !== null,
-      )
-      .map(mapItem);
+  const allItems = (data?.message?.data ?? [])
+    .filter(
+      (item) => item.start_date !== null && item.planned_end_date !== null,
+    )
+    .map(mapItem);
 
-    // Milestones are positioned by start_date; touchpoints by planned_end_date.
-    const viewItems = allItems.filter((item) =>
-      item.type === "Milestone"
-        ? item.startDate !== undefined &&
-          item.startDate >= startDate &&
-          item.startDate <= endDate
-        : item.plannedEndDate !== undefined &&
-          item.plannedEndDate >= startDate &&
-          item.plannedEndDate <= endDate,
-    );
-
-    return { items: viewItems, monthItems: viewItems };
-  }, [data, startDate, endDate]);
-
-  return { items, monthItems, isLoading, error, mutate };
+  return { items: allItems, isLoading, error, mutate };
 }


### PR DESCRIPTION
## Description
- Updated the calendar page frontend to use the API - https://github.com/rtCamp/next-pms/issues/1382
- Now we use interval overlap on backend so we don't need any filtering on frontend.
- No other change, everything should work and look the same.

## Screenshot/Screencast
<img width="1876" height="1312" alt="image" src="https://github.com/user-attachments/assets/880036f5-f29c-4b39-869d-3549546d00fb" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)