### PR TITLE
Fix: Project risk page fixes

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/risks/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/constants.ts
@@ -26,7 +26,7 @@ export type RiskStatus = (typeof RISK_STATUSES)[number];
 export const RISK_LIST_COLUMNS = [
   { key: "risk_category", label: "Risk category", width: "128px", flex: 1 },
   { key: "summary", label: "Risk Summary", width: "264px", flex: 4 },
-  { key: "owner", label: "Owner", width: "128px", flex: 0 },
+  { key: "owner", label: "Owner", width: "140px", flex: 0 },
   { key: "risk_level", label: "Risk level", width: "74px", flex: 0 },
   { key: "status", label: "Status", width: "120px", flex: 1 },
 ] as const;

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/detail/riskDetailContent.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/detail/riskDetailContent.tsx
@@ -55,7 +55,7 @@ export function RiskDetailContent({
             variant="ghost"
             onClick={() => {}}
             aria-label="Add document"
-            iconLeft={() => <Plus />}
+            icon={() => <Plus />}
           />
         </div>
 
@@ -79,7 +79,7 @@ export function RiskDetailContent({
             variant="ghost"
             onClick={() => {}}
             aria-label="Add update"
-            iconLeft={() => <Plus />}
+            icon={() => <Plus />}
           />
         </div>
 

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/detail/riskDetailHeader.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/detail/riskDetailHeader.tsx
@@ -45,7 +45,7 @@ export function RiskDetailHeader({
           type="button"
           onClick={handleBack}
           className="p-0 hover:bg-transparent focus-visible:bg-transparent"
-          iconLeft={() => <ArrowLeft />}
+          icon={() => <ArrowLeft />}
         />
 
         <h2 className="text-xl font-semibold text-ink-gray-8 truncate max-w-125">
@@ -79,7 +79,7 @@ export function RiskDetailHeader({
           variant="ghost"
           type="button"
           onClick={() => {}}
-          iconLeft={() => <MoreHorizontal />}
+          icon={() => <MoreHorizontal />}
         />
       </div>
     </div>

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/detail/updateEntry.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/detail/updateEntry.tsx
@@ -58,7 +58,7 @@ export function UpdateEntry({ entry }: UpdateEntryProps) {
                 className="ml-auto"
                 onClick={() => {}}
                 aria-label="Entry options"
-                iconLeft={() => <MoreHorizontal />}
+                icon={() => <MoreHorizontal />}
               />
             </div>
           )}

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/kanban/kanbanColumnHeader.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/kanban/kanbanColumnHeader.tsx
@@ -20,7 +20,12 @@ export function KanbanColumnHeader({ status, onAdd }: KanbanColumnHeaderProps) {
     <div className="flex items-center justify-between px-1.5">
       <RiskStatusBadge status={status} className="text-base" />
 
-      <Button variant="ghost" type="button" onClick={onAdd} iconLeft={Plus} />
+      <Button
+        variant="ghost"
+        type="button"
+        onClick={onAdd}
+        icon={() => <Plus />}
+      />
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/list/listViewGroup.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/list/listViewGroup.tsx
@@ -80,7 +80,7 @@ export function RiskGroup({ value, label, risks }: RiskGroupProps) {
               }}
               className="truncate text-ink-gray-7 px-2 py-1.5"
             >
-              <div className="flex items-center gap-2 mb-2">
+              <div className="flex items-center gap-2">
                 <Avatar
                   size="xs"
                   shape="circle"
@@ -124,7 +124,7 @@ export function RiskGroup({ value, label, risks }: RiskGroupProps) {
                   e.stopPropagation();
                   openRowActions(risk.name);
                 }}
-                iconLeft={() => <MoreHorizontal />}
+                icon={() => <MoreHorizontal />}
               />
             </div>
           </div>


### PR DESCRIPTION
## Description
- Fix icon name prop
- Fix owner alignment in list view

## Additional Information:
- Unable to replicate the kanban double border issue
- Unable to replicate owner column miss alignment issue (checked multiple resolutions - screenshot attached)

## Screenshot/Screencast
<img width="1788" height="808" alt="image" src="https://github.com/user-attachments/assets/1375d4b0-be29-4b8f-a36e-7bc1285411bf" />

<img width="1866" height="1120" alt="image" src="https://github.com/user-attachments/assets/38d8045b-28b4-4fb6-9577-a0eb4340cb19" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)