### PR TITLE
fix: remove base64 string for user_image

### DIFF
--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -4,7 +4,7 @@ import frappe
 from frappe.automation.doctype.auto_repeat.auto_repeat import getdate
 from frappe.core.doctype.recorder.recorder import redis_cache
 from frappe.email.doctype.auto_email_report.auto_email_report import DATE_FORMAT
-from frappe.utils import add_days, get_gravatar
+from frappe.utils import add_days
 
 from next_pms.resource_management.api.utils.helpers import (
     add_customer_data_if_not_exists,
@@ -121,9 +121,10 @@ def get_resource_management_project_view_data(
         modified_by = resource_allocation.get("modified_by")
         if modified_by:
             if modified_by not in user_info_cache:
+                user_data = frappe.db.get_value("User", modified_by, ["full_name", "user_image"], as_dict=True)
                 user_info_cache[modified_by] = {
-                    "avatar": get_gravatar(modified_by),
-                    "full_name": frappe.db.get_value("User", modified_by, "full_name"),
+                    "avatar": user_data.user_image if user_data else None,
+                    "full_name": user_data.full_name if user_data else None,
                 }
             resource_allocation["modified_by_avatar"] = user_info_cache[modified_by]["avatar"]
             resource_allocation["modified_by_full_name"] = user_info_cache[modified_by]["full_name"]
@@ -271,9 +272,10 @@ def get_employees_resrouce_data_for_given_project(project: str, start_date: str,
         modified_by = resource_allocation.get("modified_by")
         if modified_by:
             if modified_by not in user_info_cache:
+                user_data = frappe.db.get_value("User", modified_by, ["full_name", "user_image"], as_dict=True)
                 user_info_cache[modified_by] = {
-                    "avatar": get_gravatar(modified_by),
-                    "full_name": frappe.db.get_value("User", modified_by, "full_name"),
+                    "avatar": user_data.user_image if user_data else None,
+                    "full_name": user_data.full_name if user_data else None,
                 }
             resource_allocation["modified_by_avatar"] = user_info_cache[modified_by]["avatar"]
             resource_allocation["modified_by"] = user_info_cache[modified_by]["full_name"]

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -1,7 +1,7 @@
 import frappe
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from frappe.core.doctype.recorder.recorder import redis_cache
-from frappe.utils import DATE_FORMAT, get_gravatar, getdate
+from frappe.utils import DATE_FORMAT, getdate
 
 from next_pms.resource_management.api.utils.helpers import (
     add_customer_data_if_not_exists,
@@ -326,9 +326,10 @@ def get_resource_management_team_view_data(
         modified_by = resource_allocation.get("modified_by") or resource_allocation.get("created_by")
         if modified_by:
             if modified_by not in user_info_cache:
+                user_data = frappe.db.get_value("User", modified_by, ["full_name", "user_image"], as_dict=True)
                 user_info_cache[modified_by] = {
-                    "avatar": get_gravatar(modified_by),
-                    "full_name": frappe.db.get_value("User", modified_by, "full_name"),
+                    "avatar": user_data.user_image if user_data else None,
+                    "full_name": user_data.full_name if user_data else None,
                 }
             resource_allocation["modified_by_avatar"] = user_info_cache[modified_by]["avatar"]
             resource_allocation["modified_by_full_name"] = user_info_cache[modified_by]["full_name"]


### PR DESCRIPTION
## Description

* Replaced the use of `get_gravatar` and separate `frappe.db.get_value` calls with a single call to fetch both `full_name` and `user_image` for the user. The avatar is now set to the user's uploaded image if available, otherwise `None`. This change is applied in the following functions:
  - `get_resource_management_project_view_data` in `project.py`
  - `get_employees_resrouce_data_for_given_project` in `project.py`
  - `get_resource_management_team_view_data` in `team.py`


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/997#issuecomment-4595068827