### PR TITLE
fix: send user full name and prevent type error on repository project boards API

### DIFF
--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -86,7 +86,10 @@ def generate_pm_report(
             "drive_link": drive_link,
         },
         **({"previous_doc_url": previous_doc_url} if previous_doc_url else {}),
-        "user_metadata": {"user_name": frappe.session.user, "user_email": frappe.session.user},
+        "user_metadata": {
+            "user_name": frappe.utils.get_fullname(frappe.session.user),
+            "user_email": frappe.session.user,
+        },
         "github_metadata": get_github_metadata(project_doc, selected_repo=selected_repo, selected_board=selected_board),
         "slack_metadata": {"channel_slug": project_doc.get("custom_slack_channel_slug") or ""},
         "hours_breakdown": get_hours_breakdown(project, from_date, to_date),
@@ -492,7 +495,9 @@ def _is_valid_document_url(url: str) -> bool:
 
 
 @frappe.whitelist()
-def get_repository_project_boards(repository: str) -> list[str]:
+def get_repository_project_boards(repository: str | None = None) -> list[str]:
+    if not repository:
+        return []
     try:
         repo_doc = frappe.get_doc("GitHub Repository", repository)
         return [b.board_name for b in repo_doc.get("project_boards") or [] if b.board_name]


### PR DESCRIPTION
## Description

- Sends the user's full name instead of their email in the API payload.
- Resolves a TypeError crash during page load on get_repository_project_boards.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #