### PR TITLE
fix: allow multiple overrides in single call

### DIFF
--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -259,52 +259,65 @@ def upsert_day_override(doc_name: str, override_date: str, override_fields: dict
     If a row already exists for the given date it is updated in-place; otherwise
     a new row is appended and the parent doc is saved.
 
+    ``hours`` and ``cancelled`` are mutually exclusive:
+    - Setting ``cancelled=1`` clears ``hours`` to 0.
+    - Setting ``hours`` to a value clears ``cancelled`` to 0.
+
     Args:
         doc_name (str): Name of the Resource Allocation document.
         override_date (str): The specific date to override (``"YYYY-MM-DD"``).
         override_fields (dict): Fields to set on the row, e.g. ``{"cancelled": 1}``
                                 or ``{"hours": 4.0}``.
     """
+    fields = dict(override_fields)
+    if fields.get("cancelled") and fields.get("hours"):
+        frappe.throw(
+            frappe._("A day override cannot set both 'hours' and 'cancelled'. Use one or the other."),
+            exc=frappe.ValidationError,
+        )
+    if fields.get("cancelled"):
+        fields["hours"] = 0
+    elif fields.get("hours") is not None:
+        fields["cancelled"] = 0
+
     existing_row = frappe.db.get_value(
         "Resource Allocation Extra Entry",
         {"parent": doc_name, "parenttype": "Resource Allocation", "date": override_date},
         "name",
     )
     if existing_row:
-        frappe.db.set_value("Resource Allocation Extra Entry", existing_row, override_fields)
+        frappe.db.set_value("Resource Allocation Extra Entry", existing_row, fields)
         clear_cache()  # set_value bypasses on_update, so invalidate manually
     else:
         doc = frappe.get_doc("Resource Allocation", doc_name)
-        doc.append("override", {"date": override_date, **override_fields})
+        doc.append("override", {"date": override_date, **fields})
         doc.save()
 
 
 @frappe.whitelist(methods=["POST"])
-def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, day_override: dict | None = None):
+def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, day_overrides: list[dict] | None = None):
     """Edit a Resource Allocation, optionally propagating changes to all docs in the series.
 
     Args:
         name (str): Name of the allocation being edited.
         edit_mode (str): ``"only_this"`` — update just this doc.
                          ``"whole_series"`` — update all docs sharing the same ``recurrence_id``.
-                         ``"this_and_future"`` — used with ``day_override`` to apply a per-day
-                         change to this doc and all later docs in the series.
-        allocation (AllocationPayload): New field values (ignored when ``day_override`` is provided).
-        day_override (dict | None): Optional per-day override, e.g. ``{"date": "2025-06-05", "cancelled": 1}``
-                                    or ``{"date": "2025-06-05", "hours": 4.0}``.
-                                    When provided, ``edit_mode`` controls scope:
-                                    ``"only_this"`` — apply to this doc only.
-                                    ``"this_and_future"`` — apply to this and all later docs in the series,
-                                    targeting the same weekday in each doc's range.
+                         ``"this_and_future"`` — used with ``day_overrides`` to apply per-day
+                         changes to this doc and all later docs in the series.
+        allocation (AllocationPayload): New field values (ignored when ``day_overrides`` is provided).
+        day_overrides (list[dict] | None): Optional list of per-day overrides, each a dict with a
+                                           ``"date"`` key plus the fields to set, e.g.
+                                           ``[{"date": "2025-06-05", "cancelled": 1}, {"date": "2025-06-06", "hours": 4.0}]``.
+                                           When provided, ``edit_mode`` controls scope:
+                                           ``"only_this"`` — apply to this doc only.
+                                           ``"this_and_future"`` — apply to this and all later docs in the series,
+                                           targeting the same weekday in each doc's range.
     """
     permission = resource_api_permissions_check()
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
 
-    if day_override:
-        override_date = getdate(day_override.get("date"))
-        override_fields = {k: v for k, v in day_override.items() if k != "date"}
-
+    if day_overrides:
         if edit_mode == "this_and_future":
             recurrence_id, this_start = frappe.db.get_value(
                 "Resource Allocation", name, ["recurrence_id", "allocation_start_date"]
@@ -315,17 +328,23 @@ def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, da
                     filters={"recurrence_id": recurrence_id, "allocation_start_date": [">=", this_start]},
                     fields=["name", "allocation_start_date", "allocation_end_date"],
                 )
-                target_weekday = override_date.weekday()
-                for series_doc in series:
-                    doc_start = getdate(series_doc.allocation_start_date)
-                    doc_end = getdate(series_doc.allocation_end_date)
-                    offset = (target_weekday - doc_start.weekday()) % 7
-                    target_date = doc_start + timedelta(days=offset)
-                    if target_date <= doc_end:
-                        upsert_day_override(series_doc.name, str(target_date), override_fields)
+                for override in day_overrides:
+                    override_date = getdate(override.get("date"))
+                    override_fields = {k: v for k, v in override.items() if k != "date"}
+                    target_weekday = override_date.weekday()
+                    for series_doc in series:
+                        doc_start = getdate(series_doc.allocation_start_date)
+                        doc_end = getdate(series_doc.allocation_end_date)
+                        offset = (target_weekday - doc_start.weekday()) % 7
+                        target_date = doc_start + timedelta(days=offset)
+                        if target_date <= doc_end:
+                            upsert_day_override(series_doc.name, str(target_date), override_fields)
                 return {"success": True}
 
-        upsert_day_override(name, str(override_date), override_fields)
+        for override in day_overrides:
+            override_date = getdate(override.get("date"))
+            override_fields = {k: v for k, v in override.items() if k != "date"}
+            upsert_day_override(name, str(override_date), override_fields)
         return {"success": True}
 
     allocation.name = name

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -270,14 +270,18 @@ def upsert_day_override(doc_name: str, override_date: str, override_fields: dict
                                 or ``{"hours": 4.0}``.
     """
     fields = dict(override_fields)
-    if fields.get("cancelled") and fields.get("hours"):
+    is_cancelled = cint(fields.get("cancelled")) == 1
+    has_hours = fields.get("hours") is not None
+
+    if is_cancelled and has_hours:
         frappe.throw(
             frappe._("A day override cannot set both 'hours' and 'cancelled'. Use one or the other."),
             exc=frappe.ValidationError,
         )
-    if fields.get("cancelled"):
+    if is_cancelled:
+        fields["cancelled"] = 1
         fields["hours"] = 0
-    elif fields.get("hours") is not None:
+    elif has_hours:
         fields["cancelled"] = 0
 
     existing_row = frappe.db.get_value(


### PR DESCRIPTION
## Description

* Enforced mutual exclusivity between `hours` and `cancelled` in the `upsert_day_override` function: setting one will clear the other, and an error is thrown if both are set simultaneously.
* Updated the override logic so that if `cancelled` is set, `hours` is forced to 0, and if `hours` is set, `cancelled` is forced to 0.
* Modified the `edit_allocation` function to accept a list of per-day overrides (`day_overrides`) instead of a single override, allowing multiple days to be overridden in a single call.
* Updated the logic in `edit_allocation` to iterate over the list of overrides, applying each to the relevant documents in the series or to a single document, depending on the edit mode. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**API Call**:
<img width="1019" height="631" alt="image" src="https://github.com/user-attachments/assets/55105dff-e86f-4ac0-8e4c-7353c1eec81e" />

**Desk View**:
<img width="956" height="671" alt="image" src="https://github.com/user-attachments/assets/65420589-2b4f-4944-957b-cf4cc5747d38" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #968 