### PR TITLE
fix: add created by and permission lock

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/risks/add-update/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/add-update/index.tsx
@@ -66,6 +66,7 @@ export function AddUpdateModal({
           risk_level: e.risk_level,
           note: e.note,
           updated_at: e.updated_at,
+          updated_by: e.updated_by,
         }));
 
         if (isEditing && editEntry) {

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/detail/updateEntry.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/detail/updateEntry.tsx
@@ -19,7 +19,7 @@ interface UpdateEntryProps {
 }
 
 export function UpdateEntry({ entry, onEdit, onDelete }: UpdateEntryProps) {
-  const userDetails = entry.owner_details;
+  const userDetails = entry.updated_by_details;
   const filteredNote = entry.note ? stripTags(entry.note) : "";
 
   return (
@@ -30,11 +30,11 @@ export function UpdateEntry({ entry, onEdit, onDelete }: UpdateEntryProps) {
           size="sm"
           shape="circle"
           image={userDetails?.user_image ?? undefined}
-          label={userDetails?.full_name ?? entry.owner}
+          label={userDetails?.full_name ?? entry.updated_by}
         />
 
         <span className="text-sm font-medium text-ink-gray-9">
-          {userDetails?.full_name ?? entry.owner}
+          {userDetails?.full_name ?? entry.updated_by}
         </span>
         <span className="text-sm text-ink-gray-5">posted an update.</span>
         <span className="ml-auto text-xs text-ink-gray-5">

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/detail/useRiskDetail.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/detail/useRiskDetail.ts
@@ -29,7 +29,7 @@ export function useRiskDetail(riskId: string) {
     if (!risk) return [];
     const emails = [
       risk.owner,
-      ...(risk.risk_update_log?.map((e) => e.owner) ?? []),
+      ...(risk.risk_update_log?.map((e) => e.updated_by) ?? []),
     ].filter(Boolean) as string[];
     return [...new Set(emails)];
   }, [risk]);
@@ -85,7 +85,7 @@ export function useRiskDetail(riskId: string) {
     const enrichedLog: EnrichedRiskUpdateEntry[] = (risk.risk_update_log ?? [])
       .map((entry) => ({
         ...entry,
-        owner_details: usersMap[entry.owner] ?? null,
+        updated_by_details: usersMap[entry.updated_by] ?? null,
       }))
       .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
     return {

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/types.ts
@@ -36,7 +36,7 @@ export interface RiskItem extends ApiRiskItem {
 
 export interface RiskUpdateEntry {
   name: string;
-  owner: string;
+  updated_by: string;
   updated_at: string;
   risk_level: string | null;
   status: string | null;
@@ -46,7 +46,7 @@ export interface RiskUpdateEntry {
 }
 
 export interface EnrichedRiskUpdateEntry extends RiskUpdateEntry {
-  owner_details?: UserDetails | null;
+  updated_by_details?: UserDetails | null;
 }
 
 export interface ApiRiskDetail extends ApiRiskItem {

--- a/next_pms/next_pms/doctype/risk/risk.json
+++ b/next_pms/next_pms/doctype/risk/risk.json
@@ -103,7 +103,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-19 14:54:58.172524",
+ "modified": "2026-06-08 18:32:32.589236",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Risk",
@@ -133,6 +133,28 @@
    "role": "Projects Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects Manager",
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/next_pms/next_pms/doctype/risk/risk.py
+++ b/next_pms/next_pms/doctype/risk/risk.py
@@ -28,6 +28,7 @@ class Risk(Document):
     def before_save(self):
         self._set_updated_by_on_new_rows()
         self._prevent_deleting_others_rows()
+        self._prevent_editing_others_rows()
         self._sync_fields_from_latest_update()
 
     def _set_updated_by_on_new_rows(self):
@@ -43,13 +44,52 @@ class Risk(Document):
         existing_rows = frappe.get_all(
             "Risk Update",
             filters={"parent": self.name},
-            fields=["name", "owner"],
+            fields=["name", "updated_by"],
         )
         for row in existing_rows:
-            if row["name"] not in submitted_names and row["owner"] != frappe.session.user:
+            if row["name"] not in submitted_names and row["updated_by"] != frappe.session.user:
                 frappe.throw(
                     frappe._("You can only delete rows you created. Row created by {0} cannot be removed.").format(
-                        row["owner"]
+                        row["updated_by"]
+                    ),
+                    frappe.PermissionError,
+                )
+
+    def _prevent_editing_others_rows(self):
+        if "System Manager" in frappe.get_roles():
+            return
+
+        existing_rows = {
+            row["name"]: row
+            for row in frappe.get_all(
+                "Risk Update",
+                filters={"parent": self.name},
+                fields=["name", "updated_by", "note", "status", "risk_level", "updated_at"],
+            )
+        }
+
+        for row in self.risk_update_log:
+            # if it is a new row, skip - it is the creation flow
+            if row.is_new() or not row.name:
+                continue
+
+            prev = existing_rows.get(row.name)
+            # the user who made the row can edit it
+            if prev["updated_by"] == frappe.session.user:
+                continue
+
+            fields_changed = (
+                (row.note or None) != (prev.get("note") or None)
+                or (row.status or None) != (prev.get("status") or None)
+                or (row.risk_level or None) != (prev.get("risk_level") or None)
+                or str(row.updated_at or "") != str(prev.get("updated_at") or "")
+                or (row.updated_by or None) != (prev.get("updated_by") or None)
+            )
+
+            if fields_changed:
+                frappe.throw(
+                    frappe._("You can only edit rows you created. Row created by {0} cannot be modified.").format(
+                        prev["updated_by"]
                     ),
                     frappe.PermissionError,
                 )

--- a/next_pms/next_pms/doctype/risk/risk.py
+++ b/next_pms/next_pms/doctype/risk/risk.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, rtCamp and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -26,7 +26,31 @@ class Risk(Document):
     # end: auto-generated types
 
     def before_save(self):
+        self._set_updated_by_on_new_rows()
+        self._prevent_deleting_others_rows()
         self._sync_fields_from_latest_update()
+
+    def _set_updated_by_on_new_rows(self):
+        for row in self.risk_update_log:
+            if row.is_new():
+                row.updated_by = frappe.session.user
+
+    def _prevent_deleting_others_rows(self):
+        if "System Manager" in frappe.get_roles():
+            return
+
+        submitted_names = {row.name for row in self.risk_update_log if row.name}
+        existing_rows = frappe.get_all(
+            "Risk Update",
+            filters={"parent": self.name},
+            fields=["name", "owner"],
+        )
+        for row in existing_rows:
+            if row["name"] not in submitted_names and row["owner"] != frappe.session.user:
+                frappe.throw(
+                    f"You can only delete rows you created. Row created by {row['owner']} cannot be removed.",
+                    frappe.PermissionError,
+                )
 
     def _sync_fields_from_latest_update(self):
         if not self.risk_update_log:

--- a/next_pms/next_pms/doctype/risk/risk.py
+++ b/next_pms/next_pms/doctype/risk/risk.py
@@ -48,7 +48,9 @@ class Risk(Document):
         for row in existing_rows:
             if row["name"] not in submitted_names and row["owner"] != frappe.session.user:
                 frappe.throw(
-                    f"You can only delete rows you created. Row created by {row['owner']} cannot be removed.",
+                    frappe._("You can only delete rows you created. Row created by {0} cannot be removed.").format(
+                        row["owner"]
+                    ),
                     frappe.PermissionError,
                 )
 

--- a/next_pms/next_pms/doctype/risk_update/risk_update.json
+++ b/next_pms/next_pms/doctype/risk_update/risk_update.json
@@ -34,7 +34,8 @@
    "default": "Now",
    "fieldname": "updated_at",
    "fieldtype": "Datetime",
-   "label": "Updated At"
+   "label": "Updated At",
+   "permlevel": 1
   },
   {
    "fieldname": "updated_by",
@@ -48,7 +49,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 18:42:31.236917",
+ "modified": "2026-06-09 02:29:58.652482",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Risk Update",

--- a/next_pms/next_pms/doctype/risk_update/risk_update.json
+++ b/next_pms/next_pms/doctype/risk_update/risk_update.json
@@ -9,7 +9,8 @@
   "risk_level",
   "status",
   "note",
-  "updated_at"
+  "updated_at",
+  "updated_by"
  ],
  "fields": [
   {
@@ -34,13 +35,20 @@
    "fieldname": "updated_at",
    "fieldtype": "Datetime",
    "label": "Updated At"
+  },
+  {
+   "fieldname": "updated_by",
+   "fieldtype": "Link",
+   "label": "Updated By",
+   "options": "User",
+   "permlevel": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-20 14:49:55.321799",
+ "modified": "2026-06-08 18:42:31.236917",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Risk Update",

--- a/next_pms/next_pms/doctype/risk_update/risk_update.py
+++ b/next_pms/next_pms/doctype/risk_update/risk_update.py
@@ -21,6 +21,7 @@ class RiskUpdate(Document):
         risk_level: DF.Link | None
         status: DF.Link | None
         updated_at: DF.Datetime | None
+        updated_by: DF.Link | None
     # end: auto-generated types
 
     pass


### PR DESCRIPTION
## Description

added new field `updated_by`
added deletion lock so only row creator can delete the risk
edit hardening
frontend patch

## Relevant Technical Choices

1. frappe hooks

## Testing Instructions

1. `updated_by` field is auto filled 
<img width="1044" height="464" alt="image" src="https://github.com/user-attachments/assets/05b15913-36ec-4ca5-af08-a27db450cb4f" />
<img width="1037" height="435" alt="image" src="https://github.com/user-attachments/assets/06205823-f11e-4be3-9d2c-e6ff47293a30" />

2. the field is not editable by normal users (only system manager can)

3. deletion lock for other risk logs 
<img width="1084" height="443" alt="image" src="https://github.com/user-attachments/assets/0caec28a-a0c5-4e94-96f4-af9f01e01a9f" />

permission matrix 
<img width="1244" height="399" alt="image" src="https://github.com/user-attachments/assets/73a2dff4-1557-4719-beec-36a8607f4540" />

fixed img 
<img width="1773" height="854" alt="image" src="https://github.com/user-attachments/assets/ab3275e9-7d34-433c-bfbf-a5297d477dbc" />

stopping deletion of others
<img width="684" height="535" alt="image" src="https://github.com/user-attachments/assets/d1bdfb58-ae16-41e4-a7ff-81bf384fbeaa" />

edit hardening
<img width="569" height="261" alt="image" src="https://github.com/user-attachments/assets/583d8480-2d01-4670-859c-c8b38a1e6b37" />



## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)