### PR TITLE
fix: guard custom fields from other app referenced here

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
@@ -220,7 +220,9 @@ function OverviewForm() {
         submitting={submitting}
       />
       <Marketing form={form} isEditing={isEditing} submitting={submitting} />
-      <RepositoryConnections />
+      {window.frappe?.boot?.has_repository_connections && (
+        <RepositoryConnections />
+      )}
     </div>
   );
 }

--- a/frontend/packages/app/src/types/index.ts
+++ b/frontend/packages/app/src/types/index.ts
@@ -63,6 +63,8 @@ declare global {
         currencies?: string[];
         has_business_unit?: boolean;
         has_industry?: boolean;
+        has_repository_connections?: boolean;
+        has_customer_feedback?: boolean;
         desk_theme?: string;
         is_calendar_setup: boolean;
         global_filters: GlobalFilters;

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -361,10 +361,14 @@ def _get_project_members(project_name: str, currency: str) -> list[dict]:
     )
     user_map = {u.name: u for u in users}
 
+    employee_fields = ["name", "user_id", "designation", "department", "cell_number", "company_email"]
+    if frappe.get_meta("Employee").has_field("custom_linkedin"):
+        employee_fields.append("custom_linkedin")
+
     employees = frappe.get_all(
         "Employee",
         filters={"user_id": ["in", user_ids], "status": "Active"},
-        fields=["name", "user_id", "designation", "department", "cell_number", "company_email", "custom_linkedin"],
+        fields=employee_fields,
     )
     employee_map = {e.user_id: e for e in employees}
 
@@ -387,7 +391,7 @@ def _get_project_members(project_name: str, currency: str) -> list[dict]:
             "department": emp.department if emp else None,
             "cell_number": emp.cell_number if emp else None,
             "company_email": emp.company_email if emp else None,
-            "linkedin_url": emp.custom_linkedin if emp else None,
+            "linkedin_url": emp.get("custom_linkedin") if emp else None,
             "hourly_rate": _hourly_rate(emp.name if emp else None),
             "currency": currency if emp else None,
         }
@@ -403,20 +407,23 @@ def _get_project_customers(project_doc) -> list[dict]:
     if not contact_names:
         return []
 
+    contact_fields = [
+        "name",
+        "full_name",
+        "image",
+        "designation",
+        "company_name",
+        "email_id",
+        "phone",
+        "mobile_no",
+    ]
+    if frappe.get_meta("Contact").has_field("custom_linkedin_url"):
+        contact_fields.append("custom_linkedin_url")
+
     contacts = frappe.get_all(
         "Contact",
         filters={"name": ["in", contact_names]},
-        fields=[
-            "name",
-            "full_name",
-            "image",
-            "designation",
-            "company_name",
-            "email_id",
-            "phone",
-            "mobile_no",
-            "custom_linkedin_url",
-        ],
+        fields=contact_fields,
     )
     contact_map = {c.name: c for c in contacts}
 
@@ -429,7 +436,7 @@ def _get_project_customers(project_doc) -> list[dict]:
             "company_name": c.company_name,
             "email_id": c.email_id,
             "phone": c.phone or c.mobile_no,
-            "linkedin_url": c.custom_linkedin_url,
+            "linkedin_url": c.get("custom_linkedin_url"),
         }
         for name in contact_names
         if (c := contact_map.get(name))

--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -169,7 +169,7 @@ def filter_employees(
     if designation and len(designation) > 0:
         filters["designation"] = ["in", designation]
 
-    if business_unit and len(business_unit) > 0:
+    if business_unit and len(business_unit) > 0 and frappe.get_meta("Employee").has_field("custom_business_unit"):
         filters["custom_business_unit"] = ["in", business_unit]
 
     if ids:

--- a/next_pms/utils/employee.py
+++ b/next_pms/utils/employee.py
@@ -137,18 +137,22 @@ def generate_flat_tree(doctype: str, nsm_field: str, filters: dict, fields: list
 
 
 def employee_age_in_company(employee, end_date):
-    from frappe import get_all
+    from frappe import get_all, get_meta
     from frappe.utils import month_diff
 
     all_comapines = get_all("Company", pluck="name")
+
+    company_field = (
+        "custom_company" if get_meta("Employee Internal Work History").has_field("custom_company") else "company"
+    )
 
     all_work_history = get_all(
         "Employee Internal Work History",
         filters={
             "parent": employee.employee,
-            "custom_company": ["in", all_comapines],
+            company_field: ["in", all_comapines],
         },
-        fields=["custom_company", "from_date", "to_date"],
+        fields=[company_field, "from_date", "to_date"],
     )
 
     total_age = month_diff(end_date, employee.date_of_joining)

--- a/next_pms/www/next-pms/index.py
+++ b/next_pms/www/next-pms/index.py
@@ -4,6 +4,7 @@ import re
 import frappe
 from frappe.utils import cint
 
+from next_pms.next_projects.api.feedback import is_customer_feedback_available
 from next_pms.timesheet.api.app import has_bu_field, has_industry_field
 from next_pms.timesheet.api.project import get_project_filter_for_contractor
 from next_pms.timesheet.doctype.pms_view_setting.pms_view_setting import get_views
@@ -34,6 +35,8 @@ def get_context(context):
     boot["currencies"] = frappe.get_all("Currency", pluck="name", filters={"enabled": 1})
     boot["has_business_unit"] = has_bu_field()
     boot["has_industry"] = has_industry_field()
+    boot["has_repository_connections"] = bool(frappe.db.exists("DocType", "GitHub Repository"))
+    boot["has_customer_feedback"] = is_customer_feedback_available()
     boot["is_calendar_setup"] = is_google_calendar_enabled()
     boot["global_filters"] = get_global_filters()
     boot["allow_weekend_entries"] = bool(
@@ -75,6 +78,8 @@ def get_boot():
     boot["currencies"] = frappe.get_all("Currency", pluck="name", filters={"enabled": 1})
     boot["has_business_unit"] = has_bu_field()
     boot["has_industry"] = has_industry_field()
+    boot["has_repository_connections"] = bool(frappe.db.exists("DocType", "GitHub Repository"))
+    boot["has_customer_feedback"] = is_customer_feedback_available()
     boot["is_calendar_setup"] = is_google_calendar_enabled()
     boot["app_name"] = "Next PMS"
     boot["global_filters"] = get_global_filters()


### PR DESCRIPTION
## Description

* Added `has_repository_connections` and `has_customer_feedback` flags to the backend boot context and exposed them in the global types, enabling the frontend to conditionally render the `RepositoryConnections` component based on backend configuration. 
* Updated employee and contact data fetching logic to only request custom fields (like `custom_linkedin` and `custom_linkedin_url`) if they exist in the schema, preventing errors when custom fields are missing. This includes using `.get()` for safe access in returned data.
* Modified employee filtering and age calculation utilities to check for the existence of custom fields (such as `custom_business_unit` and `custom_company`) before using them in queries, improving compatibility with different schema configurations. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**Github Connector Not Installed**:
<img width="1470" height="816" alt="image" src="https://github.com/user-attachments/assets/f8e7ee5e-5f4e-4ee5-84b5-34e9d674e03b" />

**Github Connector Installed**:
<img width="1469" height="799" alt="image" src="https://github.com/user-attachments/assets/999ae31c-e699-4af8-8f7b-6402b0e2f996" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1445