### PR TITLE
feat(notes): published note detail view

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/notes/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/constants.ts
@@ -2,3 +2,5 @@ export const CREATE_OPTIONS = {
   newFromTemplate: "new-from-template",
   newBlankNote: "new-blank-note",
 } as const;
+
+export const NOTE_PARAM = "note";

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/content.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/content.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies.
+ */
+import { TextEditor } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import type { Note } from "../types";
+
+type NoteDetailContentProps = {
+  note: Note;
+};
+
+export function NoteDetailContent({ note }: NoteDetailContentProps) {
+  return (
+    <div className="flex flex-col gap-2 pt-4">
+      <h1 className="text-3xl font-semibold leading-tight text-ink-gray-8">
+        {note.title}
+      </h1>
+      <TextEditor
+        content={note.description}
+        editable={false}
+        fixedMenu={false}
+        editorClass="prose prose-sm max-w-none text-ink-gray-8"
+      />
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/content.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/content.tsx
@@ -14,7 +14,7 @@ type NoteDetailContentProps = {
 
 export function NoteDetailContent({ note }: NoteDetailContentProps) {
   return (
-    <div className="flex flex-col gap-2 pt-4">
+    <div className="flex flex-col gap-2 pt-2">
       <h1 className="text-3xl font-semibold leading-tight text-ink-gray-8">
         {note.title}
       </h1>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
@@ -31,7 +31,9 @@ function exportNote(note: Note) {
   anchor.href = url;
   anchor.download = filename;
   anchor.click();
-  URL.revokeObjectURL(url);
+  // Defer revoke so the browser has started reading the blob; revoking
+  // synchronously after click() can abort the download in some browsers.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 type NoteDetailHeaderProps = {

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
@@ -40,7 +40,7 @@ export function NoteDetailHeader({ note }: NoteDetailHeaderProps) {
           variant="ghost"
           type="button"
           onClick={handleBack}
-          className="p-0 hover:bg-transparent focus-visible:bg-transparent"
+          className="p-0"
           icon={() => <ArrowLeft />}
         />
         <a href={authorHref} className="shrink-0 flex items-center">
@@ -51,7 +51,7 @@ export function NoteDetailHeader({ note }: NoteDetailHeaderProps) {
             image={note.owner_image || undefined}
           />
         </a>
-        <span className="truncate text-base font-medium text-ink-gray-7">
+        <span className="truncate text-base font-medium text-ink-gray-8">
           {note.owner_full_name}
         </span>
         <span className="shrink-0 text-ink-gray-5">·</span>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
@@ -1,56 +1,48 @@
 /**
  * External dependencies.
  */
-import { useNavigate, useParams } from "react-router-dom";
-import { format } from "date-fns";
-import { Avatar, Dropdown } from "@rtcamp/frappe-ui-react";
-import { DotHorizontal, Edit1, Export } from "@rtcamp/frappe-ui-react/icons";
+import { useSearchParams } from "react-router-dom";
+import { Avatar, Button } from "@rtcamp/frappe-ui-react";
+import { ArrowLeft } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
  */
-import { ROUTES } from "@/lib/constant";
-import { formatRelativeTimeShort, stripTags } from "@/lib/utils";
+import { formatRelativeTimeShort } from "@/lib/utils";
+import { NOTE_PARAM } from "../constants";
+import { NoteActions } from "../noteActions";
 import type { Note } from "../types";
-
-const FILENAME_TITLE_CAP = 50;
-
-function exportNote(note: Note) {
-  const safeTitle =
-    note.title
-      .slice(0, FILENAME_TITLE_CAP)
-      .replace(/[^\p{L}\p{N}]+/gu, "-")
-      .replace(/^-+|-+$/g, "")
-      .toLowerCase() || "note";
-  const filename = `${safeTitle}-${format(new Date(), "yyyy-MM-dd-HHmmss")}.txt`;
-  const content = `${note.title}\n\n${stripTags(note.description)}`;
-  const url = URL.createObjectURL(
-    new Blob([content], { type: "text/plain;charset=utf-8" }),
-  );
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  anchor.click();
-  // Defer revoke so the browser has started reading the blob; revoking
-  // synchronously after click() can abort the download in some browsers.
-  setTimeout(() => URL.revokeObjectURL(url), 0);
-}
 
 type NoteDetailHeaderProps = {
   note: Note;
 };
 
 export function NoteDetailHeader({ note }: NoteDetailHeaderProps) {
-  const navigate = useNavigate();
-  const { projectId = "" } = useParams<{ projectId: string }>();
+  const [, setSearchParams] = useSearchParams();
   const lastUpdated = formatRelativeTimeShort(
     note.last_edited_at ?? note.modified,
+    new Date(),
+    true,
   );
   const authorHref = `/desk/user/${encodeURIComponent(note.owner)}`;
+
+  const handleBack = () => {
+    setSearchParams((prev) => {
+      prev.delete(NOTE_PARAM);
+      return prev;
+    });
+  };
 
   return (
     <div className="flex items-center justify-between gap-8">
       <div className="flex min-w-0 items-center gap-2">
+        <Button
+          variant="ghost"
+          type="button"
+          onClick={handleBack}
+          className="p-0 hover:bg-transparent focus-visible:bg-transparent"
+          icon={() => <ArrowLeft />}
+        />
         <a href={authorHref} className="shrink-0 flex items-center">
           <Avatar
             size="xs"
@@ -67,27 +59,7 @@ export function NoteDetailHeader({ note }: NoteDetailHeaderProps) {
           last updated {lastUpdated}
         </span>
       </div>
-      <Dropdown
-        placement="right"
-        button={{ variant: "ghost", icon: DotHorizontal }}
-        options={[
-          {
-            label: "Edit",
-            key: "edit",
-            icon: <Edit1 />,
-            onClick: () =>
-              navigate(
-                `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
-              ),
-          },
-          {
-            label: "Export note",
-            key: "export",
-            icon: <Export />,
-            onClick: () => exportNote(note),
-          },
-        ]}
-      />
+      <NoteActions note={note} />
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies.
+ */
+import { useNavigate, useParams } from "react-router-dom";
+import { format } from "date-fns";
+import { Avatar, Dropdown } from "@rtcamp/frappe-ui-react";
+import { DotHorizontal, Edit1, Export } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { ROUTES } from "@/lib/constant";
+import { formatRelativeTimeShort, stripTags } from "@/lib/utils";
+import type { Note } from "../types";
+
+const FILENAME_TITLE_CAP = 50;
+
+function exportNote(note: Note) {
+  const safeTitle =
+    note.title
+      .slice(0, FILENAME_TITLE_CAP)
+      .replace(/[^\p{L}\p{N}]+/gu, "-")
+      .replace(/^-+|-+$/g, "")
+      .toLowerCase() || "note";
+  const filename = `${safeTitle}-${format(new Date(), "yyyy-MM-dd-HHmmss")}.txt`;
+  const content = `${note.title}\n\n${stripTags(note.description)}`;
+  const url = URL.createObjectURL(
+    new Blob([content], { type: "text/plain;charset=utf-8" }),
+  );
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+type NoteDetailHeaderProps = {
+  note: Note;
+};
+
+export function NoteDetailHeader({ note }: NoteDetailHeaderProps) {
+  const navigate = useNavigate();
+  const { projectId = "" } = useParams<{ projectId: string }>();
+  const lastUpdated = formatRelativeTimeShort(
+    note.last_edited_at ?? note.modified,
+  );
+  const authorHref = `/desk/user/${encodeURIComponent(note.owner)}`;
+
+  return (
+    <div className="flex items-center justify-between gap-8">
+      <div className="flex min-w-0 items-center gap-2">
+        <a href={authorHref} className="shrink-0 flex items-center">
+          <Avatar
+            size="xs"
+            shape="circle"
+            label={note.owner_full_name}
+            image={note.owner_image || undefined}
+          />
+        </a>
+        <span className="truncate text-base font-medium text-ink-gray-7">
+          {note.owner_full_name}
+        </span>
+        <span className="shrink-0 text-ink-gray-5">·</span>
+        <span className="shrink-0 text-base text-ink-gray-5">
+          last updated {lastUpdated}
+        </span>
+      </div>
+      <Dropdown
+        placement="right"
+        button={{ variant: "ghost", icon: DotHorizontal }}
+        options={[
+          {
+            label: "Edit",
+            key: "edit",
+            icon: <Edit1 />,
+            onClick: () =>
+              navigate(
+                `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
+              ),
+          },
+          {
+            label: "Export note",
+            key: "export",
+            icon: <Export />,
+            onClick: () => exportNote(note),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/index.tsx
@@ -2,12 +2,11 @@
  * External dependencies.
  */
 import { Spinner } from "@next-pms/design-system/components";
-import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
-import type { Note } from "../types";
+import { useNotes } from "../context";
 import { NoteDetailContent } from "./content";
 import { NoteDetailHeader } from "./header";
 
@@ -16,21 +15,25 @@ type NoteDetailProps = {
 };
 
 export function NoteDetail({ noteId }: NoteDetailProps) {
-  const { data, isLoading, error } = useFrappeGetCall<{ message: Note }>(
-    "next_pms.timesheet.api.project_status_update.get_project_status_update",
-    { name: noteId },
-  );
+  const isLoading = useNotes((s) => s.state.isLoading);
+  const notes = useNotes((s) => s.state.notes);
+  const noteFromList = notes.find((note) => note.name === noteId);
+  const note = noteFromList ?? null;
 
-  if (error) throw error;
-
-  if (isLoading || !data) {
+  if (isLoading && !note) {
     return <Spinner className="py-10" />;
   }
 
-  const note = data.message;
+  if (!note) {
+    return (
+      <div className="py-10 text-center text-sm text-ink-gray-4">
+        Note not found
+      </div>
+    );
+  }
 
   return (
-    <div className="w-full p-4">
+    <div className="w-full">
       <NoteDetailHeader note={note} />
       <NoteDetailContent note={note} />
     </div>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/index.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies.
+ */
+import { Spinner } from "@next-pms/design-system/components";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal dependencies.
+ */
+import type { Note } from "../types";
+import { NoteDetailContent } from "./content";
+import { NoteDetailHeader } from "./header";
+
+type NoteDetailProps = {
+  noteId: string;
+};
+
+export function NoteDetail({ noteId }: NoteDetailProps) {
+  const { data, isLoading, error } = useFrappeGetCall<{ message: Note }>(
+    "next_pms.timesheet.api.project_status_update.get_project_status_update",
+    { name: noteId },
+  );
+
+  if (error) throw error;
+
+  if (isLoading || !data) {
+    return <Spinner className="py-10" />;
+  }
+
+  const note = data.message;
+
+  return (
+    <div className="flex justify-center">
+      <div className="max-w-200 w-full p-4">
+        <NoteDetailHeader note={note} />
+        <NoteDetailContent note={note} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/index.tsx
@@ -30,11 +30,9 @@ export function NoteDetail({ noteId }: NoteDetailProps) {
   const note = data.message;
 
   return (
-    <div className="flex justify-center">
-      <div className="max-w-200 w-full p-4">
-        <NoteDetailHeader note={note} />
-        <NoteDetailContent note={note} />
-      </div>
+    <div className="w-full p-4">
+      <NoteDetailHeader note={note} />
+      <NoteDetailContent note={note} />
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/utils.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/utils.ts
@@ -11,9 +11,7 @@ import type { Note } from "../types";
 const FILENAME_TITLE_CAP = 50;
 
 /**
- * Download the note as a .txt file. The body is written as raw HTML (per the
- * dev-team decision — no tag stripping); the filename is the length-capped,
- * sanitised title plus a timestamp.
+ * Exports the note content as a text file.
  */
 export function exportNote(note: Note) {
   const safeTitle =
@@ -30,7 +28,5 @@ export function exportNote(note: Note) {
   anchor.href = url;
   anchor.download = filename;
   anchor.click();
-  // Defer revoke so the browser has started reading the blob; revoking
-  // synchronously after click() can abort the download in some browsers.
   setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/utils.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/utils.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies.
+ */
+import { format } from "date-fns";
+
+/**
+ * Internal dependencies.
+ */
+import type { Note } from "../types";
+
+const FILENAME_TITLE_CAP = 50;
+
+/**
+ * Download the note as a .txt file. The body is written as raw HTML (per the
+ * dev-team decision — no tag stripping); the filename is the length-capped,
+ * sanitised title plus a timestamp.
+ */
+export function exportNote(note: Note) {
+  const safeTitle =
+    note.title
+      .slice(0, FILENAME_TITLE_CAP)
+      .replace(/[^\p{L}\p{N}]+/gu, "-")
+      .replace(/^-+|-+$/g, "")
+      .toLowerCase() || "note";
+  const filename = `${safeTitle}-${format(new Date(), "yyyy-MM-dd-HHmmss")}.txt`;
+  const url = URL.createObjectURL(
+    new Blob([note.description], { type: "text/plain;charset=utf-8" }),
+  );
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  // Defer revoke so the browser has started reading the blob; revoking
+  // synchronously after click() can abort the download in some browsers.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
@@ -1,12 +1,15 @@
 /**
  * External dependencies.
  */
+import { useSearchParams } from "react-router-dom";
 import { ErrorFallback, Spinner } from "@next-pms/design-system/components";
 
 /**
  * Internal dependencies.
  */
+import { NOTE_PARAM } from "./constants";
 import { useNotes } from "./context";
+import { NoteDetail } from "./detail";
 import { NoteCard } from "./noteCard";
 import { NotesSubHeader } from "./subHeader";
 
@@ -44,9 +47,12 @@ function NotesGrid() {
 }
 
 export function Notes() {
+  const [searchParams] = useSearchParams();
+  const noteId = searchParams.get(NOTE_PARAM);
+
   return (
-    <ErrorFallback>
-      <NotesGrid />
+    <ErrorFallback key={noteId ?? "grid"}>
+      {noteId ? <NoteDetail noteId={noteId} /> : <NotesGrid />}
     </ErrorFallback>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
@@ -3,7 +3,12 @@
  */
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Dropdown } from "@rtcamp/frappe-ui-react";
-import { Delete, DotHorizontal, Edit1, Export } from "@rtcamp/frappe-ui-react/icons";
+import {
+  Delete,
+  DotHorizontal,
+  Edit1,
+  Export,
+} from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -15,17 +20,10 @@ import { useNotes } from "./context";
 import { exportNote } from "./detail/utils";
 import type { Note } from "./types";
 
-const ICON_CLASS = "size-4 mr-2";
-
 type NoteActionsProps = {
   note: Note;
 };
 
-/**
- * Shared 3-dot actions dropdown rendered on both the note card and the note
- * detail header. Stops click propagation so the dropdown works inside the
- * clickable card.
- */
 export function NoteActions({ note }: NoteActionsProps) {
   const navigate = useNavigate();
   const [, setSearchParams] = useSearchParams();
@@ -50,22 +48,24 @@ export function NoteActions({ note }: NoteActionsProps) {
           {
             key: "edit",
             label: "Edit",
-            icon: <Edit1 className={ICON_CLASS} />,
+            icon: <Edit1 className="size-4 mr-2" />,
             disabled: isDeleting,
             onClick: () =>
-              navigate(`${ROUTES.project}/${projectId}/notes/${note.name}/edit`),
+              navigate(
+                `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
+              ),
           },
           {
             key: "export",
             label: "Export note",
-            icon: <Export className={ICON_CLASS} />,
+            icon: <Export className="size-4 mr-2" />,
             onClick: () => exportNote(note),
           },
           {
             key: "delete",
             label: "Delete",
             theme: "red",
-            icon: <Delete className={ICON_CLASS} />,
+            icon: <Delete className="size-4 mr-2" />,
             disabled: isDeleting,
             onClick: () => void handleDelete(),
           },

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies.
+ */
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Dropdown } from "@rtcamp/frappe-ui-react";
+import { Delete, DotHorizontal, Edit1, Export } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { ROUTES } from "@/lib/constant";
+import { useProjectDetail } from "@/pages/project-details/context";
+import { NOTE_PARAM } from "./constants";
+import { useNotes } from "./context";
+import { exportNote } from "./detail/utils";
+import type { Note } from "./types";
+
+const ICON_CLASS = "size-4 mr-2";
+
+type NoteActionsProps = {
+  note: Note;
+};
+
+/**
+ * Shared 3-dot actions dropdown rendered on both the note card and the note
+ * detail header. Stops click propagation so the dropdown works inside the
+ * clickable card.
+ */
+export function NoteActions({ note }: NoteActionsProps) {
+  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
+  const projectId = useProjectDetail((s) => s.projectId);
+  const deleteNote = useNotes((s) => s.actions.deleteNote);
+  const isDeleting = useNotes((s) => s.state.isDeleting);
+
+  const handleDelete = async () => {
+    await deleteNote(note.name);
+    setSearchParams((prev) => {
+      prev.delete(NOTE_PARAM);
+      return prev;
+    });
+  };
+
+  return (
+    <span onClick={(e) => e.stopPropagation()}>
+      <Dropdown
+        placement="right"
+        button={{ variant: "ghost", icon: DotHorizontal }}
+        options={[
+          {
+            key: "edit",
+            label: "Edit",
+            icon: <Edit1 className={ICON_CLASS} />,
+            disabled: isDeleting,
+            onClick: () =>
+              navigate(`${ROUTES.project}/${projectId}/notes/${note.name}/edit`),
+          },
+          {
+            key: "export",
+            label: "Export note",
+            icon: <Export className={ICON_CLASS} />,
+            onClick: () => exportNote(note),
+          },
+          {
+            key: "delete",
+            label: "Delete",
+            theme: "red",
+            icon: <Delete className={ICON_CLASS} />,
+            disabled: isDeleting,
+            onClick: () => void handleDelete(),
+          },
+        ]}
+      />
+    </span>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Avatar, Dropdown } from "@rtcamp/frappe-ui-react";
 import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
 
@@ -10,6 +10,7 @@ import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
  */
 import { ROUTES } from "@/lib/constant";
 import { formatRelativeTimeShort, stripTags } from "@/lib/utils";
+import { NOTE_PARAM } from "./constants";
 import { useNotes } from "./context";
 import type { Note } from "./types";
 
@@ -19,6 +20,7 @@ type NoteCardProps = {
 
 export function NoteCard({ note }: NoteCardProps) {
   const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
   const { deleteNote } = useNotes((s) => s.actions);
   const isDeleting = useNotes((s) => s.state.isDeleting);
   const { projectId = "" } = useParams<{ projectId: string }>();
@@ -26,43 +28,66 @@ export function NoteCard({ note }: NoteCardProps) {
   const relativeDate = formatRelativeTimeShort(note.creation, new Date(), true);
   const authorHref = `/desk/user/${encodeURIComponent(note.owner)}`;
 
+  const openDetail = () =>
+    setSearchParams((prev) => {
+      prev.set(NOTE_PARAM, note.name);
+      return prev;
+    });
+
   return (
-    <div className="flex h-64 min-w-65.75 max-w-131.5 flex-1 flex-col rounded-[12px] border border-outline-gray-2 bg-surface-white overflow-clip shadow-xl">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={openDetail}
+      onKeyDown={(e) => {
+        if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          openDetail();
+        }
+      }}
+      className="flex h-64 min-w-65.75 max-w-131.5 flex-1 cursor-pointer flex-col rounded-[12px] border border-outline-gray-2 bg-surface-white overflow-clip shadow-xl"
+    >
       <div className="flex items-center gap-3 px-3.5 pt-3.5">
         <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">
           {note.title}
         </h3>
-        <Dropdown
-          placement="right"
-          button={{
-            variant: "ghost",
-            icon: DotHorizontal,
-          }}
-          options={[
-            {
-              label: "Edit",
-              key: "edit",
-              disabled: isDeleting,
-              onClick: () =>
-                navigate(
-                  `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
-                ),
-            },
-            {
-              label: "Delete",
-              key: "delete",
-              theme: "red",
-              disabled: isDeleting,
-              onClick: () => deleteNote(note.name),
-            },
-          ]}
-        />
+        <span onClick={(e) => e.stopPropagation()}>
+          <Dropdown
+            placement="right"
+            button={{
+              variant: "ghost",
+              icon: DotHorizontal,
+            }}
+            options={[
+              {
+                label: "Edit",
+                key: "edit",
+                disabled: isDeleting,
+                onClick: () =>
+                  navigate(
+                    `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
+                  ),
+              },
+              {
+                label: "Delete",
+                key: "delete",
+                theme: "red",
+                disabled: isDeleting,
+                onClick: () => deleteNote(note.name),
+              },
+            ]}
+          />
+        </span>
       </div>
       <p className="flex-1 line-clamp-7 whitespace-pre-wrap px-3.5 pt-2 text-base leading-6 text-ink-gray-5">
         {excerpt}
       </p>
       <div className="flex items-center gap-2 px-3.5 pb-3.5 pt-3">
-        <a href={authorHref} className="shrink-0 flex items-center">
+        <a
+          href={authorHref}
+          onClick={(e) => e.stopPropagation()}
+          className="shrink-0 flex items-center"
+        >
           <Avatar
             size="xs"
             label={note.owner_full_name}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Avatar } from "@rtcamp/frappe-ui-react";
 
@@ -23,11 +24,12 @@ export function NoteCard({ note }: NoteCardProps) {
   const authorHref = `/desk/user/${encodeURIComponent(note.owner)}`;
   const authorName = note.owner_full_name || note.owner;
 
-  const openDetail = () =>
+  const openDetail = useCallback(() => {
     setSearchParams((prev) => {
       prev.set(NOTE_PARAM, note.name);
       return prev;
     });
+  }, [note.name, setSearchParams]);
 
   return (
     <div

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -1,17 +1,15 @@
 /**
  * External dependencies.
  */
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { Avatar, Dropdown } from "@rtcamp/frappe-ui-react";
-import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
+import { useSearchParams } from "react-router-dom";
+import { Avatar } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
-import { ROUTES } from "@/lib/constant";
 import { formatRelativeTimeShort, stripTags } from "@/lib/utils";
 import { NOTE_PARAM } from "./constants";
-import { useNotes } from "./context";
+import { NoteActions } from "./noteActions";
 import type { Note } from "./types";
 
 type NoteCardProps = {
@@ -19,11 +17,7 @@ type NoteCardProps = {
 };
 
 export function NoteCard({ note }: NoteCardProps) {
-  const navigate = useNavigate();
   const [, setSearchParams] = useSearchParams();
-  const { deleteNote } = useNotes((s) => s.actions);
-  const isDeleting = useNotes((s) => s.state.isDeleting);
-  const { projectId = "" } = useParams<{ projectId: string }>();
   const excerpt = stripTags(note.description);
   const relativeDate = formatRelativeTimeShort(note.creation, new Date(), true);
   const authorHref = `/desk/user/${encodeURIComponent(note.owner)}`;
@@ -40,7 +34,10 @@ export function NoteCard({ note }: NoteCardProps) {
       tabIndex={0}
       onClick={openDetail}
       onKeyDown={(e) => {
-        if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) {
+        if (
+          e.target === e.currentTarget &&
+          (e.key === "Enter" || e.key === " ")
+        ) {
           e.preventDefault();
           openDetail();
         }
@@ -51,33 +48,7 @@ export function NoteCard({ note }: NoteCardProps) {
         <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">
           {note.title}
         </h3>
-        <span onClick={(e) => e.stopPropagation()}>
-          <Dropdown
-            placement="right"
-            button={{
-              variant: "ghost",
-              icon: DotHorizontal,
-            }}
-            options={[
-              {
-                label: "Edit",
-                key: "edit",
-                disabled: isDeleting,
-                onClick: () =>
-                  navigate(
-                    `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
-                  ),
-              },
-              {
-                label: "Delete",
-                key: "delete",
-                theme: "red",
-                disabled: isDeleting,
-                onClick: () => deleteNote(note.name),
-              },
-            ]}
-          />
-        </span>
+        <NoteActions note={note} />
       </div>
       <p className="flex-1 line-clamp-7 whitespace-pre-wrap px-3.5 pt-2 text-base leading-6 text-ink-gray-5">
         {excerpt}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -45,7 +45,7 @@ export function NoteCard({ note }: NoteCardProps) {
           openDetail();
         }
       }}
-      className="flex h-64 min-w-65.75 max-w-131.5 flex-1 cursor-pointer flex-col rounded-[12px] border border-outline-gray-2 bg-surface-white overflow-clip shadow-xl"
+      className="flex h-64 min-w-65.75 max-w-131.5 flex-1 cursor-pointer flex-col rounded-[12px] border border-outline-gray-2 bg-surface-white overflow-clip shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink-gray-4"
     >
       <div className="flex items-center gap-3 px-3.5 pt-3.5">
         <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">


### PR DESCRIPTION
## Description

This PR adds the Note Detail View.

## Relevant Technical Choices

- Query-param routing similar to risk page.
- Export note contains raw HTML as discussed.
- Added an extra back button to the Notes Details header to match the Risk page and provide a better user experience. This was a design decision, and it can be removed if not needed.

## Screenshot/Screencast


https://github.com/user-attachments/assets/f5740ecf-b9d0-4ff6-838e-1c58a76702c4



## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality. NA — UI view; covered by the manual golden-path QA.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1100