### PR TITLE
feat(notes): template selection dialog for Create > New from template

### DIFF
--- a/frontend/packages/app/src/hooks/useNoteTemplateLookup.ts
+++ b/frontend/packages/app/src/hooks/useNoteTemplateLookup.ts
@@ -3,8 +3,6 @@
  */
 import { useRemoteLookup, type LookupOption } from "@/hooks/useRemoteLookup";
 
-const DOCTYPE = "Project Status Update Template";
-
 type NoteTemplateItem = {
   name: string;
   template_name: string;
@@ -26,6 +24,8 @@ interface UseNoteTemplateLookupOptions {
   pageSize?: number;
   /** Revalidates the lookup when the window regains focus. */
   revalidateOnFocus?: boolean;
+  /** Preserves the current list of templates while loading new data. */
+  keepPreviousData?: boolean;
 }
 
 /**
@@ -36,32 +36,46 @@ export const useNoteTemplateLookup = ({
   query,
   pageSize = 20,
   revalidateOnFocus,
+  keepPreviousData,
 }: UseNoteTemplateLookupOptions) => {
-  return useRemoteLookup<NoteTemplateItem[], NoteTemplateItem, NoteTemplateOption>(
-    {
-      shouldFetch,
-      query,
-      pageSize,
-      revalidateOnFocus,
-      params: ({ query: searchQuery, pageSize }) => ({
-        doctype: DOCTYPE,
-        fields: ["name", "template_name", "title", "description"],
-        limit_page_length: pageSize,
-        or_filters: searchQuery
-          ? [
-              [DOCTYPE, "template_name", "like", `%${searchQuery}%`],
-              [DOCTYPE, "title", "like", `%${searchQuery}%`],
-            ]
-          : undefined,
-        start: 0,
-      }),
-      getItems: (message) => message ?? [],
-      mapOption: (template) => ({
-        label: template.template_name,
-        value: template.name,
-        title: template.title,
-        description: template.description,
-      }),
-    },
-  );
+  return useRemoteLookup<
+    NoteTemplateItem[],
+    NoteTemplateItem,
+    NoteTemplateOption
+  >({
+    shouldFetch,
+    query,
+    pageSize,
+    revalidateOnFocus,
+    keepPreviousData,
+    params: ({ query: searchQuery, pageSize }) => ({
+      doctype: "Project Status Update Template",
+      fields: ["name", "template_name", "title", "description"],
+      limit_page_length: pageSize,
+      or_filters: searchQuery
+        ? [
+            [
+              "Project Status Update Template",
+              "template_name",
+              "like",
+              `%${searchQuery}%`,
+            ],
+            [
+              "Project Status Update Template",
+              "title",
+              "like",
+              `%${searchQuery}%`,
+            ],
+          ]
+        : undefined,
+      start: 0,
+    }),
+    getItems: (message) => message ?? [],
+    mapOption: (template) => ({
+      label: template.template_name,
+      value: template.name,
+      title: template.title,
+      description: template.description,
+    }),
+  });
 };

--- a/frontend/packages/app/src/hooks/useNoteTemplateLookup.ts
+++ b/frontend/packages/app/src/hooks/useNoteTemplateLookup.ts
@@ -1,0 +1,67 @@
+/**
+ * Internal Dependencies.
+ */
+import { useRemoteLookup, type LookupOption } from "@/hooks/useRemoteLookup";
+
+const DOCTYPE = "Project Status Update Template";
+
+type NoteTemplateItem = {
+  name: string;
+  template_name: string;
+  title: string;
+  description: string;
+};
+
+export type NoteTemplateOption = LookupOption & {
+  title: string;
+  description: string;
+};
+
+interface UseNoteTemplateLookupOptions {
+  /** Controls whether the template lookup should fetch for the current UI state. */
+  shouldFetch: boolean;
+  /** Filters templates through backend or_filters on template name and title. */
+  query: string;
+  /** Caps the number of template rows fetched per request. */
+  pageSize?: number;
+  /** Revalidates the lookup when the window regains focus. */
+  revalidateOnFocus?: boolean;
+}
+
+/**
+ * Fetches `Project Status Update Template` records for the note template picker.
+ */
+export const useNoteTemplateLookup = ({
+  shouldFetch,
+  query,
+  pageSize = 20,
+  revalidateOnFocus,
+}: UseNoteTemplateLookupOptions) => {
+  return useRemoteLookup<NoteTemplateItem[], NoteTemplateItem, NoteTemplateOption>(
+    {
+      shouldFetch,
+      query,
+      pageSize,
+      revalidateOnFocus,
+      params: ({ query: searchQuery, pageSize }) => ({
+        doctype: DOCTYPE,
+        fields: ["name", "template_name", "title", "description"],
+        limit_page_length: pageSize,
+        or_filters: searchQuery
+          ? [
+              [DOCTYPE, "template_name", "like", `%${searchQuery}%`],
+              [DOCTYPE, "title", "like", `%${searchQuery}%`],
+            ]
+          : undefined,
+        start: 0,
+      }),
+      getItems: (message) => message ?? [],
+      mapOption: (template) => ({
+        label: template.template_name,
+        value: template.name,
+        title: template.title,
+        description: template.description,
+      }),
+    },
+  );
+};

--- a/frontend/packages/app/src/hooks/useRemoteLookup.ts
+++ b/frontend/packages/app/src/hooks/useRemoteLookup.ts
@@ -38,6 +38,8 @@ interface UseRemoteLookupOptions<
   method?: string;
   /** Revalidates the lookup when the window regains focus. */
   revalidateOnFocus?: boolean;
+  /** Preserves the previous list of options while loading new data. */
+  keepPreviousData?: boolean;
   /** Builds backend params from the debounced query and page size. */
   params: (args: {
     query: string;
@@ -61,6 +63,7 @@ export const useRemoteLookup = <TMessage, TItem, TOption extends LookupOption>({
   pageSize = 20,
   method = "frappe.client.get_list",
   revalidateOnFocus = false,
+  keepPreviousData = false,
   params,
   getItems,
   mapOption,
@@ -73,6 +76,7 @@ export const useRemoteLookup = <TMessage, TItem, TOption extends LookupOption>({
     shouldFetch ? undefined : null,
     {
       revalidateOnFocus,
+      keepPreviousData,
     },
   );
 

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/constants.ts
@@ -2,3 +2,5 @@ export const CREATE_OPTIONS = {
   newFromTemplate: "new-from-template",
   newBlankNote: "new-blank-note",
 } as const;
+
+export const TEMPLATE_PARAM = "template";

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
@@ -31,21 +31,19 @@ import { useNotes } from "../context";
 
 function NoteEditor() {
   const navigate = useNavigate();
-  const { projectId: routeProjectId = "", noteId } = useParams<{
-    projectId: string;
+  const { noteId } = useParams<{
     noteId?: string;
   }>();
   const mode: "edit" | "new" = noteId ? "edit" : "new";
   const [searchParams] = useSearchParams();
-  const templateName =
-    mode === "new" ? searchParams.get(TEMPLATE_PARAM) : null;
+  const templateName = mode === "new" ? searchParams.get(TEMPLATE_PARAM) : null;
   const userName = useUser((s) => s.state.userName);
   const userImage = useUser((s) => s.state.image);
   const projectId = useProjectDetail((s) => s.projectId);
   const refresh = useNotes((s) => s.actions.refresh);
   const toast = useToasts();
   const [isFormInitialized, setIsFormInitialized] = useState(false);
-  const didInitForm = useRef(false);
+  const titleRef = useRef<HTMLInputElement>(null);
 
   const { call: createNote, loading: isCreating } = useFrappePostCall(
     "next_pms.timesheet.api.project_status_update.create_project_status_update",
@@ -104,7 +102,7 @@ function NoteEditor() {
 
         toast.success("Note saved");
         await refresh();
-        navigate(`${ROUTES.project}/${routeProjectId}?tab=notes`);
+        navigate(`${ROUTES.project}/${projectId}?tab=notes`);
       } catch (err) {
         const error = parseFrappeErrorMsg(err as FrappeError);
         toast.error(error);
@@ -113,23 +111,23 @@ function NoteEditor() {
   });
 
   useEffect(() => {
-    if (didInitForm.current) return;
-    // Initialise the form exactly once, after the data it seeds from has
-    // settled: the note (edit), the template (new + template), or immediately
-    // (new, no template). A failed template falls back to a blank note rather
-    // than hanging on the spinner.
     const ready =
       (mode === "edit" && !!noteData?.message) ||
       (mode === "new" &&
         (!templateName || !!templateData?.message || !!templateError));
     if (ready) {
-      didInitForm.current = true;
       setIsFormInitialized(true);
     }
   }, [noteData, templateData, templateError, templateName, mode]);
 
   const isInputDisabled =
     isCreating || isUpdating || isNoteLoading || isTemplateLoading;
+
+  useEffect(() => {
+    if (isFormInitialized && titleRef.current) {
+      titleRef.current.focus();
+    }
+  }, [isFormInitialized]);
 
   return (
     <div className="flex justify-center">
@@ -170,6 +168,7 @@ function NoteEditor() {
                 return (
                   <>
                     <input
+                      ref={titleRef}
                       value={field.state.value}
                       onChange={(e) => field.handleChange(e.target.value)}
                       disabled={isInputDisabled}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Spinner } from "@next-pms/design-system/components";
 import {
   Avatar,
@@ -26,6 +26,7 @@ import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useProjectDetail } from "@/pages/project-details/context";
 import { useUser } from "@/providers/user";
 import { noteFormSchema } from "./schema";
+import { TEMPLATE_PARAM } from "../constants";
 import { useNotes } from "../context";
 
 function NoteEditor() {
@@ -35,6 +36,9 @@ function NoteEditor() {
     noteId?: string;
   }>();
   const mode: "edit" | "new" = noteId ? "edit" : "new";
+  const [searchParams] = useSearchParams();
+  const templateName =
+    mode === "new" ? searchParams.get(TEMPLATE_PARAM) : null;
   const userName = useUser((s) => s.state.userName);
   const userImage = useUser((s) => s.state.image);
   const projectId = useProjectDetail((s) => s.projectId);
@@ -53,12 +57,20 @@ function NoteEditor() {
     { name: noteId },
     mode === "edit" && noteId ? undefined : null,
   );
+  const { data: templateData, isLoading: isTemplateLoading } = useFrappeGetCall(
+    "frappe.client.get",
+    { doctype: "Project Status Update Template", name: templateName },
+    templateName ? undefined : null,
+  );
 
   const form = useForm({
     defaultValues: {
       project: projectId,
-      title: noteData?.message.title || "",
-      description: noteData?.message.description || "",
+      title: noteData?.message.title || templateData?.message?.title || "",
+      description:
+        noteData?.message.description ||
+        templateData?.message?.description ||
+        "",
       status: "Publish",
     },
     validators: {
@@ -98,15 +110,18 @@ function NoteEditor() {
     if (mode === "edit" && noteData?.message) {
       setIsFormInitialized(true);
     } else if (mode === "new") {
-      setIsFormInitialized(true);
+      if (!templateName || templateData?.message) {
+        setIsFormInitialized(true);
+      }
     }
-  }, [noteData, mode, form, projectId]);
+  }, [noteData, templateData, templateName, mode, form, projectId]);
 
-  const isInputDisabled = isCreating || isUpdating || isNoteLoading;
+  const isInputDisabled =
+    isCreating || isUpdating || isNoteLoading || isTemplateLoading;
 
   return (
     <div className="flex justify-center">
-      {isNoteLoading || !isFormInitialized ? (
+      {isNoteLoading || isTemplateLoading || !isFormInitialized ? (
         <Spinner className="py-10" />
       ) : (
         <div className="max-w-200 w-full p-4">

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Spinner } from "@next-pms/design-system/components";
 import {
@@ -45,6 +45,7 @@ function NoteEditor() {
   const refresh = useNotes((s) => s.actions.refresh);
   const toast = useToasts();
   const [isFormInitialized, setIsFormInitialized] = useState(false);
+  const didInitForm = useRef(false);
 
   const { call: createNote, loading: isCreating } = useFrappePostCall(
     "next_pms.timesheet.api.project_status_update.create_project_status_update",
@@ -57,10 +58,15 @@ function NoteEditor() {
     { name: noteId },
     mode === "edit" && noteId ? undefined : null,
   );
-  const { data: templateData, isLoading: isTemplateLoading } = useFrappeGetCall(
+  const {
+    data: templateData,
+    isLoading: isTemplateLoading,
+    error: templateError,
+  } = useFrappeGetCall(
     "frappe.client.get",
     { doctype: "Project Status Update Template", name: templateName },
     templateName ? undefined : null,
+    { shouldRetryOnError: false },
   );
 
   const form = useForm({
@@ -107,14 +113,20 @@ function NoteEditor() {
   });
 
   useEffect(() => {
-    if (mode === "edit" && noteData?.message) {
+    if (didInitForm.current) return;
+    // Initialise the form exactly once, after the data it seeds from has
+    // settled: the note (edit), the template (new + template), or immediately
+    // (new, no template). A failed template falls back to a blank note rather
+    // than hanging on the spinner.
+    const ready =
+      (mode === "edit" && !!noteData?.message) ||
+      (mode === "new" &&
+        (!templateName || !!templateData?.message || !!templateError));
+    if (ready) {
+      didInitForm.current = true;
       setIsFormInitialized(true);
-    } else if (mode === "new") {
-      if (!templateName || templateData?.message) {
-        setIsFormInitialized(true);
-      }
     }
-  }, [noteData, templateData, templateName, mode, form, projectId]);
+  }, [noteData, templateData, templateError, templateName, mode]);
 
   const isInputDisabled =
     isCreating || isUpdating || isNoteLoading || isTemplateLoading;

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 import { Dropdown, Filter } from "@rtcamp/frappe-ui-react";
@@ -11,6 +12,7 @@ import { AddSm, SmallDown } from "@rtcamp/frappe-ui-react/icons";
  */
 import { ROUTES } from "@/lib/constant";
 import { CREATE_OPTIONS } from "./constants";
+import { TemplateDialog } from "./templateDialog";
 
 type NotesSubHeaderProps = {
   filters: FilterCondition[];
@@ -23,6 +25,7 @@ export function NotesSubHeader({
 }: NotesSubHeaderProps) {
   const navigate = useNavigate();
   const { projectId = "" } = useParams<{ projectId: string }>();
+  const [isTemplateDialogOpen, setIsTemplateDialogOpen] = useState(false);
 
   return (
     <div className="flex items-center justify-between gap-8">
@@ -53,8 +56,7 @@ export function NotesSubHeader({
             {
               label: "New from template",
               key: CREATE_OPTIONS.newFromTemplate,
-              onClick: () =>
-                console.info("[notes] New from template — coming soon"),
+              onClick: () => setIsTemplateDialogOpen(true),
             },
             {
               label: "New blank note",
@@ -65,6 +67,11 @@ export function NotesSubHeader({
           ]}
         />
       </div>
+      <TemplateDialog
+        open={isTemplateDialogOpen}
+        onOpenChange={setIsTemplateDialogOpen}
+        projectId={projectId}
+      />
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Dropdown, Select, TextInput } from "@rtcamp/frappe-ui-react";
 import { AddSm, SmallDown } from "@rtcamp/frappe-ui-react/icons";
 
@@ -13,6 +13,7 @@ import { ROUTES } from "@/lib/constant";
 import { CREATE_OPTIONS } from "./constants";
 import { TemplateDialog } from "./templateDialog";
 import type { NoteAuthorOption } from "./types";
+import { useProjectDetail } from "../../context";
 
 type NotesSubHeaderProps = {
   titleInput: string;
@@ -34,7 +35,7 @@ export function NotesSubHeader({
   onAuthorChange,
 }: NotesSubHeaderProps) {
   const navigate = useNavigate();
-  const { projectId = "" } = useParams<{ projectId: string }>();
+  const projectId = useProjectDetail((s) => s.projectId);
   const [isTemplateDialogOpen, setIsTemplateDialogOpen] = useState(false);
 
   return (
@@ -65,11 +66,6 @@ export function NotesSubHeader({
           ]}
         />
       </div>
-      <TemplateDialog
-        open={isTemplateDialogOpen}
-        onOpenChange={setIsTemplateDialogOpen}
-        projectId={projectId}
-      />
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-1 gap-2">
           <TextInput
@@ -94,6 +90,11 @@ export function NotesSubHeader({
           options={authorOptions}
         />
       </div>
+      <TemplateDialog
+        open={isTemplateDialogOpen}
+        onOpenChange={setIsTemplateDialogOpen}
+        projectId={projectId}
+      />
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/templateDialog.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/templateDialog.tsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies.
+ */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, Dialog, TextInput } from "@rtcamp/frappe-ui-react";
+import { Search } from "@rtcamp/frappe-ui-react/icons";
+import { Spinner } from "@next-pms/design-system/components";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  useNoteTemplateLookup,
+  type NoteTemplateOption,
+} from "@/hooks/useNoteTemplateLookup";
+import { ROUTES } from "@/lib/constant";
+import { mergeClassNames as cn, stripTags } from "@/lib/utils";
+import { TEMPLATE_PARAM } from "./constants";
+
+type TemplateDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+};
+
+export function TemplateDialog({
+  open,
+  onOpenChange,
+  projectId,
+}: TemplateDialogProps) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<NoteTemplateOption | null>(null);
+
+  const { options, isLoading } = useNoteTemplateLookup({
+    shouldFetch: open,
+    query,
+  });
+
+  const handleUseTemplate = () => {
+    if (!selected) return;
+    onOpenChange(false);
+    navigate(
+      `${ROUTES.project}/${projectId}/notes/new?${TEMPLATE_PARAM}=${encodeURIComponent(selected.value)}`,
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      options={{
+        title: () => <span className="text-lg font-medium">Add Template</span>,
+      }}
+      actions={
+        <div className="flex items-center justify-end w-full gap-2">
+          <Button
+            variant="ghost"
+            label="Cancel"
+            onClick={() => onOpenChange(false)}
+          />
+          <Button
+            variant="solid"
+            theme="gray"
+            label="Use template"
+            disabled={!selected}
+            onClick={handleUseTemplate}
+          />
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <TextInput
+          size="md"
+          variant="outline"
+          placeholder="Search template"
+          prefix={() => <Search className="size-4 text-ink-gray-5" />}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-ink-gray-5">Templates</span>
+          {isLoading ? (
+            <Spinner className="py-10" />
+          ) : options.length === 0 ? (
+            <div className="py-10 text-center text-sm text-ink-gray-4">
+              No templates found
+            </div>
+          ) : (
+            <div className="flex max-h-80 flex-col gap-1 overflow-auto scrollbar-thin">
+              {options.map((template) => (
+                <button
+                  key={template.value}
+                  type="button"
+                  onClick={() => setSelected(template)}
+                  className={cn(
+                    "flex flex-col items-start gap-0.5 rounded-md px-3 py-2 text-left hover:bg-surface-gray-2",
+                    selected?.value === template.value && "bg-surface-gray-3",
+                  )}
+                >
+                  <span className="w-full truncate text-base font-medium text-ink-gray-8">
+                    {template.label}
+                  </span>
+                  <span className="w-full truncate text-sm text-ink-gray-5">
+                    {stripTags(template.description)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/templateDialog.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/templateDialog.tsx
@@ -3,9 +3,9 @@
  */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { Spinner } from "@next-pms/design-system/components";
 import { Button, Dialog, TextInput } from "@rtcamp/frappe-ui-react";
 import { Search } from "@rtcamp/frappe-ui-react/icons";
-import { Spinner } from "@next-pms/design-system/components";
 
 /**
  * Internal dependencies.
@@ -35,6 +35,7 @@ export function TemplateDialog({
 
   const { options, isLoading } = useNoteTemplateLookup({
     shouldFetch: open,
+    keepPreviousData: true,
     query,
   });
 
@@ -51,7 +52,10 @@ export function TemplateDialog({
       open={open}
       onOpenChange={onOpenChange}
       options={{
-        title: () => <span className="text-lg font-medium">Add Template</span>,
+        title: () => (
+          <span className="text-[20px] font-medium">Add Template</span>
+        ),
+        size: "md",
       }}
       actions={
         <div className="flex items-center justify-end w-full gap-2">
@@ -70,37 +74,40 @@ export function TemplateDialog({
         </div>
       }
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 -my-4">
         <TextInput
           size="md"
-          variant="outline"
+          variant="subtle"
           placeholder="Search template"
           prefix={() => <Search className="size-4 text-ink-gray-5" />}
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);
-            // Clear the selection so "Use template" can't navigate with a
-            // template that the new query may have filtered out of the list.
             setSelected(null);
           }}
         />
-        <div className="flex flex-col gap-1">
-          <span className="text-sm text-ink-gray-5">Templates</span>
-          {isLoading ? (
-            <Spinner className="py-10" />
-          ) : options.length === 0 ? (
-            <div className="py-10 text-center text-sm text-ink-gray-4">
-              No templates found
+        <div className="relative flex flex-col gap-1">
+          <span className="text-base text-ink-gray-5">Templates</span>
+          {!isLoading && options.length === 0 ? (
+            <div className="py-10 h-80 max-h-80 flex items-center justify-center">
+              <span className="text-center text-base text-ink-gray-4">
+                No templates found
+              </span>
             </div>
           ) : (
-            <div className="flex max-h-80 flex-col gap-1 overflow-auto scrollbar-thin">
+            <div
+              className={cn(
+                "flex h-80 max-h-80 flex-col gap-1 overflow-auto scrollbar-thin opacity-100 transition-opacity duration-150",
+                isLoading && "pointer-events-none opacity-50",
+              )}
+            >
               {options.map((template) => (
                 <button
                   key={template.value}
                   type="button"
                   onClick={() => setSelected(template)}
                   className={cn(
-                    "flex flex-col items-start gap-0.5 rounded-md px-3 py-2 text-left hover:bg-surface-gray-2",
+                    "flex flex-col items-start gap-1 rounded-md px-3 py-2 text-left text-ink-gray-8 hover:bg-surface-gray-2",
                     selected?.value === template.value && "bg-surface-gray-3",
                   )}
                 >
@@ -112,6 +119,11 @@ export function TemplateDialog({
                   </span>
                 </button>
               ))}
+            </div>
+          )}
+          {isLoading && (
+            <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center">
+              <Spinner />
             </div>
           )}
         </div>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/templateDialog.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/templateDialog.tsx
@@ -77,7 +77,12 @@ export function TemplateDialog({
           placeholder="Search template"
           prefix={() => <Search className="size-4 text-ink-gray-5" />}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            // Clear the selection so "Use template" can't navigate with a
+            // template that the new query may have filtered out of the list.
+            setSelected(null);
+          }}
         />
         <div className="flex flex-col gap-1">
           <span className="text-sm text-ink-gray-5">Templates</span>


### PR DESCRIPTION
## Description

This PR adds a note template selection dialog allowing user to search for template they need.

- When the note editor is opened, the title field is focused by default.



## Screenshot/Screencast


https://github.com/user-attachments/assets/ebb9ff55-c72d-4262-8b58-293ad7ec12be



## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality. NA — UI flow; covered by the manual golden-path QA above.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1095
