### PR TITLE
fix: add user_image for employees to display

### DIFF
--- a/next_pms/next_projects/api/feedback.py
+++ b/next_pms/next_projects/api/feedback.py
@@ -14,6 +14,7 @@ from next_pms.next_projects.api.constant import (
     RESOURCE_RATING_FIELDS,
     TEXT_FIELDS,
 )
+from next_pms.next_projects.api.utils import get_employee_image, get_employee_image_map
 
 
 def is_customer_feedback_available() -> bool:
@@ -199,9 +200,10 @@ def get_team_feedback_list(project: str, start: int = 0, limit: int = 20):
     Returns:
         dict: ``{ data, total, has_more }`` where ``has_more`` is ``True`` when rows remain
         beyond this page, and each ``data`` row is ``{ name, period_from, period_to,
-        employee, employee_name, customer, feedback_by, contact_email, evaluation_type,
-        average, stars, star_max }``. ``average`` is on the star scale (e.g. 2.8 of 4); the
-        raw rating columns are not exposed.
+        employee, employee_name, avatar_url, customer, feedback_by, contact_email,
+        evaluation_type, average, stars, star_max }``. ``avatar_url`` is the employee's
+        avatar image. ``average`` is on the star scale (e.g. 2.8 of 4); the raw rating
+        columns are not exposed.
     """
     only_for(ALLOWED_ROLES, message=True)
     ensure_customer_feedback_available()
@@ -238,6 +240,7 @@ def get_team_feedback_list(project: str, start: int = 0, limit: int = 20):
         limit_start=start,
         limit_page_length=limit,
     )
+    employee_image_map = get_employee_image_map([row.feedback_for for row in rows if row.feedback_for])
     data = []
     for row in rows:
         rating_fields = RATING_FIELDS.get(row.evaluation_type, [])
@@ -249,6 +252,7 @@ def get_team_feedback_list(project: str, start: int = 0, limit: int = 20):
                 "period_to": row.feedback_to_date,
                 "employee": row.feedback_for,
                 "employee_name": row.feedback_for_name,
+                "avatar_url": employee_image_map.get(row.feedback_for),
                 "customer": row.customer,
                 "feedback_by": row.feedback_by,
                 "contact_email": row.contact_email,
@@ -280,10 +284,11 @@ def get_team_feedback_breakdown(feedback_name: str):
             returned in ``get_team_feedback_list``'s ``name``.
 
     Returns:
-        dict: ``{ feedback_id, evaluation_type, employee, employee_name, customer,
-        feedback_by, period_from, period_to, average, ratings, areas_for_improvement }``
-        where ``ratings`` is a list of ``{ fieldname, label, fieldtype, value, stars,
-        star_max, percent }``.
+        dict: ``{ feedback_id, evaluation_type, employee, employee_name, avatar_url,
+        customer, feedback_by, period_from, period_to, average, ratings,
+        areas_for_improvement }`` where ``avatar_url`` is the employee's avatar image and
+        ``ratings`` is a list of ``{ fieldname, label, fieldtype, value, stars, star_max,
+        percent }``.
     """
     only_for(ALLOWED_ROLES, message=True)
     ensure_customer_feedback_available()
@@ -332,6 +337,7 @@ def get_team_feedback_breakdown(feedback_name: str):
         "evaluation_type": evaluation_type,
         "employee": data.feedback_for,
         "employee_name": data.feedback_for_name,
+        "avatar_url": get_employee_image(data.feedback_for),
         "customer": data.customer,
         "feedback_by": data.feedback_by,
         "period_from": data.feedback_from_date,

--- a/next_pms/next_projects/api/utils.py
+++ b/next_pms/next_projects/api/utils.py
@@ -19,6 +19,23 @@ def get_user_image(user: str) -> str | None:
     return frappe.db.get_value("User", user, "user_image")
 
 
+def get_employee_image_map(employees: list[str]) -> dict[str, str | None]:
+    """Map each employee to their linked User's avatar image, in two bulk queries."""
+    if not employees:
+        return {}
+    emp_rows = frappe.get_all("Employee", filters={"name": ["in", employees]}, fields=["name", "user_id"])
+    user_image_map = get_user_image_map([row.user_id for row in emp_rows if row.user_id])
+    return {row.name: user_image_map.get(row.user_id) for row in emp_rows}
+
+
+def get_employee_image(employee: str) -> str | None:
+    """Get an employee's avatar image from their linked User."""
+    if not employee:
+        return None
+    user_id = frappe.db.get_value("Employee", employee, "user_id")
+    return get_user_image(user_id)
+
+
 def build_person_data(
     user: str,
     full_name: str,


### PR DESCRIPTION
## Description

* Added an `avatar_url` field (employee's avatar image) to the output of `get_team_feedback_list` and `get_team_feedback_breakdown`, updating both the API response and the function docstrings accordingly. 
* Added `get_employee_image_map` to efficiently map multiple employees to their user avatar images using bulk queries.
* Added `get_employee_image` to retrieve a single employee's avatar image by linking to their user account.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
<img width="1211" height="769" alt="Screenshot 2026-06-11 at 12 37 34 PM" src="https://github.com/user-attachments/assets/91cb0eef-119e-4d46-9b0a-a8b1f2eb71be" />
<img width="1216" height="773" alt="Screenshot 2026-06-11 at 12 38 15 PM" src="https://github.com/user-attachments/assets/8085aea8-70de-4906-8e70-5444482fca0d" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1130#issuecomment-4671723602