### PR TITLE
Fix extra blank screen in overview tab

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/overview/sections/repository-connections/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/sections/repository-connections/index.tsx
@@ -53,7 +53,7 @@ export function RepositoryConnections() {
           style={{ gridTemplateColumns }}
         >
           {REPO_COLUMNS.map((column) => (
-            <div key={column.key} className="flex h-7 items-center">
+            <div key={column.key} className="relative flex h-7 items-center">
               {column.srOnly ? (
                 <span className="sr-only">{column.label}</span>
               ) : (


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
The issue was in the `RepositoryConnections` component. In the table header, there was an action that was visually hidden and only visible to screen readers, so it used the `sr-only` class.

Normally, this would not have been an issue, even though the `sr-only` class internally applies `position: absolute`. However, when the `TextEditor` component was present on the same screen, the element with the `sr-only` class appeared to be positioned at the bottom of the page. The amount of extra blank space matched the content height of the `TextEditor` component.



The fix was simply to add a `relative` class to the action wrapper, which corrected the positioning issue and removed the extra blank space.



## Screenshot/Screencast

Before fix:

<img width="1656" height="765" alt="image" src="https://github.com/user-attachments/assets/7eccbe80-c231-4581-b474-12e38e12d9c6" />

After fix:

<img width="1656" height="765" alt="image" src="https://github.com/user-attachments/assets/897add3b-c8aa-417b-a25c-13769b487683" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1462 