### PR TITLE
fix: security hardening + pin feature

### DIFF
--- a/next_pms/next_pms/doctype/project_status_update/project_status_update.json
+++ b/next_pms/next_pms/doctype/project_status_update/project_status_update.json
@@ -10,6 +10,7 @@
   "project",
   "last_edited_at",
   "last_edited_by",
+  "pinned",
   "comments"
  ],
  "fields": [
@@ -51,12 +52,18 @@
    "fieldtype": "Link",
    "label": "Last Edited By",
    "options": "User"
+  },
+  {
+   "default": "0",
+   "fieldname": "pinned",
+   "fieldtype": "Check",
+   "label": "Pinned"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-14 03:35:23.914901",
+ "modified": "2026-06-11 20:45:23.893484",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Project Status Update",

--- a/next_pms/next_pms/doctype/project_status_update/project_status_update.py
+++ b/next_pms/next_pms/doctype/project_status_update/project_status_update.py
@@ -20,6 +20,7 @@ class ProjectStatusUpdate(Document):
         description: DF.TextEditor | None
         last_edited_at: DF.Datetime | None
         last_edited_by: DF.Link | None
+        pinned: DF.Check
         project: DF.Link | None
         status: DF.Literal["Draft", "Review", "Publish"]
         title: DF.Data | None

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -1,9 +1,10 @@
 from typing import Any
 
 import frappe
-from frappe import _, enqueue
+from frappe import _, enqueue, only_for
 from frappe.desk.notifications import extract_mentions
-from frappe.utils import now
+from frappe.types import DF
+from frappe.utils import cint, now
 from frappe.utils.user import get_user_fullname
 
 from next_pms.api.utils import error_logger
@@ -21,6 +22,7 @@ def create_project_status_update(
     title: str,
     description: str = None,
     status: str = "Draft",
+    pinned: DF.Check | None = None,
 ) -> dict[str, Any]:
     """
     Create a new Project Status Update
@@ -30,10 +32,13 @@ def create_project_status_update(
         title (str): Title of the update
         description (str, optional): Description of the update
         status (str, optional): Status (Draft/Review/Publish). Defaults to "Draft"
+        pinned (DF.Check, optional): Whether the update is pinned
 
     Returns:
         Dict[str, Any]: Created document data
     """
+    only_for(ROLES, message=True)
+
     try:
         should_enqueue_publish_notification = False
         if not frappe.db.exists("Project", project):
@@ -44,6 +49,8 @@ def create_project_status_update(
         doc.title = title
         doc.description = description or ""
         doc.status = status
+        if pinned is not None:
+            doc.pinned = cint(pinned)
         doc.insert()
 
         if status == "Publish":
@@ -79,6 +86,8 @@ def get_project_status_update(name: str) -> dict[str, Any]:
     Returns:
         Dict[str, Any]: Project Status Update data with comments
     """
+    only_for(ROLES, message=True)
+
     if not frappe.db.exists("Project Status Update", name):
         frappe.throw(_("Project Status Update '{name}' does not exist"))
 
@@ -98,6 +107,7 @@ def get_project_status_updates_by_project(project: str, author: str | None = Non
     Returns:
         List[Dict[str, Any]]: List of Project Status Updates
     """
+    only_for(ROLES, message=True)
 
     if not frappe.db.exists("Project", project):
         frappe.throw(_("Project '{project}' does not exist"))
@@ -115,6 +125,7 @@ def get_project_status_updates_by_project(project: str, author: str | None = Non
             "description",
             "status",
             "project",
+            "pinned",
             "creation",
             "modified",
             "owner",
@@ -134,7 +145,11 @@ def get_project_status_updates_by_project(project: str, author: str | None = Non
 @frappe.whitelist(methods=["POST"])
 @error_logger
 def update_project_status_update(
-    name: str, title: str = None, description: str = None, status: str = None
+    name: str,
+    title: str = None,
+    description: str = None,
+    status: str = None,
+    pinned: DF.Check | None = None,
 ) -> dict[str, Any]:
     """
     Update an existing Project Status Update
@@ -144,10 +159,13 @@ def update_project_status_update(
         title (str, optional): New title
         description (str, optional): New description
         status (str, optional): New status
+        pinned (DF.Check, optional): New pinned state
 
     Returns:
         Dict[str, Any]: Updated document data
     """
+    only_for(ROLES, message=True)
+
     if not frappe.db.exists("Project Status Update", name):
         frappe.throw(_("Project Status Update '{name}' does not exist"))
 
@@ -159,6 +177,8 @@ def update_project_status_update(
         doc.description = description
     if status is not None:
         doc.status = status
+    if pinned is not None:
+        doc.pinned = cint(pinned)
 
     doc.save()
 
@@ -182,6 +202,7 @@ def add_comment_to_project_status_update(
     Returns:
         Dict[str, Any]: Updated document data
     """
+    only_for(ROLES, message=True)
 
     if not frappe.db.exists("Project Status Update", name):
         frappe.throw(_("Project Status Update '{name}' does not exist"))
@@ -235,6 +256,7 @@ def update_comment_in_project_status_update(
     Returns:
         Dict[str, Any]: Updated document data
     """
+    only_for(ROLES, message=True)
 
     if not comment_name:
         frappe.throw(_("Comment name is required"))
@@ -312,6 +334,7 @@ def delete_comment_from_project_status_update(name: str, comment_name: str) -> d
     Returns:
         Dict[str, Any]: Updated document data
     """
+    only_for(ROLES, message=True)
 
     if not comment_name:
         frappe.throw(_("Comment name is required"))
@@ -474,6 +497,7 @@ def get_project_status_update_details(name: str) -> dict[str, Any]:
         "description": doc.description,
         "status": doc.status,
         "project": doc.project,
+        "pinned": cint(doc.pinned),
         "owner_full_name": owner_details[0] if owner_details else doc.owner,
         "owner_image": owner_details[1] if owner_details and owner_details[1] else "",
         "comments": comments_with_details,

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -42,7 +42,7 @@ def create_project_status_update(
     try:
         should_enqueue_publish_notification = False
         if not frappe.db.exists("Project", project):
-            frappe.throw(_("Project '{project}' does not exist"))
+            frappe.throw(_("Project '{project}' does not exist").format(project=project))
 
         doc = frappe.new_doc("Project Status Update")
         doc.project = project
@@ -89,7 +89,7 @@ def get_project_status_update(name: str) -> dict[str, Any]:
     only_for(ROLES, message=True)
 
     if not frappe.db.exists("Project Status Update", name):
-        frappe.throw(_("Project Status Update '{name}' does not exist"))
+        frappe.throw(_("Project Status Update '{name}' does not exist").format(name=name))
 
     return get_project_status_update_details(name)
 
@@ -110,7 +110,7 @@ def get_project_status_updates_by_project(project: str, author: str | None = Non
     only_for(ROLES, message=True)
 
     if not frappe.db.exists("Project", project):
-        frappe.throw(_("Project '{project}' does not exist"))
+        frappe.throw(_("Project '{project}' does not exist").format(project=project))
 
     filters: dict[str, str] = {"project": project}
     if author:
@@ -167,7 +167,7 @@ def update_project_status_update(
     only_for(ROLES, message=True)
 
     if not frappe.db.exists("Project Status Update", name):
-        frappe.throw(_("Project Status Update '{name}' does not exist"))
+        frappe.throw(_("Project Status Update '{name}' does not exist").format(name=name))
 
     doc = frappe.get_doc("Project Status Update", name)
 
@@ -205,7 +205,7 @@ def add_comment_to_project_status_update(
     only_for(ROLES, message=True)
 
     if not frappe.db.exists("Project Status Update", name):
-        frappe.throw(_("Project Status Update '{name}' does not exist"))
+        frappe.throw(_("Project Status Update '{name}' does not exist").format(name=name))
 
     doc = frappe.get_doc("Project Status Update", name)
 
@@ -262,7 +262,7 @@ def update_comment_in_project_status_update(
         frappe.throw(_("Comment name is required"))
 
     if not frappe.db.exists("Project Status Update", name):
-        frappe.throw(_("Project Status Update '{name}' does not exist"))
+        frappe.throw(_("Project Status Update '{name}' does not exist").format(name=name))
 
     doc = frappe.get_doc("Project Status Update", name)
 
@@ -340,7 +340,7 @@ def delete_comment_from_project_status_update(name: str, comment_name: str) -> d
         frappe.throw(_("Comment name is required"))
 
     if not frappe.db.exists("Project Status Update", name):
-        frappe.throw(_("Project Status Update '{name}' does not exist"))
+        frappe.throw(_("Project Status Update '{name}' does not exist").format(name=name))
 
     doc = frappe.get_doc("Project Status Update", name)
 


### PR DESCRIPTION
## Description

security hardening + pin feature

## Relevant Technical Choices

- some endpoints had permission checks missing. added the checks.
- added support for pin through doctype extension and backend api code.

## Testing Instructions

```
❯ curl -s -X POST \
  'http://erp16.localhost/api/method/next_pms.timesheet.api.project_status_update.create_project_status_update' \
  -H 'Content-Type: application/json' \
  -H 'Cookie: sid=907d7841e57f531784f76fd8fa842a01460daea01de34aa3fdbfef24' \
  -d '{
        "project": "PROJ-0001",
        "title": "Pinned status update",
        "description": "<p>Weekly update</p>",
        "status": "Draft",
        "pinned": true
      }'
{"message":{"name":"mbkq2e5048","title":"Pinned status update","description":"<p>Weekly update</p>","status":"Draft","project":"PROJ-0001","pinned":1,"owner_full_name":"ad","owner_image":"","comments":[],"creation":"2026-06-12 12:33:52.490235","modified":"2026-06-12 12:33:52.490235","last_edited_at":null,"last_edited_by":null,"owner":"Administrator","modified_by":"Administrator","docstatus":0}}%
~
❯ curl -s -X POST \
  'http://erp16.localhost/api/method/next_pms.timesheet.api.project_status_update.update_project_status_update' \
  -H 'Content-Type: application/json' \
  -H 'Cookie: sid=907d7841e57f531784f76fd8fa842a01460daea01de34aa3fdbfef24' \
  -d '{
        "name": "mbkq2e5048",
        "pinned": false
      }'
{"message":{"name":"mbkq2e5048","title":"Pinned status update","description":"<p>Weekly update</p>","status":"Draft","project":"PROJ-0001","pinned":0,"owner_full_name":"ad","owner_image":"","comments":[],"creation":"2026-06-12 12:33:52.490235","modified":"2026-06-12 12:34:21.001852","last_edited_at":null,"last_edited_by":null,"owner":"Administrator","modified_by":"Administrator","docstatus":0}}%
~
❯
```

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1457 