### PR TITLE
Add note pinning feature

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/notes/context.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/context.ts
@@ -14,7 +14,7 @@ export interface NotesContextProps {
     isLoading: boolean;
     error: unknown;
     filters: NoteFilters;
-    isDeleting: boolean;
+    isUpdating: boolean;
     authorOptions: NoteAuthorOption[];
   };
   actions: {
@@ -23,6 +23,7 @@ export interface NotesContextProps {
     setAuthor: (value: string) => void;
     refresh: () => Promise<unknown>;
     deleteNote: (name: string) => Promise<void>;
+    togglePin: (name: string) => Promise<void>;
   };
 }
 
@@ -38,7 +39,7 @@ export const NotesContext = createContext<NotesContextProps>({
       description: "",
       author: "",
     },
-    isDeleting: false,
+    isUpdating: false,
     authorOptions: [],
   },
   actions: {
@@ -47,6 +48,7 @@ export const NotesContext = createContext<NotesContextProps>({
     setAuthor: noop,
     refresh: async () => undefined,
     deleteNote: async () => undefined,
+    togglePin: async () => undefined,
   },
 });
 

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
@@ -23,16 +23,19 @@ function NotesGrid() {
 
   return (
     // The height is calculated by subtracting the height of the header.
-    <div className="relative flex h-full min-h-[calc(100dvh-var(--spacing)*24)]  flex-col gap-4">
+    <div className="relative flex flex-col gap-4">
       <NotesSubHeader />
       <div
-        className={cn("flex flex-col", {
-          "opacity-50 transition-opacity duration-150": isLoading,
-        })}
+        className={cn(
+          "flex flex-col h-[calc(100dvh-var(--spacing)*55)] overflow-y-auto scrollbar-thin",
+          {
+            "opacity-50 transition-opacity duration-150": isLoading,
+          },
+        )}
       >
         {!isLoading && notes.length === 0 ? (
           <div className="py-10 text-center text-sm text-ink-gray-4">
-            No risks found
+            No notes found
           </div>
         ) : notes.length > 0 ? (
           <div className="flex flex-wrap gap-5">
@@ -41,13 +44,13 @@ function NotesGrid() {
             ))}
           </div>
         ) : null}
+        {isLoading && (
+          <Spinner
+            isFull
+            className="absolute top-0 left-0 w-full h-full cursor-wait z-10"
+          />
+        )}
       </div>
-      {isLoading && (
-        <Spinner
-          isFull
-          className="absolute top-0 left-0 h-[calc(100dvh-var(--spacing)*24)]  w-full cursor-wait z-10"
-        />
-      )}
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/index.tsx
@@ -18,48 +18,29 @@ function NotesGrid() {
   const notes = useNotes((s) => s.state.notes);
   const isLoading = useNotes((s) => s.state.isLoading);
   const error = useNotes((s) => s.state.error);
-  const filters = useNotes((s) => s.state.filters);
-  const authorOptions = useNotes((s) => s.state.authorOptions);
-  const setTitleInput = useNotes((s) => s.actions.setTitleInput);
-  const setDescriptionInput = useNotes((s) => s.actions.setDescriptionInput);
-  const setAuthor = useNotes((s) => s.actions.setAuthor);
 
   if (error) throw error;
-
-  const hasFilter = Boolean(
-    filters.title.trim() || filters.description.trim() || filters.author,
-  );
 
   return (
     // The height is calculated by subtracting the height of the header.
     <div className="relative flex h-full min-h-[calc(100dvh-var(--spacing)*24)]  flex-col gap-4">
-      <NotesSubHeader
-        titleInput={filters.title}
-        descriptionInput={filters.description}
-        author={filters.author}
-        authorOptions={authorOptions}
-        onTitleInputChange={setTitleInput}
-        onDescriptionInputChange={setDescriptionInput}
-        onAuthorChange={setAuthor}
-      />
+      <NotesSubHeader />
       <div
         className={cn("flex flex-col", {
           "opacity-50 transition-opacity duration-150": isLoading,
         })}
       >
-        {notes.length === 0 ? (
+        {!isLoading && notes.length === 0 ? (
           <div className="py-10 text-center text-sm text-ink-gray-4">
-            {hasFilter
-              ? "No notes match the current filters"
-              : "No notes yet for this project"}
+            No risks found
           </div>
-        ) : (
+        ) : notes.length > 0 ? (
           <div className="flex flex-wrap gap-5">
             {notes.map((note) => (
               <NoteCard key={note.name} note={note} />
             ))}
           </div>
-        )}
+        ) : null}
       </div>
       {isLoading && (
         <Spinner

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
@@ -46,10 +46,11 @@ export function NoteActions({ note }: NoteActionsProps) {
     <span className="flex items-center" onClick={(e) => e.stopPropagation()}>
       {note.pinned ? (
         <Button
-          onClick={() => togglePin(note.name)}
+          onClick={() => void togglePin(note.name)}
           variant="ghost"
           icon={() => <Unpin className="size-4" />}
           disabled={isUpdating}
+          aria-label="Unpin note"
         />
       ) : null}
       <Dropdown

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
@@ -2,11 +2,13 @@
  * External dependencies.
  */
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Dropdown } from "@rtcamp/frappe-ui-react";
+import { Button, Dropdown } from "@rtcamp/frappe-ui-react";
 import {
   Delete,
   DotHorizontal,
   Edit1,
+  PinAlt,
+  Unpin,
   Export,
 } from "@rtcamp/frappe-ui-react/icons";
 
@@ -29,7 +31,8 @@ export function NoteActions({ note }: NoteActionsProps) {
   const [, setSearchParams] = useSearchParams();
   const projectId = useProjectDetail((s) => s.projectId);
   const deleteNote = useNotes((s) => s.actions.deleteNote);
-  const isDeleting = useNotes((s) => s.state.isDeleting);
+  const togglePin = useNotes((s) => s.actions.togglePin);
+  const isUpdating = useNotes((s) => s.state.isUpdating);
 
   const handleDelete = async () => {
     await deleteNote(note.name);
@@ -40,7 +43,15 @@ export function NoteActions({ note }: NoteActionsProps) {
   };
 
   return (
-    <span onClick={(e) => e.stopPropagation()}>
+    <span className="flex items-center" onClick={(e) => e.stopPropagation()}>
+      {note.pinned ? (
+        <Button
+          onClick={() => togglePin(note.name)}
+          variant="ghost"
+          icon={() => <Unpin className="size-4" />}
+          disabled={isUpdating}
+        />
+      ) : null}
       <Dropdown
         placement="right"
         button={{ variant: "ghost", icon: DotHorizontal }}
@@ -49,15 +60,26 @@ export function NoteActions({ note }: NoteActionsProps) {
             key: "edit",
             label: "Edit",
             icon: <Edit1 className="size-4 mr-2" />,
-            disabled: isDeleting,
+            disabled: isUpdating,
             onClick: () =>
               navigate(
                 `${ROUTES.project}/${projectId}/notes/${note.name}/edit`,
               ),
           },
           {
+            key: "pin",
+            label: note.pinned ? "Unpin" : "Pin",
+            icon: note.pinned ? (
+              <Unpin className="size-4 mr-2" />
+            ) : (
+              <PinAlt className="size-4 mr-2" />
+            ),
+            disabled: isUpdating,
+            onClick: () => void togglePin(note.name),
+          },
+          {
             key: "export",
-            label: "Export note",
+            label: "Export",
             icon: <Export className="size-4 mr-2" />,
             onClick: () => exportNote(note),
           },
@@ -66,7 +88,7 @@ export function NoteActions({ note }: NoteActionsProps) {
             label: "Delete",
             theme: "red",
             icon: <Delete className="size-4 mr-2" />,
-            disabled: isDeleting,
+            disabled: isUpdating,
             onClick: () => void handleDelete(),
           },
         ]}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -47,7 +47,7 @@ export function NoteCard({ note }: NoteCardProps) {
       }}
       className="flex h-64 min-w-65.75 max-w-131.5 flex-1 cursor-pointer flex-col rounded-[12px] border border-outline-gray-2 bg-surface-white overflow-clip shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink-gray-4"
     >
-      <div className="flex items-center gap-3 px-3.5 pt-3.5">
+      <div className="flex justify-between items-center gap-2 px-3.5 pt-3.5">
         <h3 className="flex-1 truncate text-lg font-medium text-ink-gray-8">
           {note.title}
         </h3>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/provider.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/provider.tsx
@@ -3,7 +3,11 @@
  */
 import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 import { useToasts } from "@rtcamp/frappe-ui-react";
-import { FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
+import {
+  FrappeError,
+  useFrappeDeleteDoc,
+  useFrappePostCall,
+} from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
@@ -17,8 +21,11 @@ export function NotesProvider({ children }: PropsWithChildren) {
   const [titleInput, setTitleInput] = useState("");
   const [descriptionInput, setDescriptionInput] = useState("");
   const [author, setAuthor] = useState("");
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const { deleteDoc } = useFrappeDeleteDoc();
+  const { call: updateNote } = useFrappePostCall(
+    "next_pms.timesheet.api.project_status_update.update_project_status_update",
+  );
   const toast = useToasts();
   const debouncedTitleInput = useDebounce(titleInput, 400);
   const debouncedDescriptionInput = useDebounce(descriptionInput, 400);
@@ -49,7 +56,7 @@ export function NotesProvider({ children }: PropsWithChildren) {
 
   const deleteNote = useCallback(
     async (name: string) => {
-      setIsDeleting(true);
+      setIsUpdating(true);
       try {
         await deleteDoc("Project Status Update", name);
         toast.success("Note deleted");
@@ -57,10 +64,32 @@ export function NotesProvider({ children }: PropsWithChildren) {
       } catch (err) {
         toast.error(parseFrappeErrorMsg(err as FrappeError));
       } finally {
-        setIsDeleting(false);
+        setIsUpdating(false);
       }
     },
     [deleteDoc, mutate, toast],
+  );
+
+  const togglePin = useCallback(
+    async (name: string) => {
+      const note = notes.find((item) => item.name === name);
+
+      if (!note) return;
+      setIsUpdating(true);
+      try {
+        await updateNote({
+          name,
+          pinned: !note.pinned,
+        });
+        toast.success(note.pinned ? "Note unpinned" : "Note pinned");
+        await mutate();
+      } catch (err) {
+        toast.error(parseFrappeErrorMsg(err as FrappeError));
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [mutate, notes, toast, updateNote],
   );
 
   const value = useMemo<NotesContextProps>(
@@ -74,7 +103,7 @@ export function NotesProvider({ children }: PropsWithChildren) {
           description: descriptionInput,
           author,
         },
-        isDeleting,
+        isUpdating,
         authorOptions,
       },
       actions: {
@@ -83,6 +112,7 @@ export function NotesProvider({ children }: PropsWithChildren) {
         setAuthor: handleAuthorChange,
         refresh: mutate,
         deleteNote,
+        togglePin,
       },
     }),
     [
@@ -92,13 +122,14 @@ export function NotesProvider({ children }: PropsWithChildren) {
       titleInput,
       descriptionInput,
       author,
-      isDeleting,
+      isUpdating,
       authorOptions,
       handleTitleInputChange,
       handleDescriptionInputChange,
       handleAuthorChange,
       mutate,
       deleteNote,
+      togglePin,
     ],
   );
 

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
@@ -10,29 +10,20 @@ import { AddSm, SmallDown } from "@rtcamp/frappe-ui-react/icons";
  */
 import { ROUTES } from "@/lib/constant";
 import { CREATE_OPTIONS } from "./constants";
-import type { NoteAuthorOption } from "./types";
+import { useNotes } from "./context";
 
-type NotesSubHeaderProps = {
-  titleInput: string;
-  descriptionInput: string;
-  author: string;
-  authorOptions: NoteAuthorOption[];
-  onTitleInputChange: (value: string) => void;
-  onDescriptionInputChange: (value: string) => void;
-  onAuthorChange: (value: string) => void;
-};
-
-export function NotesSubHeader({
-  titleInput,
-  descriptionInput,
-  author,
-  authorOptions,
-  onTitleInputChange,
-  onDescriptionInputChange,
-  onAuthorChange,
-}: NotesSubHeaderProps) {
+export function NotesSubHeader() {
   const navigate = useNavigate();
   const { projectId = "" } = useParams<{ projectId: string }>();
+  const titleInput = useNotes((s) => s.state.filters.title);
+  const descriptionInput = useNotes((s) => s.state.filters.description);
+  const author = useNotes((s) => s.state.filters.author);
+  const authorOptions = useNotes((s) => s.state.authorOptions);
+  const onTitleInputChange = useNotes((s) => s.actions.setTitleInput);
+  const onDescriptionInputChange = useNotes(
+    (s) => s.actions.setDescriptionInput,
+  );
+  const onAuthorChange = useNotes((s) => s.actions.setAuthor);
 
   return (
     <div className="flex flex-col gap-4">

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/types.ts
@@ -36,6 +36,7 @@ export type Note = {
   description: string;
   status: NoteStatus;
   project: string;
+  pinned?: boolean;
   owner: string;
   owner_full_name?: string;
   owner_image?: string | null;

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/useNotesData.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/useNotesData.ts
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { useMemo } from "react";
-import { useFrappeGetDocList } from "frappe-react-sdk";
+import { useFrappeGetCall, useFrappeGetDocList } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
@@ -37,15 +37,19 @@ export function useNotesData(filters: NoteFilters) {
     return base;
   }, [projectId, filters.author, filters.title, filters.description]);
 
-  const { data, isLoading, error, mutate } = useFrappeGetDocList<Note>(
-    "Project Status Update",
+  const { data, isLoading, error, mutate } = useFrappeGetCall<{
+    message: Note[];
+  }>(
+    "frappe.client.get_list",
     {
+      doctype: "Project Status Update",
       fields: [
         "name",
         "title",
         "description",
         "status",
         "project",
+        "pinned",
         "creation",
         "modified",
         "last_edited_at",
@@ -53,14 +57,11 @@ export function useNotesData(filters: NoteFilters) {
         "owner",
         "modified_by",
       ],
-      filters: frappeFilters as never,
-      orderBy: {
-        field: "creation",
-        order: "desc",
-      },
-      limit: 500,
+      filters: frappeFilters,
+      order_by: "pinned desc, creation desc",
+      limit_page_length: 500,
     },
-    undefined,
+    projectId ? undefined : null,
     {
       keepPreviousData: true,
     },
@@ -108,13 +109,14 @@ export function useNotesData(filters: NoteFilters) {
   );
 
   const notes = useMemo<Note[]>(() => {
-    if (!data?.length) return [];
+    if (!data?.message?.length) return [];
 
-    return data.map((note) => {
+    return data.message.map((note) => {
       const authorDetails = userMap[note.owner];
 
       return {
         ...note,
+        pinned: Boolean(note.pinned),
         owner_full_name: authorDetails?.full_name || note.owner,
         owner_image: authorDetails?.user_image ?? null,
       };


### PR DESCRIPTION

## Description

<!-- What do we want to achieve with this PR? -->
This pull request adds pin/unpin functionality to project notes and refactors related UI and state management.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Added an unpin icon directly to pinned cards, as well as to the Notes Details page, just before the “...” icon. This provides a clear indication that the note is pinned while also allowing users to unpin it with a single click. I considered using a “Pinned” label or a non-functional pin icon, but the label takes up too much space on cards, and a pin icon without functionality could make users think it is clickable.
- Also fixes re render issues 

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/66b5d373-518b-4b60-aaeb-7f024bf2dd43



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1456 