### PR TITLE
feat: endpoint to get the emails linked to a project

### DIFF
--- a/next_pms/next_projects/api/email.py
+++ b/next_pms/next_projects/api/email.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe import only_for
+from frappe import _, only_for
 
 from next_pms.next_projects.api.constant import ALLOWED_ROLES
 
@@ -15,6 +15,11 @@ def get_project_emails(project: str) -> list[dict]:
     project has no linked deal — the email tab simply renders empty.
     """
     only_for(ALLOWED_ROLES, message=True)
+
+    if not project:
+        frappe.throw(_("Project is required"))
+    if not frappe.db.exists("Project", project):
+        frappe.throw(_("Project {0} not found").format(project), frappe.DoesNotExistError)
 
     if "frappe_crm_xt" not in frappe.get_installed_apps():
         return []
@@ -31,11 +36,14 @@ def get_project_emails(project: str) -> list[dict]:
 
 
 def has_project_email() -> bool:
-    """Whether the Project doctype exposes the custom_deal field from frappe_crm_xt.
+    """Whether projects can link to a CRM Deal via frappe_crm_xt's custom_deal field.
 
-    The email tab is only meaningful when a project can link to a CRM Deal, so the
-    frontend gates the tab on this boot flag.
+    The email tab is only meaningful when frappe_crm_xt is installed and the Project
+    doctype exposes the custom_deal field, so the frontend gates the tab on this boot
+    flag.
     """
+    if "frappe_crm_xt" not in frappe.get_installed_apps():
+        return False
     return frappe.get_meta("Project").has_field("custom_deal")
 
 

--- a/next_pms/next_projects/api/email.py
+++ b/next_pms/next_projects/api/email.py
@@ -30,6 +30,15 @@ def get_project_emails(project: str) -> list[dict]:
     return [_to_email(activity) for activity in activities if _is_email(activity)]
 
 
+def has_project_email() -> bool:
+    """Whether the Project doctype exposes the custom_deal field from frappe_crm_xt.
+
+    The email tab is only meaningful when a project can link to a CRM Deal, so the
+    frontend gates the tab on this boot flag.
+    """
+    return frappe.get_meta("Project").has_field("custom_deal")
+
+
 def _is_email(activity: dict) -> bool:
     return activity.get("activity_type") == "communication" and activity.get("communication_type") == "Email"
 

--- a/next_pms/next_projects/api/email.py
+++ b/next_pms/next_projects/api/email.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import only_for
+
+from next_pms.next_projects.api.constant import ALLOWED_ROLES
+
+
+@frappe.whitelist(methods=["GET"])
+def get_project_emails(project: str) -> list[dict]:
+    """Return the email activities for a project's linked CRM Deal.
+
+    Degrades to an empty list when frappe_crm_xt isn't installed or the
+    project has no linked deal — the email tab simply renders empty.
+    """
+    only_for(ALLOWED_ROLES, message=True)
+
+    if "frappe_crm_xt" not in frappe.get_installed_apps():
+        return []
+
+    deal = frappe.db.get_value("Project", project, "custom_deal")
+    if not deal:
+        return []
+
+    from frappe_crm_xt.api.activity import get_activities
+
+    activities = get_activities(deal)[0]
+
+    return [_to_email(activity) for activity in activities if _is_email(activity)]
+
+
+def _is_email(activity: dict) -> bool:
+    return activity.get("activity_type") == "communication" and activity.get("communication_type") == "Email"
+
+
+def _to_email(activity: dict) -> dict:
+    data = activity.get("data") or {}
+    return {
+        "communication_date": activity.get("communication_date"),
+        "creation": activity.get("creation"),
+        "subject": data.get("subject"),
+        "content": data.get("content"),
+        "sender": data.get("sender"),
+        "sender_full_name": data.get("sender_full_name"),
+        "recipients": data.get("recipients"),
+        "cc": data.get("cc"),
+        "bcc": data.get("bcc"),
+        "attachments": data.get("attachments") or [],
+        "read_by_recipient": data.get("read_by_recipient"),
+        "delivery_status": data.get("delivery_status"),
+    }

--- a/next_pms/www/next-pms/index.py
+++ b/next_pms/www/next-pms/index.py
@@ -4,6 +4,7 @@ import re
 import frappe
 from frappe.utils import cint
 
+from next_pms.next_projects.api.email import has_project_email
 from next_pms.next_projects.api.feedback import is_customer_feedback_available
 from next_pms.timesheet.api.app import has_bu_field, has_industry_field
 from next_pms.timesheet.api.project import get_project_filter_for_contractor
@@ -37,6 +38,7 @@ def get_context(context):
     boot["has_industry"] = has_industry_field()
     boot["has_repository_connections"] = bool(frappe.db.exists("DocType", "GitHub Repository"))
     boot["has_customer_feedback"] = is_customer_feedback_available()
+    boot["has_project_email"] = has_project_email()
     boot["has_todo_custom_fields"] = has_todo_custom_fields()
     boot["is_calendar_setup"] = is_google_calendar_enabled()
     boot["global_filters"] = get_global_filters()
@@ -81,6 +83,7 @@ def get_boot():
     boot["has_industry"] = has_industry_field()
     boot["has_repository_connections"] = bool(frappe.db.exists("DocType", "GitHub Repository"))
     boot["has_customer_feedback"] = is_customer_feedback_available()
+    boot["has_project_email"] = has_project_email()
     boot["has_todo_custom_fields"] = has_todo_custom_fields()
     boot["is_calendar_setup"] = is_google_calendar_enabled()
     boot["app_name"] = "Next PMS"


### PR DESCRIPTION
## Description

* Added `get_project_emails` function in `next_pms/next_projects/api/email.py` to return email activities for a project's linked CRM Deal, with checks for required roles and app installation.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1017" height="656" alt="image" src="https://github.com/user-attachments/assets/0518f9e7-3575-40f0-b26c-ef8ad6be77e1" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1439 