### PR TITLE
feat(dashboard): leadership KPI cards row

### DIFF
--- a/frontend/packages/app/src/pages/dashboard/constants.ts
+++ b/frontend/packages/app/src/pages/dashboard/constants.ts
@@ -6,7 +6,30 @@ import type { ComboboxOption } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
+import type { KpiCardData } from "./kpiCard";
 import type { StatCardData } from "./statCard";
+
+// Hard-coded financial KPIs from the design until real data is wired in a later issue.
+export const LEADERSHIP_KPIS: KpiCardData[] = [
+  {
+    label: "Last month's revenue",
+    value: "$300,000",
+    trend: { value: "+15%", direction: "up", tone: "positive" },
+    comparison: "vs Dec 2025",
+  },
+  {
+    label: "Last month's cost",
+    value: "$120,000",
+    trend: { value: "-2%", direction: "down", tone: "positive" },
+    comparison: "vs Dec 2025",
+  },
+  {
+    label: "Last month's profit margin",
+    value: "42%",
+    trend: { value: "11%", direction: "down", tone: "negative" },
+    comparison: "vs Dec 2025",
+  },
+];
 
 // Hard-coded summary stats from the design until real data is wired in a later issue.
 export const LEADERSHIP_STATS: StatCardData[] = [

--- a/frontend/packages/app/src/pages/dashboard/kpiCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/kpiCard.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies.
+ */
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  SmallDown,
+} from "@rtcamp/frappe-ui-react/icons";
+import { cva } from "class-variance-authority";
+
+const trendVariants = cva("flex items-center gap-0.5", {
+  variants: {
+    tone: {
+      positive: "text-ink-green-4",
+      negative: "text-ink-red-4",
+    },
+  },
+});
+
+export type KpiCardData = {
+  label: string;
+  value: string;
+  trend: {
+    value: string;
+    direction: "up" | "down";
+    tone: "positive" | "negative";
+  };
+  comparison: string;
+};
+
+export function KpiCard({ label, value, trend, comparison }: KpiCardData) {
+  const TrendArrow = trend.direction === "up" ? ArrowUpRight : ArrowDownLeft;
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-outline-gray-1 bg-surface-cards p-3">
+      <span className="truncate text-base text-ink-gray-5">{label}</span>
+      <span className="truncate text-2xl font-medium text-ink-gray-8">
+        {value}
+      </span>
+      <div className="flex items-center gap-1 text-sm">
+        <span className={trendVariants({ tone: trend.tone })}>
+          <TrendArrow className="size-4 shrink-0" />
+          {trend.value}
+        </span>
+        <span className="flex min-w-0 items-center text-ink-gray-5">
+          <span className="truncate">{comparison}</span>
+          <SmallDown className="size-4 shrink-0" />
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/dashboard/leadershipView.tsx
+++ b/frontend/packages/app/src/pages/dashboard/leadershipView.tsx
@@ -1,18 +1,23 @@
 /**
  * Internal dependencies.
  */
-import { LEADERSHIP_STATS } from "./constants";
+import { LEADERSHIP_KPIS, LEADERSHIP_STATS } from "./constants";
+import { KpiCard } from "./kpiCard";
 import { StatCard } from "./statCard";
 
 export function LeadershipView() {
   return (
-    <section
-      aria-label="Leadership dashboard"
-      className="grid grid-cols-4 gap-3"
-    >
-      {LEADERSHIP_STATS.map((stat) => (
-        <StatCard key={stat.label} {...stat} />
-      ))}
+    <section aria-label="Leadership dashboard" className="flex flex-col gap-3">
+      <div className="grid grid-cols-3 gap-3">
+        {LEADERSHIP_KPIS.map((kpi) => (
+          <KpiCard key={kpi.label} {...kpi} />
+        ))}
+      </div>
+      <div className="grid grid-cols-4 gap-3">
+        {LEADERSHIP_STATS.map((stat) => (
+          <StatCard key={stat.label} {...stat} />
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Description

Builds the three financial KPI metric cards at the top of the Leadership dashboard (issue #1131): **Last month's revenue** ($300,000, +15% vs Dec 2025), **Last month's cost** ($120,000, -2% vs Dec 2025), and **Last month's profit margin** (42%, 11% vs Dec 2025). Each card shows a label, a large value, and a trend badge (arrow + percentage, colored) with a "vs &lt;period&gt;" comparison and a dropdown chevron. Static data from the design — no live wiring (deferred to a later issue).

## Relevant Technical Choices

- **`kpiCard.tsx`** (new, page-local per AC "component for kpi card in page dir", analogous to the existing `statCard.tsx`): `KpiCard({ label, value, trend, comparison })`.
  - Trend `{ value, direction: "up" | "down", tone: "positive" | "negative" }` — `direction` selects the arrow icon, `tone` selects the color; they are independent in the design (cost is a *down* arrow with a *positive*/green tone because a cost decrease is good).
  - Tone → color via a co-located `cva` (`positive` → `text-ink-green-4`, `negative` → `text-ink-red-4`), applied to the badge wrapper so the arrow (currentColor) and percentage share the color.
  - Icons reused from `@rtcamp/frappe-ui-react/icons`: `ArrowUpRight` (↗), `ArrowDownLeft` (↙), `SmallDown` (the period chevron), all `size-4` (16px).
  - Card styled per Figma: `rounded-lg` (12px), `border-outline-gray-1`, `bg-surface-cards`, `p-3`; label `text-base` (14px) `ink-gray-5`; value `text-2xl` (20px) `font-medium` `ink-gray-8`; trend `text-sm` (13px).
- **`constants.ts`**: added `LEADERSHIP_KPIS` static data (mirrors the existing `LEADERSHIP_STATS` precedent).
- **`leadershipView.tsx`**: renders a `grid-cols-3` KPI strip above the existing `grid-cols-4` stat strip, wrapped in `flex flex-col gap-3`.
- No new design-system / frappe-ui-react primitives — all tokens and icons already existed.

**Cost-badge color note:** the issue prose says the cost trend is "red", but the Figma frame (`3543-327766`) renders the `-2%` cost badge **green** (cost down = good). This PR follows the design (green) per the "static data from the design" acceptance criterion. Flagged on the Slack thread; easy to flip if the prose is authoritative.

**Base branch:** targets `feat/dashboard` (not `feat/redesign`), consistent with the sibling stat-cards PR #1520 — the files this PR builds on only exist on `feat/dashboard`, and PR #1518 integrates `feat/dashboard` → `feat/redesign`.

## Testing Instructions

1. Open `/next-pms/dashboard` as a user with the **Delivery Manager** role.
2. Confirm a row of **3 KPI cards** renders above the existing **4 stat cards**.
3. Verify values/labels: $300,000 / +15%, $120,000 / -2%, 42% / 11% — all "vs Dec 2025".
4. Verify the revenue badge is green with an up-right arrow, cost green with a down-left arrow, profit margin red with a down-left arrow; each card ends with a chevron-down after "vs Dec 2025".
5. No console errors; no unexpected network calls (static data).

Browser-verified on `/next-pms/dashboard`: 3 KPI + 4 stat cards, grid-cols-3 / grid-cols-4, revenue/cost `#137949` green, profit `#b52a2a` red, radius 12px, label 14px / value 20px, distinct up/down arrows, no console errors.

## Additional Information

- Figma frame (Copy file `h1EnhdK8swe6FCyxUW1XHx`): https://www.figma.com/design/h1EnhdK8swe6FCyxUW1XHx/Frappe-PMS--Copy-?node-id=3543-327766&m=dev
- Plan tracked in the `#bots-ai-workflow-next-pms` Slack thread; defaults taken after the plan-approval gate (Figma green cost badge, static chevron, grid-cols-3, KPI row above stat strip).

## Screenshot/Screencast

Browser-verified live render on `/next-pms/dashboard` (3 KPI cards above the 4 stat cards) matches the Figma frame. Inline image not auto-attachable from CLI — see the Figma frame link above and the Testing Instructions for the verified facts.

## Checklist

- [ ] Code follows the project conventions
- [ ] Self-reviewed the diff
- [ ] Tested the change in the browser
