### PR TITLE
Feature: Add recurrence options to delete allocation modal

### DIFF
--- a/frontend/packages/app/src/pages/allocations/allocationOutletContext.ts
+++ b/frontend/packages/app/src/pages/allocations/allocationOutletContext.ts
@@ -2,12 +2,18 @@
  * External dependencies.
  */
 import { useOutletContext } from "react-router-dom";
-import type { AllocationCallbackData } from "@next-pms/design-system/components";
+import type {
+  AllocationCallbackData,
+  DeleteAllocationMode,
+} from "@next-pms/design-system/components";
 
 export type AllocationOutletContext = {
   openAddAllocationDialog: (data: AllocationCallbackData) => void;
   openEditAllocationDialog: (data: AllocationCallbackData) => void;
-  openDeleteAllocationDialog: (data: AllocationCallbackData) => void;
+  openDeleteAllocationDialog: (
+    data: AllocationCallbackData,
+    deleteMode: DeleteAllocationMode,
+  ) => Promise<void>;
 };
 
 export function useAllocationOutletContext() {

--- a/frontend/packages/app/src/pages/allocations/team/type.ts
+++ b/frontend/packages/app/src/pages/allocations/team/type.ts
@@ -26,6 +26,7 @@ export interface ResourceAllocation {
   name: string;
   employee: string;
   employee_name: string;
+  recurrence_id: string | null;
   allocation_start_date: string;
   allocation_end_date: string;
   hours_allocated_per_day: number;

--- a/frontend/packages/app/src/pages/allocations/useAllocationModal.ts
+++ b/frontend/packages/app/src/pages/allocations/useAllocationModal.ts
@@ -2,7 +2,10 @@
  * External dependencies.
  */
 import { useCallback, useMemo, useState } from "react";
-import type { AllocationCallbackData } from "@next-pms/design-system/components";
+import type {
+  AllocationCallbackData,
+  DeleteAllocationMode,
+} from "@next-pms/design-system/components";
 import { useToasts } from "@rtcamp/frappe-ui-react";
 import { format } from "date-fns";
 import { useFrappePostCall } from "frappe-react-sdk";
@@ -58,6 +61,7 @@ export function useAllocationModal(refresh: RefreshAllocations) {
       employeeId: data.employeeId,
       ...(data.projectId ? { projectId: data.projectId } : {}),
       customer: data.customerName,
+      recurrence: data.recurrenceId ? "recurring" : "one-time",
       fromDate: data.startDate
         ? format(data.startDate, "yyyy-MM-dd")
         : undefined,
@@ -71,7 +75,7 @@ export function useAllocationModal(refresh: RefreshAllocations) {
   }, []);
 
   const handleDelete = useCallback(
-    async (data: AllocationCallbackData) => {
+    async (data: AllocationCallbackData, deleteMode: DeleteAllocationMode) => {
       if (!data.allocationId) {
         toast.error("Allocation ID not found");
         return;
@@ -80,7 +84,7 @@ export function useAllocationModal(refresh: RefreshAllocations) {
       try {
         await deleteAllocation({
           name: data.allocationId,
-          delete_mode: "only_this",
+          delete_mode: deleteMode,
         });
         const refreshTargets = {
           ...(data.employeeId ? { employeeIds: [data.employeeId] } : {}),

--- a/frontend/packages/app/src/pages/allocations/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/utils.ts
@@ -33,6 +33,7 @@ export type AllocationApiRecord = {
   employee?: string;
   project?: string;
   customer?: string | null;
+  recurrence_id?: string | null;
   hours_allocated_per_day: number;
   allocation_start_date: string;
   allocation_end_date: string;
@@ -160,6 +161,7 @@ export function mapResourceAllocation<T extends AllocationApiRecord>(
     id: allocation.name,
     employeeId: allocation.employee || undefined,
     projectId: allocation.project || undefined,
+    recurrenceId: allocation.recurrence_id ?? undefined,
     customerName: customerName ?? allocation.customer ?? undefined,
     hours: allocation.hours_allocated_per_day,
     startDate: parseISO(allocation.allocation_start_date),

--- a/frontend/packages/design-system/src/components/gantt-view/deleteAllocationDialog.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/deleteAllocationDialog.tsx
@@ -15,7 +15,7 @@ const RECURRING_DELETE_OPTIONS: Array<{
 }> = [
   { label: "This allocation", value: "only_this" },
   {
-    label: "This and future allocation",
+    label: "This and future allocations",
     value: "this_and_future",
   },
   { label: "Whole series", value: "all_in_series" },

--- a/frontend/packages/design-system/src/components/gantt-view/deleteAllocationDialog.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/deleteAllocationDialog.tsx
@@ -1,28 +1,72 @@
-import { Button, Dialog } from "@rtcamp/frappe-ui-react";
+/**
+ * External dependencies.
+ */
+import { useCallback, useState } from "react";
+import { Button, Dialog, Select } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import type { DeleteAllocationMode } from "./types";
+
+const RECURRING_DELETE_OPTIONS: Array<{
+  label: string;
+  value: DeleteAllocationMode;
+}> = [
+  { label: "This allocation", value: "only_this" },
+  {
+    label: "This and future allocation",
+    value: "this_and_future",
+  },
+  { label: "Whole series", value: "all_in_series" },
+];
 
 export interface DeleteAllocationDialogProps {
-  open: boolean;
   onOpenChange: (open: boolean) => void;
   projectName: string;
   dateRange: string;
   hoursPerDay: string;
   totalHours: string;
-  onConfirm: () => void;
+  isRecurring?: boolean;
+  onConfirm: (deleteMode: DeleteAllocationMode) => Promise<void>;
 }
 
 export function DeleteAllocationDialog({
-  open,
   onOpenChange,
   projectName,
   dateRange,
   hoursPerDay,
   totalHours,
+  isRecurring = false,
   onConfirm,
 }: DeleteAllocationDialogProps) {
+  const [deleteMode, setDeleteMode] =
+    useState<DeleteAllocationMode>("only_this");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleConfirm = useCallback(async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await onConfirm(deleteMode);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [deleteMode, onConfirm, isSubmitting]);
+
   return (
     <Dialog
-      open={open}
-      onOpenChange={onOpenChange}
+      open
+      onOpenChange={(nextOpen) => {
+        if (isSubmitting) {
+          return;
+        }
+
+        onOpenChange(nextOpen);
+      }}
       options={{ title: "Delete Allocation", size: "lg", position: "top" }}
       actions={
         <div className="flex items-center justify-end gap-1">
@@ -31,6 +75,7 @@ export function DeleteAllocationDialog({
             theme="gray"
             size="sm"
             label="Cancel"
+            disabled={isSubmitting}
             onClick={() => onOpenChange(false)}
           />
           <Button
@@ -38,7 +83,11 @@ export function DeleteAllocationDialog({
             theme="red"
             size="sm"
             label="Delete"
-            onClick={onConfirm}
+            disabled={isSubmitting}
+            loading={isSubmitting}
+            onClick={() => {
+              void handleConfirm();
+            }}
           />
         </div>
       }
@@ -50,6 +99,22 @@ export function DeleteAllocationDialog({
         </strong>
         ? This cannot be undone.
       </p>
+
+      {isRecurring ? (
+        <div className="mt-4">
+          <label className="mb-1.5 block text-sm text-ink-gray-6">
+            Apply delete to
+          </label>
+          <Select
+            value={deleteMode}
+            onChange={(value) => setDeleteMode(value as DeleteAllocationMode)}
+            variant="outline"
+            className="h-8"
+            disabled={isSubmitting}
+            options={RECURRING_DELETE_OPTIONS}
+          />
+        </div>
+      ) : null}
     </Dialog>
   );
 }

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -179,6 +179,7 @@ export function GanttAllocationBar({
         allocationId: allocation.id,
         employeeId: allocation.employeeId,
         projectId: allocation.projectId,
+        recurrenceId: allocation.recurrenceId,
         projectName: allocation.projectName,
         customerName: allocation.customerName,
         startDate,

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies.
+ */
 import { Avatar, Button } from "@rtcamp/frappe-ui-react";
 import {
   AddMd,
@@ -10,7 +13,12 @@ import {
   Time,
 } from "@rtcamp/frappe-ui-react/icons";
 import { format } from "date-fns";
+
+/**
+ * Internal dependencies.
+ */
 import { mergeClassNames as cn } from "../../../utils";
+import type { DeleteAllocationMode } from "../types";
 
 export interface AllocationEntry {
   projectName: string;
@@ -25,6 +33,8 @@ export interface AllocationEntry {
   updatedByImage?: string;
   onEdit?: () => void;
   onDelete?: () => void;
+  onConfirmDelete?: (deleteMode: DeleteAllocationMode) => Promise<void>;
+  recurrenceId?: string;
   createdOn?: Date;
   updatedOn?: Date;
 }
@@ -132,7 +142,7 @@ function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
               {entry.onEdit && (
                 <button
                   type="button"
-                  onClick={entry.onEdit}
+                  onClick={() => entry.onEdit?.()}
                   className="transition-colors text-ink-gray-6 hover:text-ink-gray-7"
                   aria-label="Edit allocation"
                 >
@@ -142,7 +152,7 @@ function AllocationItem({ entry, hasRoleAccess }: AllocationItemProps) {
               {entry.onDelete && (
                 <button
                   type="button"
-                  onClick={entry.onDelete}
+                  onClick={() => entry.onDelete?.()}
                   className="transition-colors text-ink-gray-6 hover:text-ink-gray-7"
                   aria-label="Delete allocation"
                 >

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
@@ -1,5 +1,12 @@
+/**
+ * External dependencies.
+ */
 import { format } from "date-fns";
-import type { AllocationCallbackData } from "../../types";
+
+/**
+ * Internal dependencies.
+ */
+import type { AllocationCallbackData, DeleteAllocationMode } from "../../types";
 import type { ProjectAllocationBar } from "../../utils";
 import type { AllocationEntry } from "../allocationPopover";
 
@@ -7,12 +14,16 @@ import type { AllocationEntry } from "../allocationPopover";
 export function allocationBarToEntry(
   alloc: ProjectAllocationBar,
   onEdit?: (data: AllocationCallbackData) => void,
-  onDelete?: (data: AllocationCallbackData) => void,
+  onDelete?: (
+    data: AllocationCallbackData,
+    deleteMode: DeleteAllocationMode,
+  ) => Promise<void>,
 ): AllocationEntry {
   const callbackData: AllocationCallbackData = {
     allocationId: alloc.id,
     employeeId: alloc.employeeId,
     projectId: alloc.projectId,
+    recurrenceId: alloc.recurrenceId,
     projectName: alloc.projectName,
     customerName: alloc.customerName,
     startDate: alloc.startDate,
@@ -30,10 +41,13 @@ export function allocationBarToEntry(
     totalHours: `${alloc.hours * alloc.fullNumDays} hours`,
     status: alloc.tentative ? "tentative" : "confirmed",
     billable: alloc.billable ?? true,
+    recurrenceId: alloc.recurrenceId,
     updatedByName: alloc.updatedBy?.name,
     updatedByImage: alloc.updatedBy?.image,
     onEdit: onEdit ? () => onEdit(callbackData) : undefined,
-    onDelete: onDelete ? () => onDelete(callbackData) : undefined,
+    onConfirmDelete: onDelete
+      ? (deleteMode) => onDelete(callbackData, deleteMode)
+      : undefined,
     createdOn: alloc.createdOn,
     updatedOn: alloc.updatedOn,
   };

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/withPendingDeleteEntry.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/withPendingDeleteEntry.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies.
+ */
 import type { PendingDeleteEntry } from "../../ganttStore";
 import type { AllocationEntry } from "../allocationPopover";
 
@@ -7,11 +10,11 @@ export function withPendingDeleteEntry(
   entry: AllocationEntry,
   setPendingDeleteEntry: SetPendingDeleteEntry,
 ): AllocationEntry {
-  if (!entry.onDelete) {
+  if (!entry.onConfirmDelete) {
     return entry;
   }
 
-  const onDelete = entry.onDelete;
+  const onConfirmDelete = entry.onConfirmDelete;
 
   return {
     ...entry,
@@ -21,7 +24,8 @@ export function withPendingDeleteEntry(
         dateRange: entry.dateRange,
         hoursPerDay: entry.hoursPerDay,
         totalHours: entry.totalHours,
-        onDelete,
+        recurrenceId: entry.recurrenceId,
+        onDelete: (deleteMode) => onConfirmDelete(deleteMode),
       }),
   };
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -142,23 +142,25 @@ const GanttGridInner: React.FC<{
         </div>
       </div>
 
-      <DeleteAllocationDialog
-        open={pendingDeleteEntry !== null}
-        onOpenChange={(open) => {
-          if (!open) clearPendingDeleteEntry();
-        }}
-        projectName={pendingDeleteEntry?.projectName ?? ""}
-        dateRange={pendingDeleteEntry?.dateRange ?? ""}
-        hoursPerDay={pendingDeleteEntry?.hoursPerDay ?? ""}
-        totalHours={pendingDeleteEntry?.totalHours ?? ""}
-        onConfirm={async () => {
-          try {
-            pendingDeleteEntry?.onDelete();
-          } finally {
-            clearPendingDeleteEntry();
-          }
-        }}
-      />
+      {pendingDeleteEntry ? (
+        <DeleteAllocationDialog
+          onOpenChange={(open) => {
+            if (!open) clearPendingDeleteEntry();
+          }}
+          projectName={pendingDeleteEntry.projectName}
+          dateRange={pendingDeleteEntry.dateRange}
+          hoursPerDay={pendingDeleteEntry.hoursPerDay}
+          totalHours={pendingDeleteEntry.totalHours}
+          isRecurring={Boolean(pendingDeleteEntry.recurrenceId)}
+          onConfirm={async (deleteMode) => {
+            try {
+              await pendingDeleteEntry.onDelete(deleteMode);
+            } finally {
+              clearPendingDeleteEntry();
+            }
+          }}
+        />
+      ) : null}
     </div>
   );
 };

--- a/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttStore.ts
@@ -1,10 +1,18 @@
+/**
+ * External dependencies.
+ */
 import { createContext, useContext } from "react";
 import { addDays, startOfWeek } from "date-fns";
 import { createStore, useStore } from "zustand";
 import { useShallow } from "zustand/react/shallow";
+
+/**
+ * Internal dependencies.
+ */
 import { CELL_WIDTH, ROW_HEADER_WIDTH } from "./constants";
 import type {
   AllocationCallbackData,
+  DeleteAllocationMode,
   GanttGridVariant,
   Member as BaseMember,
   ProjectGroup as BaseProjectGroup,
@@ -26,7 +34,8 @@ export interface PendingDeleteEntry {
   dateRange: string;
   hoursPerDay: string;
   totalHours: string;
-  onDelete: () => void;
+  recurrenceId?: string;
+  onDelete: (deleteMode: DeleteAllocationMode) => Promise<void>;
 }
 
 export interface GanttActiveEdit {
@@ -45,7 +54,10 @@ interface GanttProps {
   hasRoleAccess: boolean;
   onAddAllocation?: (data: AllocationCallbackData) => void;
   onEditAllocation?: (data: AllocationCallbackData) => void;
-  onDeleteAllocation?: (data: AllocationCallbackData) => void;
+  onDeleteAllocation?: (
+    data: AllocationCallbackData,
+    deleteMode: DeleteAllocationMode,
+  ) => Promise<void>;
 }
 
 interface GanttState extends GanttProps {

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,3 +1,8 @@
+export type DeleteAllocationMode =
+  | "only_this"
+  | "this_and_future"
+  | "all_in_series";
+
 export interface Allocation {
   /** Unique identifier for the allocation. */
   id?: string;
@@ -5,6 +10,8 @@ export interface Allocation {
   employeeId?: string;
   /** Project identifier this allocation belongs to. */
   projectId?: string;
+  /** Recurrence identifier shared by a series of allocations. */
+  recurrenceId?: string;
   /** Hours per day. */
   hours: number;
   /** First day of the allocation. */
@@ -83,6 +90,8 @@ export interface AllocationCallbackData {
   employeeId?: string;
   /** Project identifier. */
   projectId?: string;
+  /** Recurrence identifier shared by a series of allocations. */
+  recurrenceId?: string;
   /** Project name. */
   projectName?: string;
   /** Customer name. */
@@ -135,6 +144,9 @@ export interface GanttGridProps {
   onAddAllocation?: (data: AllocationCallbackData) => void;
   /** Called when the edit icon is clicked on an allocation entry. Receives allocation data. */
   onEditAllocation?: (data: AllocationCallbackData) => void;
-  /** Called when the delete icon is clicked on an allocation entry. Receives allocation data. */
-  onDeleteAllocation?: (data: AllocationCallbackData) => void;
+  /** Called when delete is confirmed for an allocation entry. Receives allocation data and delete scope. */
+  onDeleteAllocation?: (
+    data: AllocationCallbackData,
+    deleteMode: DeleteAllocationMode,
+  ) => Promise<void>;
 }


### PR DESCRIPTION

## Description

<!-- What do we want to achieve with this PR? -->
This pull request introduces support for deleting recurring allocations with different modes (such as deleting only the selected allocation, this and future allocations, or the whole series).

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- The selection option is only available when deleting recurring allocations.
- I used a select element instead of the radio buttons shown in the design, as we currently do not have a radio button component. This select is inspired by the one used in the Edit Recurring Schedule modal.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/ead78403-b090-46d9-9301-7bb68a633c92



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1505