### PR TITLE
fix: sanitize outgoing PM report payload by stripping whitespaces

### DIFF
--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -82,7 +82,7 @@ def generate_pm_report(
             "start_date": from_date,
             "end_date": to_date,
             "project_status": project_doc.get("custom_project_rag_status") or "Green",
-            "project_name": project_doc.get("project_name") or "",
+            "project_name": (project_doc.get("project_name") or "").strip(),
             "drive_link": drive_link,
         },
         **({"previous_doc_url": previous_doc_url} if previous_doc_url else {}),
@@ -405,6 +405,11 @@ def get_github_metadata(project_doc, selected_repo: str | None = None, selected_
         repo_name = project_doc.get("project_name") or ""
         owner_name = "rtCamp"
 
+    if repo_name:
+        repo_name = repo_name.strip()
+    if owner_name:
+        owner_name = owner_name.strip()
+
     project_board = ""
     if selected_board:
         project_board = selected_board
@@ -419,6 +424,9 @@ def get_github_metadata(project_doc, selected_repo: str | None = None, selected_
 
     if not project_board:
         project_board = project_doc.get("project_name") or ""
+
+    if project_board:
+        project_board = project_board.strip()
 
     return {"repo_name": repo_name, "owner_name": owner_name, "project_board": project_board}
 


### PR DESCRIPTION
## Description

This PR sanitizes the outgoing payload sent to the PM Report API by stripping leading and trailing whitespaces from the project and GitHub metadata fields: project name, repository owner, repository name, and project board. 

This prevents matching failures in downstream services caused by accidental spaces in the ERP database values.
## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #