### PR TITLE
feat(dashboard): utilised time donut widget

### DIFF
--- a/frontend/packages/app/src/pages/dashboard/constants.ts
+++ b/frontend/packages/app/src/pages/dashboard/constants.ts
@@ -1,12 +1,13 @@
 /**
  * External dependencies.
  */
-import type { ComboboxOption } from "@rtcamp/frappe-ui-react";
+import type { ComboboxOption, SelectOption } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
 import type { StatCardData } from "./statCard";
+import type { UtilisationData } from "./utilisedTimeCard";
 
 // Hard-coded summary stats from the design until real data is wired in a later issue.
 export const LEADERSHIP_STATS: StatCardData[] = [
@@ -22,6 +23,25 @@ export const MANAGER_STATS: StatCardData[] = [
   { label: "Timesheets to review", value: "24", subLabel: "this week" },
   { label: "Outstanding timesheets", value: "4" },
 ];
+
+export const ALL_ROLES_VALUE = "all";
+
+// Mock role filter + utilisation splits from the design until real data is wired in a later issue.
+export const ROLE_OPTIONS: SelectOption[] = [
+  { value: ALL_ROLES_VALUE, label: "All roles" },
+  { value: "delivery-manager", label: "Delivery Manager" },
+  { value: "project-manager", label: "Project Manager" },
+  { value: "developer", label: "Developer" },
+  { value: "designer", label: "Designer" },
+];
+
+export const UTILISATION_BY_ROLE: Record<string, UtilisationData> = {
+  [ALL_ROLES_VALUE]: { billable: 65, nonBillable: 35 },
+  "delivery-manager": { billable: 72, nonBillable: 28 },
+  "project-manager": { billable: 60, nonBillable: 40 },
+  developer: { billable: 80, nonBillable: 20 },
+  designer: { billable: 55, nonBillable: 45 },
+};
 
 export const ALL_CLIENTS_VALUE = "all-clients";
 export const ALL_PROJECTS_VALUE = "all-projects";

--- a/frontend/packages/app/src/pages/dashboard/leadershipView.tsx
+++ b/frontend/packages/app/src/pages/dashboard/leadershipView.tsx
@@ -3,16 +3,17 @@
  */
 import { LEADERSHIP_STATS } from "./constants";
 import { StatCard } from "./statCard";
+import { UtilisedTimeCard } from "./utilisedTimeCard";
 
 export function LeadershipView() {
   return (
-    <section
-      aria-label="Leadership dashboard"
-      className="grid grid-cols-4 gap-3"
-    >
-      {LEADERSHIP_STATS.map((stat) => (
-        <StatCard key={stat.label} {...stat} />
-      ))}
+    <section aria-label="Leadership dashboard" className="flex flex-col gap-3">
+      <div className="grid grid-cols-4 gap-3">
+        {LEADERSHIP_STATS.map((stat) => (
+          <StatCard key={stat.label} {...stat} />
+        ))}
+      </div>
+      <UtilisedTimeCard />
     </section>
   );
 }

--- a/frontend/packages/app/src/pages/dashboard/utilisationDonut.tsx
+++ b/frontend/packages/app/src/pages/dashboard/utilisationDonut.tsx
@@ -1,0 +1,54 @@
+export type DonutSegment = {
+  value: number;
+  /** Tailwind text-color class — the arc is stroked with currentColor. */
+  colorClass: string;
+};
+
+type UtilisationDonutProps = {
+  segments: DonutSegment[];
+  size?: number;
+  strokeWidth?: number;
+};
+
+export function UtilisationDonut({
+  segments,
+  size = 130,
+  strokeWidth = 16,
+}: UtilisationDonutProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+
+  let offset = 0;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="shrink-0 -rotate-90"
+      role="img"
+    >
+      {segments.map((segment, index) => {
+        const fraction = total > 0 ? segment.value / total : 0;
+        const dash = fraction * circumference;
+        const arc = (
+          <circle
+            key={index}
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={`${dash} ${circumference - dash}`}
+            strokeDashoffset={-offset}
+            className={segment.colorClass}
+          />
+        );
+        offset += dash;
+        return arc;
+      })}
+    </svg>
+  );
+}

--- a/frontend/packages/app/src/pages/dashboard/utilisedTimeCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/utilisedTimeCard.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies.
+ */
+import { useState } from "react";
+import { Select } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  ALL_ROLES_VALUE,
+  ROLE_OPTIONS,
+  UTILISATION_BY_ROLE,
+} from "./constants";
+import { UtilisationDonut } from "./utilisationDonut";
+
+export type UtilisationData = {
+  billable: number;
+  nonBillable: number;
+};
+
+export function UtilisedTimeCard() {
+  const [role, setRole] = useState<string>(ALL_ROLES_VALUE);
+  const data =
+    UTILISATION_BY_ROLE[role] ?? UTILISATION_BY_ROLE[ALL_ROLES_VALUE];
+
+  const legend = [
+    {
+      label: "Billable hours",
+      value: data.billable,
+      dotClass: "bg-surface-blue-5",
+    },
+    {
+      label: "Non-billable hours",
+      value: data.nonBillable,
+      dotClass: "bg-surface-blue-4",
+    },
+  ];
+
+  return (
+    <div className="flex max-w-md flex-col gap-4 rounded-lg border border-outline-gray-1 bg-surface-cards p-4">
+      <div className="flex items-start justify-between gap-4">
+        <h3 className="text-lg font-semibold text-ink-gray-8">
+          Utilised time in the past 30 days
+        </h3>
+        <Select
+          className="w-fit shrink-0 bg-surface-gray-2 font-bold text-ink-gray-7"
+          options={ROLE_OPTIONS}
+          value={role}
+          onChange={(value) => setRole(value ?? ALL_ROLES_VALUE)}
+        />
+      </div>
+      <div className="flex items-center gap-8">
+        <UtilisationDonut
+          segments={[
+            { value: data.billable, colorClass: "text-surface-blue-5" },
+            { value: data.nonBillable, colorClass: "text-surface-blue-4" },
+          ]}
+        />
+        <div className="flex grow flex-col gap-3">
+          {legend.map((item) => (
+            <div
+              key={item.label}
+              className="flex items-center justify-between gap-4"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <span
+                  className={`size-2 shrink-0 rounded-full ${item.dotClass}`}
+                />
+                <span className="truncate text-base text-ink-gray-6">
+                  {item.label}
+                </span>
+              </div>
+              <span className="text-base font-medium text-ink-gray-6">
+                {item.value}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds the "Utilised time in the past 30 days" widget to the Leadership dashboard (issue #1133): a donut ring with two segments — **Billable hours** (dark blue, 65%) and **Non-billable hours** (light blue, 35%) — a right-side legend (coloured dot + label + %), and an **All roles** filter. Selecting a role re-renders the donut and legend from static mock data.

## Relevant Technical Choices

- **`utilisationDonut.tsx`** (new, page-local): a lightweight SVG donut — two `<circle>` arcs via `stroke-dasharray`, `stroke="currentColor"` (coloured by a Tailwind text-class), rounded caps, empty center. API: `{ segments: { value, colorClass }[]; size?=130; strokeWidth?=16 }`.
  - **Why not the frappe-ui chart primitives** (checked both, flagged on Slack, plan-approved): `DonutChart` (echarts) hard-codes `min-w-[300px] min-h-[300px]` and always renders its own bottom legend + title (the options hook ignores `echartOptions`) — can't be a 130px ring with a custom side legend. `CircularProgressBar` always renders center text (`step`/`%`) with no prop to hide it and caps at `xl`=108px. The design is a 130px empty-center ring, so a ~45-line SVG is the precise, dependency-free fit.
- **`utilisedTimeCard.tsx`** (new, page-local): card (title 16px semibold; donut left; legend right) + `Select` (`@rtcamp/frappe-ui-react`) styled as the `surface-gray-2` pill for the role filter. `useState` holds the selected role; donut + legend read the matching entry. Colours: billable `surface-blue-5` (#007BE0), non-billable `surface-blue-4`.
- **`constants.ts`**: `ROLE_OPTIONS` + `UTILISATION_BY_ROLE` static mock (All roles 65/35, plus Delivery Manager / Project Manager / Developer / Designer splits).
- **`leadershipView.tsx`**: renders `<UtilisedTimeCard />` below the existing stat-cards strip.
- **Card width:** capped at `max-w-md` to match the Figma frame (~440px). Full-width left the card ~70% empty and squeezed the title — flagging this minor refinement of the "full-width section" default; happy to change if you'd prefer it stretched.

## Testing Instructions

1. Open `/next-pms/dashboard` as a user with the **Delivery Manager** role.
2. Confirm the "Utilised time in the past 30 days" widget renders below the stat cards: donut (dark-blue 65% / light-blue 35%), legend (Billable 65% / Non-billable 35%), and an "All roles" pill top-right.
3. Open the pill → pick another role (e.g. Developer) → the donut arcs and legend percentages update (Developer → 80/20).
4. No console errors.

Browser-verified on `/next-pms/dashboard`: donut 130px, arc1 `#007BE0` 65% / arc2 light-blue 35%, legend dots match, role pill switches All roles → Developer updating arcs+legend to 80/20, no console errors.

## Additional Information

- Figma frame (Copy fileKey `h1EnhdK8swe6FCyxUW1XHx`): https://www.figma.com/design/h1EnhdK8swe6FCyxUW1XHx/Frappe-PMS--Copy-?node-id=3543-327896&m=dev
- Static mock data only (no live utilisation API). Plan tracked in `#bots-ai-workflow-next-pms`; approved on defaults.
- **Overlap note:** both this PR and #1131 (Leadership KPI cards) edit `leadershipView.tsx`. This PR is independent (adds the widget below the stat strip); rebase if #1131 lands first.

## Screenshot/Screencast

Browser-verified live render on `/next-pms/dashboard` matches the Figma frame (donut + legend + role pill; pill updates the donut). Inline image not auto-attachable from CLI — see the Figma link and Testing Instructions.

## Checklist

- [ ] Code follows the project conventions
- [ ] Self-reviewed the diff
- [ ] Tested the change in the browser
