### PR TITLE
feat(dashboard): assigned projects table

### DIFF
--- a/frontend/packages/app/src/pages/dashboard/assignedProjectsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/assignedProjectsCard.tsx
@@ -1,0 +1,137 @@
+/**
+ * External dependencies.
+ */
+import { useState } from "react";
+import {
+  ListHeader,
+  ListHeaderItem,
+  ListRow,
+  ListRowItem,
+  ListRows,
+  ListView,
+  Select,
+} from "@rtcamp/frappe-ui-react";
+import { Folder } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  ALL_CUSTOMERS_VALUE,
+  ASSIGNED_PROJECTS,
+  ASSIGNED_PROJECTS_COLUMNS,
+  CUSTOMER_OPTIONS,
+} from "./constants";
+import { HoursBurnBar } from "./hoursBurnBar";
+
+export type AssignedProject = {
+  name: string;
+  customer: string;
+  remaining: number;
+  used: number;
+  total: number;
+  billableLastWeek: number;
+  nonBillableLastWeek: number;
+};
+
+const HOURS = (value: number) => `${value}h`;
+
+export function AssignedProjectsCard() {
+  const [customer, setCustomer] = useState<string>(ALL_CUSTOMERS_VALUE);
+  const rows =
+    customer === ALL_CUSTOMERS_VALUE
+      ? ASSIGNED_PROJECTS
+      : ASSIGNED_PROJECTS.filter((project) => project.customer === customer);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-outline-gray-1 bg-surface-cards p-4">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-ink-gray-8">
+          Assigned projects
+        </h3>
+        <Select
+          className="w-fit shrink-0 bg-surface-gray-2 font-bold text-ink-gray-7"
+          options={CUSTOMER_OPTIONS}
+          value={customer}
+          onChange={(value) => setCustomer(value ?? ALL_CUSTOMERS_VALUE)}
+        />
+      </div>
+      <ListView
+        columns={ASSIGNED_PROJECTS_COLUMNS}
+        rows={rows}
+        rowKey="name"
+        options={{
+          options: {
+            selectable: false,
+            showTooltip: false,
+            resizeColumn: false,
+          },
+        }}
+      >
+        <ListHeader className="mb-0 gap-2 rounded-none border-b border-outline-gray-1 bg-transparent p-1">
+          {ASSIGNED_PROJECTS_COLUMNS.map((column) => (
+            <ListHeaderItem key={column.key} item={column}>
+              <span className="truncate text-sm text-ink-gray-5">
+                {column.label}
+              </span>
+            </ListHeaderItem>
+          ))}
+        </ListHeader>
+        <ListRows>
+          {rows.map((row) => (
+            <ListRow key={row.name} row={row}>
+              <ListRowItem
+                column={ASSIGNED_PROJECTS_COLUMNS[0]}
+                row={row}
+                item={row.name}
+                prefix={<Folder className="size-4 shrink-0 text-ink-gray-5" />}
+              >
+                <span className="truncate text-base font-medium text-ink-gray-7">
+                  {row.name}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={ASSIGNED_PROJECTS_COLUMNS[1]}
+                row={row}
+                item={row.remaining}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {HOURS(row.remaining)}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={ASSIGNED_PROJECTS_COLUMNS[2]}
+                row={row}
+                item=""
+                align="center"
+              >
+                <HoursBurnBar used={row.used} total={row.total} />
+              </ListRowItem>
+              <ListRowItem
+                column={ASSIGNED_PROJECTS_COLUMNS[3]}
+                row={row}
+                item={row.billableLastWeek}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {HOURS(row.billableLastWeek)}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={ASSIGNED_PROJECTS_COLUMNS[4]}
+                row={row}
+                item={row.nonBillableLastWeek}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {HOURS(row.nonBillableLastWeek)}
+                </span>
+              </ListRowItem>
+            </ListRow>
+          ))}
+        </ListRows>
+      </ListView>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/dashboard/constants.ts
+++ b/frontend/packages/app/src/pages/dashboard/constants.ts
@@ -1,11 +1,12 @@
 /**
  * External dependencies.
  */
-import type { ComboboxOption } from "@rtcamp/frappe-ui-react";
+import type { ComboboxOption, SelectOption } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
+import type { AssignedProject } from "./assignedProjectsCard";
 import type { StatCardData } from "./statCard";
 
 // Hard-coded summary stats from the design until real data is wired in a later issue.
@@ -21,6 +22,83 @@ export const MANAGER_STATS: StatCardData[] = [
   { label: "Members without allocation", value: "12", subLabel: "this week" },
   { label: "Timesheets to review", value: "24", subLabel: "this week" },
   { label: "Outstanding timesheets", value: "4" },
+];
+
+export const ALL_CUSTOMERS_VALUE = "all";
+
+// Mock customer filter + assigned-project rows from the design until real data is wired in a later issue.
+export const CUSTOMER_OPTIONS: SelectOption[] = [
+  { value: ALL_CUSTOMERS_VALUE, label: "All customers" },
+  { value: "nimbus-analytics", label: "Nimbus Analytics" },
+  { value: "atlas-systems", label: "Atlas Systems" },
+  { value: "venus-ecommerce", label: "Venus E-commerce" },
+  { value: "helios-media", label: "Helios Media" },
+];
+
+export const ASSIGNED_PROJECTS_COLUMNS = [
+  { key: "name", label: "Projects", width: 3, align: "left" },
+  { key: "remaining", label: "Remaining", width: "96px", align: "right" },
+  { key: "hoursBurn", label: "Hours Burn", width: "140px", align: "center" },
+  {
+    key: "billableLastWeek",
+    label: "Billable (last week)",
+    width: "160px",
+    align: "right",
+  },
+  {
+    key: "nonBillableLastWeek",
+    label: "Non-billable (last week)",
+    width: "176px",
+    align: "right",
+  },
+];
+
+export const ASSIGNED_PROJECTS: AssignedProject[] = [
+  {
+    name: "Nimbus Analytics Enhancement",
+    customer: "nimbus-analytics",
+    remaining: 110,
+    used: 210,
+    total: 320,
+    billableLastWeek: 34,
+    nonBillableLastWeek: 6,
+  },
+  {
+    name: "Atlas UI Stabilisation",
+    customer: "atlas-systems",
+    remaining: 88,
+    used: 112,
+    total: 200,
+    billableLastWeek: 18,
+    nonBillableLastWeek: 5,
+  },
+  {
+    name: "Atlas Mobile App Checkout Flow Stabilisation",
+    customer: "atlas-systems",
+    remaining: 110,
+    used: 190,
+    total: 300,
+    billableLastWeek: 42,
+    nonBillableLastWeek: 8,
+  },
+  {
+    name: "Venus E-commerce Platform Upgrade",
+    customer: "venus-ecommerce",
+    remaining: 64,
+    used: 96,
+    total: 160,
+    billableLastWeek: 16,
+    nonBillableLastWeek: 3,
+  },
+  {
+    name: "Headless CMS Migration",
+    customer: "helios-media",
+    remaining: 82,
+    used: 138,
+    total: 220,
+    billableLastWeek: 26,
+    nonBillableLastWeek: 9,
+  },
 ];
 
 export const ALL_CLIENTS_VALUE = "all-clients";

--- a/frontend/packages/app/src/pages/dashboard/hoursBurnBar.tsx
+++ b/frontend/packages/app/src/pages/dashboard/hoursBurnBar.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies.
+ */
+import { ProgressBar } from "@next-pms/design-system/components";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
+
+export function HoursBurnBar({ used, total }: { used: number; total: number }) {
+  const usedPercent = total > 0 ? Math.min(100, (used / total) * 100) : 0;
+  return (
+    <div className="relative flex w-full items-center py-2">
+      <ProgressBar
+        value={used}
+        maxValue={total}
+        size="sm"
+        indicatorClassName="bg-surface-blue-4"
+      />
+      <div className="absolute inset-0 flex">
+        <Tooltip text={`${used}h used`}>
+          <div style={{ width: `${usedPercent}%` }} />
+        </Tooltip>
+        <Tooltip text={`${total}h total`}>
+          <div className="grow" />
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/dashboard/managerView.tsx
+++ b/frontend/packages/app/src/pages/dashboard/managerView.tsx
@@ -1,15 +1,19 @@
 /**
  * Internal dependencies.
  */
+import { AssignedProjectsCard } from "./assignedProjectsCard";
 import { MANAGER_STATS } from "./constants";
 import { StatCard } from "./statCard";
 
 export function ManagerView() {
   return (
-    <section aria-label="Manager dashboard" className="grid grid-cols-4 gap-3">
-      {MANAGER_STATS.map((stat) => (
-        <StatCard key={stat.label} {...stat} />
-      ))}
+    <section aria-label="Manager dashboard" className="flex flex-col gap-3">
+      <div className="grid grid-cols-4 gap-3">
+        {MANAGER_STATS.map((stat) => (
+          <StatCard key={stat.label} {...stat} />
+        ))}
+      </div>
+      <AssignedProjectsCard />
     </section>
   );
 }


### PR DESCRIPTION
## Description

Adds the "Assigned projects" section to the Project Manager dashboard (issue #1136): a 5-row table with **Projects** (icon + name), **Remaining** (hours), **Hours Burn** (a progress bar showing burnt vs total, with hover tooltips), **Billable (last week)** and **Non-billable (last week)** hours, plus an **All customers** filter that narrows the rows. Static mock data.

## Relevant Technical Choices

- **`assignedProjectsCard.tsx`**: built with the frappe-ui `ListView` (`ListHeader` / `ListHeaderItem` / `ListRows` / `ListRow` / `ListRowItem`) per your call to use ListView — non-selectable (`selectable: false`, so no checkbox column), non-resizable, static rows (no context / infinite-scroll). Column widths/alignment drive the grid; numeric columns right-aligned, Hours Burn centered, Projects flexes.
- **`hoursBurnBar.tsx`**: reuses the design-system `ProgressBar` (`value={used} maxValue={total} size="sm"`, `indicatorClassName="bg-surface-blue-4"`; the `surface-gray-2` track matches the design). Two transparent hover regions overlay the bar (split at the used/total boundary) so the burnt portion shows **"{used}h used"** and the remaining portion shows **"{total}h total"** — the two tooltips you confirmed.
- **Project icon**: `Folder` (`@rtcamp/frappe-ui-react/icons`) — the Figma asset is `icon/line/folder` (the issue said "checkbox"; went with the Figma asset).
- **`constants.ts`**: `ASSIGNED_PROJECTS` (5 rows; `remaining = total − used` so the bar and Remaining column stay consistent), `CUSTOMER_OPTIONS`, `ASSIGNED_PROJECTS_COLUMNS`.
- **`managerView.tsx`**: renders the card below the stat-cards strip.
- No new design-system / frappe-ui-react primitives.

**Base:** `feat/manager-dashboard` (per your instruction). Trunk `claude/feat/assigned-projects-table`.

## Testing Instructions

1. Open `/next-pms/dashboard` as a **Projects Manager**.
2. Confirm the "Assigned projects" card renders below the stat cards: header + 5 rows (folder icon + name, Remaining, Hours Burn bar, Billable, Non-billable).
3. Hover a Hours Burn bar: the left (burnt) region shows "{used}h used", the right (remaining) region shows "{total}h total".
4. Open the "All customers" pill and pick a customer (e.g. Atlas Systems) → rows narrow to that customer's projects.
5. No console errors.

Browser-verified on `/next-pms/dashboard`: 5 rows, full headers, blue Hours Burn bars on gray track, hours match the mock; "Atlas Systems" filters to its 2 projects; hovering a bar shows "190h used"; no console errors.

## Additional Information

- Figma frame (Copy fileKey `h1EnhdK8swe6FCyxUW1XHx`): https://www.figma.com/design/h1EnhdK8swe6FCyxUW1XHx/Frappe-PMS--Copy-?node-id=3709-625334&m=dev
- Static mock data only. Plan tracked in `#bots-ai-workflow-next-pms`; locked decisions: ListView, Folder icon, two tooltips.

## Screenshot/Screencast

Browser-verified live render on `/next-pms/dashboard` matches the Figma frame (table + Hours Burn bars + customer filter + hover tooltips). Inline image not auto-attachable from CLI — see the Figma link and Testing Instructions.

## Checklist

- [ ] Code follows the project conventions
- [ ] Self-reviewed the diff
- [ ] Tested the change in the browser

## Fixes

Fixes #1136