### PR TITLE
feat(dashboard): timesheets summary table

### DIFF
--- a/frontend/packages/app/src/pages/dashboard/constants.ts
+++ b/frontend/packages/app/src/pages/dashboard/constants.ts
@@ -1,12 +1,13 @@
 /**
  * External dependencies.
  */
-import type { ComboboxOption } from "@rtcamp/frappe-ui-react";
+import type { ComboboxOption, SelectOption } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
 import type { StatCardData } from "./statCard";
+import type { TimesheetMember } from "./timesheetsCard";
 
 // Hard-coded summary stats from the design until real data is wired in a later issue.
 export const LEADERSHIP_STATS: StatCardData[] = [
@@ -21,6 +22,80 @@ export const MANAGER_STATS: StatCardData[] = [
   { label: "Members without allocation", value: "12", subLabel: "this week" },
   { label: "Timesheets to review", value: "24", subLabel: "this week" },
   { label: "Outstanding timesheets", value: "4" },
+];
+
+export const LAST_WEEK_VALUE = "last-week";
+
+// Mock period filter + timesheet rows from the design until real data is wired in a later issue.
+export const PERIOD_OPTIONS: SelectOption[] = [
+  { value: LAST_WEEK_VALUE, label: "Last week" },
+  { value: "this-week", label: "This week" },
+  { value: "this-month", label: "This month" },
+];
+
+export const TIMESHEET_COLUMNS = [
+  { key: "name", label: "Members", width: 3, align: "left" },
+  { key: "billable", label: "Billable h", width: "96px", align: "right" },
+  {
+    key: "nonBillable",
+    label: "Non-billable h",
+    width: "112px",
+    align: "right",
+  },
+  { key: "expected", label: "Expected h", width: "96px", align: "right" },
+  { key: "delta", label: "Delta", width: "72px", align: "right" },
+  { key: "status", label: "", width: "48px", align: "right" },
+];
+
+export const TIMESHEET_MEMBERS: TimesheetMember[] = [
+  {
+    name: "Julian Andrews",
+    billable: 28,
+    nonBillable: 8,
+    expected: 40,
+    delta: 4,
+    status: "pending",
+  },
+  {
+    name: "Kathy Philips",
+    billable: 40,
+    nonBillable: 0,
+    expected: 40,
+    delta: 0,
+    status: "pending",
+  },
+  {
+    name: "Susanna Martin",
+    billable: 8,
+    nonBillable: 0,
+    expected: 10,
+    delta: 2,
+    status: "on-track",
+  },
+  {
+    name: "Dev Patel",
+    billable: 28,
+    nonBillable: 8,
+    expected: 40,
+    delta: 4,
+    status: "on-track",
+  },
+  {
+    name: "Divya Kumar",
+    billable: 18,
+    nonBillable: 2,
+    expected: 20,
+    delta: 0,
+    status: "off-track",
+  },
+  {
+    name: "Anusha Patel",
+    billable: 18,
+    nonBillable: 2,
+    expected: 20,
+    delta: 0,
+    status: "on-track",
+  },
 ];
 
 export const ALL_CLIENTS_VALUE = "all-clients";

--- a/frontend/packages/app/src/pages/dashboard/deltaStatusIcon.tsx
+++ b/frontend/packages/app/src/pages/dashboard/deltaStatusIcon.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies.
+ */
+import { CloseCircle, Hourglass, Success } from "@rtcamp/frappe-ui-react/icons";
+
+const STATUS = {
+  pending: { Icon: Hourglass, className: "text-ink-amber-3" },
+  "on-track": { Icon: Success, className: "text-ink-green-4" },
+  "off-track": { Icon: CloseCircle, className: "text-ink-red-4" },
+} as const;
+
+export type TimesheetStatus = keyof typeof STATUS;
+
+export function DeltaStatusIcon({ status }: { status: TimesheetStatus }) {
+  const { Icon, className } = STATUS[status];
+  return <Icon className={`size-4 shrink-0 ${className}`} />;
+}

--- a/frontend/packages/app/src/pages/dashboard/managerView.tsx
+++ b/frontend/packages/app/src/pages/dashboard/managerView.tsx
@@ -3,13 +3,17 @@
  */
 import { MANAGER_STATS } from "./constants";
 import { StatCard } from "./statCard";
+import { TimesheetsCard } from "./timesheetsCard";
 
 export function ManagerView() {
   return (
-    <section aria-label="Manager dashboard" className="grid grid-cols-4 gap-3">
-      {MANAGER_STATS.map((stat) => (
-        <StatCard key={stat.label} {...stat} />
-      ))}
+    <section aria-label="Manager dashboard" className="flex flex-col gap-3">
+      <div className="grid grid-cols-4 gap-3">
+        {MANAGER_STATS.map((stat) => (
+          <StatCard key={stat.label} {...stat} />
+        ))}
+      </div>
+      <TimesheetsCard />
     </section>
   );
 }

--- a/frontend/packages/app/src/pages/dashboard/timesheetsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/timesheetsCard.tsx
@@ -1,0 +1,138 @@
+/**
+ * External dependencies.
+ */
+import { useState } from "react";
+import {
+  Avatar,
+  ListHeader,
+  ListHeaderItem,
+  ListRow,
+  ListRowItem,
+  ListRows,
+  ListView,
+  Select,
+} from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  LAST_WEEK_VALUE,
+  PERIOD_OPTIONS,
+  TIMESHEET_COLUMNS,
+  TIMESHEET_MEMBERS,
+} from "./constants";
+import { DeltaStatusIcon, type TimesheetStatus } from "./deltaStatusIcon";
+
+export type TimesheetMember = {
+  name: string;
+  billable: number;
+  nonBillable: number;
+  expected: number;
+  delta: number;
+  status: TimesheetStatus;
+};
+
+export function TimesheetsCard() {
+  const [period, setPeriod] = useState<string>(LAST_WEEK_VALUE);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-outline-gray-1 bg-surface-cards p-4">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-ink-gray-8">Timesheets</h3>
+        <Select
+          className="w-fit shrink-0 bg-surface-gray-2 font-bold text-ink-gray-7"
+          options={PERIOD_OPTIONS}
+          value={period}
+          onChange={(value) => setPeriod(value ?? LAST_WEEK_VALUE)}
+        />
+      </div>
+      <ListView
+        columns={TIMESHEET_COLUMNS}
+        rows={TIMESHEET_MEMBERS}
+        rowKey="name"
+        options={{
+          options: {
+            selectable: false,
+            showTooltip: false,
+            resizeColumn: false,
+          },
+        }}
+      >
+        <ListHeader className="mb-0 gap-2 rounded-none border-b border-outline-gray-1 bg-transparent p-1">
+          {TIMESHEET_COLUMNS.map((column) => (
+            <ListHeaderItem key={column.key} item={column}>
+              <span className="truncate text-sm text-ink-gray-5">
+                {column.label}
+              </span>
+            </ListHeaderItem>
+          ))}
+        </ListHeader>
+        <ListRows>
+          {TIMESHEET_MEMBERS.map((member) => (
+            <ListRow key={member.name} row={member}>
+              <ListRowItem
+                column={TIMESHEET_COLUMNS[0]}
+                row={member}
+                item={member.name}
+                prefix={<Avatar size="sm" label={member.name} />}
+              >
+                <span className="truncate text-base font-medium text-ink-gray-7">
+                  {member.name}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={TIMESHEET_COLUMNS[1]}
+                row={member}
+                item={member.billable}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {member.billable}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={TIMESHEET_COLUMNS[2]}
+                row={member}
+                item={member.nonBillable}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {member.nonBillable}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={TIMESHEET_COLUMNS[3]}
+                row={member}
+                item={member.expected}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {member.expected}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={TIMESHEET_COLUMNS[4]}
+                row={member}
+                item={member.delta}
+                align="right"
+              >
+                <span className="truncate text-base text-ink-gray-6">
+                  {member.delta}
+                </span>
+              </ListRowItem>
+              <ListRowItem
+                column={TIMESHEET_COLUMNS[5]}
+                row={member}
+                item=""
+                align="right"
+              >
+                <DeltaStatusIcon status={member.status} />
+              </ListRowItem>
+            </ListRow>
+          ))}
+        </ListRows>
+      </ListView>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds the "Timesheets" section to the Project Manager dashboard (issue #1137): a 6-member table with **Members** (avatar + name), **Billable h**, **Non-billable h**, **Expected h**, **Delta**, and a status icon (hourglass = pending / green check = on-track / red cross = off-track), plus a **Last week** period filter. Static mock data.

## Relevant Technical Choices

- **`timesheetsCard.tsx`**: frappe-ui `ListView` (same non-selectable static pattern as the assigned-projects table #1136). Members column uses `Avatar` (`size="sm"`, `label={name}` → initials); numeric columns right-aligned.
- **`deltaStatusIcon.tsx`**: maps a member's `status` to the frappe-ui icon + tone — `Hourglass` (`text-ink-amber-3`), `Success` (`text-ink-green-4`), `CloseCircle` (`text-ink-red-4`) — matching the Figma node names (`icon/line/hourglass` / `success` / `close-circle`).
- **`constants.ts`**: `TIMESHEET_MEMBERS` (6 rows), `PERIOD_OPTIONS`, `TIMESHEET_COLUMNS`.
- **`managerView.tsx`**: renders the table below the stat-cards strip.
- The Figma "…" overflow button on the header's trailing column is omitted (decorative actions affordance, not in the AC); the Delta status sits in its own trailing icon column.
- The period pill is interactive (default "Last week") but the dataset is static — per-period data wiring is a later issue.
- No new design-system / frappe-ui-react primitives.

**Base:** `feat/manager-dashboard` (Project Manager Dashboard parent, same as #1136). Trunk `claude/feat/timesheets-summary-table`. Overlap note: this and the other PM-dashboard PRs (#1136, #1138) each edit `managerView.tsx`; kept independent, resolve on merge.

## Testing Instructions

1. Open `/next-pms/dashboard` as a **Projects Manager**.
2. Confirm the "Timesheets" card renders below the stat cards: 6 rows (avatar + name, Billable h, Non-billable h, Expected h, Delta) + a status icon per row.
3. Statuses: Julian Andrews & Kathy Philips → amber hourglass; Susanna Martin / Dev Patel / Anusha Patel → green check; Divya Kumar → red cross.
4. "Last week" pill opens with period options.
5. No console errors.

Browser-verified on `/next-pms/dashboard`: 6 rows with initial avatars, all columns, status icons match the design; no console errors.

## Additional Information

- Figma frame (Copy fileKey `h1EnhdK8swe6FCyxUW1XHx`): https://www.figma.com/design/h1EnhdK8swe6FCyxUW1XHx/Frappe-PMS--Copy-?node-id=3709-625315&m=dev
- Static mock data only. Plan posted in `#bots-ai-workflow-next-pms`; built on defaults per maintainer's go-ahead to make the PR.

## Screenshot/Screencast

Browser-verified live render on `/next-pms/dashboard` matches the Figma frame (table + avatars + Delta status icons). Inline image not auto-attachable from CLI — see the Figma link and Testing Instructions.

## Checklist

- [ ] Code follows the project conventions
- [ ] Self-reviewed the diff
- [ ] Tested the change in the browser

## Fixes

Fixes #1137