### PR TITLE
feat(dashboard): upcoming time-offs panel

### DIFF
--- a/frontend/packages/app/src/pages/dashboard/constants.ts
+++ b/frontend/packages/app/src/pages/dashboard/constants.ts
@@ -7,6 +7,7 @@ import type { ComboboxOption } from "@rtcamp/frappe-ui-react";
  * Internal dependencies.
  */
 import type { StatCardData } from "./statCard";
+import type { TimeOffEntry } from "./upcomingTimeOffsCard";
 
 // Hard-coded summary stats from the design until real data is wired in a later issue.
 export const LEADERSHIP_STATS: StatCardData[] = [
@@ -21,6 +22,14 @@ export const MANAGER_STATS: StatCardData[] = [
   { label: "Members without allocation", value: "12", subLabel: "this week" },
   { label: "Timesheets to review", value: "24", subLabel: "this week" },
   { label: "Outstanding timesheets", value: "4" },
+];
+
+// Mock upcoming time-offs from the design until real data is wired in a later issue.
+export const UPCOMING_TIME_OFFS: TimeOffEntry[] = [
+  { date: "Today, First half", members: ["Julian Andrews"] },
+  { date: "Tomorrow, Full day", members: ["Susanna Martin", "Kathy Philips"] },
+  { date: "Jun 20 - 21, Second half", members: ["Anusha Patel"] },
+  { date: "Jun 25, Full day", members: ["Divya Kumar", "Dev Patel"] },
 ];
 
 export const ALL_CLIENTS_VALUE = "all-clients";

--- a/frontend/packages/app/src/pages/dashboard/managerView.tsx
+++ b/frontend/packages/app/src/pages/dashboard/managerView.tsx
@@ -3,13 +3,17 @@
  */
 import { MANAGER_STATS } from "./constants";
 import { StatCard } from "./statCard";
+import { UpcomingTimeOffsCard } from "./upcomingTimeOffsCard";
 
 export function ManagerView() {
   return (
-    <section aria-label="Manager dashboard" className="grid grid-cols-4 gap-3">
-      {MANAGER_STATS.map((stat) => (
-        <StatCard key={stat.label} {...stat} />
-      ))}
+    <section aria-label="Manager dashboard" className="flex flex-col gap-3">
+      <div className="grid grid-cols-4 gap-3">
+        {MANAGER_STATS.map((stat) => (
+          <StatCard key={stat.label} {...stat} />
+        ))}
+      </div>
+      <UpcomingTimeOffsCard />
     </section>
   );
 }

--- a/frontend/packages/app/src/pages/dashboard/upcomingTimeOffsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/upcomingTimeOffsCard.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies.
+ */
+import { Avatar } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import { UPCOMING_TIME_OFFS } from "./constants";
+
+export type TimeOffEntry = {
+  date: string;
+  members: string[];
+};
+
+export function UpcomingTimeOffsCard() {
+  return (
+    <div className="flex max-w-xs flex-col gap-3 rounded-lg border border-outline-gray-1 bg-surface-cards p-4">
+      <h3 className="text-lg font-semibold text-ink-gray-8">
+        Upcoming time-offs
+      </h3>
+      <div className="flex flex-col gap-1">
+        {UPCOMING_TIME_OFFS.map((entry) => (
+          <div key={entry.date} className="flex gap-1.5 py-2">
+            <div className="w-[3px] shrink-0 self-stretch rounded-full bg-surface-gray-4" />
+            <div className="flex min-w-0 flex-col gap-1">
+              <span className="text-xs text-ink-gray-5">{entry.date}</span>
+              <div className="flex items-center gap-2">
+                <div className="flex shrink-0 items-center gap-1">
+                  {entry.members.map((name) => (
+                    <Avatar key={name} size="sm" label={name} />
+                  ))}
+                </div>
+                <span className="truncate text-base font-medium text-ink-gray-7">
+                  {entry.members.join(", ")}
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds the "Upcoming time-offs" panel to the Project Manager dashboard (issue #1138): a vertical list of time-off entries — each entry shows a date label ("Today, First half", "Tomorrow, Full day", "Jun 20 - 21, Second half", "Jun 25, Full day") and the member(s) off that day (avatar(s) + name(s), shown side by side). Static mock data.

## Relevant Technical Choices

- **`upcomingTimeOffsCard.tsx`**: a simple vertical list (no table) — each entry has a left accent bar (`surface-gray-4`), a date label (`text-xs ink-gray-5`), and a row of member `Avatar`s (`@rtcamp/frappe-ui-react`, `size="sm"`, `label={name}` → initials) followed by the names joined with ", " (matching the Figma render). Avatars are placed side by side (the `Avatar` component takes no `className`, so the subtle overlap rings from the mock are rendered as a small gap instead).
- **`constants.ts`**: `UPCOMING_TIME_OFFS` (4 entries; the multi-member days carry two members).
- **`managerView.tsx`**: renders the panel below the stat-cards strip; the card is capped at `max-w-xs` to match the narrow Figma panel (~260px).
- No new design-system / frappe-ui-react primitives.

**Base:** `feat/manager-dashboard` (Project Manager Dashboard parent, same as #1136/#1137). Trunk `claude/feat/upcoming-time-offs`. The design places this panel in the right column alongside the Timesheets table (#1137); as an independent PR it renders standalone below the stat strip — the 2-column grouping happens when both land. Overlap note: this and the other PM-dashboard PRs each edit `managerView.tsx`; kept independent, resolve on merge.

## Testing Instructions

1. Open `/next-pms/dashboard` as a **Projects Manager**.
2. Confirm the "Upcoming time-offs" panel renders below the stat cards with 4 entries.
3. Each entry shows the date label, member avatar(s), and name(s): Julian Andrews (today); Susanna Martin + Kathy Philips (tomorrow); Anusha Patel (Jun 20–21); Divya Kumar + Dev Patel (Jun 25).
4. No console errors.

Browser-verified on `/next-pms/dashboard`: 4 entries with accent bars, date labels, avatars (two for the multi-member days) + joined names; no console errors.

## Additional Information

- Figma frame (Copy fileKey `h1EnhdK8swe6FCyxUW1XHx`): https://www.figma.com/design/h1EnhdK8swe6FCyxUW1XHx/Frappe-PMS--Copy-?node-id=3709-625481&m=dev
- Static mock data only. Built on defaults per maintainer's go-ahead to make the PR.

## Screenshot/Screencast

Browser-verified live render on `/next-pms/dashboard` matches the Figma frame. Inline image not auto-attachable from CLI — see the Figma link and Testing Instructions.

## Checklist

- [ ] Code follows the project conventions
- [ ] Self-reviewed the diff
- [ ] Tested the change in the browser

## Fixes

Fixes #1138