### PR TITLE
Refactor the comments component

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/comments/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/comments/index.tsx
@@ -34,18 +34,24 @@ export function NoteComments({ noteId }: NoteCommentsProps) {
 
   return (
     <Comments
-      comments={comments.map(mapNoteComment)}
-      isLoading={isLoading}
+      className="mt-6 border-t border-outline-gray-2 pt-6"
       isUpdating={isUpdating}
       authorId={userId}
       canManageAllComments={currentUser === "Administrator"}
-      title="Comments"
-      inputPlaceholder="Type a comment"
-      inputSubmitLabel="Post"
-      onAddComment={addComment}
       onReply={(parentId, comment) => addComment(comment, parentId)}
       onEdit={updateComment}
       onDelete={deleteComment}
-    />
+    >
+      <Comments.Title>Comments</Comments.Title>
+      <Comments.List
+        comments={comments.map(mapNoteComment)}
+        isLoading={isLoading}
+      />
+      <Comments.Input
+        placeholder="Type a comment"
+        submitLabel="Post"
+        onSubmit={addComment}
+      />
+    </Comments>
   );
 }

--- a/frontend/packages/design-system/src/components/comments/commentInput.tsx
+++ b/frontend/packages/design-system/src/components/comments/commentInput.tsx
@@ -2,11 +2,17 @@
  * External dependencies.
  */
 import { useEffect, useState } from "react";
-import { Button, TextEditor } from "@rtcamp/frappe-ui-react";
+import { mergeClassNames as cn } from "@next-pms/design-system";
+import { Avatar, Button, TextEditor } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
+import {
+  CommentInputContext,
+  useCommentInputContext,
+} from "./commentInputContext";
+import { CommentInputContextValue } from "./types";
 import { stripTags } from "../../utils";
 
 export type CommentInputProps = {
@@ -19,9 +25,10 @@ export type CommentInputProps = {
   onCancel?: () => void;
   submitLabel?: string;
   collapsible?: boolean;
+  children?: React.ReactNode;
 };
 
-export function CommentInput({
+function CommentInputRoot({
   onSubmit,
   placeholder = "Add a comment...",
   initialValue = "",
@@ -31,6 +38,7 @@ export function CommentInput({
   onCancel,
   submitLabel = "Post",
   collapsible = false,
+  children,
 }: CommentInputProps) {
   const [draft, setDraft] = useState(initialValue);
   const [isExpanded, setIsExpanded] = useState(
@@ -57,66 +65,181 @@ export function CommentInput({
       setDraft("");
       setEditorKey((key) => key + 1);
     }
-    if (collapsible) {
-      setIsExpanded(false);
-    }
+    if (collapsible) setIsExpanded(false);
   };
 
   const handleCancel = () => {
     resetEditor();
-    if (collapsible) {
-      setIsExpanded(false);
-    }
+    if (collapsible) setIsExpanded(false);
     onCancel?.();
   };
 
-  // Dummy input to avoid rendering the heavy TextEditor component.
-  if (!isExpanded) {
+  const value: CommentInputContextValue = {
+    draft,
+    setDraft,
+    isExpanded,
+    setIsExpanded,
+    editorKey,
+    isEmpty,
+    isSubmitting,
+    autoFocus,
+    collapsible,
+    showCancel: !!onCancel || collapsible,
+    handleSubmit,
+    handleCancel,
+  };
+
+  // Composable - consumer controls layout via sub-components.
+  if (children) {
     return (
-      <input
-        aria-label={placeholder}
-        type="text"
-        className="transition-colors w-full min-h-8 outline-none appearance-none text-base rounded h-7 border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 pl-2 pr-2 py-1.5"
-        onFocus={() => setIsExpanded(true)}
-        placeholder={placeholder}
-      />
+      <CommentInputContext.Provider value={value}>
+        {children}
+      </CommentInputContext.Provider>
     );
   }
 
+  // Default layout (backward-compat, no children).
   return (
-    <div className="flex w-full flex-col gap-2">
-      <div className="flex w-full flex-col gap-2">
-        <TextEditor
-          key={editorKey}
-          content={draft}
-          editable={!isSubmitting}
-          autofocus={autoFocus || collapsible}
-          fixedMenu={false}
-          placeholder={placeholder}
-          onChange={setDraft}
-          editorClass="min-h-11 w-full max-w-full rounded-lg border border-outline-gray-2 bg-surface-white px-2 text-ink-gray-8 prose-sm prose-p:my-0 focus:outline-none"
-        />
-        <div className="flex items-center justify-end gap-2">
-          {(onCancel || collapsible) && (
-            <Button
-              variant="ghost"
-              size="sm"
-              label="Cancel"
-              onClick={handleCancel}
-              disabled={isSubmitting}
-            />
-          )}
-          <Button
-            variant="solid"
-            theme="gray"
-            size="sm"
-            label={submitLabel}
-            loading={isSubmitting}
-            disabled={isEmpty || isSubmitting}
-            onClick={() => void handleSubmit()}
-          />
-        </div>
-      </div>
+    <CommentInputContext.Provider value={value}>
+      {!isExpanded && collapsible ? (
+        <CommentInputTrigger placeholder={placeholder} />
+      ) : (
+        <CommentInputContent>
+          <CommentInputEditor placeholder={placeholder} />
+          <CommentInputActions submitLabel={submitLabel} />
+        </CommentInputContent>
+      )}
+    </CommentInputContext.Provider>
+  );
+}
+
+// Sub-components
+
+function CommentInputTrigger({
+  placeholder = "Add a comment...",
+  className,
+  avatarName,
+  avatarImage,
+}: {
+  placeholder?: string;
+  className?: string;
+  avatarName?: string;
+  avatarImage?: string;
+}) {
+  const { isExpanded, collapsible, setIsExpanded } = useCommentInputContext();
+
+  if (isExpanded || !collapsible) return null;
+
+  const input = (
+    <input
+      aria-label={placeholder}
+      type="text"
+      className={cn(
+        "transition-colors w-full min-h-8 outline-none appearance-none text-base rounded h-7 border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 pl-2 pr-2 py-1.5",
+        className,
+      )}
+      onFocus={() => setIsExpanded(true)}
+      placeholder={placeholder}
+    />
+  );
+
+  if (!avatarName && !avatarImage) return input;
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Avatar
+        size="lg"
+        shape="circle"
+        label={avatarName ?? ""}
+        image={avatarImage}
+      />
+      {input}
     </div>
   );
 }
+
+function CommentInputContent({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { isExpanded, collapsible } = useCommentInputContext();
+
+  if (!isExpanded && collapsible) return null;
+
+  return (
+    <div className={cn("flex w-full flex-col gap-2", className)}>
+      {children}
+    </div>
+  );
+}
+
+function CommentInputEditor({
+  placeholder = "Add a comment...",
+  className,
+}: {
+  placeholder?: string;
+  className?: string;
+}) {
+  const { draft, setDraft, editorKey, isSubmitting, autoFocus, collapsible } =
+    useCommentInputContext();
+
+  return (
+    <TextEditor
+      key={editorKey}
+      content={draft}
+      editable={!isSubmitting}
+      autofocus={autoFocus || collapsible}
+      fixedMenu={false}
+      placeholder={placeholder}
+      onChange={setDraft}
+      editorClass={cn(
+        "min-h-11 w-full max-w-full rounded-lg border border-outline-gray-2 bg-surface-white px-2 text-ink-gray-8 prose-sm prose-p:my-0 focus:outline-none",
+        className,
+      )}
+    />
+  );
+}
+
+function CommentInputActions({
+  submitLabel = "Post",
+}: {
+  submitLabel?: string;
+}) {
+  const { isEmpty, isSubmitting, showCancel, handleSubmit, handleCancel } =
+    useCommentInputContext();
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      {showCancel && (
+        <Button
+          variant="ghost"
+          size="sm"
+          label="Cancel"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+        />
+      )}
+      <Button
+        variant="solid"
+        theme="gray"
+        size="sm"
+        label={submitLabel}
+        loading={isSubmitting}
+        disabled={isEmpty || isSubmitting}
+        onClick={() => void handleSubmit()}
+      />
+    </div>
+  );
+}
+
+// Export
+
+export const CommentInput = Object.assign(CommentInputRoot, {
+  Trigger: CommentInputTrigger,
+  Content: CommentInputContent,
+  Editor: CommentInputEditor,
+  Actions: CommentInputActions,
+});

--- a/frontend/packages/design-system/src/components/comments/commentInputContext.tsx
+++ b/frontend/packages/design-system/src/components/comments/commentInputContext.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies.
+ */
+import { createContext, useContext } from "react";
+import { CommentInputContextValue } from "./types";
+
+export const CommentInputContext =
+  createContext<CommentInputContextValue | null>(null);
+
+export function useCommentInputContext() {
+  const ctx = useContext(CommentInputContext);
+  if (!ctx)
+    throw new Error(
+      "CommentInput sub-components must be used inside CommentInput.",
+    );
+  return ctx;
+}

--- a/frontend/packages/design-system/src/components/comments/componentActions.tsx
+++ b/frontend/packages/design-system/src/components/comments/componentActions.tsx
@@ -1,8 +1,14 @@
 /**
  * External dependencies.
  */
+import { useState } from "react";
 import { Button } from "@rtcamp/frappe-ui-react";
 import { Delete, EditAlt, Reply } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { DeleteCommentDialog } from "./deleteCommentDialog";
 
 type ComponentActionsProps = {
   onReply?: () => void;
@@ -17,52 +23,68 @@ export function ComponentActions({
   onDelete,
   isUpdating,
 }: ComponentActionsProps) {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const handleDeleteConfirm = () => {
+    setConfirmDelete(false);
+    onDelete?.();
+  };
+
   return (
-    <div className="flex flex-wrap items-center">
-      {onReply ? (
-        <>
+    <>
+      <div className="flex flex-wrap items-center">
+        {onReply ? (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              label="Reply"
+              iconLeft={Reply}
+              disabled={isUpdating}
+              onClick={onReply}
+            />
+          </>
+        ) : null}
+
+        {onReply && (onEdit || onDelete) ? (
+          <span className="mx-1 h-4 w-px bg-outline-gray-3" />
+        ) : null}
+
+        {onEdit ? (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              label="Edit"
+              iconLeft={EditAlt}
+              disabled={isUpdating}
+              onClick={onEdit}
+            />
+          </>
+        ) : null}
+
+        {onEdit && onDelete ? (
+          <span className="mx-1 h-4 w-px bg-outline-gray-3" />
+        ) : null}
+
+        {onDelete ? (
           <Button
             variant="ghost"
             size="sm"
-            label="Reply"
-            iconLeft={Reply}
+            label="Delete"
+            iconLeft={Delete}
             disabled={isUpdating}
-            onClick={onReply}
+            onClick={() => setConfirmDelete(true)}
           />
-        </>
-      ) : null}
+        ) : null}
+      </div>
 
-      {onReply && (onEdit || onDelete) ? (
-        <span className="mx-1 h-4 w-px bg-outline-gray-3" />
-      ) : null}
-
-      {onEdit ? (
-        <>
-          <Button
-            variant="ghost"
-            size="sm"
-            label="Edit"
-            iconLeft={EditAlt}
-            disabled={isUpdating}
-            onClick={onEdit}
-          />
-        </>
-      ) : null}
-
-      {onEdit && onDelete ? (
-        <span className="mx-1 h-4 w-px bg-outline-gray-3" />
-      ) : null}
-
-      {onDelete ? (
-        <Button
-          variant="ghost"
-          size="sm"
-          label="Delete"
-          iconLeft={Delete}
-          disabled={isUpdating}
-          onClick={onDelete}
-        />
-      ) : null}
-    </div>
+      <DeleteCommentDialog
+        open={confirmDelete}
+        isDeleting={isUpdating}
+        onConfirm={handleDeleteConfirm}
+        onClose={() => setConfirmDelete(false)}
+      />
+    </>
   );
 }

--- a/frontend/packages/design-system/src/components/comments/deleteCommentDialog.tsx
+++ b/frontend/packages/design-system/src/components/comments/deleteCommentDialog.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies.
+ */
+import { Dialog } from "@base-ui/react/dialog";
+import { Button } from "@rtcamp/frappe-ui-react";
+
+type DeleteCommentDialogProps = {
+  open: boolean;
+  isDeleting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+export function DeleteCommentDialog({
+  open,
+  isDeleting,
+  onConfirm,
+  onClose,
+}: DeleteCommentDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 bg-black-overlay-200 backdrop-blur-md" />
+        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-surface-modal shadow-xl">
+          <div className="px-4 pb-6 pt-5 sm:px-6">
+            <div className="mb-4">
+              <Dialog.Title className="text-xl font-semibold text-ink-gray-9">
+                Delete comment
+              </Dialog.Title>
+            </div>
+            <p className="text-base text-ink-gray-7">
+              Are you sure you want to delete this comment? This action cannot
+              be undone.
+            </p>
+          </div>
+          <div className="flex items-center justify-end gap-1 px-4 pb-6 pt-2 sm:px-6">
+            <Button
+              variant="ghost"
+              theme="gray"
+              size="sm"
+              label="Cancel"
+              onClick={onClose}
+              disabled={isDeleting}
+            />
+            <Button
+              variant="solid"
+              theme="red"
+              size="sm"
+              label="Delete"
+              onClick={onConfirm}
+              disabled={isDeleting}
+              loading={isDeleting}
+            />
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/packages/design-system/src/components/comments/index.tsx
+++ b/frontend/packages/design-system/src/components/comments/index.tsx
@@ -14,7 +14,11 @@ import { CommentsProvider } from "./provider";
 import Spinner from "../spinner";
 import type { CommentNode, CommentsRootProps } from "./types";
 
-export type { CommentNode, CommentsRootProps } from "./types";
+export type {
+  CommentNode,
+  CommentsRootProps,
+  CommentsRootProps as CommentsProps,
+} from "./types";
 
 function CommentsRoot({
   className,

--- a/frontend/packages/design-system/src/components/comments/index.tsx
+++ b/frontend/packages/design-system/src/components/comments/index.tsx
@@ -2,32 +2,30 @@
  * External dependencies.
  */
 import { useMemo } from "react";
+import { mergeClassNames as cn } from "@next-pms/design-system";
 
 /**
  * Internal dependencies.
  */
 import { CommentInput } from "./commentInput";
 import { CommentThread } from "./commentThread";
+import { useCommentsContext } from "./context";
 import { CommentsProvider } from "./provider";
 import Spinner from "../spinner";
-import type { CommentsProps } from "./types";
+import type { CommentNode, CommentsRootProps } from "./types";
 
-export type { CommentNode, CommentsProps } from "./types";
+export type { CommentNode, CommentsRootProps } from "./types";
 
-export function Comments({
-  comments,
-  isLoading = false,
+function CommentsRoot({
+  className,
+  children,
   isUpdating = false,
   authorId,
   canManageAllComments = false,
-  title = "Comments",
-  inputPlaceholder = "Type a comment",
-  inputSubmitLabel = "Post",
-  onAddComment,
   onReply,
   onEdit,
   onDelete,
-}: CommentsProps) {
+}: CommentsRootProps) {
   const value = useMemo(
     () => ({
       onReply,
@@ -42,28 +40,75 @@ export function Comments({
 
   return (
     <CommentsProvider {...value}>
-      <div className="mt-6 flex flex-col gap-5 border-t border-outline-gray-2 pt-6">
-        <h2 className="text-lg font-medium text-ink-gray-8">{title}</h2>
-
-        {isLoading ? (
-          <Spinner className="py-6" />
-        ) : comments?.length ? (
-          <div className="flex flex-col gap-3">
-            {comments.map((comment) => (
-              <CommentThread key={comment.id} comment={comment} />
-            ))}
-          </div>
-        ) : null}
-
-        <CommentInput
-          placeholder={inputPlaceholder}
-          submitLabel={inputSubmitLabel}
-          collapsible
-          resetOnSubmit
-          isSubmitting={isUpdating}
-          onSubmit={onAddComment}
-        />
-      </div>
+      <div className={cn("flex flex-col gap-5", className)}>{children}</div>
     </CommentsProvider>
   );
 }
+
+function CommentsTitle({ children }: { children: React.ReactNode }) {
+  if (typeof children === "string") {
+    return <h2 className="text-lg font-medium text-ink-gray-8">{children}</h2>;
+  }
+  return <>{children}</>;
+}
+
+function CommentsList({
+  comments,
+  isLoading = false,
+}: {
+  comments: CommentNode[];
+  isLoading?: boolean;
+}) {
+  if (isLoading) return <Spinner className="py-6" />;
+  if (!comments?.length) return null;
+  return (
+    <div className="flex flex-col gap-3">
+      {comments.map((comment) => (
+        <CommentThread key={comment.id} comment={comment} />
+      ))}
+    </div>
+  );
+}
+
+function CommentsInput({
+  onSubmit,
+  placeholder = "Type a comment",
+  submitLabel = "Post",
+  triggerClassName,
+  avatarName,
+  avatarImage,
+}: {
+  onSubmit: (comment: string) => Promise<void>;
+  placeholder?: string;
+  submitLabel?: string;
+  triggerClassName?: string;
+  avatarName?: string;
+  avatarImage?: string;
+}) {
+  const { isUpdating } = useCommentsContext();
+  return (
+    <CommentInput
+      onSubmit={onSubmit}
+      collapsible
+      resetOnSubmit
+      isSubmitting={isUpdating}
+    >
+      <CommentInput.Trigger
+        placeholder={placeholder}
+        className={triggerClassName}
+        avatarName={avatarName}
+        avatarImage={avatarImage}
+      />
+      <CommentInput.Content>
+        <CommentInput.Editor placeholder={placeholder} />
+        <CommentInput.Actions submitLabel={submitLabel} />
+      </CommentInput.Content>
+    </CommentInput>
+  );
+}
+
+export const Comments = Object.assign(CommentsRoot, {
+  Title: CommentsTitle,
+  List: CommentsList,
+  Input: CommentsInput,
+});

--- a/frontend/packages/design-system/src/components/comments/types.ts
+++ b/frontend/packages/design-system/src/components/comments/types.ts
@@ -18,17 +18,28 @@ export type CommentActions = {
   canManageAllComments?: boolean;
 };
 
-export type CommentsProps = {
-  comments: CommentNode[];
-  isLoading?: boolean;
+export type CommentsRootProps = {
+  className?: string;
+  children?: React.ReactNode;
   isUpdating?: boolean;
   authorId?: string;
   canManageAllComments?: boolean;
-  title?: string;
-  inputPlaceholder?: string;
-  inputSubmitLabel?: string;
-  onAddComment: (comment: string) => Promise<void>;
   onReply: (parentId: string, comment: string) => Promise<void>;
   onEdit: (commentId: string, comment: string) => Promise<void>;
   onDelete: (commentId: string) => Promise<void>;
+};
+
+export type CommentInputContextValue = {
+  draft: string;
+  setDraft: (v: string) => void;
+  isExpanded: boolean;
+  setIsExpanded: (v: boolean) => void;
+  editorKey: number;
+  isEmpty: boolean;
+  isSubmitting: boolean;
+  autoFocus: boolean;
+  collapsible: boolean;
+  showCancel: boolean;
+  handleSubmit: () => Promise<void>;
+  handleCancel: () => void;
 };


### PR DESCRIPTION
## Description
- Refactor existing comments component to be more reusable
- Update existing comments usage
- Add comment delete confirmation dialog

## Relevant Technical Choices
- The existing comment component was made for specifically for the notes page, I refactored it so it can be reused easily. This enables us to reuse the component for feedback details dialog.
- Note that we are not using the dialog from frappe-ui-react on purpose since we need to stack dialogs for the feedback delete confirmation - and frappe-ui-react's implementation does not handle this.

## Screenshot/Screencast
<img width="2908" height="1524" alt="image" src="https://github.com/user-attachments/assets/914a0be3-334f-40bd-bccb-ea77b63181b8" />

<img width="2268" height="1404" alt="image" src="https://github.com/user-attachments/assets/78238642-0bcc-4e83-be55-ad0080e8da2d" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #