### PR TITLE
feat: dashboard notifications for PMS

### DIFF
--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -195,6 +195,7 @@ scheduler_events = {
         "next_pms.timesheet.tasks.daily_reminder_for_time_entry.send_reminder",
         "next_pms.timesheet.tasks.send_weekly_reminder.send_reminder",
         "next_pms.resource_management.tasks.no_allocation_reminder.send_reminder",
+        "next_pms.next_pms.notifications.send_review_reminders",
     ],
     "weekly": [
         "next_pms.project_currency.tasks.reminde_project_threshold.send_reminder_mail",
@@ -262,8 +263,15 @@ doc_events = {
             "next_pms.project_currency.doc_events.project.on_update",
             "next_pms.next_projects.doc_events.project.clear_cache",
             "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+            "next_pms.next_pms.notifications.project_on_update",
         ],
         "on_trash": ["next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache"],
+    },
+    "Risk": {
+        "on_update": "next_pms.next_pms.notifications.risk_on_update",
+    },
+    "Customer Feedback": {
+        "on_submit": "next_pms.next_pms.notifications.customer_feedback_on_submit",
     },
     "Customer": {"validate": "next_pms.resource_management.doc_events.customer.validate_abbr"},
     "Employee": {

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.js
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, rtCamp and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("NextPMS Notifications", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.json
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "allow_rename": 1,
  "creation": "2026-06-18 22:19:35.913633",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -46,7 +45,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-22 03:41:21.283426",
+ "modified": "2026-06-22 14:27:10.565940",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "NextPMS Notifications",

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.json
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.json
@@ -5,19 +5,48 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "label"
+  "label",
+  "user",
+  "linked_doctype",
+  "linked_document"
  ],
  "fields": [
   {
    "fieldname": "label",
    "fieldtype": "Data",
-   "label": "Label"
+   "in_list_view": 1,
+   "label": "Label",
+   "reqd": 1
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  },
+  {
+   "fieldname": "linked_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Linked Doctype",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "linked_document",
+   "fieldtype": "Dynamic Link",
+   "in_list_view": 1,
+   "label": "Linked Document",
+   "options": "linked_doctype",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-18 22:19:45.962454",
+ "modified": "2026-06-22 03:41:21.283426",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "NextPMS Notifications",
@@ -34,6 +63,24 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects Manager",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.json
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-06-18 22:19:35.913633",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "label"
+ ],
+ "fields": [
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "label": "Label"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-18 22:19:45.962454",
+ "modified_by": "Administrator",
+ "module": "Next PMS",
+ "name": "NextPMS Notifications",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.py
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class NextPMSNotifications(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        label: DF.Data | None
+    # end: auto-generated types
+
+    pass

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.py
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, rtCamp and contributors
 # For license information, please see license.txt
 
-import frappe
+from frappe.deferred_insert import deferred_insert
 from frappe.model.document import Document
 from frappe.permissions import add_user_permission
 
@@ -34,12 +34,12 @@ class NextPMSNotifications(Document):
 
 
 def create_notification(user, label, linked_doctype, linked_document):
-    frappe.get_doc(
+    deferred_insert(
+        "NextPMS Notifications",
         {
-            "doctype": "NextPMS Notifications",
             "user": user,
             "label": label,
             "linked_doctype": linked_doctype,
             "linked_document": linked_document,
-        }
-    ).insert(ignore_permissions=True)
+        },
+    )

--- a/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.py
+++ b/next_pms/next_pms/doctype/nextpms_notifications/nextpms_notifications.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2026, rtCamp and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.permissions import add_user_permission
 
 
 class NextPMSNotifications(Document):
@@ -14,7 +15,31 @@ class NextPMSNotifications(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        label: DF.Data | None
+        label: DF.Data
+        linked_doctype: DF.Link
+        linked_document: DF.DynamicLink
+        user: DF.Link
     # end: auto-generated types
 
-    pass
+    def after_insert(self):
+        # Restrict each user to their own notifications (one User Permission per user, scoped to this doctype).
+        if self.user:
+            add_user_permission(
+                "User",
+                self.user,
+                self.user,
+                applicable_for="NextPMS Notifications",
+                ignore_permissions=True,
+            )
+
+
+def create_notification(user, label, linked_doctype, linked_document):
+    frappe.get_doc(
+        {
+            "doctype": "NextPMS Notifications",
+            "user": user,
+            "label": label,
+            "linked_doctype": linked_doctype,
+            "linked_document": linked_document,
+        }
+    ).insert(ignore_permissions=True)

--- a/next_pms/next_pms/doctype/nextpms_notifications/test_nextpms_notifications.py
+++ b/next_pms/next_pms/doctype/nextpms_notifications/test_nextpms_notifications.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, rtCamp and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestNextPMSNotifications(IntegrationTestCase):
+    """
+    Integration tests for NextPMSNotifications.
+    Use this class for testing interactions between multiple components.
+    """
+
+    pass

--- a/next_pms/next_pms/notifications.py
+++ b/next_pms/next_pms/notifications.py
@@ -60,6 +60,10 @@ def project_on_update(doc, method=None):
 
 def customer_feedback_on_submit(doc, method=None):
     """Notify the project manager(s) of the related project(s) when customer feedback is received."""
+    if doc.flags.get("next_pms_customer_feedback_notified"):
+        return
+    doc.flags.next_pms_customer_feedback_notified = True
+
     projects = frappe.get_all(
         "Customer Feedback Project",
         filters={"parent": doc.customer_feedback_schedule, "parenttype": "Customer Feedback Schedule"},

--- a/next_pms/next_pms/notifications.py
+++ b/next_pms/next_pms/notifications.py
@@ -90,8 +90,11 @@ def send_review_reminders():
     )
 
     by_reviewer = {}
+    reviewer_cache = {}
     for ts in pending:
-        reviewer = get_reviewer(ts.employee)
+        if ts.employee not in reviewer_cache:
+            reviewer_cache[ts.employee] = get_reviewer(ts.employee)
+        reviewer = reviewer_cache[ts.employee]
         if not reviewer:
             continue
 

--- a/next_pms/next_pms/notifications.py
+++ b/next_pms/next_pms/notifications.py
@@ -1,0 +1,115 @@
+import frappe
+from frappe import _
+from frappe.utils import formatdate, get_fullname, getdate
+
+from next_pms.next_pms.doctype.nextpms_notifications.nextpms_notifications import create_notification
+
+
+def get_followers(doctype, name):
+    return frappe.get_all(
+        "Document Follow",
+        filters={"ref_doctype": doctype, "ref_docname": name},
+        pluck="user",
+    )
+
+
+def get_reviewer(employee):
+    reports_to = frappe.db.get_value("Employee", employee, "reports_to")
+    return frappe.db.get_value("Employee", reports_to, "user_id")
+
+
+def risk_on_update(doc, method=None):
+    """Notify followers of a Risk when its status changes."""
+    if not doc.status:
+        return
+
+    previous = doc.get_doc_before_save()
+    if not previous or previous.status == doc.status:
+        return
+
+    actor = frappe.session.user
+    project_name = frappe.db.get_value("Project", doc.project, "project_name")
+    label = _("{0} updated the risk status to {1} in {2}").format(get_fullname(actor), doc.status, project_name)
+
+    for user in get_followers("Risk", doc.name):
+        if user == actor:
+            continue
+        create_notification(user, label, "Risk", doc.name)
+
+
+def project_on_update(doc, method=None):
+    """Notify the project manager and followers when the project health (RAG) changes."""
+    if not doc.custom_project_rag_status:
+        return
+
+    previous = doc.get_doc_before_save()
+    if not previous or previous.custom_project_rag_status == doc.custom_project_rag_status:
+        return
+
+    actor = frappe.session.user
+    label = _("Project health for {0} is now {1}").format(doc.project_name, doc.custom_project_rag_status)
+
+    recipients = set(get_followers("Project", doc.name))
+    if doc.custom_project_manager:
+        recipients.add(doc.custom_project_manager)
+    recipients.discard(actor)
+
+    for user in recipients:
+        create_notification(user, label, "Project", doc.name)
+
+
+def customer_feedback_on_submit(doc, method=None):
+    """Notify the project manager(s) of the related project(s) when customer feedback is received."""
+    projects = frappe.get_all(
+        "Customer Feedback Project",
+        filters={"parent": doc.customer_feedback_schedule, "parenttype": "Customer Feedback Schedule"},
+        pluck="project",
+    )
+
+    date = formatdate(getdate(doc.feedback_to_date), "dd/mm/yyyy")
+    for project in projects:
+        manager = frappe.db.get_value("Project", project, "custom_project_manager")
+        if not manager:
+            continue
+        project_name = frappe.db.get_value("Project", project, "project_name")
+        label = _("{0} client feedback received for {1}").format(date, project_name)
+        create_notification(manager, label, "Customer Feedback", doc.name)
+
+
+def send_review_reminders():
+    """Nightly: notify each reviewer of how many timesheets are pending their review."""
+    pending = frappe.get_all(
+        "Timesheet",
+        filters={"custom_approval_status": "Approval Pending", "docstatus": 0},
+        fields=["name", "employee", "start_date", "end_date"],
+        order_by="modified desc",
+    )
+
+    by_reviewer = {}
+    for ts in pending:
+        reviewer = get_reviewer(ts.employee)
+        if not reviewer:
+            continue
+
+        start, end = getdate(ts.start_date), getdate(ts.end_date)
+        entry = by_reviewer.get(reviewer)
+        if not entry:
+            by_reviewer[reviewer] = {
+                "count": 1,
+                "timesheet": ts.name,
+                "start_date": start,
+                "end_date": end,
+            }
+            continue
+
+        entry["count"] += 1
+        entry["start_date"] = min(entry["start_date"], start)
+        entry["end_date"] = max(entry["end_date"], end)
+
+    for reviewer, entry in by_reviewer.items():
+        label = _("You have {0} timesheets to review between {1} and {2}").format(
+            entry["count"],
+            formatdate(entry["start_date"], "dd/mm/yyyy"),
+            formatdate(entry["end_date"], "dd/mm/yyyy"),
+        )
+        create_notification(reviewer, label, "Timesheet", entry["timesheet"])


### PR DESCRIPTION
## Description

dashboard notifications for PMS. backend for 
<img width="281" height="278" alt="image" src="https://github.com/user-attachments/assets/b38d3db0-65f1-4e5b-8653-382fe8b8e6e4" />
<img width="232" height="202" alt="image" src="https://github.com/user-attachments/assets/13ccbef9-807f-4522-b53a-1d6abfae5c78" />


## Relevant Technical Choices

- new doctype made for notifications 
- doctype locked to user perms (the user can only see their documents)
- added doc event hooks for notifications
- used deferred insert for perf 

## Testing Instructions

the user can only see their documents
<img width="1252" height="475" alt="image" src="https://github.com/user-attachments/assets/6102ecce-d54a-4db4-9d33-bfe1f203d943" />

inside view 
<img width="555" height="385" alt="image" src="https://github.com/user-attachments/assets/7396e971-a22f-45d1-afa9-2cf212081d01" />

admins (system manager) can see all notifications
<img width="1237" height="791" alt="image" src="https://github.com/user-attachments/assets/e13ad941-eafb-479d-ae28-02e66bcc9367" />

permission matrix
<img width="1100" height="320" alt="image" src="https://github.com/user-attachments/assets/5a9551ae-1d79-4efa-850e-91528188d234" />

frappe crud api respects the permission lock
```
next_pms feat/notifications* ≡
 ❯ curl -s 'http://erp16.localhost/api/resource/NextPMS%20Notifications' \
  -H 'Cookie: sid=4a14be8b6a8075cde30165831847dfb1b3ea68e1313284692046d3db' | jq
{
  "data": [
    {
      "name": "n5h5d0pagu"
    },
    {
      "name": "o8dia24f5b"
    },
    {
      "name": "qmmkj06qe6"
    }
  ]
}

next_pms feat/notifications* ≡
 ❯
 ```

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1145 