### PR TITLE
Feature: Implement override-aware virtual segments

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/project/utils.ts
@@ -12,10 +12,11 @@ import { parseISO } from "date-fns";
  * Internal dependencies.
  */
 import {
+  buildRecurrenceSeriesMetaMap,
   calculateAllocationHourlyRate,
   formatAllocationCapacity,
   getAllocationCapacityHoursPerDay,
-  mapResourceAllocation,
+  mapResourceAllocationSegments,
 } from "../utils";
 import type {
   Customer,
@@ -126,19 +127,22 @@ function getProjectMembers(
   managerNameMap?: ManagerNameMap,
 ): ProjectMember[] {
   const membersById = new Map<string, ProjectMember>();
+  const recurrenceSeriesMetaByAllocationName =
+    buildRecurrenceSeriesMetaMap(projectAllocations);
 
   for (const allocation of projectAllocations) {
     const memberId = allocation.employee;
     const member = membersById.get(memberId);
     const employee = employees[memberId];
-    const mappedAllocation = mapResourceAllocation(
+    const mappedAllocations = mapResourceAllocationSegments(
       allocation,
       resolveCustomerName(allocation.customer, customerLookup),
+      recurrenceSeriesMetaByAllocationName.get(allocation.name),
     );
 
     if (member) {
       const memberAllocations = member.allocations ?? [];
-      memberAllocations.push(mappedAllocation);
+      memberAllocations.push(...mappedAllocations);
       member.allocations = memberAllocations;
       continue;
     }
@@ -170,7 +174,7 @@ function getProjectMembers(
           undefined)
         : undefined,
       image: employee?.image ?? undefined,
-      allocations: [mappedAllocation],
+      allocations: mappedAllocations,
     });
   }
 

--- a/frontend/packages/app/src/pages/allocations/project/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/project/utils.ts
@@ -12,7 +12,6 @@ import { parseISO } from "date-fns";
  * Internal dependencies.
  */
 import {
-  buildRecurrenceSeriesMetaMap,
   calculateAllocationHourlyRate,
   formatAllocationCapacity,
   getAllocationCapacityHoursPerDay,
@@ -127,8 +126,6 @@ function getProjectMembers(
   managerNameMap?: ManagerNameMap,
 ): ProjectMember[] {
   const membersById = new Map<string, ProjectMember>();
-  const recurrenceSeriesMetaByAllocationName =
-    buildRecurrenceSeriesMetaMap(projectAllocations);
 
   for (const allocation of projectAllocations) {
     const memberId = allocation.employee;
@@ -137,7 +134,6 @@ function getProjectMembers(
     const mappedAllocations = mapResourceAllocationSegments(
       allocation,
       resolveCustomerName(allocation.customer, customerLookup),
-      recurrenceSeriesMetaByAllocationName.get(allocation.name),
     );
 
     if (member) {

--- a/frontend/packages/app/src/pages/allocations/team/type.ts
+++ b/frontend/packages/app/src/pages/allocations/team/type.ts
@@ -1,3 +1,5 @@
+import type { AllocationOverrideEntry } from "../utils";
+
 export interface Employee {
   name: string;
   image: string | null;
@@ -40,6 +42,7 @@ export interface ResourceAllocation {
   creation: string;
   status: string;
   modified_by_avatar: string | null;
+  override?: AllocationOverrideEntry[];
 }
 
 export interface Customer {

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -1,10 +1,11 @@
 import type { Member, Project } from "@next-pms/design-system/components";
 import { parseISO } from "date-fns";
 import {
+  buildRecurrenceSeriesMetaMap,
   calculateAllocationHourlyRate,
   formatAllocationCapacity,
   getAllocationCapacityHoursPerDay,
-  mapResourceAllocation,
+  mapResourceAllocationSegments,
 } from "../utils";
 import type { ManagerNameMap, TeamAllocationResponse } from "./type";
 
@@ -24,6 +25,8 @@ export function mapTeamAllocationToMembers(
   const employeeList = employees ?? [];
   const allocationList = resource_allocations ?? [];
   const leaveList = leaves ?? [];
+  const recurrenceSeriesMetaByAllocationName =
+    buildRecurrenceSeriesMetaMap(allocationList);
 
   // Group allocations by employee, then by project
   const allocationsByEmployee = new Map<
@@ -34,7 +37,7 @@ export function mapTeamAllocationToMembers(
         projectName: string;
         projectId: string;
         customerName: string;
-        allocations: ReturnType<typeof mapResourceAllocation>[];
+        allocations: ReturnType<typeof mapResourceAllocationSegments>;
       }
     >
   >();
@@ -71,7 +74,13 @@ export function mapTeamAllocationToMembers(
 
     projectMap
       .get(alloc.project)!
-      .allocations.push(mapResourceAllocation(alloc, customerName));
+      .allocations.push(
+        ...mapResourceAllocationSegments(
+          alloc,
+          customerName,
+          recurrenceSeriesMetaByAllocationName.get(alloc.name),
+        ),
+      );
   }
 
   return employeeList.map((employee): Member => {

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -1,7 +1,6 @@
 import type { Member, Project } from "@next-pms/design-system/components";
 import { parseISO } from "date-fns";
 import {
-  buildRecurrenceSeriesMetaMap,
   calculateAllocationHourlyRate,
   formatAllocationCapacity,
   getAllocationCapacityHoursPerDay,
@@ -25,8 +24,6 @@ export function mapTeamAllocationToMembers(
   const employeeList = employees ?? [];
   const allocationList = resource_allocations ?? [];
   const leaveList = leaves ?? [];
-  const recurrenceSeriesMetaByAllocationName =
-    buildRecurrenceSeriesMetaMap(allocationList);
 
   // Group allocations by employee, then by project
   const allocationsByEmployee = new Map<
@@ -74,13 +71,7 @@ export function mapTeamAllocationToMembers(
 
     projectMap
       .get(alloc.project)!
-      .allocations.push(
-        ...mapResourceAllocationSegments(
-          alloc,
-          customerName,
-          recurrenceSeriesMetaByAllocationName.get(alloc.name),
-        ),
-      );
+      .allocations.push(...mapResourceAllocationSegments(alloc, customerName));
   }
 
   return employeeList.map((employee): Member => {

--- a/frontend/packages/app/src/pages/allocations/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/utils.ts
@@ -3,7 +3,7 @@
  */
 import type { Allocation } from "@next-pms/design-system/components";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
-import { addMonths, addWeeks, parseISO } from "date-fns";
+import { addDays, addMonths, addWeeks, format, parseISO } from "date-fns";
 
 /**
  * Internal dependencies.
@@ -47,7 +47,65 @@ export type AllocationApiRecord = {
   modified?: string | null;
   modified_by?: string | null;
   modified_by_avatar?: string | null;
+  override?: AllocationOverrideEntry[];
 };
+
+export type AllocationOverrideEntry = {
+  date: string;
+  hours?: number | null;
+  cancelled?: number | null;
+};
+
+export type RecurrenceSeriesMeta = {
+  recurrenceWeekCount: number;
+  recurrenceSeriesEndDate: string;
+};
+
+/**
+ * Builds per-allocation recurrence metadata for a flat list of allocations.
+ * Allocations sharing a `recurrence_id` are grouped into a series, and every
+ * member of that series is annotated with the total number of allocations in
+ * the series and the last date the series covers, keyed by allocation name.
+ */
+export function buildRecurrenceSeriesMetaMap<T extends AllocationApiRecord>(
+  allocations: T[],
+): Map<string, RecurrenceSeriesMeta> {
+  const allocationsByRecurrenceId = new Map<string, T[]>();
+
+  for (const allocation of allocations) {
+    if (!allocation.recurrence_id) {
+      continue;
+    }
+
+    const seriesAllocations =
+      allocationsByRecurrenceId.get(allocation.recurrence_id) ?? [];
+    seriesAllocations.push(allocation);
+    allocationsByRecurrenceId.set(allocation.recurrence_id, seriesAllocations);
+  }
+
+  const metaByAllocationName = new Map<string, RecurrenceSeriesMeta>();
+
+  for (const seriesAllocations of allocationsByRecurrenceId.values()) {
+    const sortedAllocations = [...seriesAllocations].sort((left, right) =>
+      left.allocation_start_date.localeCompare(right.allocation_start_date),
+    );
+    const recurrenceSeriesEndDate =
+      sortedAllocations[sortedAllocations.length - 1]?.allocation_end_date;
+
+    if (!recurrenceSeriesEndDate) {
+      continue;
+    }
+
+    for (const allocation of sortedAllocations) {
+      metaByAllocationName.set(allocation.name, {
+        recurrenceWeekCount: sortedAllocations.length,
+        recurrenceSeriesEndDate,
+      });
+    }
+  }
+
+  return metaByAllocationName;
+}
 
 type AllocationApiFilter = [string, string, string | string[] | number | null];
 
@@ -200,6 +258,7 @@ export function formatAllocationCapacity(
 export function mapResourceAllocation<T extends AllocationApiRecord>(
   allocation: T,
   customerName?: string,
+  recurrenceSeriesMeta?: RecurrenceSeriesMeta,
 ): Allocation & { customerName?: string } {
   return {
     id: allocation.name,
@@ -210,9 +269,17 @@ export function mapResourceAllocation<T extends AllocationApiRecord>(
     hours: allocation.hours_allocated_per_day,
     startDate: parseISO(allocation.allocation_start_date),
     endDate: parseISO(allocation.allocation_end_date),
+    allocationStartDate: parseISO(allocation.allocation_start_date),
+    allocationEndDate: parseISO(allocation.allocation_end_date),
+    allocationHoursPerDay: allocation.hours_allocated_per_day,
     billable: Boolean(allocation.is_billable),
     tentative: allocation.status === "Tentative",
     note: allocation.note ?? undefined,
+    override: allocation.override,
+    recurrenceWeekCount: recurrenceSeriesMeta?.recurrenceWeekCount,
+    recurrenceSeriesEndDate: recurrenceSeriesMeta?.recurrenceSeriesEndDate
+      ? parseISO(recurrenceSeriesMeta.recurrenceSeriesEndDate)
+      : undefined,
     createdOn: allocation.creation
       ? parseFrappeDatetime(allocation.creation)
       : undefined,
@@ -226,6 +293,85 @@ export function mapResourceAllocation<T extends AllocationApiRecord>(
         }
       : undefined,
   };
+}
+
+/**
+ * Splits an allocation into visible contiguous segments after applying per-day overrides.
+ * Each segment is treated as its own visible allocation entry while still pointing at
+ * the same underlying allocation document id.
+ */
+export function mapResourceAllocationSegments<T extends AllocationApiRecord>(
+  allocation: T,
+  customerName?: string,
+  recurrenceSeriesMeta?: RecurrenceSeriesMeta,
+): Array<Allocation & { customerName?: string }> {
+  const baseAllocation = mapResourceAllocation(
+    allocation,
+    customerName,
+    recurrenceSeriesMeta,
+  );
+  const overrideByDate = new Map(
+    (allocation.override ?? []).map((entry) => [entry.date, entry]),
+  );
+
+  if (!overrideByDate.size) {
+    return [baseAllocation];
+  }
+
+  const segments: Array<Allocation & { customerName?: string }> = [];
+
+  let currentDate = baseAllocation.startDate;
+  let segmentStart: Date | null = null;
+  let segmentEnd: Date | null = null;
+  let segmentHours: number | null = null;
+
+  const pushSegment = () => {
+    if (!segmentStart || !segmentEnd || segmentHours === null) {
+      return;
+    }
+
+    segments.push({
+      ...baseAllocation,
+      startDate: segmentStart,
+      endDate: segmentEnd,
+      hours: segmentHours,
+      override: allocation.override,
+    });
+  };
+
+  while (currentDate <= baseAllocation.endDate) {
+    const dateKey = format(currentDate, "yyyy-MM-dd");
+    const dayOverride = overrideByDate.get(dateKey);
+    const dayHours =
+      dayOverride?.cancelled === 1
+        ? 0
+        : (dayOverride?.hours ?? baseAllocation.hours);
+
+    if (dayHours <= 0) {
+      pushSegment();
+      segmentStart = null;
+      segmentEnd = null;
+      segmentHours = null;
+      currentDate = addDays(currentDate, 1);
+      continue;
+    }
+
+    if (segmentStart && segmentHours === dayHours) {
+      segmentEnd = currentDate;
+      currentDate = addDays(currentDate, 1);
+      continue;
+    }
+
+    pushSegment();
+    segmentStart = currentDate;
+    segmentEnd = currentDate;
+    segmentHours = dayHours;
+    currentDate = addDays(currentDate, 1);
+  }
+
+  pushSegment();
+
+  return segments;
 }
 
 /**

--- a/frontend/packages/app/src/pages/allocations/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/utils.ts
@@ -56,57 +56,6 @@ export type AllocationOverrideEntry = {
   cancelled?: number | null;
 };
 
-export type RecurrenceSeriesMeta = {
-  recurrenceWeekCount: number;
-  recurrenceSeriesEndDate: string;
-};
-
-/**
- * Builds per-allocation recurrence metadata for a flat list of allocations.
- * Allocations sharing a `recurrence_id` are grouped into a series, and every
- * member of that series is annotated with the total number of allocations in
- * the series and the last date the series covers, keyed by allocation name.
- */
-export function buildRecurrenceSeriesMetaMap<T extends AllocationApiRecord>(
-  allocations: T[],
-): Map<string, RecurrenceSeriesMeta> {
-  const allocationsByRecurrenceId = new Map<string, T[]>();
-
-  for (const allocation of allocations) {
-    if (!allocation.recurrence_id) {
-      continue;
-    }
-
-    const seriesAllocations =
-      allocationsByRecurrenceId.get(allocation.recurrence_id) ?? [];
-    seriesAllocations.push(allocation);
-    allocationsByRecurrenceId.set(allocation.recurrence_id, seriesAllocations);
-  }
-
-  const metaByAllocationName = new Map<string, RecurrenceSeriesMeta>();
-
-  for (const seriesAllocations of allocationsByRecurrenceId.values()) {
-    const sortedAllocations = [...seriesAllocations].sort((left, right) =>
-      left.allocation_start_date.localeCompare(right.allocation_start_date),
-    );
-    const recurrenceSeriesEndDate =
-      sortedAllocations[sortedAllocations.length - 1]?.allocation_end_date;
-
-    if (!recurrenceSeriesEndDate) {
-      continue;
-    }
-
-    for (const allocation of sortedAllocations) {
-      metaByAllocationName.set(allocation.name, {
-        recurrenceWeekCount: sortedAllocations.length,
-        recurrenceSeriesEndDate,
-      });
-    }
-  }
-
-  return metaByAllocationName;
-}
-
 type AllocationApiFilter = [string, string, string | string[] | number | null];
 
 type AllocationFiltersResult = {
@@ -258,7 +207,6 @@ export function formatAllocationCapacity(
 export function mapResourceAllocation<T extends AllocationApiRecord>(
   allocation: T,
   customerName?: string,
-  recurrenceSeriesMeta?: RecurrenceSeriesMeta,
 ): Allocation & { customerName?: string } {
   return {
     id: allocation.name,
@@ -276,10 +224,6 @@ export function mapResourceAllocation<T extends AllocationApiRecord>(
     tentative: allocation.status === "Tentative",
     note: allocation.note ?? undefined,
     override: allocation.override,
-    recurrenceWeekCount: recurrenceSeriesMeta?.recurrenceWeekCount,
-    recurrenceSeriesEndDate: recurrenceSeriesMeta?.recurrenceSeriesEndDate
-      ? parseISO(recurrenceSeriesMeta.recurrenceSeriesEndDate)
-      : undefined,
     createdOn: allocation.creation
       ? parseFrappeDatetime(allocation.creation)
       : undefined,
@@ -303,13 +247,8 @@ export function mapResourceAllocation<T extends AllocationApiRecord>(
 export function mapResourceAllocationSegments<T extends AllocationApiRecord>(
   allocation: T,
   customerName?: string,
-  recurrenceSeriesMeta?: RecurrenceSeriesMeta,
 ): Array<Allocation & { customerName?: string }> {
-  const baseAllocation = mapResourceAllocation(
-    allocation,
-    customerName,
-    recurrenceSeriesMeta,
-  );
+  const baseAllocation = mapResourceAllocation(allocation, customerName);
   const overrideByDate = new Map(
     (allocation.override ?? []).map((entry) => [entry.date, entry]),
   );

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -188,6 +188,15 @@ export function GanttAllocationBar({
         billable: allocation.billable,
         tentative: allocation.tentative,
         note: allocation.note,
+        override: allocation.override,
+        allocationStartDate: allocation.allocationStartDate,
+        allocationEndDate: allocation.allocationEndDate,
+        allocationHoursPerDay: allocation.allocationHoursPerDay,
+        segmentStartDate: allocation.startDate,
+        segmentEndDate: allocation.endDate,
+        segmentHoursPerDay: allocation.hours,
+        recurrenceWeekCount: allocation.recurrenceWeekCount,
+        recurrenceSeriesEndDate: allocation.recurrenceSeriesEndDate,
       });
     },
     [

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -195,8 +195,6 @@ export function GanttAllocationBar({
         segmentStartDate: allocation.startDate,
         segmentEndDate: allocation.endDate,
         segmentHoursPerDay: allocation.hours,
-        recurrenceWeekCount: allocation.recurrenceWeekCount,
-        recurrenceSeriesEndDate: allocation.recurrenceSeriesEndDate,
       });
     },
     [

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
@@ -32,6 +32,15 @@ export function allocationBarToEntry(
     billable: alloc.billable,
     tentative: alloc.tentative,
     note: alloc.note,
+    override: alloc.override,
+    allocationStartDate: alloc.allocationStartDate,
+    allocationEndDate: alloc.allocationEndDate,
+    allocationHoursPerDay: alloc.allocationHoursPerDay,
+    segmentStartDate: alloc.startDate,
+    segmentEndDate: alloc.endDate,
+    segmentHoursPerDay: alloc.hours,
+    recurrenceWeekCount: alloc.recurrenceWeekCount,
+    recurrenceSeriesEndDate: alloc.recurrenceSeriesEndDate,
   };
 
   return {

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/allocationBarToEntry.ts
@@ -39,8 +39,6 @@ export function allocationBarToEntry(
     segmentStartDate: alloc.startDate,
     segmentEndDate: alloc.endDate,
     segmentHoursPerDay: alloc.hours,
-    recurrenceWeekCount: alloc.recurrenceWeekCount,
-    recurrenceSeriesEndDate: alloc.recurrenceSeriesEndDate,
   };
 
   return {

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -85,7 +85,11 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
           member.allocations?.map((allocation, allocationIndex) => (
             // TODO: Restore project allocation capacity labels when this view consumes backend-computed employee capacity summaries.
             <GanttAllocationBar
-              key={allocation.id ?? allocationIndex}
+              key={
+                allocation.id
+                  ? `${allocation.id}-${allocation.startDate.getTime()}`
+                  : allocationIndex
+              }
               allocation={allocation}
               memberName={member.name}
               memberImage={member.image}

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -33,6 +33,22 @@ export interface Allocation {
     name: string;
     image?: string;
   };
+  /** Existing day-level overrides attached to the allocation. */
+  override?: {
+    date: string;
+    hours?: number | null;
+    cancelled?: number | null;
+  }[];
+  /** Underlying allocation document start date. */
+  allocationStartDate?: Date;
+  /** Underlying allocation document end date. */
+  allocationEndDate?: Date;
+  /** Underlying allocation document default hours per day. */
+  allocationHoursPerDay?: number;
+  /** Total number of weekly allocations in the recurrence series. */
+  recurrenceWeekCount?: number;
+  /** Last date covered by the recurrence series. */
+  recurrenceSeriesEndDate?: Date;
 }
 
 export interface MemberBarAllocation extends Allocation {
@@ -108,6 +124,28 @@ export interface AllocationCallbackData {
   tentative?: boolean;
   /** Note for the allocation. */
   note?: string;
+  /** Existing day-level overrides attached to the allocation. */
+  override?: {
+    date: string;
+    hours?: number | null;
+    cancelled?: number | null;
+  }[];
+  /** Underlying allocation document start date. */
+  allocationStartDate?: Date;
+  /** Underlying allocation document end date. */
+  allocationEndDate?: Date;
+  /** Underlying allocation document default hours per day. */
+  allocationHoursPerDay?: number;
+  /** Total number of weekly allocations in the recurrence series. */
+  recurrenceWeekCount?: number;
+  /** Last date covered by the recurrence series. */
+  recurrenceSeriesEndDate?: Date;
+  /** Visible segment start date before the current edit. */
+  segmentStartDate?: Date;
+  /** Visible segment end date before the current edit. */
+  segmentEndDate?: Date;
+  /** Visible segment hours per day before the current edit. */
+  segmentHoursPerDay?: number;
   /** Called after the allocation is successfully saved. */
   onSuccess?: () => void;
 }

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -45,10 +45,6 @@ export interface Allocation {
   allocationEndDate?: Date;
   /** Underlying allocation document default hours per day. */
   allocationHoursPerDay?: number;
-  /** Total number of weekly allocations in the recurrence series. */
-  recurrenceWeekCount?: number;
-  /** Last date covered by the recurrence series. */
-  recurrenceSeriesEndDate?: Date;
 }
 
 export interface MemberBarAllocation extends Allocation {
@@ -136,10 +132,6 @@ export interface AllocationCallbackData {
   allocationEndDate?: Date;
   /** Underlying allocation document default hours per day. */
   allocationHoursPerDay?: number;
-  /** Total number of weekly allocations in the recurrence series. */
-  recurrenceWeekCount?: number;
-  /** Last date covered by the recurrence series. */
-  recurrenceSeriesEndDate?: Date;
   /** Visible segment start date before the current edit. */
   segmentStartDate?: Date;
   /** Visible segment end date before the current edit. */


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds base support for rendering virtual segments based on the day overrides. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- `mapResourceAllocationSegments`: walks the
  allocation's day range applying per-day overrides, coalesces consecutive
  equal-hour days into one segment, and breaks the bar on cancelled/zero-hour
  days. Returns an array of `Allocation` objects that share the same document
  `id` but carry segment-specific `startDate`/`endDate`/`hours`. Short-circuits
  to a single segment when there are no overrides.

## Screenshot/Screencast

- Add an allocation for one week.
- Go to the Desk and add an override for a specific day.
- Check the frontend. It should now show the split allocation.


https://github.com/user-attachments/assets/3ae144cf-dec5-421f-9e6c-cfeecbd542ae



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
Depends on #1567
Fixes #958