### PR TITLE
Fix: Typography fix project notes tab

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/content.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/content.tsx
@@ -15,12 +15,12 @@ type NoteDetailContentProps = {
 export function NoteDetailContent({ note }: NoteDetailContentProps) {
   return (
     <div className="flex flex-col gap-2 pt-2">
-      <h1 className="text-3xl font-semibold leading-tight text-ink-gray-8">
+      <h1 className="text-3xl font-semibold leading-tight text-ink-gray-7">
         {note.title}
       </h1>
       <StaticTextEditor
         content={note.description}
-        editorClass="prose prose-sm max-w-none text-ink-gray-8"
+        editorClass="prose prose-sm max-w-none text-ink-gray-6 [&_:is(h1,h2,h3,h4,h5,h6)]:text-ink-gray-7"
       />
     </div>
   );

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/header.tsx
@@ -52,7 +52,7 @@ export function NoteDetailHeader({ note }: NoteDetailHeaderProps) {
             image={note.owner_image || undefined}
           />
         </a>
-        <span className="truncate text-base font-medium text-ink-gray-8">
+        <span className="truncate text-base font-medium text-ink-gray-7">
           {authorName}
         </span>
         <span className="shrink-0 text-ink-gray-5">·</span>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/editor/index.tsx
@@ -190,7 +190,7 @@ function NoteEditor() {
                       disabled={isInputDisabled}
                       placeholder="Add note title"
                       aria-label="Note title"
-                      className="w-full resize-none border-0 bg-transparent text-3xl font-semibold leading-tight text-ink-gray-8 placeholder:text-ink-gray-4 focus:outline-none"
+                      className="w-full resize-none border-0 bg-transparent text-3xl font-semibold leading-tight text-ink-gray-7 placeholder:text-ink-gray-4 focus:outline-none"
                     />
                     {!field.state.meta.isValid && (
                       <ErrorMessage
@@ -213,7 +213,7 @@ function NoteEditor() {
                       placeholder="Type a note description..."
                       editable={!isInputDisabled}
                       fixedMenu={false}
-                      editorClass="prose prose-sm max-w-none min-h-[400px] text-ink-gray-8 focus:outline-none"
+                      editorClass="prose prose-sm max-w-none min-h-[400px] text-ink-gray-6 [&_:is(h1,h2,h3,h4,h5,h6)]:text-ink-gray-7 focus:outline-none"
                     />
                     {!field.state.meta.isValid && (
                       <ErrorMessage

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteCard.tsx
@@ -55,7 +55,7 @@ export function NoteCard({ note }: NoteCardProps) {
       <div className="flex-1 overflow-hidden relative">
         <StaticTextEditor
           content={note.description}
-          editorClass="prose-sm px-3.5 pt-2"
+          editorClass="prose-sm px-3.5 pt-2 text-ink-gray-5 leading-normal"
         />
         <span className="absolute block left-0 bottom-0 z-10 w-full h-12 from-surface-white to-transparent pointer-events-none bg-linear-to-t"></span>
       </div>
@@ -71,7 +71,7 @@ export function NoteCard({ note }: NoteCardProps) {
             image={note.owner_image || undefined}
           />
         </a>
-        <span className="flex-1 truncate leading-tight text-sm text-ink-gray-5">
+        <span className="flex-1 truncate text-sm text-ink-gray-5">
           {authorName}
         </span>
         <span className="shrink-0 text-base text-ink-gray-5">

--- a/frontend/packages/design-system/src/components/comments/commentItem.tsx
+++ b/frontend/packages/design-system/src/components/comments/commentItem.tsx
@@ -91,7 +91,10 @@ export function CommentItem({ comment, canReply }: CommentItemProps) {
         />
       ) : (
         <div className="rounded-lg bg-surface-gray-1 px-3">
-          <StaticTextEditor content={comment.content} editorClass="prose-sm" />
+          <StaticTextEditor
+            content={comment.content}
+            editorClass="prose-sm text-ink-gray-7"
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Description
- Fixes typography (font-size, font-weight, line height, color) for Projects notes tab.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Partially addresses #1552 