### PR TITLE
feat: endpoint to get extra weeks in edit schedule modal

### DIFF
--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -383,7 +383,7 @@ def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, da
 
 
 @frappe.whitelist()
-def get_series_remaining_weeks(name: str, recurrence_id: str | None = None):
+def get_series_remaining_weeks(name: str):
     """Return how many weeks of the recurrence series run from this allocation onward.
 
     Used by the edit-schedule modal to show how far the series still repeats from the
@@ -392,9 +392,8 @@ def get_series_remaining_weeks(name: str, recurrence_id: str | None = None):
     weeks (weeks 3, 4 and 5).
 
     Args:
-        name (str): Name of the picked allocation.
-        recurrence_id (str | None): Optional series id. When omitted it is resolved
-                                    from the allocation itself.
+        name (str): Name of the picked allocation. The series is resolved from this
+                    doc's own ``recurrence_id``.
 
     Returns:
         dict: ``allocation_start_date`` / ``allocation_end_date`` of the picked doc,
@@ -417,10 +416,8 @@ def get_series_remaining_weeks(name: str, recurrence_id: str | None = None):
             exc=frappe.DoesNotExistError,
         )
 
-    recurrence_id = recurrence_id or allocation.recurrence_id
-
     # a standalone allocation (no series) is its own single remaining week
-    if not recurrence_id:
+    if not allocation.recurrence_id:
         return {
             "allocation_start_date": allocation.allocation_start_date,
             "allocation_end_date": allocation.allocation_end_date,
@@ -428,21 +425,23 @@ def get_series_remaining_weeks(name: str, recurrence_id: str | None = None):
             "series_end_date": allocation.allocation_end_date,
         }
 
-    future = frappe.get_all(
+    future_filters = {
+        "recurrence_id": allocation.recurrence_id,
+        "allocation_start_date": [">=", allocation.allocation_start_date],
+    }
+    remaining_weeks = frappe.db.count("Resource Allocation", filters=future_filters)
+    series_end_date = frappe.db.get_value(
         "Resource Allocation",
-        filters={
-            "recurrence_id": recurrence_id,
-            "allocation_start_date": [">=", allocation.allocation_start_date],
-        },
-        fields=["allocation_end_date"],
-        order_by="allocation_start_date asc",
+        future_filters,
+        "allocation_end_date",
+        order_by="allocation_start_date desc",
     )
 
     return {
         "allocation_start_date": allocation.allocation_start_date,
         "allocation_end_date": allocation.allocation_end_date,
-        "remaining_weeks": len(future),
-        "series_end_date": future[-1].allocation_end_date if future else allocation.allocation_end_date,
+        "remaining_weeks": remaining_weeks,
+        "series_end_date": series_end_date or allocation.allocation_end_date,
     }
 
 

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -382,6 +382,70 @@ def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, da
     return update_allocation(allocation)
 
 
+@frappe.whitelist()
+def get_series_remaining_weeks(name: str, recurrence_id: str | None = None):
+    """Return how many weeks of the recurrence series run from this allocation onward.
+
+    Used by the edit-schedule modal to show how far the series still repeats from the
+    picked allocation (e.g. "Repeats for 3 weeks till Feb 18"). The count is inclusive
+    of the picked allocation: for a 5-week series, the 3rd week reports 3 remaining
+    weeks (weeks 3, 4 and 5).
+
+    Args:
+        name (str): Name of the picked allocation.
+        recurrence_id (str | None): Optional series id. When omitted it is resolved
+                                    from the allocation itself.
+
+    Returns:
+        dict: ``allocation_start_date`` / ``allocation_end_date`` of the picked doc,
+        ``remaining_weeks`` (count from this doc onward, inclusive), and
+        ``series_end_date`` (the last allocation's end date in the series).
+    """
+    permission = resource_api_permissions_check()
+    if not permission["read"]:
+        frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    allocation = frappe.db.get_value(
+        "Resource Allocation",
+        name,
+        ["allocation_start_date", "allocation_end_date", "recurrence_id"],
+        as_dict=True,
+    )
+    if not allocation:
+        frappe.throw(
+            frappe._("Resource Allocation {0} does not exist.").format(name),
+            exc=frappe.DoesNotExistError,
+        )
+
+    recurrence_id = recurrence_id or allocation.recurrence_id
+
+    # a standalone allocation (no series) is its own single remaining week
+    if not recurrence_id:
+        return {
+            "allocation_start_date": allocation.allocation_start_date,
+            "allocation_end_date": allocation.allocation_end_date,
+            "remaining_weeks": 1,
+            "series_end_date": allocation.allocation_end_date,
+        }
+
+    future = frappe.get_all(
+        "Resource Allocation",
+        filters={
+            "recurrence_id": recurrence_id,
+            "allocation_start_date": [">=", allocation.allocation_start_date],
+        },
+        fields=["allocation_end_date"],
+        order_by="allocation_start_date asc",
+    )
+
+    return {
+        "allocation_start_date": allocation.allocation_start_date,
+        "allocation_end_date": allocation.allocation_end_date,
+        "remaining_weeks": len(future),
+        "series_end_date": future[-1].allocation_end_date if future else allocation.allocation_end_date,
+    }
+
+
 @frappe.whitelist(methods=["POST"])
 def delete_allocation(name: str, delete_mode: str):
     """Delete a Resource Allocation, optionally deleting all or future docs in the series.


### PR DESCRIPTION
## Description

* Added the `get_series_remaining_weeks` function to `allocation.py`, which returns the number of weeks left in a recurrence series from a given allocation onward, including the selected allocation. The response includes the allocation's start and end dates, the count of remaining weeks, and the series' end date.
* The function handles both standalone allocations and allocations that are part of a recurrence series, and includes permission checks to ensure only authorized users can access this information.

for :
<img width="377" height="148" alt="image" src="https://github.com/user-attachments/assets/1667ff00-4120-4821-ac78-73b36e916ddc" />

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1013" height="319" alt="image" src="https://github.com/user-attachments/assets/b59b4d98-4ffb-4994-83c7-9b4f40ca9f8b" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1563#issuecomment-4779927298