### PR TITLE
feat: delete day override and get over allocated dates

### DIFF
--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -3,11 +3,19 @@ from dataclasses import asdict, dataclass
 from datetime import date, timedelta
 
 import frappe
+from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from frappe.automation.doctype.auto_repeat.auto_repeat import add_days
-from frappe.utils import cint, getdate
+from frappe.utils import cint, flt, getdate
 
-from next_pms.resource_management.api.utils.helpers import resource_api_permissions_check
+from next_pms.resource_management.api.utils.helpers import is_on_leave, resource_api_permissions_check
+from next_pms.resource_management.api.utils.query import (
+    attach_extra_entries,
+    get_allocation_list_for_employee_for_given_range,
+    get_employee_leaves,
+)
 from next_pms.resource_management.doctype.resource_allocation.resource_allocation import clear_cache
+from next_pms.resource_management.report.utils import get_employee_allocations_for_date
+from next_pms.timesheet.api.employee import get_employee_daily_working_norm
 
 NON_DATE_FIELDS = frozenset({"project", "customer", "is_billable", "status", "note", "hours_allocated_per_day"})
 RECURRING_IMMUTABLE_FIELDS = ("employee", "project", "customer")
@@ -588,3 +596,116 @@ def delete_allocation(name: str, delete_mode: str):
     for doc_name in names:
         frappe.delete_doc("Resource Allocation", doc_name)
     return {"success": True}
+
+
+def _override_hours_by_date(allocation: dict) -> dict:
+    """Map each overridden date to its effective hours (0 when cancelled)."""
+    return {
+        getdate(row["date"]): 0 if cint(row.get("cancelled")) else flt(row.get("hours"))
+        for row in allocation.get("override") or []
+    }
+
+
+def _existing_hours_for_date(allocations: list[dict], override_maps: dict, target_date: date) -> float:
+    """Sum the effective allocated hours of existing allocations active on a date.
+
+    Uses a day-override value when present for that date, otherwise the allocation's
+    default ``hours_allocated_per_day``.
+    """
+    total = 0.0
+    for allocation in get_employee_allocations_for_date(allocations, target_date):
+        override = override_maps.get(allocation["name"], {})
+        if target_date in override:
+            total += override[target_date]
+        else:
+            total += flt(allocation.get("hours_allocated_per_day"))
+    return total
+
+
+@frappe.whitelist(methods=["GET", "POST"])
+def get_over_allocated_dates(
+    employee: str,
+    start_date: str,
+    end_date: str,
+    hours_per_day: float,
+    include_weekends: bool = False,
+    repeat_till_week_count: int = 0,
+    allocation_name: str | None = None,
+) -> list[dict]:
+    """Return the dates where a proposed allocation would over-allocate the employee.
+
+    Computes, per day, the employee's available hours (daily working hours reduced by
+    leaves/holidays) against the sum of their existing allocations (day-override aware)
+    plus the proposed ``hours_per_day``. A date is over-allocated when that sum exceeds
+    the available hours.
+
+    Args:
+        employee (str): Employee being allocated.
+        start_date (str): Proposed allocation start ("YYYY-MM-DD").
+        end_date (str): Proposed allocation end ("YYYY-MM-DD").
+        hours_per_day (float): Proposed hours/day for the new allocation.
+        include_weekends (bool): When False, weekend days are skipped.
+        repeat_till_week_count (int): Number of additional weekly copies; the window is
+            also evaluated shifted by +7 days per copy (0 for one-time or edit).
+        allocation_name (str | None): Allocation to exclude from the existing-hours sum
+            (the allocation being edited).
+
+    Returns:
+        list[dict]: ``[{"date": "YYYY-MM-DD", "excess_hours": 2.5}, ...]``, one entry per
+        over-allocated date across all weekly copies.
+    """
+    permission = resource_api_permissions_check()
+    if not permission["read"]:
+        frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
+
+    base_start = getdate(start_date)
+    base_end = getdate(end_date)
+    if base_start > base_end:
+        frappe.throw(frappe._("start_date must be on or before end_date."), exc=frappe.ValidationError)
+
+    hours_per_day = flt(hours_per_day)
+    repeat_till_week_count = cint(repeat_till_week_count)
+    if hours_per_day <= 0:
+        return []
+
+    daily_working_hours = get_employee_daily_working_norm(employee)
+    fetch_end = add_days(base_end, repeat_till_week_count * 7)
+
+    existing = get_allocation_list_for_employee_for_given_range(
+        columns=["name", "allocation_start_date", "allocation_end_date", "hours_allocated_per_day"],
+        value_key="employee",
+        values=[employee],
+        start_date=base_start,
+        end_date=fetch_end,
+    )
+    if allocation_name:
+        existing = [a for a in existing if a["name"] != allocation_name]
+    attach_extra_entries(existing)
+    override_maps = {a["name"]: _override_hours_by_date(a) for a in existing}
+
+    leaves = get_employee_leaves(employee=employee, start_date=str(base_start), end_date=str(fetch_end))
+    holiday_list = get_holiday_list_for_employee(employee, raise_exception=False)
+    holidays = (
+        frappe.get_all(
+            "Holiday",
+            filters={"parent": holiday_list, "holiday_date": ["between", (base_start, fetch_end)]},
+            fields=["holiday_date"],
+        )
+        if holiday_list
+        else []
+    )
+
+    result = []
+    for week in range(repeat_till_week_count + 1):
+        week_delta = timedelta(days=7 * week)
+        current = base_start + week_delta
+        week_end = base_end + week_delta
+        while current <= week_end:
+            if include_weekends or current.weekday() < 5:
+                available = is_on_leave(current, daily_working_hours, leaves, holidays)["leave_work_hours"]
+                total = _existing_hours_for_date(existing, override_maps, current) + hours_per_day
+                if total > available:
+                    result.append({"date": current.strftime("%Y-%m-%d"), "excess_hours": round(total - available, 2)})
+            current = add_days(current, 1)
+
+    return result

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -20,6 +20,7 @@ from next_pms.timesheet.api.employee import get_employee_daily_working_norm
 NON_DATE_FIELDS = frozenset({"project", "customer", "is_billable", "status", "note", "hours_allocated_per_day"})
 RECURRING_IMMUTABLE_FIELDS = ("employee", "project", "customer")
 VALID_DELETE_MODES = frozenset({"only_this", "this_and_future", "all_in_series"})
+VALID_EDIT_MODES = frozenset({"only_this", "whole_series", "this_and_future"})
 
 
 @dataclass
@@ -433,6 +434,14 @@ def edit_allocation(
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
 
+    if edit_mode not in VALID_EDIT_MODES:
+        frappe.throw(
+            frappe._("Invalid edit_mode '{0}'. Allowed values: {1}.").format(
+                edit_mode, ", ".join(sorted(VALID_EDIT_MODES))
+            ),
+            exc=frappe.ValidationError,
+        )
+
     allocation.name = name
     stored = frappe.db.get_value(
         "Resource Allocation",
@@ -440,6 +449,12 @@ def edit_allocation(
         ("recurrence_id", "employee", "project", "customer", "hours_allocated_per_day", "allocation_start_date"),
         as_dict=True,
     )
+
+    if not stored:
+        frappe.throw(
+            frappe._("Resource Allocation {0} does not exist.").format(name),
+            exc=frappe.DoesNotExistError,
+        )
 
     if stored.recurrence_id:
         _assert_recurring_immutable(allocation, stored)
@@ -458,21 +473,25 @@ def edit_allocation(
             fields=["name", "allocation_start_date", "allocation_end_date"],
         )
         update_fields = {k: v for k, v in asdict(allocation).items() if k in NON_DATE_FIELDS and v is not None}
+        new_hours = update_fields.get("hours_allocated_per_day")
         for series_doc_meta in series:
             series_doc = frappe.get_doc("Resource Allocation", series_doc_meta.name)
             day_count = (
                 getdate(series_doc_meta.allocation_end_date) - getdate(series_doc_meta.allocation_start_date)
             ).days + 1
+            doc_hours_changed = new_hours is not None and float(new_hours) != float(
+                series_doc.hours_allocated_per_day or 0
+            )
             series_doc.update(
                 {
                     **update_fields,
-                    "total_allocated_hours": update_fields.get(
-                        "hours_allocated_per_day", series_doc.hours_allocated_per_day
+                    "total_allocated_hours": (
+                        new_hours if new_hours is not None else series_doc.hours_allocated_per_day
                     )
                     * day_count,
                 }
             )
-            if hours_changed:
+            if doc_hours_changed:
                 series_doc.override = []
             series_doc.save()
 
@@ -667,7 +686,7 @@ def get_over_allocated_dates(
     hours_per_day = flt(hours_per_day)
     repeat_till_week_count = cint(repeat_till_week_count)
     if hours_per_day <= 0:
-        return []
+        return {"dates": [], "total_excess_hours": 0}
 
     daily_working_hours = get_employee_daily_working_norm(employee)
     fetch_end = add_days(base_end, repeat_till_week_count * 7)

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -298,57 +298,106 @@ def upsert_day_override(doc_name: str, override_date: str, override_fields: dict
         doc.save()
 
 
+def delete_day_override(doc_name: str, override_date: str):
+    """Remove a single day override row from a Resource Allocation doc.
+
+    Deleting the row (as opposed to setting ``cancelled=1``) reverts the day back to the
+    allocation's default hours. No-op if no row exists for the given date.
+
+    Args:
+        doc_name (str): Name of the Resource Allocation document.
+        override_date (str): The specific date to clear (``"YYYY-MM-DD"``).
+    """
+    existing_row = frappe.db.get_value(
+        "Resource Allocation Extra Entry",
+        {"parent": doc_name, "parenttype": "Resource Allocation", "date": override_date},
+        "name",
+    )
+    if not existing_row:
+        return
+
+    doc = frappe.get_doc("Resource Allocation", doc_name)
+    doc.override = [row for row in doc.override if row.name != existing_row]
+    doc.save()
+
+
+def apply_day_overrides(doc_name: str, day_overrides: list[dict] | None, deleted_day_overrides: list[str] | None):
+    """Apply a batch of add/edit (``day_overrides``) and delete (``deleted_day_overrides``)
+    operations to a single Resource Allocation doc, keyed on the literal override dates."""
+    for override in day_overrides or []:
+        override_fields = {k: v for k, v in override.items() if k != "date"}
+        upsert_day_override(doc_name, str(getdate(override.get("date"))), override_fields)
+
+    for deleted_date in deleted_day_overrides or []:
+        delete_day_override(doc_name, str(getdate(deleted_date)))
+
+
 @frappe.whitelist(methods=["POST"])
-def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, day_overrides: list[dict] | None = None):
+def edit_allocation(
+    name: str,
+    edit_mode: str,
+    allocation: AllocationPayload,
+    day_overrides: list[dict] | None = None,
+    deleted_day_overrides: list[str] | None = None,
+):
     """Edit a Resource Allocation, optionally propagating changes to all docs in the series.
 
     Args:
         name (str): Name of the allocation being edited.
-        edit_mode (str): ``"only_this"`` — update just this doc.
-                         ``"whole_series"`` — update all docs sharing the same ``recurrence_id``.
-                         ``"this_and_future"`` — used with ``day_overrides`` to apply per-day
-                         changes to this doc and all later docs in the series.
-        allocation (AllocationPayload): New field values (ignored when ``day_overrides`` is provided).
-        day_overrides (list[dict] | None): Optional list of per-day overrides, each a dict with a
+        edit_mode (str): ``"only_this"`` — update this doc: apply ``allocation`` (duration +
+                         fields) and then any day-override add/edit/delete in a single pass.
+                         ``"whole_series"`` — update all docs sharing the same ``recurrence_id``
+                         with the non-date ``allocation`` fields.
+                         ``"this_and_future"`` — apply the day-override changes to this doc and
+                         all later docs in the series (overrides only, duration unchanged).
+        allocation (AllocationPayload): New field values. Always applied for ``only_this``
+                                        (alongside any overrides); used for the non-date fields
+                                        under ``whole_series``; ignored under ``this_and_future``.
+        day_overrides (list[dict] | None): Per-day overrides to add or edit, each a dict with a
                                            ``"date"`` key plus the fields to set, e.g.
                                            ``[{"date": "2025-06-05", "cancelled": 1}, {"date": "2025-06-06", "hours": 4.0}]``.
-                                           When provided, ``edit_mode`` controls scope:
-                                           ``"only_this"`` — apply to this doc only.
-                                           ``"this_and_future"`` — apply to this and all later docs in the series,
-                                           targeting the same weekday in each doc's range.
+        deleted_day_overrides (list[str] | None): Dates whose override rows should be removed,
+                                           e.g. ``["2025-06-05"]``. Deleting reverts the day to
+                                           the allocation's default hours (unlike ``cancelled=1``).
     """
     permission = resource_api_permissions_check()
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
 
-    if day_overrides:
-        if edit_mode == "this_and_future":
-            recurrence_id, this_start = frappe.db.get_value(
-                "Resource Allocation", name, ["recurrence_id", "allocation_start_date"]
+    if edit_mode == "this_and_future" and (day_overrides or deleted_day_overrides):
+        recurrence_id, this_start = frappe.db.get_value(
+            "Resource Allocation", name, ["recurrence_id", "allocation_start_date"]
+        )
+        if recurrence_id:
+            series = frappe.get_all(
+                "Resource Allocation",
+                filters={"recurrence_id": recurrence_id, "allocation_start_date": [">=", this_start]},
+                fields=["name", "allocation_start_date", "allocation_end_date"],
             )
-            if recurrence_id:
-                series = frappe.get_all(
-                    "Resource Allocation",
-                    filters={"recurrence_id": recurrence_id, "allocation_start_date": [">=", this_start]},
-                    fields=["name", "allocation_start_date", "allocation_end_date"],
-                )
-                for override in day_overrides:
-                    override_date = getdate(override.get("date"))
-                    override_fields = {k: v for k, v in override.items() if k != "date"}
-                    target_weekday = override_date.weekday()
-                    for series_doc in series:
-                        doc_start = getdate(series_doc.allocation_start_date)
-                        doc_end = getdate(series_doc.allocation_end_date)
-                        offset = (target_weekday - doc_start.weekday()) % 7
-                        target_date = doc_start + timedelta(days=offset)
-                        if target_date <= doc_end:
-                            upsert_day_override(series_doc.name, str(target_date), override_fields)
-                return {"success": True}
 
-        for override in day_overrides:
-            override_date = getdate(override.get("date"))
-            override_fields = {k: v for k, v in override.items() if k != "date"}
-            upsert_day_override(name, str(override_date), override_fields)
+            def each_series_target(source_date):
+                """Yield (series_doc_name, target_date) for the weekday matching source_date."""
+                target_weekday = getdate(source_date).weekday()
+                for series_doc in series:
+                    doc_start = getdate(series_doc.allocation_start_date)
+                    doc_end = getdate(series_doc.allocation_end_date)
+                    offset = (target_weekday - doc_start.weekday()) % 7
+                    target_date = doc_start + timedelta(days=offset)
+                    if target_date <= doc_end:
+                        yield series_doc.name, str(target_date)
+
+            for override in day_overrides or []:
+                override_fields = {k: v for k, v in override.items() if k != "date"}
+                for doc_name, target_date in each_series_target(override.get("date")):
+                    upsert_day_override(doc_name, target_date, override_fields)
+
+            for deleted_date in deleted_day_overrides or []:
+                for doc_name, target_date in each_series_target(deleted_date):
+                    delete_day_override(doc_name, target_date)
+            return {"success": True}
+
+        # No series to propagate to: apply the override diffs to this doc only.
+        apply_day_overrides(name, day_overrides, deleted_day_overrides)
         return {"success": True}
 
     allocation.name = name
@@ -379,7 +428,9 @@ def edit_allocation(name: str, edit_mode: str, allocation: AllocationPayload, da
                 series_doc.save()
             return frappe.get_doc("Resource Allocation", name)
 
-    return update_allocation(allocation)
+    result = update_allocation(allocation)
+    apply_day_overrides(name, day_overrides, deleted_day_overrides)
+    return result
 
 
 @frappe.whitelist()

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -355,6 +355,36 @@ def clear_day_overrides(doc_name: str):
         doc.save()
 
 
+def _propagate_day_overrides_to_series(
+    series: list, day_overrides: list[dict] | None, deleted_day_overrides: list[str] | None
+):
+    """Propagate day-override add/edit/delete to each series doc, matching by weekday.
+
+    A source override date is mapped onto the corresponding weekday within each series doc's
+    own date range, so e.g. a Tuesday override applies to every doc's Tuesday.
+    """
+
+    def each_series_target(source_date):
+        """Yield (series_doc_name, target_date) for the weekday matching source_date."""
+        target_weekday = getdate(source_date).weekday()
+        for series_doc in series:
+            doc_start = getdate(series_doc.allocation_start_date)
+            doc_end = getdate(series_doc.allocation_end_date)
+            offset = (target_weekday - doc_start.weekday()) % 7
+            target_date = doc_start + timedelta(days=offset)
+            if target_date <= doc_end:
+                yield series_doc.name, str(target_date)
+
+    for override in day_overrides or []:
+        override_fields = {k: v for k, v in override.items() if k != "date"}
+        for doc_name, target_date in each_series_target(override.get("date")):
+            upsert_day_override(doc_name, target_date, override_fields)
+
+    for deleted_date in deleted_day_overrides or []:
+        for doc_name, target_date in each_series_target(deleted_date):
+            delete_day_override(doc_name, target_date)
+
+
 @frappe.whitelist(methods=["POST"])
 def edit_allocation(
     name: str,
@@ -371,11 +401,13 @@ def edit_allocation(
                          fields) and then any day-override add/edit/delete in a single pass.
                          ``"whole_series"`` — update all docs sharing the same ``recurrence_id``
                          with the non-date ``allocation`` fields.
-                         ``"this_and_future"`` — apply the day-override changes to this doc and
-                         all later docs in the series (overrides only, duration unchanged).
+                         ``"this_and_future"`` — update this doc and all later docs in the series
+                         with the non-date ``allocation`` fields, and propagate the day-override
+                         add/edit/delete to each (matched by weekday). Individual date ranges are
+                         left unchanged.
         allocation (AllocationPayload): New field values. Always applied for ``only_this``
-                                        (alongside any overrides); used for the non-date fields
-                                        under ``whole_series``; ignored under ``this_and_future``.
+                                        (alongside any overrides); the non-date fields are applied
+                                        under ``whole_series`` and ``this_and_future``.
         day_overrides (list[dict] | None): Per-day overrides to add or edit, each a dict with a
                                            ``"date"`` key plus the fields to set, e.g.
                                            ``[{"date": "2025-06-05", "cancelled": 1}, {"date": "2025-06-06", "hours": 4.0}]``.
@@ -393,47 +425,11 @@ def edit_allocation(
     if not permission["write"]:
         frappe.throw(frappe._("You are not allowed to perform this action."), exc=frappe.PermissionError)
 
-    if edit_mode == "this_and_future" and (day_overrides or deleted_day_overrides):
-        recurrence_id, this_start = frappe.db.get_value(
-            "Resource Allocation", name, ["recurrence_id", "allocation_start_date"]
-        )
-        if recurrence_id:
-            series = frappe.get_all(
-                "Resource Allocation",
-                filters={"recurrence_id": recurrence_id, "allocation_start_date": [">=", this_start]},
-                fields=["name", "allocation_start_date", "allocation_end_date"],
-            )
-
-            def each_series_target(source_date):
-                """Yield (series_doc_name, target_date) for the weekday matching source_date."""
-                target_weekday = getdate(source_date).weekday()
-                for series_doc in series:
-                    doc_start = getdate(series_doc.allocation_start_date)
-                    doc_end = getdate(series_doc.allocation_end_date)
-                    offset = (target_weekday - doc_start.weekday()) % 7
-                    target_date = doc_start + timedelta(days=offset)
-                    if target_date <= doc_end:
-                        yield series_doc.name, str(target_date)
-
-            for override in day_overrides or []:
-                override_fields = {k: v for k, v in override.items() if k != "date"}
-                for doc_name, target_date in each_series_target(override.get("date")):
-                    upsert_day_override(doc_name, target_date, override_fields)
-
-            for deleted_date in deleted_day_overrides or []:
-                for doc_name, target_date in each_series_target(deleted_date):
-                    delete_day_override(doc_name, target_date)
-            return {"success": True}
-
-        # No series to propagate to: apply the override diffs to this doc only.
-        apply_day_overrides(name, day_overrides, deleted_day_overrides)
-        return {"success": True}
-
     allocation.name = name
     stored = frappe.db.get_value(
         "Resource Allocation",
         name,
-        ("recurrence_id", "employee", "project", "customer", "hours_allocated_per_day"),
+        ("recurrence_id", "employee", "project", "customer", "hours_allocated_per_day", "allocation_start_date"),
         as_dict=True,
     )
 
@@ -444,10 +440,13 @@ def edit_allocation(
         allocation.hours_allocated_per_day
     ) != float(stored.hours_allocated_per_day or 0)
 
-    if edit_mode == "whole_series" and stored.recurrence_id:
+    if edit_mode in ("whole_series", "this_and_future") and stored.recurrence_id:
+        filters = {"recurrence_id": stored.recurrence_id}
+        if edit_mode == "this_and_future":
+            filters["allocation_start_date"] = [">=", stored.allocation_start_date]
         series = frappe.get_all(
             "Resource Allocation",
-            filters={"recurrence_id": stored.recurrence_id},
+            filters=filters,
             fields=["name", "allocation_start_date", "allocation_end_date"],
         )
         update_fields = {k: v for k, v in asdict(allocation).items() if k in NON_DATE_FIELDS and v is not None}
@@ -468,6 +467,9 @@ def edit_allocation(
             if hours_changed:
                 series_doc.override = []
             series_doc.save()
+
+        if edit_mode == "this_and_future":
+            _propagate_day_overrides_to_series(series, day_overrides, deleted_day_overrides)
         return frappe.get_doc("Resource Allocation", name)
 
     result = update_allocation(allocation)

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -331,15 +331,35 @@ def delete_day_override(doc_name: str, override_date: str):
     doc.save()
 
 
+def _require_override_date(value) -> date:
+    """Coerce a client-supplied override date, failing loudly on a missing/invalid value.
+
+    ``getdate(None)`` silently returns today, so an entry without a usable ``date`` would
+    otherwise be applied to an unintended day instead of being rejected.
+    """
+    if value in (None, ""):
+        frappe.throw(
+            frappe._("A valid date is required for each day override."),
+            exc=frappe.ValidationError,
+        )
+    try:
+        return getdate(value)
+    except Exception:
+        frappe.throw(
+            frappe._("Invalid day override date: {0}.").format(value),
+            exc=frappe.ValidationError,
+        )
+
+
 def apply_day_overrides(doc_name: str, day_overrides: list[dict] | None, deleted_day_overrides: list[str] | None):
     """Apply a batch of add/edit (``day_overrides``) and delete (``deleted_day_overrides``)
     operations to a single Resource Allocation doc, keyed on the literal override dates."""
     for override in day_overrides or []:
         override_fields = {k: v for k, v in override.items() if k != "date"}
-        upsert_day_override(doc_name, str(getdate(override.get("date"))), override_fields)
+        upsert_day_override(doc_name, str(_require_override_date(override.get("date"))), override_fields)
 
     for deleted_date in deleted_day_overrides or []:
-        delete_day_override(doc_name, str(getdate(deleted_date)))
+        delete_day_override(doc_name, str(_require_override_date(deleted_date)))
 
 
 def _assert_recurring_immutable(allocation: AllocationPayload, stored: dict):
@@ -375,7 +395,7 @@ def _propagate_day_overrides_to_series(
 
     def each_series_target(source_date):
         """Yield (series_doc_name, target_date) for the weekday matching source_date."""
-        target_weekday = getdate(source_date).weekday()
+        target_weekday = _require_override_date(source_date).weekday()
         for series_doc in series:
             doc_start = getdate(series_doc.allocation_start_date)
             doc_end = getdate(series_doc.allocation_end_date)
@@ -439,6 +459,12 @@ def edit_allocation(
             frappe._("Invalid edit_mode '{0}'. Allowed values: {1}.").format(
                 edit_mode, ", ".join(sorted(VALID_EDIT_MODES))
             ),
+            exc=frappe.ValidationError,
+        )
+
+    if edit_mode == "whole_series" and (day_overrides or deleted_day_overrides):
+        frappe.throw(
+            frappe._("Day overrides are not supported in 'whole_series' edit mode."),
             exc=frappe.ValidationError,
         )
 
@@ -685,6 +711,8 @@ def get_over_allocated_dates(
 
     hours_per_day = flt(hours_per_day)
     repeat_till_week_count = cint(repeat_till_week_count)
+    if repeat_till_week_count < 0:
+        frappe.throw(frappe._("repeat_till_week_count cannot be negative."), exc=frappe.ValidationError)
     if hours_per_day <= 0:
         return {"dates": [], "total_excess_hours": 0}
 

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -631,7 +631,7 @@ def get_over_allocated_dates(
     include_weekends: bool = False,
     repeat_till_week_count: int = 0,
     allocation_name: str | None = None,
-) -> list[dict]:
+) -> dict:
     """Return the dates where a proposed allocation would over-allocate the employee.
 
     Computes, per day, the employee's available hours (daily working hours reduced by
@@ -651,8 +651,9 @@ def get_over_allocated_dates(
             (the allocation being edited).
 
     Returns:
-        list[dict]: ``[{"date": "YYYY-MM-DD", "excess_hours": 2.5}, ...]``, one entry per
-        over-allocated date across all weekly copies.
+        dict: ``{"dates": [{"date": "YYYY-MM-DD", "excess_hours": 2.5}, ...],
+        "total_excess_hours": 5.0}`` — one ``dates`` entry per over-allocated date across
+        all weekly copies, and ``total_excess_hours`` summing their ``excess_hours``.
     """
     permission = resource_api_permissions_check()
     if not permission["read"]:
@@ -708,4 +709,5 @@ def get_over_allocated_dates(
                     result.append({"date": current.strftime("%Y-%m-%d"), "excess_hours": round(total - available, 2)})
             current = add_days(current, 1)
 
-    return result
+    total_excess_hours = round(sum(entry["excess_hours"] for entry in result), 2)
+    return {"dates": result, "total_excess_hours": total_excess_hours}

--- a/next_pms/resource_management/api/allocation.py
+++ b/next_pms/resource_management/api/allocation.py
@@ -10,6 +10,7 @@ from next_pms.resource_management.api.utils.helpers import resource_api_permissi
 from next_pms.resource_management.doctype.resource_allocation.resource_allocation import clear_cache
 
 NON_DATE_FIELDS = frozenset({"project", "customer", "is_billable", "status", "note", "hours_allocated_per_day"})
+RECURRING_IMMUTABLE_FIELDS = ("employee", "project", "customer")
 VALID_DELETE_MODES = frozenset({"only_this", "this_and_future", "all_in_series"})
 
 
@@ -332,6 +333,28 @@ def apply_day_overrides(doc_name: str, day_overrides: list[dict] | None, deleted
         delete_day_override(doc_name, str(getdate(deleted_date)))
 
 
+def _assert_recurring_immutable(allocation: AllocationPayload, stored: dict):
+    """For a recurring allocation, employee/project/customer must not change."""
+    changed = [
+        f
+        for f in RECURRING_IMMUTABLE_FIELDS
+        if getattr(allocation, f) is not None and getattr(allocation, f) != stored.get(f)
+    ]
+    if changed:
+        frappe.throw(
+            frappe._("Cannot change {0} for a recurring allocation.").format(", ".join(changed)),
+            exc=frappe.ValidationError,
+        )
+
+
+def clear_day_overrides(doc_name: str):
+    """Remove all day-override rows from a Resource Allocation doc."""
+    doc = frappe.get_doc("Resource Allocation", doc_name)
+    if doc.override:
+        doc.override = []
+        doc.save()
+
+
 @frappe.whitelist(methods=["POST"])
 def edit_allocation(
     name: str,
@@ -359,6 +382,12 @@ def edit_allocation(
         deleted_day_overrides (list[str] | None): Dates whose override rows should be removed,
                                            e.g. ``["2025-06-05"]``. Deleting reverts the day to
                                            the allocation's default hours (unlike ``cancelled=1``).
+
+    Notes:
+        - For a recurring allocation (one with a ``recurrence_id``), ``employee``, ``project`` and
+          ``customer`` are immutable: a request that changes any of them raises ``ValidationError``.
+        - Changing ``hours_allocated_per_day`` wipes the entire day-override table on every affected
+          doc, since overrides store absolute per-day hours that no longer reflect the new default.
     """
     permission = resource_api_permissions_check()
     if not permission["write"]:
@@ -401,34 +430,49 @@ def edit_allocation(
         return {"success": True}
 
     allocation.name = name
+    stored = frappe.db.get_value(
+        "Resource Allocation",
+        name,
+        ("recurrence_id", "employee", "project", "customer", "hours_allocated_per_day"),
+        as_dict=True,
+    )
 
-    if edit_mode == "whole_series":
-        recurrence_id = frappe.db.get_value("Resource Allocation", name, "recurrence_id")
-        if recurrence_id:
-            series = frappe.get_all(
-                "Resource Allocation",
-                filters={"recurrence_id": recurrence_id},
-                fields=["name", "allocation_start_date", "allocation_end_date"],
+    if stored.recurrence_id:
+        _assert_recurring_immutable(allocation, stored)
+
+    hours_changed = allocation.hours_allocated_per_day is not None and float(
+        allocation.hours_allocated_per_day
+    ) != float(stored.hours_allocated_per_day or 0)
+
+    if edit_mode == "whole_series" and stored.recurrence_id:
+        series = frappe.get_all(
+            "Resource Allocation",
+            filters={"recurrence_id": stored.recurrence_id},
+            fields=["name", "allocation_start_date", "allocation_end_date"],
+        )
+        update_fields = {k: v for k, v in asdict(allocation).items() if k in NON_DATE_FIELDS and v is not None}
+        for series_doc_meta in series:
+            series_doc = frappe.get_doc("Resource Allocation", series_doc_meta.name)
+            day_count = (
+                getdate(series_doc_meta.allocation_end_date) - getdate(series_doc_meta.allocation_start_date)
+            ).days + 1
+            series_doc.update(
+                {
+                    **update_fields,
+                    "total_allocated_hours": update_fields.get(
+                        "hours_allocated_per_day", series_doc.hours_allocated_per_day
+                    )
+                    * day_count,
+                }
             )
-            update_fields = {k: v for k, v in asdict(allocation).items() if k in NON_DATE_FIELDS and v is not None}
-            for series_doc_meta in series:
-                series_doc = frappe.get_doc("Resource Allocation", series_doc_meta.name)
-                day_count = (
-                    getdate(series_doc_meta.allocation_end_date) - getdate(series_doc_meta.allocation_start_date)
-                ).days + 1
-                series_doc.update(
-                    {
-                        **update_fields,
-                        "total_allocated_hours": update_fields.get(
-                            "hours_allocated_per_day", series_doc.hours_allocated_per_day
-                        )
-                        * day_count,
-                    }
-                )
-                series_doc.save()
-            return frappe.get_doc("Resource Allocation", name)
+            if hours_changed:
+                series_doc.override = []
+            series_doc.save()
+        return frappe.get_doc("Resource Allocation", name)
 
     result = update_allocation(allocation)
+    if hours_changed:
+        clear_day_overrides(name)
     apply_day_overrides(name, day_overrides, deleted_day_overrides)
     return result
 


### PR DESCRIPTION
## Description

* Added functions to add, edit, and delete per-day override rows (`upsert_day_override`, `delete_day_override`, `apply_day_overrides`, `clear_day_overrides`), allowing more granular control over daily allocation adjustments.
* Introduced `_propagate_day_overrides_to_series` to batch-apply day overrides across all documents in a recurring allocation series, matching by weekday.
* Enhanced `edit_allocation` to support new edit modes and atomic application of allocation field changes and day overrides, including deletion of overrides. Now enforces that `employee`, `project`, and `customer` fields cannot be changed for recurring allocations.
* When the default daily hours (`hours_allocated_per_day`) are changed, all day overrides are cleared to maintain consistency.
* Added a new API endpoint `get_over_allocated_dates` that calculates, for a proposed allocation, which dates would result in the employee being over-allocated, considering existing allocations, per-day overrides, holidays, and leaves. Returns both the list of problematic dates and the total excess hours.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="974" height="597" alt="image" src="https://github.com/user-attachments/assets/40877c82-0afe-496f-ada4-d45b2fd1e9b8" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1490 , #1563 