### PR TITLE
Fix: Form field overflow

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-leave/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-leave/index.tsx
@@ -149,7 +149,7 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
       }}
     >
       <div className="space-y-4">
-        <div className="flex gap-4">
+        <div className="gap-4 flex">
           <form.Field
             name="fromDate"
             children={(field) => {
@@ -166,15 +166,13 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
                   >
                     {({ displayValue }) => {
                       return (
-                        <div
-                          className={`w-full relative flex items-center border border-outline-gray-2 px-2.5 py-1 rounded`}
-                        >
+                        <div className="w-full relative flex items-center border border-outline-gray-2 px-2.5 py-1 rounded">
                           <input
                             readOnly
                             type="text"
                             id="start"
                             value={displayValue}
-                            className="flex-1 text-base text-ink-gray-7"
+                            className="w-full text-base text-ink-gray-7"
                           />
                           <Calendar className="size-4" />
                         </div>
@@ -206,15 +204,13 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
                   >
                     {({ displayValue }) => {
                       return (
-                        <div
-                          className={`w-full relative flex items-center border border-outline-gray-2 px-2.5 py-1 rounded`}
-                        >
+                        <div className="w-full relative flex items-center border border-outline-gray-2 px-2.5 py-1 rounded">
                           <input
                             readOnly
                             type="text"
                             id="start"
                             value={displayValue}
-                            className="flex-1 text-base text-ink-gray-7"
+                            className="w-full text-base text-ink-gray-7"
                           />
                           <Calendar className="size-4" />
                         </div>

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/index.tsx
@@ -206,13 +206,13 @@ const AddEmployeeLeave = ({
                   >
                     {({ displayValue }) => {
                       return (
-                        <div className="flex relative items-center py-1 w-full rounded-lg border border-outline-gray-2 px-2.5">
+                        <div className="flex relative items-center py-1 w-full rounded border border-outline-gray-2 px-2.5">
                           <input
                             readOnly
                             type="text"
                             id="start"
                             value={displayValue}
-                            className="flex-1 text-ink-gray-7"
+                            className="w-full text-base text-ink-gray-7"
                           />
                           <Calendar className="size-4" />
                         </div>
@@ -242,13 +242,13 @@ const AddEmployeeLeave = ({
                   >
                     {({ displayValue }) => {
                       return (
-                        <div className="flex relative items-center py-1 w-full rounded-lg border border-outline-gray-2 px-2.5">
+                        <div className="flex relative items-center py-1 w-full rounded border border-outline-gray-2 px-2.5">
                           <input
                             readOnly
                             type="text"
                             id="start"
                             value={displayValue}
-                            className="flex-1 text-ink-gray-7"
+                            className="w-full text-base text-ink-gray-7"
                           />
                           <Calendar className="size-4" />
                         </div>
@@ -311,6 +311,7 @@ const AddEmployeeLeave = ({
                   className="h-8 text-ink-gray-7"
                   options={[...unpaidLeaveOptions, ...allocatedLeaveOptions]}
                   placeholder="Select Leave Type"
+                  disabled={!employeeIdFormValue}
                 />
                 {!field.state.meta.isValid && (
                   <ErrorMessage message={field.state.meta.errors[0]?.message} />


### PR DESCRIPTION
## Description
- Fix form field overflow issue on add leave form (personal and team timesheet)
- Disable leave type field until employee is selected for team add leave form.

## Screenshot
Safari
<img width="1472" height="1326" alt="image" src="https://github.com/user-attachments/assets/545ec859-7e82-4b9b-b69b-e8b038758be8" />

---

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially addresses #1552 