### PR TITLE
Add interactivity to edit schedule modal

### DIFF
--- a/frontend/packages/app/src/pages/allocations/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/constants.ts
@@ -25,6 +25,18 @@ export const DURATION_PARAM_VALUES = [
   "this-quarter",
 ] as const satisfies readonly AllocationsDuration[];
 
+export const propagationModeLabels = {
+  only_this: "This allocation",
+  this_and_future: "This and future",
+  whole_series: "All allocations",
+} as const;
+
+export const EDIT_SCHEDULE_APPLY_MODES = new Set([
+  "only_this",
+  "this_and_future",
+  "whole_series",
+] as const);
+
 export const durationOptions: SelectOption[] = [
   { label: "This week", value: "this-week" },
   { label: "This month", value: "this-month" },

--- a/frontend/packages/app/src/pages/allocations/overrideUtils.ts
+++ b/frontend/packages/app/src/pages/allocations/overrideUtils.ts
@@ -1,0 +1,158 @@
+/**
+ * External dependencies.
+ */
+import { eachDayOfInterval, format, parseISO } from "date-fns";
+
+/**
+ * Internal dependencies.
+ */
+import type { AllocationOverrideEntry } from "./utils";
+
+interface AllocationScheduleContext {
+  allocationStartDate: string;
+  allocationEndDate: string;
+  allocationHoursPerDay: number;
+  override?: AllocationOverrideEntry[];
+}
+
+interface AllocationEditRange {
+  startDate: string;
+  endDate: string;
+  hoursPerDay: number;
+}
+
+type DayOverridePayload = {
+  date: string;
+  hours?: number;
+  cancelled?: number;
+};
+
+type DayOverridePatch = {
+  dayOverrides: DayOverridePayload[];
+  deletedDayOverrides: string[];
+};
+
+/**
+ * Lists every calendar date in an inclusive range as `yyyy-MM-dd` strings.
+ */
+const getDateKeysInRange = (startDate: string, endDate: string) =>
+  eachDayOfInterval({
+    start: parseISO(startDate),
+    end: parseISO(endDate),
+  }).map((date) => format(date, "yyyy-MM-dd"));
+
+/**
+ * Orders a date range so the start is on or before the end.
+ */
+const normalizeRange = (startDate: string, endDate: string) =>
+  startDate <= endDate
+    ? { startDate, endDate }
+    : { startDate: endDate, endDate: startDate };
+
+/**
+ * Maps each date in the allocation range to its currently effective hours,
+ * applying stored day overrides (a cancelled day resolves to 0 hours).
+ */
+const buildEffectiveHoursByDate = ({
+  allocationStartDate,
+  allocationEndDate,
+  allocationHoursPerDay,
+  override = [],
+}: AllocationScheduleContext) => {
+  const overrideByDate = new Map(override.map((entry) => [entry.date, entry]));
+  const hoursByDate = new Map<string, number>();
+
+  for (const date of getDateKeysInRange(
+    allocationStartDate,
+    allocationEndDate,
+  )) {
+    const dayOverride = overrideByDate.get(date);
+    const hours =
+      dayOverride?.cancelled === 1
+        ? 0
+        : (dayOverride?.hours ?? allocationHoursPerDay);
+
+    hoursByDate.set(date, hours);
+  }
+
+  return hoursByDate;
+};
+
+/**
+ * Diffs desired hours against current hours and emits the minimal override patch:
+ * dates reverting to the allocation default become deletions, zero-hour days become
+ * cancellations, and everything else becomes an explicit hours override.
+ */
+const buildDayOverrideDiff = (
+  currentHoursByDate: Map<string, number>,
+  desiredHoursByDate: Map<string, number>,
+  allocation: AllocationScheduleContext,
+): DayOverridePatch => {
+  const overrideByDate = new Map(
+    (allocation.override ?? []).map((entry) => [entry.date, entry]),
+  );
+
+  return [...currentHoursByDate.entries()].reduce<DayOverridePatch>(
+    (patch, [date, currentHours]) => {
+      const desiredHours = desiredHoursByDate.get(date);
+
+      if (desiredHours === undefined || desiredHours === currentHours) {
+        return patch;
+      }
+
+      if (
+        desiredHours === allocation.allocationHoursPerDay &&
+        overrideByDate.has(date)
+      ) {
+        patch.deletedDayOverrides.push(date);
+        return patch;
+      }
+
+      if (desiredHours <= 0) {
+        patch.dayOverrides.push({ date, cancelled: 1 });
+        return patch;
+      }
+
+      patch.dayOverrides.push({
+        date,
+        hours: desiredHours,
+      });
+
+      return patch;
+    },
+    {
+      dayOverrides: [],
+      deletedDayOverrides: [],
+    },
+  );
+};
+
+/**
+ * Builds the day-override patch for an Edit Schedule submission: sets the selected
+ * date range to the chosen hours-per-day and diffs it against the allocation's current
+ * effective hours, returning the add/edit and delete operations to send to the API.
+ */
+export const buildScheduleSelectionOverridePatch = ({
+  allocation,
+  next,
+}: {
+  allocation: AllocationScheduleContext;
+  next: AllocationEditRange;
+}): DayOverridePatch => {
+  const currentHoursByDate = buildEffectiveHoursByDate(allocation);
+  const desiredHoursByDate = new Map(currentHoursByDate);
+  const normalizedNextRange = normalizeRange(next.startDate, next.endDate);
+
+  for (const date of getDateKeysInRange(
+    normalizedNextRange.startDate,
+    normalizedNextRange.endDate,
+  )) {
+    desiredHoursByDate.set(date, next.hoursPerDay);
+  }
+
+  return buildDayOverrideDiff(
+    currentHoursByDate,
+    desiredHoursByDate,
+    allocation,
+  );
+};

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/types.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/types.ts
@@ -1,4 +1,5 @@
 import type { AllocationRefreshTargets } from "../../types";
+import type { AllocationOverrideEntry } from "../../utils";
 
 export type AddAllocationLayoutVariant = "team" | "project";
 
@@ -16,6 +17,11 @@ export interface AddAllocationInitialValues {
   isBillable?: boolean;
   isTentative?: boolean;
   note?: string;
+  allocationStartDate?: string;
+  allocationEndDate?: string;
+  allocationHoursPerDay?: number;
+  override?: AllocationOverrideEntry[];
+  recurrenceId?: string;
 }
 
 export interface AddAllocationModalProps {

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleHoursPerDayField.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleHoursPerDayField.tsx
@@ -19,7 +19,7 @@ function ScheduleHoursPerDayField({
   return (
     <div className="flex-1 space-y-1.5">
       <label className="block text-base text-ink-gray-5">
-        Edit Hours / day
+        Edit hours / day
       </label>
       <DurationInput
         snap="smooth"

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleSummaryTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleSummaryTable.tsx
@@ -7,9 +7,13 @@ import { formatRange, getRangeHours, toDisplayHours } from "../utils";
 
 interface ScheduleSummaryTableProps {
   rows: PreviewRow[];
+  repeatWeeks?: number;
 }
 
-function ScheduleSummaryTable({ rows }: ScheduleSummaryTableProps) {
+function ScheduleSummaryTable({
+  rows,
+  repeatWeeks,
+}: ScheduleSummaryTableProps) {
   return (
     <div className="overflow-hidden rounded border border-outline-gray-2">
       <table className="relative w-full table-fixed border-collapse">
@@ -20,7 +24,7 @@ function ScheduleSummaryTable({ rows }: ScheduleSummaryTableProps) {
           </tr>
         </thead>
         <tbody>
-          {rows.map((row) => (
+          {rows.map((row, index) => (
             <tr
               key={`${row.startDate}_${row.endDate}`}
               className={cn(
@@ -31,6 +35,9 @@ function ScheduleSummaryTable({ rows }: ScheduleSummaryTableProps) {
             >
               <td className="w-1/2 truncate border-r border-outline-gray-2 px-2 py-2.25 text-base text-ink-gray-6">
                 {formatRange(row.startDate, row.endDate)}
+                {repeatWeeks && index === rows.length - 1 ? (
+                  <span className="text-ink-gray-5">{` (+${repeatWeeks} week${repeatWeeks === 1 ? "" : "s"})`}</span>
+                ) : null}
               </td>
               <td className="w-1/2 px-2 py-2.25 text-base">
                 <span className="text-ink-gray-6">

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleTotalHoursField.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleTotalHoursField.tsx
@@ -19,7 +19,7 @@ function ScheduleTotalHoursField({
   return (
     <div className="flex-1 space-y-1.5">
       <label className="block text-base text-ink-gray-5">
-        Edit Total Hours
+        Edit total hours
       </label>
       <TextInput
         type="number"

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -103,6 +103,23 @@ function EditScheduleModal({
     [fullRange.endDate, fullRange.startDate],
   );
 
+  const allocationContext = useMemo(
+    () =>
+      initialValues
+        ? {
+            allocationStartDate:
+              initialValues.allocationStartDate ?? initialValues.rangeStart,
+            allocationEndDate:
+              initialValues.allocationEndDate ?? initialValues.rangeEnd,
+            allocationHoursPerDay:
+              initialValues.allocationHoursPerDay ??
+              initialValues.defaultHoursPerDay,
+            override: initialValues.override,
+          }
+        : null,
+    [initialValues],
+  );
+
   const formDefaultValues = useMemo<EditScheduleFormValues>(
     () => ({
       schedule: {
@@ -120,19 +137,9 @@ function EditScheduleModal({
       onSubmit: editScheduleFormSchema,
     },
     onSubmit: async ({ value }) => {
-      if (!initialValues?.allocationName) {
+      if (!initialValues?.allocationName || !allocationContext) {
         return;
       }
-      const allocationContext = {
-        allocationStartDate:
-          initialValues.allocationStartDate ?? initialValues.rangeStart,
-        allocationEndDate:
-          initialValues.allocationEndDate ?? initialValues.rangeEnd,
-        allocationHoursPerDay:
-          initialValues.allocationHoursPerDay ??
-          initialValues.defaultHoursPerDay,
-        override: initialValues.override,
-      };
       const draft = buildScheduleDraft({
         rangeStart: fullRange.startDate,
         rangeEnd: fullRange.endDate,
@@ -211,6 +218,24 @@ function EditScheduleModal({
     ],
   );
 
+  const overridePatch = useMemo(
+    () =>
+      allocationContext && scheduleDraft.selection
+        ? buildScheduleSelectionOverridePatch({
+            allocation: allocationContext,
+            next: {
+              startDate: scheduleDraft.selection.startDate,
+              endDate: scheduleDraft.selection.endDate,
+              hoursPerDay: scheduleDraft.hoursPerDay,
+            },
+          })
+        : { dayOverrides: [], deletedDayOverrides: [] },
+    [allocationContext, scheduleDraft],
+  );
+  const hasOverrideChange =
+    overridePatch.dayOverrides.length > 0 ||
+    overridePatch.deletedDayOverrides.length > 0;
+
   useEffect(() => {
     if (!open) {
       return;
@@ -256,11 +281,7 @@ function EditScheduleModal({
                 label="Save changes"
                 onClick={() => form.handleSubmit()}
                 loading={submitting}
-                disabled={
-                  !scheduleDraft.hasMeaningfulChange ||
-                  isSubmitting ||
-                  submitting
-                }
+                disabled={!hasOverrideChange || isSubmitting || submitting}
               />
             )}
           </form.Subscribe>

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -2,20 +2,32 @@
  * External dependencies.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Dialog } from "@rtcamp/frappe-ui-react";
+import { Button, Dialog, Select, useToasts } from "@rtcamp/frappe-ui-react";
+import { useForm, useStore } from "@tanstack/react-form";
 import { format, parseISO } from "date-fns";
+import {
+  FrappeError,
+  useFrappeGetCall,
+  useFrappePostCall,
+} from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
+import { parseFrappeErrorMsg } from "@/lib/utils";
+import { propagationModeLabels } from "@/pages/allocations/constants";
+import { buildScheduleSelectionOverridePatch } from "@/pages/allocations/overrideUtils";
 import ScheduleDateSelectionField from "./components/scheduleDateSelectionField";
 import ScheduleHoursPerDayField from "./components/scheduleHoursPerDayField";
 import ScheduleSummaryTable from "./components/scheduleSummaryTable";
 import ScheduleTotalHoursField from "./components/scheduleTotalHoursField";
-import type { EditScheduleModalProps, EditScheduleValueMode } from "./types";
+import { editScheduleFormSchema, type EditScheduleFormValues } from "./schema";
+import type { EditScheduleApplyMode, EditScheduleModalProps } from "./types";
 import {
   buildDays,
   buildScheduleDraft,
+  getErrorMessage,
+  isEditScheduleApplyMode,
   normalizeRange,
   toDisplayHours,
 } from "./utils";
@@ -24,16 +36,17 @@ function EditScheduleModal({
   open,
   onOpenChange,
   initialValues,
+  onSuccess,
 }: EditScheduleModalProps) {
+  const toast = useToasts();
+  const { call: editAllocation } = useFrappePostCall(
+    "next_pms.resource_management.api.allocation.edit_allocation",
+  );
   const today = useMemo(() => format(new Date(), "yyyy-MM-dd"), []);
   const [selectionAnchor, setSelectionAnchor] = useState<string | null>(null);
-  const [selection, setSelection] = useState<{
-    startDate: string;
-    endDate: string;
-  }>({ startDate: "", endDate: "" });
-  const [inputValue, setInputValue] = useState(0);
-  const [inputMode, setInputMode] =
-    useState<EditScheduleValueMode>("hoursPerDay");
+  const [submitting, setSubmitting] = useState(false);
+  const [applyMode, setApplyMode] =
+    useState<EditScheduleApplyMode>("this_and_future");
 
   const safeValues = useMemo(
     () =>
@@ -56,26 +69,130 @@ function EditScheduleModal({
       ),
     [safeValues.rangeEnd, safeValues.rangeStart, today],
   );
+  const { data: seriesData } = useFrappeGetCall<{
+    message: { remaining_weeks: number; series_end_date: string };
+  }>(
+    "next_pms.resource_management.api.allocation.get_series_remaining_weeks",
+    { name: safeValues.allocationName },
+    open && isRecurringAllocation && safeValues.allocationName
+      ? undefined
+      : false,
+  );
   const recurrenceHelperText = useMemo(() => {
+    const series = seriesData?.message;
     if (
       !isRecurringAllocation ||
-      !safeValues.recurrenceWeekCount ||
-      !safeValues.recurrenceSeriesEndDate
+      applyMode === "only_this" ||
+      !series?.series_end_date
     ) {
       return undefined;
     }
 
-    return `Repeats for ${safeValues.recurrenceWeekCount} week${safeValues.recurrenceWeekCount === 1 ? "" : "s"} till ${format(parseISO(safeValues.recurrenceSeriesEndDate), "MMM d")}`;
-  }, [
-    isRecurringAllocation,
-    safeValues.recurrenceSeriesEndDate,
-    safeValues.recurrenceWeekCount,
-  ]);
+    return `Repeats for ${series.remaining_weeks} week${series.remaining_weeks === 1 ? "" : "s"} till ${format(parseISO(series.series_end_date), "MMM d")}`;
+  }, [applyMode, isRecurringAllocation, seriesData]);
+
+  const summaryRepeatWeeks =
+    isRecurringAllocation &&
+    applyMode !== "only_this" &&
+    seriesData?.message?.remaining_weeks
+      ? Math.max(0, seriesData.message.remaining_weeks - 1)
+      : 0;
+
   const days = useMemo(
     () => buildDays(fullRange.startDate, fullRange.endDate),
     [fullRange.endDate, fullRange.startDate],
   );
 
+  const formDefaultValues = useMemo<EditScheduleFormValues>(
+    () => ({
+      schedule: {
+        selection: { startDate: "", endDate: "" },
+        input: { value: defaultHoursPerDay, mode: "hoursPerDay" },
+      },
+    }),
+    [defaultHoursPerDay],
+  );
+
+  const form = useForm({
+    defaultValues: formDefaultValues,
+    validators: {
+      onChange: editScheduleFormSchema,
+      onSubmit: editScheduleFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (!initialValues?.allocationName) {
+        return;
+      }
+      const allocationContext = {
+        allocationStartDate:
+          initialValues.allocationStartDate ?? initialValues.rangeStart,
+        allocationEndDate:
+          initialValues.allocationEndDate ?? initialValues.rangeEnd,
+        allocationHoursPerDay:
+          initialValues.allocationHoursPerDay ??
+          initialValues.defaultHoursPerDay,
+        override: initialValues.override,
+      };
+      const draft = buildScheduleDraft({
+        rangeStart: fullRange.startDate,
+        rangeEnd: fullRange.endDate,
+        defaultHoursPerDay,
+        override: safeValues.override,
+        schedule: value.schedule,
+      });
+      const patch = draft.selection
+        ? buildScheduleSelectionOverridePatch({
+            allocation: allocationContext,
+            next: {
+              startDate: draft.selection.startDate,
+              endDate: draft.selection.endDate,
+              hoursPerDay: draft.hoursPerDay,
+            },
+          })
+        : { dayOverrides: [], deletedDayOverrides: [] };
+
+      try {
+        setSubmitting(true);
+        await editAllocation({
+          name: initialValues.allocationName,
+          edit_mode: isRecurringAllocation ? applyMode : "only_this",
+          allocation: {
+            doctype: "Resource Allocation",
+            employee: initialValues.employeeId ?? "",
+            project: initialValues.projectId ?? null,
+            customer: initialValues.customer ?? "",
+            allocation_start_date: allocationContext.allocationStartDate,
+            allocation_end_date: allocationContext.allocationEndDate,
+            hours_allocated_per_day: allocationContext.allocationHoursPerDay,
+            include_weekends: true,
+            is_billable: Number(initialValues.isBillable ?? true),
+            status: initialValues.isTentative ? "Tentative" : "Confirmed",
+            note: initialValues.note ?? "",
+          },
+          day_overrides: patch.dayOverrides,
+          deleted_day_overrides: patch.deletedDayOverrides,
+        });
+        await onSuccess?.({
+          ...(safeValues.employeeId
+            ? { employeeIds: [safeValues.employeeId] }
+            : {}),
+          ...(safeValues.projectId
+            ? { projectIds: [safeValues.projectId] }
+            : {}),
+        });
+        toast.success("Schedule updated.");
+        if (!onSuccess) {
+          onOpenChange(false);
+        }
+      } catch (error) {
+        toast.error(parseFrappeErrorMsg(error as FrappeError));
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  });
+
+  const schedule = useStore(form.store, (state) => state.values.schedule);
   const scheduleDraft = useMemo(
     () =>
       buildScheduleDraft({
@@ -83,56 +200,33 @@ function EditScheduleModal({
         rangeEnd: fullRange.endDate,
         defaultHoursPerDay,
         override: safeValues.override,
-        schedule: {
-          selection,
-          input: { value: inputValue, mode: inputMode },
-        },
+        schedule,
       }),
     [
       defaultHoursPerDay,
       fullRange.endDate,
       fullRange.startDate,
-      inputMode,
-      inputValue,
       safeValues.override,
-      selection,
+      schedule,
     ],
   );
-
-  const resetState = useCallback(() => {
-    setSelection({ startDate: "", endDate: "" });
-    setSelectionAnchor(null);
-    setInputValue(defaultHoursPerDay);
-    setInputMode("hoursPerDay");
-  }, [defaultHoursPerDay]);
 
   useEffect(() => {
     if (!open) {
       return;
     }
 
-    resetState();
-  }, [open, resetState]);
-
-  const handleDayClick = useCallback(
-    (date: string) => {
-      if (!selectionAnchor) {
-        setSelectionAnchor(date);
-        setSelection({ startDate: date, endDate: date });
-        return;
-      }
-
-      const nextSelection = normalizeRange(selectionAnchor, date);
-      setSelectionAnchor(null);
-      setSelection(nextSelection);
-    },
-    [selectionAnchor],
-  );
+    form.reset(formDefaultValues);
+    setSelectionAnchor(null);
+    setApplyMode("this_and_future");
+  }, [form, formDefaultValues, open]);
 
   const closeModal = useCallback(() => {
     onOpenChange(false);
-    resetState();
-  }, [onOpenChange, resetState]);
+    form.reset(formDefaultValues);
+    setSelectionAnchor(null);
+    setApplyMode("this_and_future");
+  }, [form, formDefaultValues, onOpenChange]);
 
   return (
     <Dialog
@@ -155,7 +249,21 @@ function EditScheduleModal({
       actions={
         <div className="flex w-full items-center justify-end gap-2">
           <Button variant="ghost" label="Cancel" onClick={closeModal} />
-          <Button variant="solid" label="Save changes" disabled />
+          <form.Subscribe selector={(state) => state.isSubmitting}>
+            {(isSubmitting) => (
+              <Button
+                variant="solid"
+                label="Save changes"
+                onClick={() => form.handleSubmit()}
+                loading={submitting}
+                disabled={
+                  !scheduleDraft.hasMeaningfulChange ||
+                  isSubmitting ||
+                  submitting
+                }
+              />
+            )}
+          </form.Subscribe>
         </div>
       }
       className="max-w-90"
@@ -166,41 +274,116 @@ function EditScheduleModal({
       }}
     >
       <div className="space-y-3">
-        <ScheduleDateSelectionField
-          days={days}
-          headerRangeLabel={scheduleDraft.headerRangeLabel}
-          recurrenceHelperText={recurrenceHelperText}
-          selection={scheduleDraft.selection}
-          onDayClick={handleDayClick}
-        />
+        <form.Field name="schedule.selection.startDate">
+          {(startField) => (
+            <form.Field name="schedule.selection.endDate">
+              {(endField) => (
+                <ScheduleDateSelectionField
+                  days={days}
+                  headerRangeLabel={scheduleDraft.headerRangeLabel}
+                  recurrenceHelperText={recurrenceHelperText}
+                  selection={scheduleDraft.selection}
+                  onDayClick={(date) => {
+                    if (!selectionAnchor) {
+                      setSelectionAnchor(date);
+                      startField.handleChange(date);
+                      endField.handleChange(date);
+                      return;
+                    }
+
+                    const next = normalizeRange(selectionAnchor, date);
+                    setSelectionAnchor(null);
+                    startField.handleChange(next.startDate);
+                    endField.handleChange(next.endDate);
+                  }}
+                  error={
+                    getErrorMessage(startField.state.meta.errors[0]) ??
+                    getErrorMessage(endField.state.meta.errors[0])
+                  }
+                />
+              )}
+            </form.Field>
+          )}
+        </form.Field>
+
         <div className="flex w-full items-start gap-2 pb-1.5">
-          <ScheduleHoursPerDayField
-            value={scheduleDraft.hoursPerDay}
-            disabled={!scheduleDraft.hasSelection}
-            onChange={(value) => {
-              setInputMode("hoursPerDay");
-              setInputValue(value);
-            }}
-          />
-          <ScheduleTotalHoursField
-            value={
-              scheduleDraft.hasSelection
-                ? toDisplayHours(scheduleDraft.totalHours)
-                : ""
-            }
-            disabled={!scheduleDraft.hasSelection}
-            onChange={(value) => {
-              setInputMode("totalHours");
-              setInputValue(value);
-            }}
-          />
+          <form.Field name="schedule.input.value">
+            {(field) => (
+              <ScheduleHoursPerDayField
+                value={scheduleDraft.hoursPerDay}
+                disabled={!scheduleDraft.hasSelection}
+                onChange={(value) => {
+                  form.setFieldValue("schedule.input.mode", "hoursPerDay");
+                  field.handleChange(value);
+                }}
+                error={
+                  schedule.input.mode === "hoursPerDay"
+                    ? getErrorMessage(field.state.meta.errors[0])
+                    : undefined
+                }
+              />
+            )}
+          </form.Field>
+          <form.Field name="schedule.input.value">
+            {(field) => (
+              <ScheduleTotalHoursField
+                value={
+                  scheduleDraft.hasSelection
+                    ? toDisplayHours(scheduleDraft.totalHours)
+                    : ""
+                }
+                disabled={!scheduleDraft.hasSelection}
+                onChange={(value) => {
+                  form.setFieldValue("schedule.input.mode", "totalHours");
+                  field.handleChange(value);
+                }}
+                error={
+                  schedule.input.mode === "totalHours"
+                    ? getErrorMessage(field.state.meta.errors[0])
+                    : undefined
+                }
+              />
+            )}
+          </form.Field>
         </div>
+
+        {isRecurringAllocation ? (
+          <div className="space-y-1.5">
+            <label className="block text-base text-ink-gray-5">
+              Apply edits to
+            </label>
+            <Select
+              value={applyMode}
+              options={[
+                { value: "only_this", label: propagationModeLabels.only_this },
+                {
+                  value: "this_and_future",
+                  label: propagationModeLabels.this_and_future,
+                },
+                {
+                  value: "whole_series",
+                  label: propagationModeLabels.whole_series,
+                },
+              ]}
+              onChange={(value) => {
+                if (value && isEditScheduleApplyMode(value)) {
+                  setApplyMode(value);
+                }
+              }}
+              variant="outline"
+              size="md"
+            />
+          </div>
+        ) : null}
 
         <div className="space-y-1.5">
           <label className="block text-base text-ink-gray-5">
             Schedule summary
           </label>
-          <ScheduleSummaryTable rows={scheduleDraft.previewRows} />
+          <ScheduleSummaryTable
+            rows={scheduleDraft.previewRows}
+            repeatWeeks={summaryRepeatWeeks}
+          />
         </div>
       </div>
     </Dialog>

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/schema.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const editScheduleFormSchema = z
+  .object({
+    schedule: z.object({
+      selection: z.object({
+        startDate: z.string().trim(),
+        endDate: z.string().trim(),
+      }),
+      input: z.object({
+        value: z
+          .number({
+            required_error: "Please enter hours.",
+          })
+          .min(0, { message: "Must be greater than or equal to 0." }),
+        mode: z.enum(["hoursPerDay", "totalHours"]),
+      }),
+    }),
+  })
+  .superRefine((value, ctx) => {
+    const { startDate, endDate } = value.schedule.selection;
+
+    if (!startDate || !endDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["schedule", "selection", "startDate"],
+        message: "Please select a date.",
+      });
+      return;
+    }
+
+    if (startDate > endDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["schedule", "selection", "endDate"],
+        message: "End date must be on or after start date.",
+      });
+    }
+  });
+
+export type EditScheduleFormValues = z.infer<typeof editScheduleFormSchema>;

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/types.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/types.ts
@@ -23,6 +23,10 @@ export type NormalizedSelection = {
 };
 
 export type EditScheduleValueMode = "hoursPerDay" | "totalHours";
+export type EditScheduleApplyMode =
+  | "only_this"
+  | "this_and_future"
+  | "whole_series";
 
 export type EditScheduleDraft = {
   selection: NormalizedSelection | null;
@@ -50,8 +54,6 @@ export interface EditScheduleInitialValues {
   note?: string;
   override?: AllocationOverrideEntry[];
   recurrenceId?: string;
-  recurrenceWeekCount?: number;
-  recurrenceSeriesEndDate?: string;
 }
 
 export interface EditScheduleModalProps {

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
@@ -13,9 +13,11 @@ import {
 /**
  * Internal dependencies.
  */
+import { EDIT_SCHEDULE_APPLY_MODES } from "@/pages/allocations/constants";
 import type { AllocationOverrideEntry } from "@/pages/allocations/utils";
 import type {
   DayItem,
+  EditScheduleApplyMode,
   EditScheduleDraft,
   EditScheduleValueMode,
   PreviewRow,
@@ -26,6 +28,34 @@ import type {
  */
 export const toDisplayHours = (value: number): string =>
   String(Number(value.toFixed(2)));
+
+/**
+ * Normalizes a TanStack field error into a displayable message string.
+ */
+export const getErrorMessage = (error: unknown): string | undefined => {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
+  return undefined;
+};
+
+/**
+ * Type guard for the recurring edit-schedule apply mode.
+ */
+export const isEditScheduleApplyMode = (
+  value: string,
+): value is EditScheduleApplyMode =>
+  EDIT_SCHEDULE_APPLY_MODES.has(value as EditScheduleApplyMode);
 
 /**
  * Normalizes a date range to ensure the start date is less than or equal to the end date.
@@ -79,7 +109,12 @@ export const formatRange = (
     return format(parseISO(safe.startDate), "MMM d");
   }
 
-  return `${format(parseISO(safe.startDate), "MMM d")} - ${format(parseISO(safe.endDate), "MMM d")}`;
+  const start = parseISO(safe.startDate);
+  const end = parseISO(safe.endDate);
+
+  return isSameMonth(start, end)
+    ? `${format(start, "MMM d")} - ${format(end, "d")}`
+    : `${format(start, "MMM d")} - ${format(end, "MMM d")}`;
 };
 
 /**

--- a/frontend/packages/app/src/pages/allocations/useAllocationModal.ts
+++ b/frontend/packages/app/src/pages/allocations/useAllocationModal.ts
@@ -75,6 +75,15 @@ export function useAllocationModal(refresh: RefreshAllocations) {
       isBillable: data.billable,
       isTentative: data.tentative,
       note: data.note,
+      allocationStartDate: data.allocationStartDate
+        ? format(data.allocationStartDate, "yyyy-MM-dd")
+        : undefined,
+      allocationEndDate: data.allocationEndDate
+        ? format(data.allocationEndDate, "yyyy-MM-dd")
+        : undefined,
+      allocationHoursPerDay: data.allocationHoursPerDay,
+      override: data.override,
+      recurrenceId: data.recurrenceId,
     });
     setIsOpen(true);
   }, []);
@@ -154,14 +163,28 @@ export function useAllocationModal(refresh: RefreshAllocations) {
           rangeStart: initialValues?.fromDate ?? "",
           rangeEnd: initialValues?.toDate ?? "",
           defaultHoursPerDay: initialValues?.hoursPerDay ?? 0,
+          allocationStartDate: initialValues?.allocationStartDate,
+          allocationEndDate: initialValues?.allocationEndDate,
+          allocationHoursPerDay: initialValues?.allocationHoursPerDay,
           isBillable: initialValues?.isBillable,
           isTentative: initialValues?.isTentative,
           note: initialValues?.note,
+          override: initialValues?.override,
+          recurrenceId: initialValues?.recurrenceId,
         });
         setIsEditScheduleOpen(true);
       },
     }),
     [variant, isOpen, handleOpenChange, initialValues, handleSuccess],
+  );
+
+  const handleEditScheduleSuccess = useCallback(
+    async (targets?: AllocationRefreshTargets) => {
+      await refresh(targets);
+      setIsEditScheduleOpen(false);
+      setEditScheduleInitialValues(undefined);
+    },
+    [refresh],
   );
 
   const editScheduleModalProps = useMemo(
@@ -174,8 +197,9 @@ export function useAllocationModal(refresh: RefreshAllocations) {
         }
       },
       initialValues: editScheduleInitialValues,
+      onSuccess: handleEditScheduleSuccess,
     }),
-    [isEditScheduleOpen, editScheduleInitialValues],
+    [isEditScheduleOpen, editScheduleInitialValues, handleEditScheduleSuccess],
   );
 
   return {


### PR DESCRIPTION


## Description

<!-- What do we want to achieve with this PR? -->
- This PR adds interactivity to the static edit schedule modal


  
## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Added a new `overrideUtils.ts` file specifically for preparing day override data before sending it to the API.
- Date selection behavior:
  - The user can select a single day and update the hours for that day.
  - After selecting a day, the user can select another day to create a date range.
  - If the user clicks a different day after a range is already selected, the current selection is reset and the clicked day becomes the new start date.
- Schedule summary table behaviour:
  - When the modal is opened, the Schedule summary shows the current allocation range as a single row.
  - When the user selects a date or date range and updates the hours/day, the summary is split into separate date ranges based on the changed schedule.
  - Each row shows:
    - the date range
    - the hours allocated per day for that range
    - the total allocated hours for that range
  - If the edited dates are in the middle of the allocation range, the summary is split into three rows:
    - dates before the edited range
    - the edited range
    - dates after the edited range
  - If the edited dates start or end at the allocation boundary, the summary is split into two rows.
- One-time allocation
  - Allows editing the schedule for any day within the allocation range.
- Recurring allocation
  - Allows editing the schedule for any day within the allocation range.
  - Provides an option to apply the changes to:
    - Only the currently selected allocation (This allocation)
    - The current and future allocations (This and future allocation)
  
Design notes:
- In the design, the intermediate days within a selected range used a lighter visual style. During the weekly sync, it was decided to use the same selected-day style for all days in the range, so the full selection is easier to understand.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/144fdcd7-0f46-473b-8390-217c6152a787



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
Depends on #1607
Fixes #953 #954 #955 #956 