### PR TITLE
Update edit allocation modal and overallocation API usage

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { mergeClassNames as cn } from "@next-pms/design-system";
 import { formatDateRange } from "@next-pms/design-system/date";
 import {
   Button,
@@ -16,7 +17,7 @@ import {
   DurationInput,
   useToasts,
 } from "@rtcamp/frappe-ui-react";
-import { Calendar } from "@rtcamp/frappe-ui-react/icons";
+import { AlertTriangle, Calendar } from "@rtcamp/frappe-ui-react/icons";
 import { useForm, useStore } from "@tanstack/react-form";
 import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
@@ -52,6 +53,12 @@ function AddAllocationModal({
   const [projectSearch, setProjectSearch] = useState("");
   const [customerSearch, setCustomerSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  const isRecurringEdit =
+    variant === "edit" && Boolean(initialValues?.recurrenceId);
+  const hasExistingOverrides = (initialValues?.override?.length ?? 0) > 0;
+  const isLockedAllocationMetadataEdit =
+    variant === "edit" && (isRecurringEdit || hasExistingOverrides);
 
   const { call: handleAllocation } = useFrappePostCall(
     "next_pms.resource_management.api.allocation.handle_allocation",
@@ -102,8 +109,6 @@ function AddAllocationModal({
       onSubmit: addAllocationFormSchema,
     },
     onSubmit: async ({ value }) => {
-      setSubmitting(true);
-
       const totalAllocatedHours = computeTotalHours({
         hoursPerDay: value.hoursPerDay,
         recurrence: value.recurrence,
@@ -112,6 +117,8 @@ function AddAllocationModal({
         repeatFor: value.repeatFor ?? 0,
         includeWeekends: weekendEntriesAllowed && value.includeWeekends,
       });
+
+      setSubmitting(true);
 
       try {
         const payload = {
@@ -279,6 +286,7 @@ function AddAllocationModal({
             searchValue={employeeSearch}
             placeholder="Select Employee"
             value={field.state.value}
+            disabled={isLockedAllocationMetadataEdit}
             onChange={(value) => field.handleChange(value as string)}
             onSearchChange={setEmployeeSearch}
             openOnFocus
@@ -306,6 +314,7 @@ function AddAllocationModal({
             searchValue={projectSearch}
             placeholder="Select Project"
             value={field.state.value}
+            disabled={isLockedAllocationMetadataEdit}
             onChange={handleProjectChange}
             onSearchChange={setProjectSearch}
             openOnFocus
@@ -333,6 +342,7 @@ function AddAllocationModal({
             searchValue={customerSearch}
             placeholder="Select Customer"
             value={field.state.value}
+            disabled={isLockedAllocationMetadataEdit}
             onChange={(value) => {
               field.handleChange(value as string);
               setCustomerSearch("");
@@ -347,6 +357,79 @@ function AddAllocationModal({
       )}
     />
   );
+
+  const recurrenceSection =
+    variant === "add" ? (
+      <form.Field
+        name="recurrence"
+        children={(field) => (
+          <>
+            <label className="block text-base text-ink-gray-5 mb-1.5">
+              Recurrence
+            </label>
+            <TabButtons
+              className="[&_button:not([data-pressed])]:text-ink-gray-5 [&_[data-pressed]]:text-ink-gray-8"
+              value={field.state.value}
+              onChange={(value) =>
+                field.handleChange(value as "one-time" | "recurring")
+              }
+              buttons={Object.entries(allocationRecurrenceLabels).map(
+                ([value, label]) => ({ value, label }),
+              )}
+            />
+            {!field.state.meta.isValid && (
+              <ErrorMessage message={field.state.meta.errors[0]?.message} />
+            )}
+          </>
+        )}
+      />
+    ) : isRecurringEdit ? (
+      <div>
+        <label className="block text-base text-ink-gray-5 mb-1.5">
+          Recurrence
+        </label>
+        <TabButtons
+          className="[&_button:not([data-pressed])]:text-ink-gray-5 [&_[data-pressed]]:text-ink-gray-8"
+          value="recurring"
+          onChange={() => {}}
+          buttons={Object.entries(allocationRecurrenceLabels).map(
+            ([value, label]) => ({
+              value,
+              label,
+              disabled: value === "one-time",
+            }),
+          )}
+        />
+      </div>
+    ) : (
+      <form.Field
+        name="recurrence"
+        children={(field) => (
+          <>
+            <label className="block text-base text-ink-gray-5 mb-1.5">
+              Recurrence
+            </label>
+            <TabButtons
+              className="[&_button:not([data-pressed])]:text-ink-gray-5 [&_[data-pressed]]:text-ink-gray-8"
+              value={field.state.value}
+              onChange={(value) =>
+                field.handleChange(value as "one-time" | "recurring")
+              }
+              buttons={Object.entries(allocationRecurrenceLabels).map(
+                ([value, label]) => ({
+                  value,
+                  label,
+                  disabled: value === "recurring",
+                }),
+              )}
+            />
+            {!field.state.meta.isValid && (
+              <ErrorMessage message={field.state.meta.errors[0]?.message} />
+            )}
+          </>
+        )}
+      />
+    );
 
   return (
     <Dialog
@@ -374,6 +457,7 @@ function AddAllocationModal({
               <label className="inline-flex items-center gap-2 text-base shrink-0 text-ink-gray-7">
                 <Checkbox
                   value={field.state.value}
+                  disabled={isLockedAllocationMetadataEdit}
                   onChange={(checked) => field.handleChange(Boolean(checked))}
                 />
                 Mark as tentative
@@ -386,7 +470,7 @@ function AddAllocationModal({
               variant="solid"
               label={variant === "add" ? "Allocate" : "Save Changes"}
               onClick={() => form.handleSubmit()}
-              disabled={submitting}
+              disabled={submitting || isLockedAllocationMetadataEdit}
               loading={submitting}
             />
           </div>
@@ -408,29 +492,7 @@ function AddAllocationModal({
           </>
         )}
 
-        <form.Field
-          name="recurrence"
-          children={(field) => (
-            <>
-              <label className="block text-base text-ink-gray-5 mb-1.5">
-                Recurrence
-              </label>
-              <TabButtons
-                className="[&_button:not([data-pressed])]:text-ink-gray-5 [&_[data-pressed]]:text-ink-gray-8"
-                value={field.state.value}
-                onChange={(value) =>
-                  field.handleChange(value as "one-time" | "recurring")
-                }
-                buttons={Object.entries(allocationRecurrenceLabels).map(
-                  ([value, label]) => ({ value, label }),
-                )}
-              />
-              {!field.state.meta.isValid && (
-                <ErrorMessage message={field.state.meta.errors[0]?.message} />
-              )}
-            </>
-          )}
-        />
+        {recurrenceSection}
 
         {weekendEntriesAllowed ? (
           <form.Field
@@ -439,6 +501,7 @@ function AddAllocationModal({
               <label className="inline-flex items-center gap-2 text-base text-ink-gray-6">
                 <Checkbox
                   value={field.state.value}
+                  disabled={isLockedAllocationMetadataEdit}
                   onChange={(checked) => field.handleChange(Boolean(checked))}
                 />
                 Include weekends
@@ -469,6 +532,7 @@ function AddAllocationModal({
                   </div>
                   <DateRangePicker
                     value={[fromField.state.value, toField.state.value]}
+                    disabled={isLockedAllocationMetadataEdit}
                     onChange={(value) => {
                       const rawFrom = value?.[0] ?? "";
                       const rawTo = value?.[1] ?? "";
@@ -482,14 +546,23 @@ function AddAllocationModal({
                     formatter={formatDateRange}
                     placeholder="Start Date - End Date"
                   >
-                    {({ displayValue }) => (
-                      <div className="w-full relative flex items-center border border-outline-gray-2 px-2.5 py-1 rounded">
+                    {({ displayValue, disabled }) => (
+                      <div
+                        className={cn(
+                          "w-full h-7 relative flex items-center border border-outline-gray-2 px-2.5 py-1 rounded",
+                          disabled && "bg-surface-gray-1 text-ink-gray-5",
+                        )}
+                      >
                         <input
                           readOnly
+                          disabled={disabled}
                           type="text"
                           id="start"
                           value={displayValue}
-                          className="flex-1 text-base text-ink-gray-7"
+                          className={cn(
+                            "flex-1 text-base text-ink-gray-7",
+                            disabled && "text-ink-gray-5",
+                          )}
                         />
                         <Calendar className="size-4" />
                       </div>
@@ -523,6 +596,7 @@ function AddAllocationModal({
                   variant="outline"
                   size="md"
                   value={field.state.value}
+                  disabled={isLockedAllocationMetadataEdit}
                   onChange={(value) => field.handleChange(value)}
                   label={false}
                 />
@@ -533,7 +607,7 @@ function AddAllocationModal({
             )}
           />
 
-          {recurrence === "recurring" && (
+          {(recurrence === "recurring" || isRecurringEdit) && (
             <form.Field
               name="repeatFor"
               children={(field) => (
@@ -545,6 +619,7 @@ function AddAllocationModal({
                     type="number"
                     size="md"
                     variant="outline"
+                    disabled={variant === "edit"}
                     value={field.state.value ?? ""}
                     onChange={(e) =>
                       field.handleChange(Math.max(1, Number(e.target.value)))
@@ -569,12 +644,29 @@ function AddAllocationModal({
               size="md"
               value={totalHours}
               variant="outline"
-              className="[&_input]:text-ink-gray-7"
+              inputClassName={
+                isLockedAllocationMetadataEdit
+                  ? ""
+                  : "text-ink-gray-7 bg-surface-white"
+              }
             />
           </div>
         </div>
 
-        <OverAllocationWarning overAllocatedDays={overAllocatedDays} />
+        {isLockedAllocationMetadataEdit && (
+          <div className="flex items-center gap-2 bg-(--color-violet-50) rounded-lg px-2.5 py-2">
+            <AlertTriangle className="size-4 shrink-0 text-(--color-violet-700)" />
+            <p className="flex-1 min-w-0 text-xs text-ink-gray-9 text-left">
+              {isRecurringEdit
+                ? "Recurring allocations can only be modified using Edit Schedule."
+                : "This allocation has schedule changes. Use Edit Schedule to modify them."}
+            </p>
+          </div>
+        )}
+
+        {!(hasExistingOverrides || isRecurringEdit) ? (
+          <OverAllocationWarning overAllocatedDays={overAllocatedDays} />
+        ) : null}
 
         <form.Field
           name="isBillable"
@@ -582,6 +674,7 @@ function AddAllocationModal({
             <label className="inline-flex items-center gap-2 text-base text-ink-gray-6">
               <Checkbox
                 value={!field.state.value}
+                disabled={isLockedAllocationMetadataEdit}
                 onChange={(checked) => field.handleChange(!checked)}
               />
               Mark as non-billable
@@ -596,10 +689,11 @@ function AddAllocationModal({
             <div className="flex flex-col gap-1.5">
               <label className="block text-base text-ink-gray-5">Note</label>
               <Textarea
+                variant="outline"
                 value={field.state.value ?? ""}
+                disabled={isLockedAllocationMetadataEdit}
                 onChange={(e) => field.handleChange(e.target.value)}
                 placeholder="Add a note"
-                className="bg-white border-outline-gray-2 text-ink-gray-7"
               />
             </div>
           )}

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/types.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/types.ts
@@ -20,6 +20,9 @@ export interface AddAllocationInitialValues {
   allocationStartDate?: string;
   allocationEndDate?: string;
   allocationHoursPerDay?: number;
+  segmentStartDate?: string;
+  segmentEndDate?: string;
+  segmentHoursPerDay?: number;
   override?: AllocationOverrideEntry[];
   recurrenceId?: string;
 }

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useOverAllocation.ts
@@ -2,21 +2,12 @@
  * External dependencies.
  */
 import { useMemo } from "react";
-import {
-  addDays,
-  eachDayOfInterval,
-  format,
-  isWeekend,
-  parseISO,
-} from "date-fns";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
 import { useDebounce } from "@/hooks/useDebounce";
-import { expectatedHours } from "@/lib/utils";
-import { FALLBACK_DAILY_WORKING_HOURS } from "./constants";
 import { OverAllocatedDay } from "./overAllocationWarning";
 
 interface UseOverAllocationOptions {
@@ -34,17 +25,10 @@ interface UseOverAllocationOptions {
   allocationName?: string;
 }
 
-interface ExistingAllocation {
-  name: string;
-  allocation_start_date: string;
-  allocation_end_date: string;
-  hours_allocated_per_day: number;
-}
-
-interface EmployeeWorkingHoursResponse {
+interface OverAllocatedDatesResponse {
   message?: {
-    working_hour?: number;
-    working_frequency?: string;
+    dates?: { date: string; excess_hours: number }[];
+    total_excess_hours?: number;
   };
 }
 
@@ -69,111 +53,26 @@ export function useOverAllocation({
     debouncedFromDate <= debouncedToDate &&
     debouncedHoursPerDay > 0;
 
-  // Extend the fetch range to cover all recurring copies.
-  const fetchEndDate = useMemo(() => {
-    if (!debouncedToDate || debouncedRepeatWeeks <= 0) return debouncedToDate;
-    return format(
-      addDays(parseISO(debouncedToDate), debouncedRepeatWeeks * 7),
-      "yyyy-MM-dd",
-    );
-  }, [debouncedToDate, debouncedRepeatWeeks]);
-
-  const { data } = useFrappeGetCall(
-    "frappe.client.get_list",
+  const { data } = useFrappeGetCall<OverAllocatedDatesResponse>(
+    "next_pms.resource_management.api.allocation.get_over_allocated_dates",
     {
-      doctype: "Resource Allocation",
-      fields: [
-        "name",
-        "allocation_start_date",
-        "allocation_end_date",
-        "hours_allocated_per_day",
-      ],
-      filters: JSON.stringify([
-        ["employee", "=", employeeId],
-        ["allocation_start_date", "<=", fetchEndDate],
-        ["allocation_end_date", ">=", debouncedFromDate],
-      ]),
-      limit_page_length: "null",
+      employee: employeeId,
+      start_date: debouncedFromDate,
+      end_date: debouncedToDate,
+      hours_per_day: debouncedHoursPerDay,
+      include_weekends: includeWeekends,
+      repeat_till_week_count: debouncedRepeatWeeks,
+      ...(allocationName ? { allocation_name: allocationName } : {}),
     },
     enabled ? undefined : false,
   );
 
-  const { data: workingHoursData } =
-    useFrappeGetCall<EmployeeWorkingHoursResponse>(
-      "next_pms.timesheet.api.employee.get_employee_working_hours",
-      {
-        employee: employeeId,
-      },
-      employeeId ? undefined : false,
-    );
-
-  const dailyWorkingHours = useMemo(() => {
-    const workingHour = workingHoursData?.message?.working_hour;
-    const resolvedWorkingHour =
-      workingHour && workingHour > 0
-        ? workingHour
-        : FALLBACK_DAILY_WORKING_HOURS;
-
-    const workingFrequency =
-      workingHoursData?.message?.working_frequency === "Per Week"
-        ? "Per Week"
-        : "Per Day";
-
-    return Number(
-      expectatedHours(resolvedWorkingHour, workingFrequency).toFixed(2),
-    );
-  }, [workingHoursData]);
-
-  return useMemo(() => {
-    if (!enabled || !data?.message) return [];
-
-    const existing = (data.message as ExistingAllocation[]).filter(
-      (a) => a.name !== allocationName,
-    );
-
-    const result: OverAllocatedDay[] = [];
-    const baseStart = parseISO(debouncedFromDate);
-    const baseEnd = parseISO(debouncedToDate);
-
-    // Iterate each weekly copy (week 0 = base range, week 1..N = recurring copies).
-    for (let week = 0; week <= debouncedRepeatWeeks; week++) {
-      const weekStart = addDays(baseStart, week * 7);
-      const weekEnd = addDays(baseEnd, week * 7);
-
-      for (const d of eachDayOfInterval({ start: weekStart, end: weekEnd })) {
-        if (!includeWeekends && isWeekend(d)) {
-          continue;
-        }
-
-        const dateStr = format(d, "yyyy-MM-dd");
-        const existingHours = existing
-          .filter(
-            (a) =>
-              a.allocation_start_date <= dateStr &&
-              a.allocation_end_date >= dateStr,
-          )
-          .reduce((sum, a) => sum + (a.hours_allocated_per_day ?? 0), 0);
-
-        const total = existingHours + debouncedHoursPerDay;
-        if (total > dailyWorkingHours) {
-          result.push({
-            date: dateStr,
-            excessHours: Math.round((total - dailyWorkingHours) * 100) / 100,
-          });
-        }
-      }
-    }
-
-    return result;
-  }, [
-    enabled,
-    data,
-    allocationName,
-    debouncedFromDate,
-    debouncedToDate,
-    debouncedRepeatWeeks,
-    debouncedHoursPerDay,
-    dailyWorkingHours,
-    includeWeekends,
-  ]);
+  return useMemo(
+    () =>
+      (data?.message?.dates ?? []).map((entry) => ({
+        date: entry.date,
+        excessHours: entry.excess_hours,
+      })),
+    [data],
+  );
 }

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleDateSelectionField.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleDateSelectionField.tsx
@@ -38,12 +38,13 @@ function ScheduleDateSelectionField({
       </div>
       <div
         className={cn(
-          "relative pb-1.5",
+          "relative pb-1.5 -mx-3.5",
           showInlineRecurrenceHelper &&
             "flex items-center justify-between gap-3",
         )}
       >
-        <div className="flex overflow-x-auto no-scrollbar items-start gap-1 py-1.5">
+        <div className="absolute top-0 left-0 z-10 w-12 h-full from-surface-white to-transparent pointer-events-none bg-linear-to-r"></div>
+        <div className="flex overflow-x-auto no-scrollbar items-start gap-1 py-1.5 px-3.5">
           {days.map((day) => (
             <DayChip
               className="shrink-0"

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -290,7 +290,7 @@ function EditScheduleModal({
       className="max-w-90"
       classNames={{
         content: "p-[14px] sm:p-[14px] pb-0 sm:pb-0",
-        header: "mb-5",
+        header: "mb-3",
         footer: "p-[14px] sm:p-[14px] pt-5 sm:pt-5",
       }}
     >

--- a/frontend/packages/app/src/pages/allocations/useAllocationModal.ts
+++ b/frontend/packages/app/src/pages/allocations/useAllocationModal.ts
@@ -59,6 +59,16 @@ export function useAllocationModal(refresh: RefreshAllocations) {
   }, []);
 
   const openEditDialog = useCallback((data: AllocationCallbackData) => {
+    const isRecurringAllocation = Boolean(data.recurrenceId);
+    const formStartDate =
+      isRecurringAllocation && data.allocationStartDate
+        ? data.allocationStartDate
+        : data.startDate;
+    const formEndDate =
+      isRecurringAllocation && data.allocationEndDate
+        ? data.allocationEndDate
+        : data.endDate;
+
     setOnSuccess(undefined);
     setVariant("edit");
     setInitialValues({
@@ -67,11 +77,12 @@ export function useAllocationModal(refresh: RefreshAllocations) {
       ...(data.projectId ? { projectId: data.projectId } : {}),
       customer: data.customerName,
       recurrence: data.recurrenceId ? "recurring" : "one-time",
-      fromDate: data.startDate
-        ? format(data.startDate, "yyyy-MM-dd")
-        : undefined,
-      toDate: data.endDate ? format(data.endDate, "yyyy-MM-dd") : undefined,
-      hoursPerDay: data.hoursPerDay,
+      fromDate: formStartDate ? format(formStartDate, "yyyy-MM-dd") : undefined,
+      toDate: formEndDate ? format(formEndDate, "yyyy-MM-dd") : undefined,
+      hoursPerDay:
+        isRecurringAllocation && data.allocationHoursPerDay !== undefined
+          ? data.allocationHoursPerDay
+          : data.hoursPerDay,
       isBillable: data.billable,
       isTentative: data.tentative,
       note: data.note,
@@ -82,6 +93,17 @@ export function useAllocationModal(refresh: RefreshAllocations) {
         ? format(data.allocationEndDate, "yyyy-MM-dd")
         : undefined,
       allocationHoursPerDay: data.allocationHoursPerDay,
+      segmentStartDate: data.segmentStartDate
+        ? format(data.segmentStartDate, "yyyy-MM-dd")
+        : data.startDate
+          ? format(data.startDate, "yyyy-MM-dd")
+          : undefined,
+      segmentEndDate: data.segmentEndDate
+        ? format(data.segmentEndDate, "yyyy-MM-dd")
+        : data.endDate
+          ? format(data.endDate, "yyyy-MM-dd")
+          : undefined,
+      segmentHoursPerDay: data.segmentHoursPerDay ?? data.hoursPerDay,
       override: data.override,
       recurrenceId: data.recurrenceId,
     });
@@ -160,9 +182,14 @@ export function useAllocationModal(refresh: RefreshAllocations) {
           employeeId: initialValues?.employeeId,
           projectId: initialValues?.projectId,
           customer: initialValues?.customer,
-          rangeStart: initialValues?.fromDate ?? "",
-          rangeEnd: initialValues?.toDate ?? "",
-          defaultHoursPerDay: initialValues?.hoursPerDay ?? 0,
+          rangeStart:
+            initialValues?.segmentStartDate ?? initialValues?.fromDate ?? "",
+          rangeEnd:
+            initialValues?.segmentEndDate ?? initialValues?.toDate ?? "",
+          defaultHoursPerDay:
+            initialValues?.segmentHoursPerDay ??
+            initialValues?.hoursPerDay ??
+            0,
           allocationStartDate: initialValues?.allocationStartDate,
           allocationEndDate: initialValues?.allocationEndDate,
           allocationHoursPerDay: initialValues?.allocationHoursPerDay,


### PR DESCRIPTION
## Description

- This PR updated edit allocation variant of add allocation modal 
- This PR also updates overallocation warning component to use a newly added endpoint

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Based on the discussion and to avoid edge cases:
  - One-time allocations can only be edited if their schedule has not been updated. Otherwise, only the schedule can be edited.
  - Once a recurring allocation is created, only its schedule can be edited. All other fields are disabled.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/dd607138-0a66-4d2f-92cd-37e65f6cf072



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1187