### PR TITLE
Fix: Star icon on personal timesheet

### DIFF
--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -8,7 +8,7 @@ import {
   type TaskStatusType,
 } from "@next-pms/design-system/components";
 import { Button } from "@rtcamp/frappe-ui-react";
-import { AddMd, Star } from "@rtcamp/frappe-ui-react/icons";
+import { AddMd, Star, SolidStar } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -107,17 +107,13 @@ export const TaskRow: React.FC<TaskRowProps> = ({
               )}
               onClick={(e) => onStarClick?.(e, taskKey)}
               aria-label={starred ? "Unstar task" : "Star task"}
-              icon={() => (
-                <Star
-                  strokeWidth={1.5}
-                  size={16}
-                  className={cn(
-                    starred
-                      ? "fill-current text-ink-amber-2"
-                      : "text-ink-gray-4",
-                  )}
-                />
-              )}
+              icon={() =>
+                starred ? (
+                  <SolidStar className="text-ink-amber-2" size={16} />
+                ) : (
+                  <Star className="text-ink-gray-4" size={16} />
+                )
+              }
             />
           ) : null}
         </div>

--- a/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
   type BreadcrumbsProps,
 } from "@rtcamp/frappe-ui-react";
-import { AddMd, Star } from "@rtcamp/frappe-ui-react/icons";
+import { AddMd, SolidStar } from "@rtcamp/frappe-ui-react/icons";
 import { StarOff } from "lucide-react";
 
 /**
@@ -61,11 +61,7 @@ export const TotalRow: React.FC<TotalRowProps> = ({
     }
 
     const starIcon = starred ? (
-      <Star
-        strokeWidth={1.5}
-        size={16}
-        className="fill-current text-ink-amber-2"
-      />
+      <SolidStar size={16} className="text-ink-amber-2" />
     ) : (
       <StarOff
         strokeWidth={1.5}

--- a/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
@@ -7,8 +7,7 @@ import {
   Tooltip,
   type BreadcrumbsProps,
 } from "@rtcamp/frappe-ui-react";
-import { AddMd, SolidStar } from "@rtcamp/frappe-ui-react/icons";
-import { StarOff } from "lucide-react";
+import { AddMd, SolidStar, StarCrossed } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -63,11 +62,7 @@ export const TotalRow: React.FC<TotalRowProps> = ({
     const starIcon = starred ? (
       <SolidStar size={16} className="text-ink-amber-2" />
     ) : (
-      <StarOff
-        strokeWidth={1.5}
-        size={16}
-        className="text-ink-gray-4 scale-x-[-1]"
-      />
+      <StarCrossed size={16} className="text-ink-gray-4 scale-x-[-1]" />
     );
 
     if (onStarClick) {


### PR DESCRIPTION
## Description
- Fix star icon on personal timesheet page - instead of line icon use solid icon for liked tasks.

## Screenshot/Screencast
<img width="2468" height="1066" alt="image" src="https://github.com/user-attachments/assets/67e11b27-dd9b-4943-a540-15b9d0b6c2ed" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially addresses #1552