### PR TITLE
fix: remove foreign key deletion lock in notification linked documents

### DIFF
--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -302,7 +302,7 @@ doc_events = {
 # Ignore links to specified DocTypes when deleting documents
 # -----------------------------------------------------------
 
-# ignore_links_on_delete = ["Communication", "ToDo"]
+ignore_links_on_delete = ["NextPMS Notifications"]
 
 # Request Events
 # ----------------


### PR DESCRIPTION
## Description

ignore links on deletion - otherwise this will prevent linked document deletion.

## Relevant Technical Choices

added a hook 

## Testing Instructions

1. add a notification
2. delete the document
3. observe deletion happening and notification still persisting (orphaned link which is fine for a notification)

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1615