### PR TITLE
Fix: Timesheet Team Page Unable to remove reporting manager

### DIFF
--- a/frontend/packages/app/src/components/filters/reportsToFilter.tsx
+++ b/frontend/packages/app/src/components/filters/reportsToFilter.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Combobox } from "@rtcamp/frappe-ui-react";
 import useApproverOptions from "@/hooks/useApproverOptions";
+import { REPORTS_TO_ALL_VALUE } from "@/pages/timesheet/hooks/useTimesheetFilters";
 
 type ReportsToFilterProps = {
   value?: string | null;
@@ -14,7 +15,7 @@ const ReportsToFilter: React.FC<ReportsToFilterProps> = ({
   const approvers = useApproverOptions();
 
   const options = useMemo(
-    () => [...approvers, { label: "All", value: "" }],
+    () => [{ label: "All", value: REPORTS_TO_ALL_VALUE }, ...approvers],
     [approvers],
   );
 

--- a/frontend/packages/app/src/components/filters/reportsToFilter.tsx
+++ b/frontend/packages/app/src/components/filters/reportsToFilter.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { Combobox } from "@rtcamp/frappe-ui-react";
 import useApproverOptions from "@/hooks/useApproverOptions";
-import { REPORTS_TO_ALL_VALUE } from "@/pages/timesheet/hooks/useTimesheetFilters";
 
 type ReportsToFilterProps = {
   value?: string | null;
@@ -15,7 +14,7 @@ const ReportsToFilter: React.FC<ReportsToFilterProps> = ({
   const approvers = useApproverOptions();
 
   const options = useMemo(
-    () => [{ label: "All", value: REPORTS_TO_ALL_VALUE }, ...approvers],
+    () => [{ label: "All", value: "" }, ...approvers],
     [approvers],
   );
 

--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -187,7 +187,12 @@ const Sidebar = () => {
   if (roles.includes("Timesheet Manager") || roles.includes("Timesheet User")) {
     searchItems.push({
       label: "Timesheet - Team",
-      action: () => navigate(teamTimesheetRoute),
+      action: () =>
+        navigate(
+          employeeId
+            ? `${ROUTES["timesheet-team"]}?reportsTo=${encodeURIComponent(employeeId)}`
+            : ROUTES["timesheet-team"],
+        ),
     });
     searchItems.push({
       label: "Timesheet - Projects",

--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -38,12 +38,14 @@ const Sidebar = () => {
 
   const {
     isSidebarCollapsed,
+    employeeId,
     employeeName,
     roles,
     updateIsSidebarCollapsed,
     logout,
   } = useUser(({ state, actions }) => ({
     isSidebarCollapsed: state.isSidebarCollapsed,
+    employeeId: state.employeeId,
     employeeName: state.employeeName,
     roles: state.roles,
     updateIsSidebarCollapsed: actions.updateIsSidebarCollapsed,
@@ -95,7 +97,12 @@ const Sidebar = () => {
     label: "Team",
     icon: People,
     isActive: pathname === ROUTES["timesheet-team"],
-    onClick: () => navigate(ROUTES["timesheet-team"]),
+    onClick: () =>
+      navigate(
+        employeeId
+          ? `${ROUTES["timesheet-team"]}?reportsTo=${encodeURIComponent(employeeId)}`
+          : ROUTES["timesheet-team"],
+      ),
   };
 
   const projectTimesheet = {
@@ -180,7 +187,7 @@ const Sidebar = () => {
   if (roles.includes("Timesheet Manager") || roles.includes("Timesheet User")) {
     searchItems.push({
       label: "Timesheet - Team",
-      action: () => navigate(ROUTES["timesheet-team"]),
+      action: () => navigate(teamTimesheetRoute),
     });
     searchItems.push({
       label: "Timesheet - Projects",

--- a/frontend/packages/app/src/pages/timesheet/components/timesheet-breadcrumbs.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/timesheet-breadcrumbs.tsx
@@ -14,7 +14,10 @@ import { useUser } from "@/providers/user";
 export const TimesheetBreadcrumbs = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const roles = useUser(({ state }) => state.roles);
+  const { employeeId, roles } = useUser(({ state }) => ({
+    employeeId: state.employeeId,
+    roles: state.roles,
+  }));
 
   const hasRoleAccess =
     roles.includes("Projects Manager") ||
@@ -31,7 +34,9 @@ export const TimesheetBreadcrumbs = () => {
     {
       key: "team",
       label: "Team",
-      to: ROUTES["timesheet-team"],
+      to: employeeId
+        ? `${ROUTES["timesheet-team"]}?reportsTo=${encodeURIComponent(employeeId)}`
+        : ROUTES["timesheet-team"],
       icon: People,
     },
     {

--- a/frontend/packages/app/src/pages/timesheet/hooks/useTimesheetFilters.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useTimesheetFilters.ts
@@ -15,7 +15,6 @@ const SEARCH_PARAM_KEY = "search";
 const APPROVAL_PARAM_KEY = "approval";
 const REPORTS_TO_PARAM_KEY = "reportsTo";
 const COMPOSITE_FILTERS_PARAM_KEY = "compositeFilters";
-export const REPORTS_TO_ALL_VALUE = "all";
 
 const APPROVAL_STATUS_PARAM_VALUES = [
   "not-submitted",

--- a/frontend/packages/app/src/pages/timesheet/hooks/useTimesheetFilters.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useTimesheetFilters.ts
@@ -15,6 +15,7 @@ const SEARCH_PARAM_KEY = "search";
 const APPROVAL_PARAM_KEY = "approval";
 const REPORTS_TO_PARAM_KEY = "reportsTo";
 const COMPOSITE_FILTERS_PARAM_KEY = "compositeFilters";
+export const REPORTS_TO_ALL_VALUE = "all";
 
 const APPROVAL_STATUS_PARAM_VALUES = [
   "not-submitted",
@@ -78,8 +79,8 @@ export function useTimesheetFilters({
       )
     : undefined;
   const reportsTo =
-    includeReportsTo && searchParams.get(REPORTS_TO_PARAM_KEY)
-      ? (searchParams.get(REPORTS_TO_PARAM_KEY) ?? undefined)
+    includeReportsTo && searchParams.has(REPORTS_TO_PARAM_KEY)
+      ? (searchParams.get(REPORTS_TO_PARAM_KEY) ?? "")
       : undefined;
 
   const updateSearchParams = useCallback(

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -4,6 +4,7 @@
 import {
   FC,
   PropsWithChildren,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -24,7 +25,10 @@ import {
   type TeamTimesheetContextProps,
 } from "./context";
 import { useTeamTimesheetData } from "./useTeamTimesheetData";
-import { useTimesheetFilters } from "../hooks/useTimesheetFilters";
+import {
+  REPORTS_TO_ALL_VALUE,
+  useTimesheetFilters,
+} from "../hooks/useTimesheetFilters";
 
 export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   const toast = useToasts();
@@ -45,18 +49,34 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   }));
 
   useEffect(() => {
-    if (!employeeId || filters.reportsTo) {
+    if (!employeeId || filters.reportsTo !== undefined) {
       return;
     }
 
     setReportsTo(employeeId);
   }, [employeeId, filters.reportsTo, setReportsTo]);
 
+  // A missing param means first visit and "all" means the user explicitly cleared it.
+  const resolvedReportsTo = useMemo(() => {
+    if (filters.reportsTo === undefined) {
+      return employeeId || undefined;
+    }
+
+    if (filters.reportsTo === REPORTS_TO_ALL_VALUE) {
+      return undefined;
+    }
+
+    return filters.reportsTo;
+  }, [employeeId, filters.reportsTo]);
+
   const uiFilters = useMemo(
     () => ({
       search: filters.search,
       approvalStatus: filters.approvalStatus,
-      reportsTo: (filters.reportsTo ?? employeeId) || undefined,
+      reportsTo:
+        filters.reportsTo === undefined
+          ? employeeId || undefined
+          : filters.reportsTo,
     }),
     [employeeId, filters.search, filters.approvalStatus, filters.reportsTo],
   );
@@ -65,9 +85,16 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
     () => ({
       search: debouncedSearch,
       approvalStatus: filters.approvalStatus,
-      reportsTo: (filters.reportsTo ?? employeeId) || undefined,
+      reportsTo: resolvedReportsTo,
     }),
-    [debouncedSearch, employeeId, filters.reportsTo, filters.approvalStatus],
+    [debouncedSearch, filters.approvalStatus, resolvedReportsTo],
+  );
+
+  const handleReportsToChange = useCallback(
+    (value: string | null) => {
+      setReportsTo(value || REPORTS_TO_ALL_VALUE);
+    },
+    [setReportsTo],
   );
 
   // Only pass complete filter conditions to the data hook so that selecting a
@@ -140,7 +167,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
         loadMore,
         handleSearchChange: setSearch,
         handleApprovalStatusChange: setApprovalStatus,
-        handleReportsToChange: setReportsTo,
+        handleReportsToChange,
         handleCompositeFilterChange: setCompositeFilters,
       },
     }),
@@ -154,7 +181,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       filters.compositeFilters,
       setSearch,
       setApprovalStatus,
-      setReportsTo,
+      handleReportsToChange,
       setCompositeFilters,
     ],
   );

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -4,7 +4,6 @@
 import {
   FC,
   PropsWithChildren,
-  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -19,16 +18,12 @@ import type { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
 import { useFrappeEventListener } from "frappe-react-sdk";
 import { useDebounce } from "@/hooks/useDebounce";
 import { isCompleteFilterCondition, parseFrappeErrorMsg } from "@/lib/utils";
-import { useUser } from "@/providers/user";
 import {
   TeamTimesheetContext,
   type TeamTimesheetContextProps,
 } from "./context";
 import { useTeamTimesheetData } from "./useTeamTimesheetData";
-import {
-  REPORTS_TO_ALL_VALUE,
-  useTimesheetFilters,
-} from "../hooks/useTimesheetFilters";
+import { useTimesheetFilters } from "../hooks/useTimesheetFilters";
 
 export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   const toast = useToasts();
@@ -44,57 +39,22 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
   });
   const debouncedSearch = useDebounce(filters.search, 400);
 
-  const { employeeId } = useUser(({ state }) => ({
-    employeeId: state.employeeId,
-  }));
-
-  useEffect(() => {
-    if (!employeeId || filters.reportsTo !== undefined) {
-      return;
-    }
-
-    setReportsTo(employeeId);
-  }, [employeeId, filters.reportsTo, setReportsTo]);
-
-  // A missing param means first visit and "all" means the user explicitly cleared it.
-  const resolvedReportsTo = useMemo(() => {
-    if (filters.reportsTo === undefined) {
-      return employeeId || undefined;
-    }
-
-    if (filters.reportsTo === REPORTS_TO_ALL_VALUE) {
-      return undefined;
-    }
-
-    return filters.reportsTo;
-  }, [employeeId, filters.reportsTo]);
-
   const uiFilters = useMemo(
     () => ({
       search: filters.search,
       approvalStatus: filters.approvalStatus,
-      reportsTo:
-        filters.reportsTo === undefined
-          ? employeeId || undefined
-          : filters.reportsTo,
+      reportsTo: filters.reportsTo,
     }),
-    [employeeId, filters.search, filters.approvalStatus, filters.reportsTo],
+    [filters.search, filters.approvalStatus, filters.reportsTo],
   );
 
   const effectiveFilters = useMemo(
     () => ({
       search: debouncedSearch,
       approvalStatus: filters.approvalStatus,
-      reportsTo: resolvedReportsTo,
+      reportsTo: filters.reportsTo,
     }),
-    [debouncedSearch, filters.approvalStatus, resolvedReportsTo],
-  );
-
-  const handleReportsToChange = useCallback(
-    (value: string | null) => {
-      setReportsTo(value || REPORTS_TO_ALL_VALUE);
-    },
-    [setReportsTo],
+    [debouncedSearch, filters.approvalStatus, filters.reportsTo],
   );
 
   // Only pass complete filter conditions to the data hook so that selecting a
@@ -167,7 +127,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
         loadMore,
         handleSearchChange: setSearch,
         handleApprovalStatusChange: setApprovalStatus,
-        handleReportsToChange,
+        handleReportsToChange: setReportsTo,
         handleCompositeFilterChange: setCompositeFilters,
       },
     }),
@@ -181,7 +141,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       filters.compositeFilters,
       setSearch,
       setApprovalStatus,
-      handleReportsToChange,
+      setReportsTo,
       setCompositeFilters,
     ],
   );


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
Fixes users not able to remove reporting manager on Timesheet Team Page.

## Relevant Technical Choices

- The global search and the sidebar link now append the `reportsTo` filter by default, ensuring the page initially loads only the relevant data. At the same time, this resolves the issue where users were unable to remove the reporting manager filter.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<!-- 
https://github.com/user-attachments/assets/4b555f71-27bb-4369-b83b-9cc9fc516234 -->


https://github.com/user-attachments/assets/683ca2af-fd2a-4b98-b763-11b53b9b3fa2





## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1629