### PR TITLE
fix: send field value so backend validation fires

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-leave/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-leave/index.tsx
@@ -87,6 +87,7 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
           to_date: value.toDate,
           leave_type: value.leaveType,
           half_day,
+          half_day_date: half_day ? value.fromDate : undefined,
           custom_first_halfsecond_half,
         };
         await createDoc("Leave Application", data);

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/index.tsx
@@ -86,6 +86,7 @@ const AddEmployeeLeave = ({
           to_date: value.toDate,
           leave_type: value.leaveType,
           half_day,
+          half_day_date: half_day ? value.fromDate : undefined,
           custom_first_halfsecond_half,
         };
         await createDoc("Leave Application", data);


### PR DESCRIPTION
## Description

* Added the `half_day_date` field to the leave application data in both `AddLeave` and `AddEmployeeLeave` components, assigning it the `fromDate` value when a half-day leave is selected. This provides more accurate tracking of half-day leaves. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**Before**:

https://github.com/user-attachments/assets/cc4fd0cd-9cfe-44cf-ad6c-91b99b7e2f15

**After**: 

https://github.com/user-attachments/assets/79c4cfcf-9c44-4741-aee3-ae61e8dc4e0d




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1516 