### PR TITLE
QA Fix: Allow adding time entries from all row day cells with pre-filled data

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
@@ -63,7 +63,7 @@ export const MemberRow = ({
                 timeEntries={memberData.totalTimeEntries}
                 onCellClick={
                   rest.onCellClick
-                    ? (dayIndex) => rest.onCellClick?.(dates[dayIndex] ?? "")
+                    ? (date) => rest.onCellClick?.(date)
                     : undefined
                 }
                 totalHours={floatToTime(memberData.total, 2)}

--- a/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
@@ -24,6 +24,7 @@ export const MemberRow = ({
   workingHour,
   workingFrequency,
   status,
+  disabled,
   onButtonClick,
   children,
   avatarUrl,
@@ -60,7 +61,10 @@ export const MemberRow = ({
                 avatarUrl={avatarUrl}
                 collapsed={collapsed}
                 status={status ? ApprovalStatusMap[status] : "none"}
-                timeEntries={memberData.totalTimeEntries}
+                timeEntries={memberData.totalTimeEntries.map((timeEntry) => ({
+                  ...timeEntry,
+                  disabled: disabled || timeEntry.disabled,
+                }))}
                 onCellClick={
                   rest.onCellClick
                     ? (date) => rest.onCellClick?.(date)

--- a/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
@@ -61,6 +61,11 @@ export const MemberRow = ({
                 collapsed={collapsed}
                 status={status ? ApprovalStatusMap[status] : "none"}
                 timeEntries={memberData.totalTimeEntries}
+                onCellClick={
+                  rest.onCellClick
+                    ? (dayIndex) => rest.onCellClick?.(dates[dayIndex] ?? "")
+                    : undefined
+                }
                 totalHours={floatToTime(memberData.total, 2)}
                 totalHoursTheme={totalHoursThemeMap[memberData.isExtended]}
                 onButtonClick={() => onButtonClick?.()}

--- a/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
@@ -11,6 +11,7 @@ import { ProjectRow as BaseProjectRow } from "@next-pms/design-system/components
  */
 import { calculateTotalHours } from "@/lib/utils";
 import type { ProjectRowProps } from "./types";
+import { hasApprovedTimeEntry } from "../../utils";
 
 /**
  * @description This is the project row component for the timesheet table.
@@ -25,6 +26,8 @@ export const ProjectRow = ({
   dates,
   tasks,
   hideTime,
+  disabled,
+  lockApproved = true,
   onCellClick,
   children,
   ...rest
@@ -33,7 +36,7 @@ export const ProjectRow = ({
 
   const projectData = useMemo(() => {
     let total = 0;
-    const totalTimeEntries: string[] = [];
+    const totalTimeEntries: { time: string; disabled: boolean }[] = [];
 
     if (hideTime) {
       return { total, totalTimeEntries };
@@ -41,13 +44,16 @@ export const ProjectRow = ({
 
     for (const date of dates) {
       const currentTotal = calculateTotalHours(tasks, date);
-      totalTimeEntries.push(
-        currentTotal === 0 ? "" : floatToTime(currentTotal, 2),
-      );
+      totalTimeEntries.push({
+        time: currentTotal === 0 ? "" : floatToTime(currentTotal, 2),
+        disabled:
+          Boolean(disabled) ||
+          (lockApproved && hasApprovedTimeEntry(tasks, date)),
+      });
       total += currentTotal;
     }
     return { total, totalTimeEntries };
-  }, [dates, tasks, hideTime]);
+  }, [dates, tasks, hideTime, disabled, lockApproved]);
 
   return (
     <Accordion.Root

--- a/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
@@ -25,6 +25,7 @@ export const ProjectRow = ({
   dates,
   tasks,
   hideTime,
+  onCellClick,
   children,
   ...rest
 }: ProjectRowProps) => {
@@ -62,6 +63,11 @@ export const ProjectRow = ({
                 {...rest}
                 totalHours={hideTime ? "" : floatToTime(projectData.total, 2)}
                 timeEntries={projectData.totalTimeEntries}
+                onCellClick={
+                  hideTime
+                    ? undefined
+                    : (dayIndex) => onCellClick?.(dates[dayIndex] ?? "")
+                }
                 collapsed={collapsed}
                 totalHoursTheme="green"
               />

--- a/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
@@ -62,7 +62,7 @@ export type WeekRowProps = ReadOnlyWeekRowProps | EditableWeekRowProps;
 
 export interface MemberRowProps extends Omit<
   BaseMemberRowProps,
-  "status" | "timeEntries"
+  "status" | "timeEntries" | "onCellClick"
 > {
   dates: string[];
   tasks: TaskProps;
@@ -71,6 +71,7 @@ export interface MemberRowProps extends Omit<
   workingHour: number;
   workingFrequency: WorkingFrequency;
   status: ApprovalStatusLabelType;
+  onCellClick?: (date: string) => void;
   children?: (props: {
     totalTimeEntriesInHours: number[];
     dailyWorkingHours: number;
@@ -81,11 +82,12 @@ export type TotalRowProps = BaseTotalRowProps;
 
 export interface ProjectRowProps extends Omit<
   BaseProjectRowProps,
-  "timeEntries"
+  "timeEntries" | "onCellClick"
 > {
   dates: string[];
   tasks: TaskProps;
   hideTime?: boolean;
+  onCellClick?: (date: string) => void;
   children?: React.ReactNode;
 }
 

--- a/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
@@ -30,7 +30,7 @@ interface WeekRowBaseProps extends Omit<BaseWeekRowProps, "status"> {
   children?: (props: {
     totalHours: string;
     totalHoursTheme: TotalHoursTheme;
-    totalTimeEntries: { date: string; time: string }[];
+    totalTimeEntries: { date: string; time: string; disabled?: boolean }[];
     totalTimeEntriesInHours: number[];
     dailyWorkingHours: number;
     status: ApprovalStatusType;
@@ -71,6 +71,7 @@ export interface MemberRowProps extends Omit<
   workingHour: number;
   workingFrequency: WorkingFrequency;
   status: ApprovalStatusLabelType;
+  disabled?: boolean;
   onCellClick?: (date: string) => void;
   children?: (props: {
     totalTimeEntriesInHours: number[];
@@ -87,6 +88,8 @@ export interface ProjectRowProps extends Omit<
   dates: string[];
   tasks: TaskProps;
   hideTime?: boolean;
+  disabled?: boolean;
+  lockApproved?: boolean;
   onCellClick?: (date: string) => void;
   children?: React.ReactNode;
 }

--- a/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
@@ -139,7 +139,7 @@ export const PersonalTimesheetRow = ({
                 className="pl-7.5"
                 starred={isWeekImported}
                 disabled={disabled}
-                onCellClick={openAddTimeDialog}
+                onCellClick={(date) => openAddTimeDialog({ date })}
                 onStarClick={handleStarClick}
               />
             ) : null}
@@ -152,6 +152,13 @@ export const PersonalTimesheetRow = ({
                 label={project.project_name || project.project}
                 hideTime={hideTotalRow}
                 className="pl-7.5"
+                onCellClick={(date) =>
+                  openAddTimeDialog({
+                    date,
+                    project: project.project,
+                    projectLabel: project.project_name || project.project,
+                  })
+                }
               >
                 {Object.entries(project.tasks).map(([taskKey, task]) => (
                   <TaskRow

--- a/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
@@ -152,6 +152,7 @@ export const PersonalTimesheetRow = ({
                 label={project.project_name || project.project}
                 hideTime={hideTotalRow}
                 className="pl-7.5"
+                disabled={disabled}
                 onCellClick={(date) =>
                   openAddTimeDialog({
                     date,

--- a/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
@@ -10,6 +10,7 @@ import {
 /**
  * Internal dependencies
  */
+import { useTimesheetOutletContext } from "@/pages/timesheet/outletContext";
 import type { WorkingFrequency } from "@/types";
 import type { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
 import { MemberRow } from "./components/row/memberRow";
@@ -49,6 +50,7 @@ export const ProjectTimesheetRow = ({
   firstWeek,
   projects,
 }: ProjectTimesheetRowProps) => {
+  const { openAddTimeDialog } = useTimesheetOutletContext();
   const projectsData = useMemo(() => {
     return projects.map((project) => ({
       ...project,
@@ -76,6 +78,13 @@ export const ProjectTimesheetRow = ({
                 label={project.projectName || project.project}
                 highlightTimeEntries={true}
                 className="pl-7.5"
+                onCellClick={(date) =>
+                  openAddTimeDialog({
+                    date,
+                    project: project.project,
+                    projectLabel: project.projectName || project.project,
+                  })
+                }
               >
                 {project.members.map((member) => (
                   <MemberRow
@@ -91,6 +100,15 @@ export const ProjectTimesheetRow = ({
                     status="None"
                     className="pl-13.5"
                     collapsed={true}
+                    onCellClick={(date) =>
+                      openAddTimeDialog({
+                        date,
+                        employeeId: member.employee,
+                        employeeLabel: member.label,
+                        project: project.project,
+                        projectLabel: project.projectName || project.project,
+                      })
+                    }
                   >
                     {({ totalTimeEntriesInHours, dailyWorkingHours }) => (
                       <>

--- a/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
@@ -77,6 +77,7 @@ export const ProjectTimesheetRow = ({
                 tasks={project.mergedTasks}
                 label={project.projectName || project.project}
                 highlightTimeEntries={true}
+                lockApproved={false}
                 className="pl-7.5"
                 onCellClick={(date) =>
                   openAddTimeDialog({
@@ -100,6 +101,7 @@ export const ProjectTimesheetRow = ({
                     status="None"
                     className="pl-13.5"
                     collapsed={true}
+                    disabled={member.status === "Approved"}
                     onCellClick={(date) =>
                       openAddTimeDialog({
                         date,

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -11,6 +11,7 @@ import {
  * Internal dependencies
  */
 import { getHolidayList } from "@/lib/utils";
+import { useTimesheetOutletContext } from "@/pages/timesheet/outletContext";
 import type { WorkingFrequency } from "@/types";
 import type { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
 import { MemberRow } from "./components/row/memberRow";
@@ -51,6 +52,7 @@ export const TeamTimesheetRow = ({
   setSelectedTask,
   openWeeklyApproval,
 }: TeamTimesheetRowProps) => {
+  const { openAddTimeDialog } = useTimesheetOutletContext();
   const teamMembersData = useMemo(() => {
     return teamMembers.map((member) => {
       const projects = groupTasksByProject(member.tasks);
@@ -91,6 +93,13 @@ export const TeamTimesheetRow = ({
                 status={member.status}
                 className="pl-7.5"
                 collapsed={true}
+                onCellClick={(date) =>
+                  openAddTimeDialog({
+                    date,
+                    employeeId: member.employee,
+                    employeeLabel: member.label,
+                  })
+                }
                 onButtonClick={() =>
                   openWeeklyApproval?.(member.employee, dates[0])
                 }
@@ -104,6 +113,16 @@ export const TeamTimesheetRow = ({
                         tasks={project.tasks}
                         label={project.project_name || project.project}
                         className="pl-13.5"
+                        onCellClick={(date) =>
+                          openAddTimeDialog({
+                            date,
+                            project: project.project,
+                            projectLabel:
+                              project.project_name || project.project,
+                            employeeId: member.employee,
+                            employeeLabel: member.label,
+                          })
+                        }
                       >
                         {Object.entries(project.tasks).map(
                           ([taskKey, task]) => (

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -93,6 +93,7 @@ export const TeamTimesheetRow = ({
                 status={member.status}
                 className="pl-7.5"
                 collapsed={true}
+                disabled={member.status === "Approved"}
                 onCellClick={(date) =>
                   openAddTimeDialog({
                     date,
@@ -113,6 +114,7 @@ export const TeamTimesheetRow = ({
                         tasks={project.tasks}
                         label={project.project_name || project.project}
                         className="pl-13.5"
+                        disabled={member.status === "Approved"}
                         onCellClick={(date) =>
                           openAddTimeDialog({
                             date,

--- a/frontend/packages/app/src/components/timesheet-row/utils.ts
+++ b/frontend/packages/app/src/components/timesheet-row/utils.ts
@@ -67,7 +67,8 @@ export const computeRowData = ({
   const dailyWorkingHours = expectatedHours(workingHour, workingFrequency);
 
   let total = 0;
-  const totalTimeEntries: { date: string; time: string }[] = [];
+  const totalTimeEntries: { date: string; time: string; disabled: boolean }[] =
+    [];
   const totalTimeEntriesInHours: number[] = [];
 
   for (const date of dates) {
@@ -78,6 +79,7 @@ export const computeRowData = ({
     totalTimeEntries.push({
       date,
       time: currentTotal === 0 ? "" : floatToTime(currentTotal, 2),
+      disabled: false,
     });
     totalTimeEntriesInHours.push(currentTotal);
     total += currentTotal;
@@ -151,3 +153,16 @@ export const mergeImportedTasks = (
 
   return merged;
 };
+
+/**
+ * Checks if there are any approved time entries for a given date in the provided tasks.
+ * @param tasks - An object where keys are task identifiers and values are task data.
+ * @param date - The date string to check for approved time entries.
+ * @returns A boolean indicating whether there are any approved time entries for the specified date.
+ */
+export const hasApprovedTimeEntry = (tasks: TaskProps, date: string): boolean =>
+  Object.values(tasks).some((task) =>
+    task.data.some(
+      (entry) => entry.from_time.includes(date) && entry.docstatus === 1,
+    ),
+  );

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   DatePicker,
   Dialog,
@@ -44,7 +44,9 @@ const AddTime = ({
   open = false,
   onOpenChange,
   task = "",
+  taskLabel = "",
   project = "",
+  projectLabel = "",
 }: AddTimeProps) => {
   const { employeeId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
@@ -111,6 +113,34 @@ const AddTime = ({
 
   const selectedProject = useStore(form.store, (state) => state.values.project);
   const selectedDate = useStore(form.store, (state) => state.values.date);
+  const selectedProjectOption = project
+    ? {
+        label: projectLabel || project,
+        value: project,
+      }
+    : null;
+  const selectedTaskOption = task
+    ? {
+        label: taskLabel || task,
+        value: task,
+        projectId: project,
+        projectName: projectLabel || project,
+      }
+    : null;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    form.reset({
+      project,
+      task,
+      date: initialDate,
+      duration: 0,
+      comment: "",
+    });
+  }, [form, initialDate, open, project, task]);
 
   const { options: projectOptions, isLoading: isProjectLookupLoading } =
     useProjectLookup({
@@ -118,6 +148,7 @@ const AddTime = ({
       filters: window.frappe?.boot?.global_filters.project,
       pageSize: 20,
       query: projectSearch,
+      selectedOption: selectedProjectOption,
     });
 
   const { options: taskOptions, isLoading: isTaskLookupLoading } =
@@ -126,6 +157,7 @@ const AddTime = ({
       pageSize: 20,
       projectId: selectedProject || undefined,
       query: taskSearch,
+      selectedOption: selectedTaskOption,
     });
 
   const handleCalendarSelectionChange = useCallback(

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/type.ts
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/type.ts
@@ -43,6 +43,8 @@ export interface AddTimeProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSuccess?: (data: any) => void;
   task?: string;
+  taskLabel?: string;
   project?: string;
+  projectLabel?: string;
   employeeName?: string;
 }

--- a/frontend/packages/app/src/pages/timesheet/outletContext.ts
+++ b/frontend/packages/app/src/pages/timesheet/outletContext.ts
@@ -3,8 +3,18 @@
  */
 import { useOutletContext } from "react-router-dom";
 
+export type OpenAddTimeDialogOptions = {
+  date?: string;
+  project?: string;
+  projectLabel?: string;
+  task?: string;
+  taskLabel?: string;
+  employeeId?: string;
+  employeeLabel?: string;
+};
+
 export type TimesheetOutletContext = {
-  openAddTimeDialog: (date?: string) => void;
+  openAddTimeDialog: (prefill?: OpenAddTimeDialogOptions) => void;
   openAddLeaveDialog: () => void;
   handleApproval: (
     startDate: string,

--- a/frontend/packages/app/src/pages/timesheet/personal/layout.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/layout.tsx
@@ -15,10 +15,20 @@ import AddLeave from "@/pages/timesheet/components/add-leave";
 import AddTime from "@/pages/timesheet/components/add-time";
 import SubmitApproval from "@/pages/timesheet/components/submit-approval";
 import { TimesheetBreadcrumbs } from "@/pages/timesheet/components/timesheet-breadcrumbs";
-import type { TimesheetOutletContext } from "../outletContext";
+import type {
+  OpenAddTimeDialogOptions,
+  TimesheetOutletContext,
+} from "../outletContext";
 
 function PersonalTimesheetLayout() {
-  const [initialDate, setInitialDate] = useState(getTodayDate());
+  const [addTimePrefill, setAddTimePrefill] =
+    useState<OpenAddTimeDialogOptions>({
+      date: getTodayDate(),
+      project: "",
+      projectLabel: "",
+      task: "",
+      taskLabel: "",
+    });
   const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false);
   const [isLeaveDialogOpen, setIsLeaveDialogOpen] = useState(false);
   const [isSubmitApprovalOpen, setIsSubmitApprovalOpen] = useState(false);
@@ -28,10 +38,20 @@ function PersonalTimesheetLayout() {
     totalHours: 0,
   });
 
-  const handleAddTime = useCallback((date?: string) => {
-    setInitialDate(date || getTodayDate());
-    setIsTimeDialogOpen(true);
-  }, []);
+  const handleAddTime = useCallback(
+    (prefill: OpenAddTimeDialogOptions = {}) => {
+      setAddTimePrefill({
+        date: getTodayDate(),
+        project: "",
+        projectLabel: "",
+        task: "",
+        taskLabel: "",
+        ...prefill,
+      });
+      setIsTimeDialogOpen(true);
+    },
+    [],
+  );
 
   const handleApproval = useCallback(
     (startDate: string, endDate: string, totalHours: number) => {
@@ -78,10 +98,14 @@ function PersonalTimesheetLayout() {
       />
 
       <AddTime
-        initialDate={initialDate}
+        initialDate={addTimePrefill.date || getTodayDate()}
         open={isTimeDialogOpen}
         onOpenChange={setIsTimeDialogOpen}
         onSuccess={() => setIsTimeDialogOpen(false)}
+        project={addTimePrefill.project}
+        projectLabel={addTimePrefill.projectLabel}
+        task={addTimePrefill.task}
+        taskLabel={addTimePrefill.taskLabel}
       />
       <AddLeave open={isLeaveDialogOpen} onOpenChange={setIsLeaveDialogOpen} />
       <SubmitApproval

--- a/frontend/packages/app/src/pages/timesheet/project/layout.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/layout.tsx
@@ -12,18 +12,43 @@ import { AddMd, TimeOff } from "@rtcamp/frappe-ui-react/icons";
  */
 import { Header } from "@/layout/header";
 import { TimesheetBreadcrumbs } from "@/pages/timesheet/components/timesheet-breadcrumbs";
+import type {
+  OpenAddTimeDialogOptions,
+  TimesheetOutletContext,
+} from "../outletContext";
 import AddEmployeeLeave from "../team/add-employee-leave";
 import AddEmployeeTime from "../team/add-employee-time";
 
 function ProjectTimesheetLayout() {
-  const [initialDate, setInitialDate] = useState(getTodayDate());
+  const [addTimePrefill, setAddTimePrefill] =
+    useState<OpenAddTimeDialogOptions>({
+      date: getTodayDate(),
+      project: "",
+      projectLabel: "",
+      task: "",
+      taskLabel: "",
+      employeeId: "",
+      employeeLabel: "",
+    });
   const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false);
   const [isLeaveDialogOpen, setIsLeaveDialogOpen] = useState(false);
 
-  const handleAddTime = useCallback((date?: string) => {
-    setInitialDate(date || getTodayDate());
-    setIsTimeDialogOpen(true);
-  }, []);
+  const handleAddTime = useCallback(
+    (prefill: OpenAddTimeDialogOptions = {}) => {
+      setAddTimePrefill({
+        date: getTodayDate(),
+        project: "",
+        projectLabel: "",
+        task: "",
+        taskLabel: "",
+        employeeId: "",
+        employeeLabel: "",
+        ...prefill,
+      });
+      setIsTimeDialogOpen(true);
+    },
+    [],
+  );
 
   return (
     <>
@@ -50,13 +75,27 @@ function ProjectTimesheetLayout() {
         </div>
       </Header>
 
-      <Outlet />
+      <Outlet
+        context={
+          {
+            openAddTimeDialog: handleAddTime,
+            openAddLeaveDialog: () => setIsLeaveDialogOpen(true),
+            handleApproval: () => undefined,
+          } satisfies TimesheetOutletContext
+        }
+      />
 
       <AddEmployeeTime
-        initialDate={initialDate}
+        initialDate={addTimePrefill.date || getTodayDate()}
         open={isTimeDialogOpen}
         onOpenChange={setIsTimeDialogOpen}
         onSuccess={() => setIsTimeDialogOpen(false)}
+        project={addTimePrefill.project}
+        projectLabel={addTimePrefill.projectLabel}
+        task={addTimePrefill.task}
+        taskLabel={addTimePrefill.taskLabel}
+        employeeId={addTimePrefill.employeeId}
+        employeeLabel={addTimePrefill.employeeLabel}
       />
       <AddEmployeeLeave
         open={isLeaveDialogOpen}

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   DatePicker,
   Dialog,
@@ -31,8 +31,11 @@ const AddEmployeeTime = ({
   open = false,
   onOpenChange,
   task = "",
+  taskLabel = "",
   project = "",
+  projectLabel = "",
   employeeId = "",
+  employeeLabel = "",
 }: AddTeamTimeProps) => {
   const toast = useToasts();
   const [employeeSearch, setEmployeeSearch] = useState("");
@@ -97,12 +100,48 @@ const AddEmployeeTime = ({
   );
 
   const selectedProject = useStore(form.store, (state) => state.values.project);
+  const selectedProjectOption = project
+    ? {
+        label: projectLabel || project,
+        value: project,
+      }
+    : null;
+  const selectedEmployeeOption = employeeId
+    ? {
+        label: employeeLabel || employeeId,
+        value: employeeId,
+      }
+    : null;
+  const selectedTaskOption = task
+    ? {
+        label: taskLabel || task,
+        value: task,
+        projectId: project,
+        projectName: projectLabel || project,
+      }
+    : null;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    form.reset({
+      employeeId,
+      project,
+      task,
+      date: initialDate,
+      duration: 0,
+      comment: "",
+    });
+  }, [employeeId, form, initialDate, open, project, task]);
 
   const { options: employeeOptions, isLoading: isEmployeeLookupLoading } =
     useEmployeeLookup({
       shouldFetch: open,
       pageSize: 20,
       query: employeeSearch,
+      selectedOption: selectedEmployeeOption,
     });
 
   const { options: projectOptions, isLoading: isProjectLookupLoading } =
@@ -110,6 +149,7 @@ const AddEmployeeTime = ({
       shouldFetch: open,
       pageSize: 20,
       query: projectSearch,
+      selectedOption: selectedProjectOption,
     });
 
   const { options: taskOptions, isLoading: isTaskLookupLoading } =
@@ -118,6 +158,7 @@ const AddEmployeeTime = ({
       pageSize: 20,
       projectId: selectedProject || undefined,
       query: taskSearch,
+      selectedOption: selectedTaskOption,
     });
 
   return (

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/type.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/type.ts
@@ -43,6 +43,9 @@ export interface AddTeamTimeProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSuccess?: (data: any) => void;
   task?: string;
+  taskLabel?: string;
   project?: string;
+  projectLabel?: string;
   employeeId?: string;
+  employeeLabel?: string;
 }

--- a/frontend/packages/app/src/pages/timesheet/team/layout.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/layout.tsx
@@ -12,18 +12,43 @@ import { AddMd, TimeOff } from "@rtcamp/frappe-ui-react/icons";
  */
 import { Header } from "@/layout/header";
 import { TimesheetBreadcrumbs } from "@/pages/timesheet/components/timesheet-breadcrumbs";
+import type {
+  OpenAddTimeDialogOptions,
+  TimesheetOutletContext,
+} from "../outletContext";
 import AddEmployeeLeave from "./add-employee-leave";
 import AddEmployeeTime from "./add-employee-time";
 
 function TeamTimesheetLayout() {
-  const [initialDate, setInitialDate] = useState(getTodayDate());
+  const [addTimePrefill, setAddTimePrefill] =
+    useState<OpenAddTimeDialogOptions>({
+      date: getTodayDate(),
+      project: "",
+      projectLabel: "",
+      task: "",
+      taskLabel: "",
+      employeeId: "",
+      employeeLabel: "",
+    });
   const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false);
   const [isLeaveDialogOpen, setIsLeaveDialogOpen] = useState(false);
 
-  const handleAddTime = useCallback((date?: string) => {
-    setInitialDate(date || getTodayDate());
-    setIsTimeDialogOpen(true);
-  }, []);
+  const handleAddTime = useCallback(
+    (prefill: OpenAddTimeDialogOptions = {}) => {
+      setAddTimePrefill({
+        date: getTodayDate(),
+        project: "",
+        projectLabel: "",
+        task: "",
+        taskLabel: "",
+        employeeId: "",
+        employeeLabel: "",
+        ...prefill,
+      });
+      setIsTimeDialogOpen(true);
+    },
+    [],
+  );
 
   return (
     <>
@@ -50,13 +75,27 @@ function TeamTimesheetLayout() {
         </div>
       </Header>
 
-      <Outlet />
+      <Outlet
+        context={
+          {
+            openAddTimeDialog: handleAddTime,
+            openAddLeaveDialog: () => setIsLeaveDialogOpen(true),
+            handleApproval: () => undefined,
+          } satisfies TimesheetOutletContext
+        }
+      />
 
       <AddEmployeeTime
-        initialDate={initialDate}
+        initialDate={addTimePrefill.date || getTodayDate()}
         open={isTimeDialogOpen}
         onOpenChange={setIsTimeDialogOpen}
         onSuccess={() => setIsTimeDialogOpen(false)}
+        project={addTimePrefill.project}
+        projectLabel={addTimePrefill.projectLabel}
+        task={addTimePrefill.task}
+        taskLabel={addTimePrefill.taskLabel}
+        employeeId={addTimePrefill.employeeId}
+        employeeLabel={addTimePrefill.employeeLabel}
       />
       <AddEmployeeLeave
         open={isLeaveDialogOpen}

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { Badge, Button, Avatar } from "@rtcamp/frappe-ui-react";
-import { SmallDown } from "@rtcamp/frappe-ui-react/icons";
+import { AddMd, SmallDown } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -29,6 +29,8 @@ export interface MemberRowProps {
   status?: ApprovalStatusType;
   /** Callback function when the action button is clicked. */
   onButtonClick?: () => void;
+  /** Optional function to handle day-cell click events. */
+  onCellClick?: (dayIndex: number) => void;
   /** Array of time entries for each day of the week for the member. */
   timeEntries: { date: string; time: string }[];
   /** Total hours logged for the week. */
@@ -46,6 +48,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
   status = "not-submitted",
   timeEntries,
   onButtonClick,
+  onCellClick,
   totalHours = "",
   totalHoursTheme,
   className,
@@ -84,17 +87,42 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         return (
           <div
             key={index}
-            className="shrink-0 flex justify-end items-center text-base text-ink-gray-8 whitespace-nowrap w-16 h-7 px-2 py-1.5 lining-nums tabular-nums"
+            className="shrink-0 flex justify-end items-center whitespace-nowrap w-16 h-7 pl-2 py-1.5 lining-nums tabular-nums"
           >
-            {timeEntry.time === "" ? (
-              <span className="flex-1 ml-2 text-center text-ink-gray-4">-</span>
-            ) : (
-              <span
-                className={cn(isStatusNone ? "text-ink-gray-6" : "font-medium")}
-              >
-                {timeEntry.time}
-              </span>
-            )}
+            <Button
+              variant="ghost"
+              className={cn(
+                "w-14.25 relative group flex justify-center items-center enabled:hover:bg-surface-gray-2",
+                "enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3 disabled:cursor-default!",
+                "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
+                "text-base text-ink-gray-8",
+              )}
+              disabled={!onCellClick}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCellClick?.(index);
+              }}
+              aria-label="Add time"
+            >
+              {timeEntry.time === "" ? (
+                <>
+                  <span className="flex-1 text-center group-hover:hidden group-disabled:group-hover:flex text-ink-gray-4">
+                    -
+                  </span>
+                  <span className="hidden absolute top-0 left-0 justify-center items-center w-full h-full group-hover:flex group-disabled:group-hover:hidden text-ink-gray-6">
+                    <AddMd size={16} />
+                  </span>
+                </>
+              ) : (
+                <span
+                  className={cn(
+                    isStatusNone ? "text-ink-gray-6" : "font-medium",
+                  )}
+                >
+                  {timeEntry.time}
+                </span>
+              )}
+            </Button>
           </div>
         );
       })}

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -32,7 +32,7 @@ export interface MemberRowProps {
   /** Optional function to handle day-cell click events. */
   onCellClick?: (date: string, dayIndex: number) => void;
   /** Array of time entries for each day of the week for the member. */
-  timeEntries: { date: string; time: string }[];
+  timeEntries: { date: string; time: string; disabled?: boolean }[];
   /** Total hours logged for the week. */
   totalHours?: string;
   /** Theme for the total hours */
@@ -84,20 +84,26 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         </div>
       </div>
       {timeEntries.map((timeEntry, index) => {
+        const isCellDisabled = Boolean(timeEntry.disabled);
+
         return (
           <div
             key={index}
             className="shrink-0 flex justify-end items-center whitespace-nowrap w-16 h-7 pl-2 py-1.5 lining-nums tabular-nums"
+            onClick={(e) => e.stopPropagation()}
           >
             <Button
               variant="ghost"
               className={cn(
-                "w-14.25 relative group flex justify-center items-center enabled:hover:bg-surface-gray-2",
-                "enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3 disabled:cursor-default!",
+                "w-14.25 relative group flex justify-center items-center",
+                !isCellDisabled &&
+                  "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
+                "disabled:cursor-default! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent! disabled:text-ink-gray-8!",
+                isCellDisabled && "cursor-default!",
                 "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                 "text-base text-ink-gray-8",
               )}
-              disabled={!onCellClick}
+              disabled={isCellDisabled || !onCellClick}
               onClick={(e) => {
                 e.stopPropagation();
                 onCellClick?.(timeEntry.date, index);
@@ -106,10 +112,22 @@ export const MemberRow: React.FC<MemberRowProps> = ({
             >
               {timeEntry.time === "" ? (
                 <>
-                  <span className="flex-1 text-center group-hover:hidden group-disabled:group-hover:flex text-ink-gray-4">
+                  <span
+                    className={cn(
+                      "flex-1 text-center text-ink-gray-4",
+                      !isCellDisabled &&
+                        "group-hover:hidden group-disabled:group-hover:flex",
+                    )}
+                  >
                     -
                   </span>
-                  <span className="hidden absolute top-0 left-0 justify-center items-center w-full h-full group-hover:flex group-disabled:group-hover:hidden text-ink-gray-6">
+                  <span
+                    className={cn(
+                      "hidden absolute top-0 left-0 justify-center items-center w-full h-full text-ink-gray-6",
+                      !isCellDisabled &&
+                        "group-hover:flex group-disabled:group-hover:hidden",
+                    )}
+                  >
                     <AddMd size={16} />
                   </span>
                 </>

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -30,7 +30,7 @@ export interface MemberRowProps {
   /** Callback function when the action button is clicked. */
   onButtonClick?: () => void;
   /** Optional function to handle day-cell click events. */
-  onCellClick?: (dayIndex: number) => void;
+  onCellClick?: (date: string, dayIndex: number) => void;
   /** Array of time entries for each day of the week for the member. */
   timeEntries: { date: string; time: string }[];
   /** Total hours logged for the week. */
@@ -100,7 +100,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
               disabled={!onCellClick}
               onClick={(e) => {
                 e.stopPropagation();
-                onCellClick?.(index);
+                onCellClick?.(timeEntry.date, index);
               }}
               aria-label="Add time"
             >

--- a/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
@@ -16,7 +16,7 @@ export interface ProjectRowProps {
   /** Whether the project row is collapsed or expanded. */
   collapsed?: boolean;
   /** Array of time entries for each day of the week for the project. */
-  timeEntries: string[];
+  timeEntries: { time: string; disabled?: boolean }[];
   /** Total hours logged for the week. */
   totalHours?: string;
   /** Theme for the total hours */
@@ -72,39 +72,63 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({
         </div>
       </div>
       {timeEntries.map((timeEntry, index) => {
+        const isCellDisabled = Boolean(timeEntry.disabled);
+
         return (
           <div
-            key={`${timeEntry}-${index}`}
+            key={`${timeEntry.time}-${index}`}
             className="shrink-0 flex justify-end items-center whitespace-nowrap w-16 h-7 pl-2 py-1.5 lining-nums tabular-nums"
+            onClick={(e) => e.stopPropagation()}
           >
             <Button
               variant="ghost"
               className={cn(
-                "w-14.25 relative group flex justify-center items-center enabled:hover:bg-surface-gray-2",
-                "enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3 disabled:cursor-default!",
+                "w-14.25 relative group flex justify-center items-center",
+                !isCellDisabled &&
+                  "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
+                "disabled:cursor-default! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent!",
+                isCellDisabled && "cursor-default!",
                 "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                 "text-base text-ink-gray-6",
-                highlightTimeEntries && timeEntry !== "" && "text-ink-gray-8",
-                highlightTimeEntries && timeEntry !== "" && "font-medium",
+                highlightTimeEntries &&
+                  timeEntry.time !== "" &&
+                  "text-ink-gray-8",
+                highlightTimeEntries && timeEntry.time !== "" && "font-medium",
+                !highlightTimeEntries && "disabled:text-ink-gray-6!",
+                highlightTimeEntries &&
+                  timeEntry.time !== "" &&
+                  "disabled:text-ink-gray-8!",
               )}
-              disabled={!onCellClick}
+              disabled={isCellDisabled || !onCellClick}
               onClick={(e) => {
                 e.stopPropagation();
                 onCellClick?.(index);
               }}
               aria-label="Add time"
             >
-              {timeEntry === "" ? (
+              {timeEntry.time === "" ? (
                 <>
-                  <span className="flex-1 text-center group-hover:hidden group-disabled:group-hover:flex text-ink-gray-4">
+                  <span
+                    className={cn(
+                      "flex-1 text-center text-ink-gray-4",
+                      !isCellDisabled &&
+                        "group-hover:hidden group-disabled:group-hover:flex",
+                    )}
+                  >
                     -
                   </span>
-                  <span className="hidden absolute top-0 left-0 justify-center items-center w-full h-full group-hover:flex group-disabled:group-hover:hidden text-ink-gray-6">
+                  <span
+                    className={cn(
+                      "hidden absolute top-0 left-0 justify-center items-center w-full h-full text-ink-gray-6",
+                      !isCellDisabled &&
+                        "group-hover:flex group-disabled:group-hover:hidden",
+                    )}
+                  >
                     <AddMd size={16} />
                   </span>
                 </>
               ) : (
-                <span>{timeEntry}</span>
+                <span>{timeEntry.time}</span>
               )}
             </Button>
           </div>

--- a/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies.
  */
-import { SmallDown, Folder } from "@rtcamp/frappe-ui-react/icons";
+import { Button } from "@rtcamp/frappe-ui-react";
+import { AddMd, SmallDown, Folder } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -22,6 +23,8 @@ export interface ProjectRowProps {
   totalHoursTheme?: TotalHoursTheme;
   /** Optionally highlight time entries **/
   highlightTimeEntries?: boolean;
+  /** Optional function to handle day-cell click events. */
+  onCellClick?: (dayIndex: number) => void;
   /** Optional function to render a prefix icon next to the label. */
   renderPrefix?: () => React.ReactNode;
   /** Additional class names for the project row container. */
@@ -35,6 +38,7 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({
   totalHours = "",
   totalHoursTheme,
   highlightTimeEntries = false,
+  onCellClick,
   renderPrefix,
   className,
 }) => {
@@ -71,18 +75,38 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({
         return (
           <div
             key={`${timeEntry}-${index}`}
-            className={cn(
-              "shrink-0 flex justify-end items-center text-base text-ink-gray-6 whitespace-nowrap w-16 h-7 px-2 py-1.5 lining-nums tabular-nums",
-              highlightTimeEntries &&
-                timeEntry !== "" &&
-                "text-ink-gray-8 font-medium",
-            )}
+            className="shrink-0 flex justify-end items-center whitespace-nowrap w-16 h-7 pl-2 py-1.5 lining-nums tabular-nums"
           >
-            {timeEntry === "" ? (
-              <span className="flex-1 ml-2 text-center text-ink-gray-4">-</span>
-            ) : (
-              <span>{timeEntry}</span>
-            )}
+            <Button
+              variant="ghost"
+              className={cn(
+                "w-14.25 relative group flex justify-center items-center enabled:hover:bg-surface-gray-2",
+                "enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3 disabled:cursor-default!",
+                "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
+                "text-base text-ink-gray-6",
+                highlightTimeEntries && timeEntry !== "" && "text-ink-gray-8",
+                highlightTimeEntries && timeEntry !== "" && "font-medium",
+              )}
+              disabled={!onCellClick}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCellClick?.(index);
+              }}
+              aria-label="Add time"
+            >
+              {timeEntry === "" ? (
+                <>
+                  <span className="flex-1 text-center group-hover:hidden group-disabled:group-hover:flex text-ink-gray-4">
+                    -
+                  </span>
+                  <span className="hidden absolute top-0 left-0 justify-center items-center w-full h-full group-hover:flex group-disabled:group-hover:hidden text-ink-gray-6">
+                    <AddMd size={16} />
+                  </span>
+                </>
+              ) : (
+                <span>{timeEntry}</span>
+              )}
+            </Button>
           </div>
         );
       })}

--- a/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
@@ -21,7 +21,7 @@ export interface TotalRowProps {
   /** Whether the total row is starred or not. */
   starred?: boolean;
   /** Array of total time entries for each day of the week. */
-  totalTimeEntries: { date: string; time: string }[];
+  totalTimeEntries: { date: string; time: string; disabled?: boolean }[];
   /** Total hours logged for the week. */
   totalHours?: string;
   /** Theme for the total hours */
@@ -100,29 +100,49 @@ export const TotalRow: React.FC<TotalRowProps> = ({
       </div>
 
       {totalTimeEntries.map((totalTimeEntry, index) => {
+        const isCellDisabled = disabled || Boolean(totalTimeEntry.disabled);
+
         return (
           <div
             key={index}
             className="shrink-0 flex justify-end items-center whitespace-nowrap w-16 h-7 pl-2 py-1.5 lining-nums tabular-nums"
+            onClick={(e) => e.stopPropagation()}
           >
             <Button
               variant="ghost"
               className={cn(
-                "w-14.25 relative group flex justify-center items-center enabled:hover:bg-surface-gray-2 ",
-                "enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3 disabled:cursor-default!",
+                "w-14.25 relative group flex justify-center items-center",
+                !isCellDisabled &&
+                  "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
+                "disabled:cursor-default! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent! disabled:text-ink-gray-8!",
+                isCellDisabled && "cursor-default!",
                 "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                 "text-base font-medium text-ink-gray-8",
               )}
-              disabled={disabled || !onCellClick}
-              onClick={() => onCellClick?.(totalTimeEntry.date)}
+              disabled={isCellDisabled || !onCellClick}
+              onClick={() => {
+                onCellClick?.(totalTimeEntry.date);
+              }}
               aria-label="Add time"
             >
               {totalTimeEntry.time === "" ? (
                 <>
-                  <span className="flex-1 text-center group-hover:hidden group-disabled:group-hover:flex text-ink-gray-4">
+                  <span
+                    className={cn(
+                      "flex-1 text-center text-ink-gray-4",
+                      !isCellDisabled &&
+                        "group-hover:hidden group-disabled:group-hover:flex",
+                    )}
+                  >
                     -
                   </span>
-                  <span className="hidden absolute top-0 left-0 justify-center items-center w-full h-full group-hover:flex group-disabled:group-hover:hidden text-ink-gray-6">
+                  <span
+                    className={cn(
+                      "hidden absolute top-0 left-0 justify-center items-center w-full h-full text-ink-gray-6",
+                      !isCellDisabled &&
+                        "group-hover:flex group-disabled:group-hover:hidden",
+                    )}
+                  >
                     <AddMd size={16} className="" />
                   </span>
                 </>


### PR DESCRIPTION

## Description

<!-- What do we want to achieve with this PR? -->
This pull request enhances the timesheet pages by improving how the "Add Time" dialog is opened and prefilled. Now, when users click on a cell in various timesheet rows, the dialog will open with relevant fields (date, project, task, employee) already filled.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/2dd874e1-90b7-4526-af40-a7070f38fd63



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1543