### PR TITLE
fix: set_date before validating existing timesheet

### DIFF
--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -20,6 +20,7 @@ def validate(doc, method=None):
 
 
 def before_insert(doc, method=None):
+    set_date(doc)
     validate_existing_timesheet(doc)
     validate_approved_timesheet(doc)
 


### PR DESCRIPTION
## Description
This pull request introduces a small update to the `before_insert` function in `next_pms/timesheet/doc_events/timesheet.py`. The change ensures that the `set_date` function is called before other validation checks when inserting a timesheet.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1621 