### PR TITLE
Performance: Reduce response size for timesheet project page

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -31,7 +31,7 @@ type UseProjectTimesheetOptions = {
   compositeFilters: FilterCondition[];
 };
 
-const PROJECT_PAGE_LENGTH = 10;
+const PROJECT_PAGE_LENGTH = 4;
 
 export function useProjectTimesheetData({
   requestKey,


### PR DESCRIPTION
## Description
- Reduces the page size for the project timesheet page from 10 to 4 - this will lead smaller response from server, making the page feel more responsive. There will more requests but thats a tradeoff we will need to make.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)