### PR TITLE
Fix: Show error when follow is disabled

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/index.tsx
@@ -108,11 +108,15 @@ export function CalendarTab() {
   async function handleFollowDocument(item: ProjectTimelineItem) {
     const isFollowing = item.watchers.some((w) => w.name === userId);
     try {
-      await updateFollow({
+      const res = await updateFollow({
         doctype: "Project Timeline Item",
         doc_name: item.id,
         following: !isFollowing,
       });
+      if (!isFollowing && !res?.message) {
+        toast.error("Document follow is not enabled for current user.");
+        return;
+      }
       toast.success(isFollowing ? "Unfollowed document" : "Following document");
       void mutate();
     } catch (err) {

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/riskRowActions.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/riskRowActions.tsx
@@ -35,11 +35,15 @@ export function RiskRowActions({
 
   const handleFollow = async () => {
     try {
-      await updateFollow({
+      const res = await updateFollow({
         doctype: "Risk",
         doc_name: riskName,
         following: !isFollowing,
       });
+      if (!isFollowing && !res?.message) {
+        toast.error("Document follow is not enabled for current user.");
+        return;
+      }
       toast.success(isFollowing ? "Unfollowed document" : "Following document");
       onAfterFollow?.();
     } catch (err) {


### PR DESCRIPTION
## Description
- Show error toast when follow is disabled from user side.

## Screenshot/Screencast
<img width="2152" height="1722" alt="image" src="https://github.com/user-attachments/assets/ee62150b-25ec-44cc-80c3-b7b13d693231" />

<img width="2162" height="1724" alt="image" src="https://github.com/user-attachments/assets/27155a95-b0c4-4555-a93f-aa71e02aceed" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)