### PR TITLE
Enhance inline editor interaction and resizing functionality in timesheet pages

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -1,7 +1,14 @@
 /**
  * External Dependencies
  */
-import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Accordion } from "@base-ui/react/accordion";
 import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
 import { stripTags } from "@next-pms/design-system/utils";
@@ -12,12 +19,14 @@ import {
   useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { EditAlt, Compose, AddSm, Delete } from "@rtcamp/frappe-ui-react/icons";
+import { useStore } from "@tanstack/react-form";
 import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
  */
 import { parseFrappeErrorMsg } from "@/lib/utils";
+import { useUnsavedChangesSource } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { TaskDataItemProps } from "@/types/timesheet";
 import { useInlineTimeEntryForm } from "./form";
 import { TimeEntryForm } from "./timeEntryForm";
@@ -54,6 +63,7 @@ export const InlineTimeEntry = ({
   dailyWorkingHours = 8,
   totalUsedHoursInDay,
   onSubmitSuccess,
+  onEngagedChange,
   timeEntry,
   tasks,
   disabled,
@@ -75,6 +85,7 @@ export const InlineTimeEntry = ({
   const editBaselineRef = useRef<{ duration: number; comment: string } | null>(
     null,
   );
+  const pendingProceedAfterSaveRef = useRef<(() => void) | null>(null);
 
   const { call: saveTime } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
@@ -140,10 +151,12 @@ export const InlineTimeEntry = ({
         if (hasNoTimeEntries && entryFormMode === ENTRY_FORM_MODE.DEFAULT) {
           onSubmitSuccess?.();
         }
+        pendingProceedAfterSaveRef.current?.();
       } catch (err) {
         const error = parseFrappeErrorMsg(err as FrappeError);
         toast.error(error);
       } finally {
+        pendingProceedAfterSaveRef.current = null;
         setSubmitting(false);
         form.reset();
         editBaselineRef.current = null;
@@ -153,6 +166,55 @@ export const InlineTimeEntry = ({
       }
     },
   });
+
+  const { duration: liveDuration, comment: liveComment } = useStore(
+    form.store,
+    (state) => state.values,
+  );
+  const hasUnsavedChanges =
+    entryFormMode === ENTRY_FORM_MODE.EDIT && editBaselineRef.current
+      ? liveDuration !== editBaselineRef.current.duration ||
+        liveComment !== editBaselineRef.current.comment
+      : liveDuration !== defaultValues.duration ||
+        liveComment !== defaultValues.comment;
+  const isEngaged =
+    entryFormMode !== ENTRY_FORM_MODE.DEFAULT || hasUnsavedChanges;
+
+  const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
+  hasUnsavedChangesRef.current = hasUnsavedChanges;
+
+  // Layout effect so the pin lands before the browser fires the hover-leave.
+  useLayoutEffect(() => {
+    onEngagedChange?.(isEngaged);
+  }, [isEngaged, onEngagedChange]);
+
+  const discardChanges = useCallback(() => {
+    form.reset();
+    editBaselineRef.current = null;
+    setSelectedEntry(null);
+    setAddDraft(null);
+    setEntryFormMode(ENTRY_FORM_MODE.DEFAULT);
+  }, [form]);
+
+  const unsavedChangesSourceRef = useUnsavedChangesSource();
+  useEffect(() => {
+    const source = {
+      hasUnsavedChanges: () => hasUnsavedChangesRef.current,
+      saveChanges: (onSaved?: () => void) => {
+        pendingProceedAfterSaveRef.current = onSaved ?? null;
+        void form.handleSubmit().finally(() => {
+          pendingProceedAfterSaveRef.current = null;
+        });
+      },
+      discardChanges,
+    };
+    unsavedChangesSourceRef.current = source;
+    return () => {
+      if (unsavedChangesSourceRef.current === source) {
+        unsavedChangesSourceRef.current = null;
+      }
+    };
+  }, [unsavedChangesSourceRef, form, discardChanges]);
 
   const handleDelete = useCallback(async () => {
     if (!selectedEntry) return;
@@ -340,6 +402,8 @@ export const InlineTimeEntry = ({
                               "w-5 h-5 absolute right-0 top-0 opacity-0 pointer-events-none",
                               "group-hover:opacity-100 group-hover:pointer-events-auto",
                               "group-focus-within:opacity-100 group-focus-within:pointer-events-auto",
+                              !isExpanded &&
+                                "group-active:opacity-0 group-active:pointer-events-none",
                             )}
                             variant="ghost"
                             icon={() => (

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  type PointerEvent,
   useRef,
   useState,
 } from "react";
@@ -80,6 +81,7 @@ export const InlineTimeEntry = ({
     duration: number;
     comment: string;
   } | null>(null);
+  const [commentResizeActive, setCommentResizeActive] = useState(false);
   const [collapsedEntryNames, setCollapsedEntryNames] = useState<string[]>([]);
   const hasInitializedInteractiveModeRef = useRef(false);
   const editBaselineRef = useRef<{ duration: number; comment: string } | null>(
@@ -178,7 +180,9 @@ export const InlineTimeEntry = ({
       : liveDuration !== defaultValues.duration ||
         liveComment !== defaultValues.comment;
   const isEngaged =
-    entryFormMode !== ENTRY_FORM_MODE.DEFAULT || hasUnsavedChanges;
+    entryFormMode !== ENTRY_FORM_MODE.DEFAULT ||
+    hasUnsavedChanges ||
+    commentResizeActive;
 
   const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
   hasUnsavedChangesRef.current = hasUnsavedChanges;
@@ -187,6 +191,28 @@ export const InlineTimeEntry = ({
   useLayoutEffect(() => {
     onEngagedChange?.(isEngaged);
   }, [isEngaged, onEngagedChange]);
+
+  useEffect(() => {
+    if (!commentResizeActive) return;
+
+    const stopResize = () => setCommentResizeActive(false);
+
+    window.addEventListener("pointerup", stopResize);
+    window.addEventListener("pointercancel", stopResize);
+    window.addEventListener("mouseup", stopResize);
+    window.addEventListener("touchend", stopResize);
+    window.addEventListener("contextmenu", stopResize);
+    window.addEventListener("blur", stopResize);
+
+    return () => {
+      window.removeEventListener("pointerup", stopResize);
+      window.removeEventListener("pointercancel", stopResize);
+      window.removeEventListener("mouseup", stopResize);
+      window.removeEventListener("touchend", stopResize);
+      window.removeEventListener("contextmenu", stopResize);
+      window.removeEventListener("blur", stopResize);
+    };
+  }, [commentResizeActive]);
 
   const discardChanges = useCallback(() => {
     form.reset();
@@ -310,6 +336,26 @@ export const InlineTimeEntry = ({
     [form],
   );
 
+  const handleCommentPointerDown = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      if (e.button !== 0) return;
+
+      const editor = (e.target as Element | null)?.closest(".ProseMirror");
+      if (!(editor instanceof HTMLElement)) return;
+
+      const rect = editor.getBoundingClientRect();
+      const resizeHandleSize = 20;
+      const isResizeHandlePointerDown =
+        e.clientX >= rect.right - resizeHandleSize &&
+        e.clientY >= rect.bottom - resizeHandleSize;
+
+      if (isResizeHandlePointerDown) {
+        setCommentResizeActive(true);
+      }
+    },
+    [],
+  );
+
   const handleToggleEntryExpand = useCallback((entryName: string) => {
     setCollapsedEntryNames((prev) => {
       if (prev.includes(entryName)) {
@@ -324,7 +370,7 @@ export const InlineTimeEntry = ({
   }
 
   return (
-    <div className="animate-fade-in w-68 max-h-[min(350px,90dvh)] overflow-y-auto scrollbar-thin shadow bg-surface-modal rounded-lg flex flex-col gap-2 p-2">
+    <div className="animate-fade-in min-w-68 w-fit max-w-[min(720px,90vw)] max-h-[min(500px,90dvh)] overflow-auto scrollbar-thin shadow bg-surface-modal rounded-lg flex flex-col gap-2 p-2">
       {tasks.map((entry: TaskDataItemProps, index: number) => {
         const isEditingThisEntry =
           entryFormMode === ENTRY_FORM_MODE.EDIT &&
@@ -333,7 +379,13 @@ export const InlineTimeEntry = ({
           isEditingThisEntry || !collapsedEntryNames.includes(entry.name);
 
         return (
-          <div key={entry.name} className="w-full group">
+          <div
+            key={entry.name}
+            className={cn(
+              "w-full min-w-0 group",
+              !isEditingThisEntry && "contain-[inline-size]",
+            )}
+          >
             <Accordion.Root
               value={isExpanded ? [entry.name] : []}
               onValueChange={() => handleToggleEntryExpand(entry.name)}
@@ -351,11 +403,11 @@ export const InlineTimeEntry = ({
                       <div
                         {...props}
                         className={cn(
-                          "w-full relative flex justify-start gap-2 cursor-pointer text-left",
+                          "w-full relative gap-2 cursor-pointer text-left",
                           "focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded-sm",
                           !isExpanded
-                            ? "flex-row items-center"
-                            : "flex-col items-start ",
+                            ? "grid grid-cols-[auto_minmax(0,1fr)] items-center"
+                            : "flex flex-col items-start ",
                         )}
                       >
                         <div
@@ -384,11 +436,7 @@ export const InlineTimeEntry = ({
                         {!isExpanded ? (
                           <span
                             className={cn(
-                              "w-full min-w-0 text-sm truncate text-ink-gray-6",
-                              {
-                                "group-hover:pr-4 group-focus-within:pr-4":
-                                  !disabled,
-                              },
+                              "block min-w-0 max-w-full truncate pr-4 text-sm text-ink-gray-6",
                             )}
                           >
                             {entry.description
@@ -403,7 +451,7 @@ export const InlineTimeEntry = ({
                               "group-hover:opacity-100 group-hover:pointer-events-auto",
                               "group-focus-within:opacity-100 group-focus-within:pointer-events-auto",
                               !isExpanded &&
-                                "group-active:opacity-0 group-active:pointer-events-none",
+                                "group-active:not-hover:opacity-0 group-active:not-hover:pointer-events-none",
                             )}
                             variant="ghost"
                             icon={() => (
@@ -420,7 +468,7 @@ export const InlineTimeEntry = ({
                   />
                 ) : null}
                 <Accordion.Panel className="accordion-panel">
-                  <div className="pt-2">
+                  <div className="w-full pt-2">
                     {!disabled && isEditingThisEntry ? (
                       <TimeEntryForm
                         form={form}
@@ -432,6 +480,7 @@ export const InlineTimeEntry = ({
                         submitting={submitting}
                         onSave={() => handleSubmit()}
                         onCommentKeyDown={handleSubmit}
+                        onCommentPointerDown={handleCommentPointerDown}
                       >
                         <Button
                           variant="subtle"
@@ -447,7 +496,7 @@ export const InlineTimeEntry = ({
                     ) : (
                       <StaticTextEditor
                         content={entry.description}
-                        editorClass="max-h-30 prose-sm overflow-auto scrollbar-thin text-ink-gray-7 text-base leading-5.25"
+                        editorClass="w-full max-w-full max-h-30 prose-sm overflow-auto scrollbar-thin text-ink-gray-7 text-base leading-5.25"
                       />
                     )}
                   </div>
@@ -470,6 +519,7 @@ export const InlineTimeEntry = ({
               submitting={submitting}
               onSave={() => handleSubmit()}
               onCommentKeyDown={handleSubmit}
+              onCommentPointerDown={handleCommentPointerDown}
             />
           ) : null}
           {!hasNoTimeEntries && entryFormMode !== ENTRY_FORM_MODE.ADD ? (

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -6,7 +6,6 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
-  type PointerEvent,
   useRef,
   useState,
 } from "react";
@@ -32,6 +31,7 @@ import { TaskDataItemProps } from "@/types/timesheet";
 import { useInlineTimeEntryForm } from "./form";
 import { TimeEntryForm } from "./timeEntryForm";
 import type { InlineTimeEntryProps, TimeEntryFormValues } from "./types";
+import { useResizeEngagement } from "./useResizeEngagement";
 
 export const ENTRY_FORM_MODE = {
   DEFAULT: "default",
@@ -81,7 +81,10 @@ export const InlineTimeEntry = ({
     duration: number;
     comment: string;
   } | null>(null);
-  const [commentResizeActive, setCommentResizeActive] = useState(false);
+  const {
+    isResizeActive: commentResizeActive,
+    onResizePointerDown: handleCommentPointerDown,
+  } = useResizeEngagement();
   const [collapsedEntryNames, setCollapsedEntryNames] = useState<string[]>([]);
   const hasInitializedInteractiveModeRef = useRef(false);
   const editBaselineRef = useRef<{ duration: number; comment: string } | null>(
@@ -191,28 +194,6 @@ export const InlineTimeEntry = ({
   useLayoutEffect(() => {
     onEngagedChange?.(isEngaged);
   }, [isEngaged, onEngagedChange]);
-
-  useEffect(() => {
-    if (!commentResizeActive) return;
-
-    const stopResize = () => setCommentResizeActive(false);
-
-    window.addEventListener("pointerup", stopResize);
-    window.addEventListener("pointercancel", stopResize);
-    window.addEventListener("mouseup", stopResize);
-    window.addEventListener("touchend", stopResize);
-    window.addEventListener("contextmenu", stopResize);
-    window.addEventListener("blur", stopResize);
-
-    return () => {
-      window.removeEventListener("pointerup", stopResize);
-      window.removeEventListener("pointercancel", stopResize);
-      window.removeEventListener("mouseup", stopResize);
-      window.removeEventListener("touchend", stopResize);
-      window.removeEventListener("contextmenu", stopResize);
-      window.removeEventListener("blur", stopResize);
-    };
-  }, [commentResizeActive]);
 
   const discardChanges = useCallback(() => {
     form.reset();
@@ -336,26 +317,6 @@ export const InlineTimeEntry = ({
     [form],
   );
 
-  const handleCommentPointerDown = useCallback(
-    (e: PointerEvent<HTMLElement>) => {
-      if (e.button !== 0) return;
-
-      const editor = (e.target as Element | null)?.closest(".ProseMirror");
-      if (!(editor instanceof HTMLElement)) return;
-
-      const rect = editor.getBoundingClientRect();
-      const resizeHandleSize = 20;
-      const isResizeHandlePointerDown =
-        e.clientX >= rect.right - resizeHandleSize &&
-        e.clientY >= rect.bottom - resizeHandleSize;
-
-      if (isResizeHandlePointerDown) {
-        setCommentResizeActive(true);
-      }
-    },
-    [],
-  );
-
   const handleToggleEntryExpand = useCallback((entryName: string) => {
     setCollapsedEntryNames((prev) => {
       if (prev.includes(entryName)) {
@@ -379,13 +340,7 @@ export const InlineTimeEntry = ({
           isEditingThisEntry || !collapsedEntryNames.includes(entry.name);
 
         return (
-          <div
-            key={entry.name}
-            className={cn(
-              "w-full min-w-0 group",
-              !isEditingThisEntry && "contain-[inline-size]",
-            )}
-          >
+          <div key={entry.name} className="w-full min-w-0 group">
             <Accordion.Root
               value={isExpanded ? [entry.name] : []}
               onValueChange={() => handleToggleEntryExpand(entry.name)}
@@ -436,7 +391,7 @@ export const InlineTimeEntry = ({
                         {!isExpanded ? (
                           <span
                             className={cn(
-                              "block min-w-0 max-w-full truncate pr-4 text-sm text-ink-gray-6",
+                              "block min-w-0 max-w-full truncate pr-4 text-sm text-ink-gray-6 contain-[inline-size]",
                             )}
                           >
                             {entry.description
@@ -494,10 +449,19 @@ export const InlineTimeEntry = ({
                         </Button>
                       </TimeEntryForm>
                     ) : (
-                      <StaticTextEditor
-                        content={entry.description}
-                        editorClass="w-full max-w-full max-h-30 prose-sm overflow-auto scrollbar-thin text-ink-gray-7 text-base leading-5.25"
-                      />
+                      <div
+                        className="w-full min-w-0"
+                        onPointerDownCapture={handleCommentPointerDown}
+                      >
+                        <StaticTextEditor
+                          content={entry.description}
+                          editorClass={cn(
+                            "max-h-40 resize prose-sm overflow-auto scrollbar-thin bg-surface-white text-ink-gray-7 text-base leading-5.25",
+                            "box-border w-full min-w-64 max-w-[min(680px,calc(90vw-2rem))]",
+                            "contain-[inline-size] wrap-anywhere **:max-w-full **:wrap-anywhere",
+                          )}
+                        />
+                      </div>
                     )}
                   </div>
                 </Accordion.Panel>

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { mergeClassNames as cn } from "@next-pms/design-system";
 import {
   Button,
   ErrorMessage,
@@ -79,10 +80,15 @@ export const TimeEntryForm = ({
                   onChange={(value) => field.handleChange(value)}
                   fixedMenu={false}
                   placeholder="Comment"
-                  editorClass="px-2 h-24 min-h-24 max-h-60 w-full min-w-64 max-w-[min(680px,calc(90vw-2rem))] resize prose-sm overflow-auto scrollbar-thin bg-white border rounded-md border-outline-gray-2 text-ink-gray-7 text-base leading-5.25"
+                  editorClass={cn(
+                    "px-2 h-24 min-h-24 max-h-60 resize prose-sm overflow-auto scrollbar-thin",
+                    "bg-surface-white border rounded-md border-outline-gray-2 text-ink-gray-7 text-base leading-5.25",
+                    "box-border w-full min-w-64 max-w-[min(680px,calc(90vw-2rem))]",
+                    "contain-[inline-size] wrap-anywhere **:max-w-full **:wrap-anywhere",
+                  )}
                 />
                 {field.state.value === "" ? (
-                  <span className="absolute text-sm align-middle right-5 bottom-1 text-ink-gray-4">
+                  <span className="absolute text-[12px] align-middle right-2 bottom-1 text-ink-gray-4">
                     ⌘+↵
                   </span>
                 ) : null}

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
@@ -37,6 +37,7 @@ export const TimeEntryForm = ({
   editBaseline = null,
   onSave,
   onCommentKeyDown,
+  onCommentPointerDown,
   children,
 }: TimeEntryFormProps) => {
   return (
@@ -70,6 +71,7 @@ export const TimeEntryForm = ({
               <div
                 className="relative w-full"
                 onKeyDownCapture={(e) => onCommentKeyDown(e)}
+                onPointerDownCapture={onCommentPointerDown}
               >
                 <TextEditor
                   editable={!submitting}
@@ -77,10 +79,10 @@ export const TimeEntryForm = ({
                   onChange={(value) => field.handleChange(value)}
                   fixedMenu={false}
                   placeholder="Comment"
-                  editorClass="px-2 h-24 prose-sm overflow-scroll scrollbar-thin bg-white border rounded-md border-outline-gray-2 text-ink-gray-7 text-base leading-5.25"
+                  editorClass="px-2 h-24 min-h-24 max-h-60 w-full min-w-64 max-w-[min(680px,calc(90vw-2rem))] resize prose-sm overflow-auto scrollbar-thin bg-white border rounded-md border-outline-gray-2 text-ink-gray-7 text-base leading-5.25"
                 />
                 {field.state.value === "" ? (
-                  <span className="absolute text-sm align-middle right-2 bottom-1 text-ink-gray-4">
+                  <span className="absolute text-sm align-middle right-5 bottom-1 text-ink-gray-4">
                     ⌘+↵
                   </span>
                 ) : null}

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, ReactNode } from "react";
+import type { KeyboardEvent, PointerEvent, ReactNode } from "react";
 import type { TaskRowTimeEntry } from "@next-pms/design-system/components";
 import type { TaskDataItemProps } from "@/types/timesheet";
 import type { EntryFormMode } from ".";
@@ -34,5 +34,6 @@ export type TimeEntryFormProps = {
   editBaseline?: { duration: number; comment: string } | null;
   onSave: () => void;
   onCommentKeyDown: (e: KeyboardEvent<Element>) => void;
+  onCommentPointerDown?: (e: PointerEvent<HTMLElement>) => void;
   children?: ReactNode;
 };

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
@@ -13,6 +13,7 @@ export interface InlineTimeEntryProps {
   dailyWorkingHours?: number;
   totalUsedHoursInDay?: number;
   onSubmitSuccess?: () => void;
+  onEngagedChange?: (engaged: boolean) => void;
   timeEntry: TaskRowTimeEntry;
 }
 

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/useResizeEngagement.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/useResizeEngagement.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useState, type PointerEvent } from "react";
+
+export const useResizeEngagement = () => {
+  const [isResizeActive, setIsResizeActive] = useState(false);
+
+  useEffect(() => {
+    if (!isResizeActive) return;
+
+    const stopResize = () => setIsResizeActive(false);
+
+    window.addEventListener("pointerup", stopResize);
+    window.addEventListener("pointercancel", stopResize);
+    window.addEventListener("mouseup", stopResize);
+    window.addEventListener("touchend", stopResize);
+    window.addEventListener("contextmenu", stopResize);
+    window.addEventListener("blur", stopResize);
+
+    return () => {
+      window.removeEventListener("pointerup", stopResize);
+      window.removeEventListener("pointercancel", stopResize);
+      window.removeEventListener("mouseup", stopResize);
+      window.removeEventListener("touchend", stopResize);
+      window.removeEventListener("contextmenu", stopResize);
+      window.removeEventListener("blur", stopResize);
+    };
+  }, [isResizeActive]);
+
+  const onResizePointerDown = useCallback((e: PointerEvent<HTMLElement>) => {
+    if (e.button !== 0) return;
+
+    const editor = (e.target as Element | null)?.closest(".ProseMirror");
+    if (!(editor instanceof HTMLElement)) return;
+
+    const rect = editor.getBoundingClientRect();
+    const resizeHandleSize = 20;
+    const isResizeHandlePointerDown =
+      e.clientX >= rect.right - resizeHandleSize &&
+      e.clientY >= rect.bottom - resizeHandleSize;
+
+    if (isResizeHandlePointerDown) {
+      setIsResizeActive(true);
+    }
+  }, []);
+
+  return { isResizeActive, onResizePointerDown };
+};

--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -16,6 +16,7 @@ import { useFrappePostCall } from "frappe-react-sdk";
  */
 import TaskPopover from "@/components/taskPopover";
 import { calculateTotalHours, parseFrappeErrorMsg } from "@/lib/utils";
+import { useGuardedAction } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { usePersonalTimesheet } from "@/pages/timesheet/personal/context";
 import type { TaskDataItemProps } from "@/types/timesheet";
 import type { TaskRowProps } from "./types";
@@ -58,6 +59,7 @@ export const TaskRow = ({
     "frappe.desk.like.toggle_like",
   );
   const toast = useToasts();
+  const requestGuarded = useGuardedAction();
 
   const taskData = useMemo(() => {
     let total = 0;
@@ -151,8 +153,15 @@ export const TaskRow = ({
       onLabelClick={onLabelClick}
       onStarClick={handleStar}
       hideStarButton={hideLikeButton}
-      renderInlineTimeEntryPopover={(_, dayIndex, closePopover) => (
+      requestGuarded={requestGuarded}
+      renderInlineTimeEntryPopover={(
+        _,
+        dayIndex,
+        closePopover,
+        reportEngaged,
+      ) => (
         <InlineTimeEntry
+          key={`${taskKey}-${dates[dayIndex]}`}
           tasks={taskData.tasksForDates[dayIndex]}
           dailyWorkingHours={dailyWorkingHours}
           totalUsedHoursInDay={totalTimeEntriesInHours?.[dayIndex]}
@@ -162,6 +171,7 @@ export const TaskRow = ({
           taskKey={taskKey}
           employee={employee ?? ""}
           onSubmitSuccess={closePopover}
+          onEngagedChange={reportEngaged}
         />
       )}
     />

--- a/frontend/packages/app/src/pages/allocations/components/unsavedChangesDialog.tsx
+++ b/frontend/packages/app/src/pages/allocations/components/unsavedChangesDialog.tsx
@@ -22,18 +22,20 @@ export function UnsavedChangesDialog({
     <Dialog
       open={open}
       onOpenChange={onOpenChange}
-      className="my-0"
+      className="my-0 max-w-120"
       classNames={{
-        header: "mb-5",
+        header: "mb-4",
         content: "pt-5 pb-2",
         viewport: "justify-start pt-30",
         footer: "pb-6",
       }}
       options={{
-        title: () => <span className="text-lg font-medium">Save Changes</span>,
+        title: () => (
+          <span className="text-[20px] font-semibold">Save Changes</span>
+        ),
       }}
       actions={
-        <div className="flex items-center justify-end w-full gap-2 -mt-5">
+        <div className="flex items-center justify-end w-full gap-2">
           <Button
             variant="ghost"
             label="Discard Changes"
@@ -52,7 +54,7 @@ export function UnsavedChangesDialog({
         </div>
       }
     >
-      <div className="-mt-2">
+      <div>
         <p className="text-base text-ink-gray-6">
           You have unsaved changes. Would you like to save them before leaving?
         </p>

--- a/frontend/packages/app/src/pages/allocations/unsavedChanges/UnsavedChangesProvider.tsx
+++ b/frontend/packages/app/src/pages/allocations/unsavedChanges/UnsavedChangesProvider.tsx
@@ -79,8 +79,10 @@ export function UnsavedChangesProvider({ children }: { children: ReactNode }) {
   }, [blocker]);
 
   const handleSaveChanges = useCallback(() => {
-    // Hands off to the feature's own save flow don't auto-proceed navigation.
-    sourceRef.current?.saveChanges();
+    const queued = queuedActionRef.current;
+    sourceRef.current?.saveChanges(
+      blocker.state === "blocked" ? undefined : (queued ?? undefined),
+    );
     setPendingAction(null);
     if (blocker.state === "blocked") blocker.reset();
   }, [blocker]);

--- a/frontend/packages/app/src/pages/allocations/unsavedChanges/context.ts
+++ b/frontend/packages/app/src/pages/allocations/unsavedChanges/context.ts
@@ -5,7 +5,7 @@ import { createContext, type RefObject } from "react";
 
 export interface UnsavedChangesSource {
   hasUnsavedChanges: () => boolean;
-  saveChanges: () => void;
+  saveChanges: (onSaved?: () => void) => void;
   discardChanges: () => void;
 }
 

--- a/frontend/packages/app/src/pages/timesheet/personal/layout.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/layout.tsx
@@ -11,6 +11,7 @@ import { AddMd, TimeOff } from "@rtcamp/frappe-ui-react/icons";
  * Internal dependencies.
  */
 import { Header } from "@/layout/header";
+import { UnsavedChangesProvider } from "@/pages/allocations/unsavedChanges/UnsavedChangesProvider";
 import AddLeave from "@/pages/timesheet/components/add-leave";
 import AddTime from "@/pages/timesheet/components/add-time";
 import SubmitApproval from "@/pages/timesheet/components/submit-approval";
@@ -62,7 +63,7 @@ function PersonalTimesheetLayout() {
   );
 
   return (
-    <>
+    <UnsavedChangesProvider>
       <Header className="justify-between">
         <TimesheetBreadcrumbs />
 
@@ -115,7 +116,7 @@ function PersonalTimesheetLayout() {
         endDate={submitApprovalDates.endDate}
         totalHours={submitApprovalDates.totalHours}
       />
-    </>
+    </UnsavedChangesProvider>
   );
 }
 

--- a/frontend/packages/app/src/pages/timesheet/project/layout.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/layout.tsx
@@ -11,6 +11,7 @@ import { AddMd, TimeOff } from "@rtcamp/frappe-ui-react/icons";
  * Internal dependencies.
  */
 import { Header } from "@/layout/header";
+import { UnsavedChangesProvider } from "@/pages/allocations/unsavedChanges/UnsavedChangesProvider";
 import { TimesheetBreadcrumbs } from "@/pages/timesheet/components/timesheet-breadcrumbs";
 import type {
   OpenAddTimeDialogOptions,
@@ -51,7 +52,7 @@ function ProjectTimesheetLayout() {
   );
 
   return (
-    <>
+    <UnsavedChangesProvider>
       <Header className="justify-between">
         <TimesheetBreadcrumbs />
 
@@ -101,7 +102,7 @@ function ProjectTimesheetLayout() {
         open={isLeaveDialogOpen}
         onOpenChange={setIsLeaveDialogOpen}
       />
-    </>
+    </UnsavedChangesProvider>
   );
 }
 

--- a/frontend/packages/app/src/pages/timesheet/team/layout.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/layout.tsx
@@ -11,6 +11,7 @@ import { AddMd, TimeOff } from "@rtcamp/frappe-ui-react/icons";
  * Internal dependencies.
  */
 import { Header } from "@/layout/header";
+import { UnsavedChangesProvider } from "@/pages/allocations/unsavedChanges/UnsavedChangesProvider";
 import { TimesheetBreadcrumbs } from "@/pages/timesheet/components/timesheet-breadcrumbs";
 import type {
   OpenAddTimeDialogOptions,
@@ -51,7 +52,7 @@ function TeamTimesheetLayout() {
   );
 
   return (
-    <>
+    <UnsavedChangesProvider>
       <Header className="justify-between">
         <TimesheetBreadcrumbs />
 
@@ -101,7 +102,7 @@ function TeamTimesheetLayout() {
         open={isLeaveDialogOpen}
         onOpenChange={setIsLeaveDialogOpen}
       />
-    </>
+    </UnsavedChangesProvider>
   );
 }
 

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -244,15 +244,17 @@ export const TaskRow: React.FC<TaskRowProps> = ({
               <Popover.Backdrop className="fixed inset-0 pointer-events-auto!" />
             ) : null}
             <Popover.Positioner sideOffset={8} align="end">
-              <Popover.Popup>
-                {payload
-                  ? renderInlineTimeEntryPopover?.(
-                      taskKey,
-                      payload.dayIndex,
-                      closePopover,
-                      reportEngaged,
-                    )
-                  : null}
+              <Popover.Popup className="relative before:absolute before:-left-12 before:-right-12 before:-bottom-12 before:top-0 before:content-['']">
+                <div className="relative z-1">
+                  {payload
+                    ? renderInlineTimeEntryPopover?.(
+                        taskKey,
+                        payload.dayIndex,
+                        closePopover,
+                        reportEngaged,
+                      )
+                    : null}
+                </div>
               </Popover.Popup>
             </Popover.Positioner>
           </Popover.Portal>

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { createRef, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Popover, PreviewCard } from "@base-ui/react";
 import {
   TaskStatus,
@@ -35,6 +35,7 @@ export interface TaskRowProps {
     taskKey: string,
     dayIndex: number,
     closePopover: () => void,
+    reportEngaged: (engaged: boolean) => void,
   ) => React.ReactNode;
   /** Total hours logged for the week. */
   totalHours?: string;
@@ -50,6 +51,8 @@ export interface TaskRowProps {
   taskKey: string;
   /** Whether to hide the star button for liking the task. */
   hideStarButton?: boolean;
+  /** Guard for intentional popover dismissals */
+  requestGuarded?: (action: () => void) => void;
 }
 
 export const TaskRow: React.FC<TaskRowProps> = ({
@@ -66,10 +69,54 @@ export const TaskRow: React.FC<TaskRowProps> = ({
   onLabelClick,
   taskKey,
   hideStarButton,
+  requestGuarded = (action) => action(),
 }) => {
-  const actionRefs = useRef<
-    Array<React.RefObject<Popover.Root.Actions | null>>
-  >([]);
+  const [handle] = useState(() => Popover.createHandle<{ dayIndex: number }>());
+  // Once the user starts editing, the popover stays put on pointer/focus drift
+  // and a backdrop catches outside clicks until they dismiss it.
+  const pinnedRef = useRef(false);
+  const [pinned, setPinned] = useState(false);
+
+  const reportEngaged = useCallback((engaged: boolean) => {
+    pinnedRef.current = engaged;
+    setPinned(engaged);
+  }, []);
+
+  const closePopover = useCallback(() => handle.close(), [handle]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean, details: Popover.Root.ChangeEventDetails) => {
+      const reason = details.reason;
+
+      if (
+        pinnedRef.current &&
+        (reason === "trigger-hover" || reason === "focus-out")
+      ) {
+        details.cancel();
+        return;
+      }
+
+      if (open) {
+        return;
+      }
+
+      if (
+        pinnedRef.current &&
+        (reason === "escape-key" ||
+          reason === "outside-press" ||
+          reason === "trigger-press")
+      ) {
+        details.cancel();
+        requestGuarded(() => queueMicrotask(() => handle.close()));
+        return;
+      }
+
+      pinnedRef.current = false;
+      setPinned(false);
+    },
+    [handle, requestGuarded],
+  );
+
   return (
     <div
       className={cn(
@@ -119,79 +166,67 @@ export const TaskRow: React.FC<TaskRowProps> = ({
         </div>
       </div>
       {timeEntries.map((timeEntry, index) => {
-        if (!actionRefs.current[index]) {
-          actionRefs.current[index] = createRef<Popover.Root.Actions | null>();
-        }
-        const actionsRef = actionRefs.current[index];
-        const closePopover = () => actionsRef.current?.close();
-
         return (
           <div
             key={index}
             className="shrink-0 flex justify-end items-center text-base text-ink-gray-6 whitespace-nowrap w-16 h-7 pl-2 py-1.5"
           >
-            <Popover.Root actionsRef={actionsRef}>
-              <Popover.Trigger
-                openOnHover={!(timeEntry.disabled && timeEntry.time === "")}
-                render={(props) => (
-                  <Button
-                    {...props}
-                    variant="ghost"
-                    className={cn(
-                      "w-14.25 relative group flex justify-center items-center text-ink-gray-6 lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
-                      "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
-                      "aria-disabled:cursor-default! aria-disabled:text-ink-gray-5 aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent aria-disabled:active:bg-transparent",
-                    )}
-                    aria-disabled={timeEntry.disabled}
-                    onClick={() =>
-                      !timeEntry.disabled
-                        ? onCellClick?.(taskKey, index)
-                        : undefined
+            <Popover.Trigger
+              handle={handle}
+              payload={{ dayIndex: index }}
+              openOnHover={!(timeEntry.disabled && timeEntry.time === "")}
+              delay={250}
+              closeDelay={220}
+              render={(props, state) => (
+                <Button
+                  {...props}
+                  variant="ghost"
+                  className={cn(
+                    "w-14.25 relative group flex justify-center items-center text-ink-gray-6 lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
+                    "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
+                    "aria-disabled:cursor-default! aria-disabled:text-ink-gray-5 aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent aria-disabled:active:bg-transparent",
+                  )}
+                  aria-disabled={timeEntry.disabled}
+                  onClick={(event) => {
+                    if (!state.open) {
+                      props.onClick?.(event);
                     }
-                  >
-                    {timeEntry.time === "" ? (
-                      <>
-                        <span
-                          className={cn("flex-1 text-center text-ink-gray-4", {
-                            "group-hover:hidden group-disabled:group-hover:flex":
+                    if (!timeEntry.disabled) {
+                      onCellClick?.(taskKey, index);
+                    }
+                  }}
+                >
+                  {timeEntry.time === "" ? (
+                    <>
+                      <span
+                        className={cn("flex-1 text-center text-ink-gray-4", {
+                          "group-hover:hidden group-disabled:group-hover:flex":
+                            !timeEntry.disabled,
+                        })}
+                      >
+                        -
+                      </span>
+                      <span
+                        className={cn(
+                          "hidden absolute top-0 left-0 justify-center items-center w-full h-full",
+                          {
+                            "group-hover:flex group-disabled:group-hover:hidden":
                               !timeEntry.disabled,
-                          })}
-                        >
-                          -
-                        </span>
-                        <span
-                          className={cn(
-                            "hidden absolute top-0 left-0 justify-center items-center w-full h-full",
-                            {
-                              "group-hover:flex group-disabled:group-hover:hidden":
-                                !timeEntry.disabled,
-                            },
-                          )}
-                        >
-                          <AddMd size={16} className="" />
-                        </span>
-                      </>
-                    ) : (
-                      <span>{timeEntry.time}</span>
-                    )}
-                    {timeEntry.nonBillable ? (
-                      <span className="block absolute z-10 -bottom-0.5 left-1/2 w-1 h-1 rounded-full bg-surface-amber-3 transform -translate-x-1/2"></span>
-                    ) : null}
-                  </Button>
-                )}
-              />
-              <Popover.Portal>
-                <Popover.Positioner sideOffset={8} align="end">
-                  <Popover.Popup>
-                    {renderInlineTimeEntryPopover?.(
-                      taskKey,
-                      index,
-                      closePopover,
-                    )}
-                  </Popover.Popup>
-                </Popover.Positioner>
-              </Popover.Portal>
-            </Popover.Root>
+                          },
+                        )}
+                      >
+                        <AddMd size={16} className="" />
+                      </span>
+                    </>
+                  ) : (
+                    <span>{timeEntry.time}</span>
+                  )}
+                  {timeEntry.nonBillable ? (
+                    <span className="block absolute z-10 -bottom-0.5 left-1/2 w-1 h-1 rounded-full bg-surface-amber-3 transform -translate-x-1/2"></span>
+                  ) : null}
+                </Button>
+              )}
+            />
           </div>
         );
       })}
@@ -201,6 +236,28 @@ export const TaskRow: React.FC<TaskRowProps> = ({
       </div>
 
       <div className="w-12 h-7 shrink-0"></div>
+
+      <Popover.Root handle={handle} onOpenChange={handleOpenChange}>
+        {({ payload }) => (
+          <Popover.Portal>
+            {pinned ? (
+              <Popover.Backdrop className="fixed inset-0 pointer-events-auto!" />
+            ) : null}
+            <Popover.Positioner sideOffset={8} align="end">
+              <Popover.Popup>
+                {payload
+                  ? renderInlineTimeEntryPopover?.(
+                      taskKey,
+                      payload.dayIndex,
+                      closePopover,
+                      reportEngaged,
+                    )
+                  : null}
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        )}
+      </Popover.Root>
     </div>
   );
 };

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -166,6 +166,10 @@ export const TaskRow: React.FC<TaskRowProps> = ({
         </div>
       </div>
       {timeEntries.map((timeEntry, index) => {
+        const canOpenInlineTimeEntry = !(
+          timeEntry.disabled && timeEntry.time === ""
+        );
+
         return (
           <div
             key={index}
@@ -174,7 +178,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
             <Popover.Trigger
               handle={handle}
               payload={{ dayIndex: index }}
-              openOnHover={!(timeEntry.disabled && timeEntry.time === "")}
+              openOnHover={canOpenInlineTimeEntry}
               delay={250}
               closeDelay={220}
               render={(props, state) => (
@@ -188,7 +192,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
                   )}
                   aria-disabled={timeEntry.disabled}
                   onClick={(event) => {
-                    if (!state.open) {
+                    if (canOpenInlineTimeEntry && !state.open) {
                       props.onClick?.(event);
                     }
                     if (!timeEntry.disabled) {

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -84,6 +84,14 @@ export const TaskRow: React.FC<TaskRowProps> = ({
 
   const closePopover = useCallback(() => handle.close(), [handle]);
 
+  const requestClosePinnedPopover = useCallback(() => {
+    requestGuarded(() => {
+      pinnedRef.current = false;
+      setPinned(false);
+      queueMicrotask(() => handle.close());
+    });
+  }, [handle, requestGuarded]);
+
   const handleOpenChange = useCallback(
     (open: boolean, details: Popover.Root.ChangeEventDetails) => {
       const reason = details.reason;
@@ -107,14 +115,14 @@ export const TaskRow: React.FC<TaskRowProps> = ({
           reason === "trigger-press")
       ) {
         details.cancel();
-        requestGuarded(() => queueMicrotask(() => handle.close()));
+        requestClosePinnedPopover();
         return;
       }
 
       pinnedRef.current = false;
       setPinned(false);
     },
-    [handle, requestGuarded],
+    [requestClosePinnedPopover],
   );
 
   return (
@@ -245,7 +253,10 @@ export const TaskRow: React.FC<TaskRowProps> = ({
         {({ payload }) => (
           <Popover.Portal>
             {pinned ? (
-              <Popover.Backdrop className="fixed inset-0 pointer-events-auto!" />
+              <Popover.Backdrop
+                className="fixed inset-0 pointer-events-auto!"
+                onClick={requestClosePinnedPopover}
+              />
             ) : null}
             <Popover.Positioner sideOffset={8} align="end">
               <Popover.Popup className="relative before:absolute before:-left-12 before:-right-12 before:-bottom-12 before:top-0 before:content-['']">


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
* Fixed an issue where the popover would accidentally close when the user's cursor left the popover.
* Added keyboard support to open the popover using Enter and Space.
* Made the message input and the previously added time entry messages resizable.
* Added an unsaved changes confirmation dialog when the user clicks outside after making changes, preventing accidental data loss.
* Prevented the popover from closing when users click the Add Time button while the last time entries contain long message.
* Fixed the spacing and font size of the unsaved changes modal to match the design.
* Both hover and click on the cell opens the popover.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* Added a hook to keep the popover open while the user is resizing the `StaticTextEditor` or `TextEditor`, even if no changes have been made. This is required because otherwise the popover would close as soon as the user's cursor moves outside of it during resizing.
* The unsaved changes behavior for the timesheet popover is slightly different from the allocation pages.
  - When the user has unsaved changes, an invisible overlay is shown. This prevents them from clicking another timesheet cell, which would otherwise open a second popover. Clicking outside the popover or pressing Esc triggers the overlay and displays the unsaved changes confirmation dialog.
  - Because of this, the behavior differs from the allocation pages. On allocation pages, if the user clicks another link (for example, a Projects in the sidebar) and then chooses to discard their changes, they are automatically taken to that page.
  - In the timesheet popover, users must first discard or save their changes, then click the cell they want to open again.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/48e1ae88-a3b7-4d23-9c2c-c199d43971e8

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1545 #1553 #1561 #1583