### PR TITLE
Fix visibility of allocation bars in Safari

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -25,7 +25,7 @@ export interface GanttBarRenderState {
 }
 
 const ganttBarVariants = cva(
-  "group absolute shrink-0 flex items-center gap-1.5 rounded-[9px] mx-0.5 px-2.5 py-2 whitespace-nowrap",
+  "group pointer-events-auto absolute shrink-0 flex items-center gap-1.5 rounded-[9px] mx-0.5 px-2.5 py-2 whitespace-nowrap",
   {
     variants: {
       variant: {

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/rowAllocationOverlay.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/rowAllocationOverlay.tsx
@@ -227,7 +227,7 @@ export const RowAllocationOverlay = forwardRef<
           variant="subtle"
           aria-label="Add allocation"
           className={cn(
-            "absolute opacity-100 transition-opacity duration-100 ease-out motion-reduce:transition-none",
+            "pointer-events-auto absolute opacity-100 transition-opacity duration-100 ease-out motion-reduce:transition-none",
             "starting:opacity-0",
           )}
           style={{

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -13,6 +13,7 @@ import {
   type RowAllocationOverlayHandle,
 } from "./gantt-bar/rowAllocationOverlay";
 import { GanttMemberItem } from "./ganttMemberItem";
+import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
 import type { ProjectGroup, ProjectMember } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
@@ -47,7 +48,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
 
   return (
     <tr
-      className={cn("relative touch-pan-y", {
+      className={cn("touch-pan-y", {
         "pointer-events-none": !isExpanded,
       })}
       aria-hidden={!isExpanded}
@@ -80,7 +81,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
           style={{ height: animatedRowHeight }}
         />
       ))}
-      <td className="p-0 border-0 w-0 min-w-0 max-w-0" style={{ width: 0 }}>
+      <GanttRowOverlayCell height={animatedRowHeight}>
         {isExpanded &&
           member.allocations?.map((allocation, allocationIndex) => (
             // TODO: Restore project allocation capacity labels when this view consumes backend-computed employee capacity summaries.
@@ -112,7 +113,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
           })}
           onOpenAllocation={onAddAllocation}
         />
-      </td>
+      </GanttRowOverlayCell>
     </tr>
   );
 };

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -15,6 +15,7 @@ import {
 } from "./gantt-bar/rowAllocationOverlay";
 import { GanttMemberItem } from "./ganttMemberItem";
 import { GanttProjectRow } from "./ganttProjectRow";
+import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
 
@@ -58,12 +59,11 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
   const canEditAllocations = hasRoleAccess && Boolean(onEditAllocation);
   const memberRowKey = `member-${memberInd}`;
   const addProjectRowHeight = isExpanded ? ADD_PROJECT_ROW_HEIGHT : 0;
-
   return (
     <React.Fragment>
       {/* Member row */}
       <tr
-        className="relative touch-pan-y last:border-b border-outline-gray-1 animate-fade-in"
+        className="touch-pan-y last:border-b border-outline-gray-1 animate-fade-in"
         onPointerDown={(e) => overlayRef.current?.handleRowPointerDown(e)}
         onPointerMove={(e) => overlayRef.current?.handleRowPointerMove(e)}
         onPointerLeave={() => overlayRef.current?.clearHoveredSlot()}
@@ -79,7 +79,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
             style={{ height: CELL_HEIGHT }}
           />
         ))}
-        <td className="p-0 border-0 w-0 min-w-0 max-w-0" style={{ width: 0 }}>
+        <GanttRowOverlayCell>
           {member.memberSummaryBars.map((summary, idx) => (
             <GanttMemberSummaryBar
               key={idx}
@@ -100,7 +100,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
             })}
             onOpenAllocation={onAddAllocation}
           />
-        </td>
+        </GanttRowOverlayCell>
       </tr>
 
       {/* Project child rows */}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -119,7 +119,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
       {/* Add project row */}
       {canManageAllocations && (
         <tr
-          className={cn("relative", { "pointer-events-none": !isExpanded })}
+          className={cn("touch-pan-y", { "pointer-events-none": !isExpanded })}
           aria-hidden={!isExpanded}
         >
           <th
@@ -141,10 +141,14 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
                 })
               }
               tabIndex={isExpanded ? undefined : -1}
-              className="w-full h-full flex items-center gap-2 text-base font-medium text-ink-gray-8 overflow-hidden"
+              className="w-full flex items-center gap-2 text-base font-medium text-ink-gray-8 overflow-hidden"
             >
-              <AddMd className="size-4 shrink-0" />
-              <span className="truncate">Add project</span>
+              {isExpanded ? (
+                <>
+                  <AddMd className="size-4 shrink-0" />
+                  <span className="truncate">Add project</span>
+                </>
+              ) : null}
             </button>
           </th>
           {weeks.map((_, i) => (

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
@@ -81,7 +81,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
           key={i}
           colSpan={daysPerWeek}
           className={cn(
-            "dd overflow-hidden transition-[height] duration-200 ease-in-out",
+            "overflow-hidden transition-[height] duration-200 ease-in-out",
             { "border-r border-outline-gray-1": isExpanded },
           )}
           style={{ height: animatedRowHeight }}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
@@ -13,6 +13,7 @@ import {
   type RowAllocationOverlayHandle,
 } from "./gantt-bar/rowAllocationOverlay";
 import { GanttProjectItem } from "./ganttProjectItem";
+import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
 import type { Member } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
@@ -53,7 +54,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
 
   return (
     <tr
-      className={cn("relative touch-pan-y", {
+      className={cn("touch-pan-y", {
         "pointer-events-none": !isExpanded,
       })}
       aria-hidden={!isExpanded}
@@ -86,7 +87,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
           style={{ height: animatedRowHeight }}
         />
       ))}
-      <td className="p-0 border-0 w-0 min-w-0 max-w-0" style={{ width: 0 }}>
+      <GanttRowOverlayCell height={animatedRowHeight}>
         {isExpanded &&
           project.allocations?.map((alloc, allocIndex) => (
             <GanttAllocationBar
@@ -113,7 +114,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
           })}
           onOpenAllocation={onAddAllocation}
         />
-      </td>
+      </GanttRowOverlayCell>
     </tr>
   );
 };

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -15,6 +15,7 @@ import {
 } from "./gantt-bar/rowAllocationOverlay";
 import { GanttMemberRow } from "./ganttMemberRow";
 import { GanttProjectItem } from "./ganttProjectItem";
+import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
 import { mergeClassNames as cn } from "../../utils";
 
@@ -66,7 +67,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
   return (
     <React.Fragment>
       <tr
-        className="relative touch-pan-y last:border-b border-outline-gray-1 animate-fade-in"
+        className="touch-pan-y last:border-b border-outline-gray-1 animate-fade-in"
         onPointerDown={(e) => overlayRef.current?.handleRowPointerDown(e)}
         onPointerMove={(e) => overlayRef.current?.handleRowPointerMove(e)}
         onPointerLeave={() => overlayRef.current?.clearHoveredSlot()}
@@ -97,7 +98,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
             style={{ height: CELL_HEIGHT }}
           />
         ))}
-        <td className="p-0 border-0 w-0 min-w-0 max-w-0" style={{ width: 0 }}>
+        <GanttRowOverlayCell>
           {project.projectSummaryBars.map((summary, summaryIndex) => (
             <GanttProjectSummaryBar
               key={`${project.id ?? project.name}-summary-${summaryIndex}`}
@@ -119,7 +120,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
             })}
             onOpenAllocation={onAddAllocation}
           />
-        </td>
+        </GanttRowOverlayCell>
       </tr>
 
       {project.members?.map((member) => {

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -138,7 +138,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
 
       {canManageAllocations && (
         <tr
-          className={cn("relative", { "pointer-events-none": !isExpanded })}
+          className={cn("touch-pan-y", { "pointer-events-none": !isExpanded })}
           aria-hidden={!isExpanded}
         >
           <th
@@ -161,10 +161,14 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
                 })
               }
               tabIndex={isExpanded ? undefined : -1}
-              className="w-full h-full flex items-center gap-2 text-base font-medium text-ink-gray-8 overflow-hidden"
+              className="w-full flex items-center gap-2 text-base font-medium text-ink-gray-8 overflow-hidden"
             >
-              <AddMd className="size-4 shrink-0" />
-              <span className="truncate">Add member</span>
+              {isExpanded ? (
+                <>
+                  <AddMd className="size-4 shrink-0" />
+                  <span className="truncate">Add member</span>
+                </>
+              ) : null}
             </button>
           </th>
           {weeks.map((week, index) => (

--- a/frontend/packages/design-system/src/components/gantt-view/ganttRowOverlayCell.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttRowOverlayCell.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies.
+ */
+import type { ReactNode } from "react";
+
+/**
+ * Internal dependencies.
+ */
+import { CELL_HEIGHT } from "./constants";
+import { useGanttStore } from "./ganttStore";
+
+interface GanttRowOverlayCellProps {
+  children: ReactNode;
+  height?: number;
+}
+
+export function GanttRowOverlayCell({
+  children,
+  height = CELL_HEIGHT,
+}: GanttRowOverlayCellProps) {
+  const { headerWidth, columnWidth, columnCount } = useGanttStore((s) => ({
+    headerWidth: s.headerWidth,
+    columnWidth: s.columnWidth,
+    columnCount: s.columnCount,
+  }));
+
+  const rowWidth = headerWidth + columnWidth * columnCount;
+
+  return (
+    <td
+      className="relative p-0 border-0 w-0 min-w-0 max-w-0"
+      style={{ width: 0 }}
+    >
+      <div
+        className="pointer-events-none absolute top-0"
+        style={{
+          left: -rowWidth,
+          width: rowWidth,
+          height,
+        }}
+      >
+        {children}
+      </div>
+    </td>
+  );
+}


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
- This PR fixes Safari mispositioning of allocation bars caused by relying on `position: relative` on table rows.
- Safari does not reliably use `<tr>` as the containing block for absolutely positioned children, so allocation bars, summary bars, draft bars, and the add-allocation hover
  control could be positioned relative to the table instead of the intended row.
- This change introduces a valid table-cell based row overlay and renders row-level absolute Gantt elements inside that overlay instead of anchoring them to `<tr>`.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Added `GanttRowOverlayCell` as a shared wrapper for row-level absolute Gantt content.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1700" height="915" alt="Screenshot 2026-07-01 at 1 50 23 PM" src="https://github.com/user-attachments/assets/7e59df30-9799-4727-92ed-01ce0f95a831" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1670