### PR TITLE
Fix allocation modals to display correct hours per day

### DIFF
--- a/frontend/packages/app/src/global.css
+++ b/frontend/packages/app/src/global.css
@@ -55,7 +55,7 @@
 
   .scrollbar::-webkit-scrollbar-thumb {
     background: var(--color-surface-gray-4);
-    border-radius: 100%;
+    border-radius: 54px;
   }
 
   .scrollbar::-webkit-scrollbar-corner {
@@ -78,7 +78,7 @@
 
   .scrollbar-thin::-webkit-scrollbar-thumb {
     background: var(--color-surface-gray-4);
-    border-radius: 100%;
+    border-radius: 54px;
   }
 
   .scrollbar-thin::-webkit-scrollbar-corner {

--- a/frontend/packages/app/src/pages/allocations/overrideUtils.ts
+++ b/frontend/packages/app/src/pages/allocations/overrideUtils.ts
@@ -53,6 +53,10 @@ const normalizeRange = (startDate: string, endDate: string) =>
     ? { startDate, endDate }
     : { startDate: endDate, endDate: startDate };
 
+/**
+ * Checks if the proposed edit range is the same as the allocation's current range, ignoring hours-per-day.
+ * This is used to determine if the edit is a base-hours change or a day-override change.
+ */
 const isFullAllocationRangeEdit = ({
   allocation,
   next,

--- a/frontend/packages/app/src/pages/allocations/overrideUtils.ts
+++ b/frontend/packages/app/src/pages/allocations/overrideUtils.ts
@@ -32,6 +32,10 @@ type DayOverridePatch = {
   deletedDayOverrides: string[];
 };
 
+type ScheduleSelectionPayload = DayOverridePatch & {
+  allocationHoursPerDay: number;
+};
+
 /**
  * Lists every calendar date in an inclusive range as `yyyy-MM-dd` strings.
  */
@@ -48,6 +52,25 @@ const normalizeRange = (startDate: string, endDate: string) =>
   startDate <= endDate
     ? { startDate, endDate }
     : { startDate: endDate, endDate: startDate };
+
+const isFullAllocationRangeEdit = ({
+  allocation,
+  next,
+}: {
+  allocation: AllocationScheduleContext;
+  next: Pick<AllocationEditRange, "startDate" | "endDate">;
+}): boolean => {
+  const normalizedNextRange = normalizeRange(next.startDate, next.endDate);
+  const normalizedAllocationRange = normalizeRange(
+    allocation.allocationStartDate,
+    allocation.allocationEndDate,
+  );
+
+  return (
+    normalizedNextRange.startDate === normalizedAllocationRange.startDate &&
+    normalizedNextRange.endDate === normalizedAllocationRange.endDate
+  );
+};
 
 /**
  * Maps each date in the allocation range to its currently effective hours,
@@ -128,17 +151,32 @@ const buildDayOverrideDiff = (
 };
 
 /**
- * Builds the day-override patch for an Edit Schedule submission: sets the selected
- * date range to the chosen hours-per-day and diffs it against the allocation's current
- * effective hours, returning the add/edit and delete operations to send to the API.
+ * Builds the payload for an Edit Schedule submission. Full-allocation range edits
+ * update the allocation's base hours and partial edits become day-override diffs.
  */
-export const buildScheduleSelectionOverridePatch = ({
+export const buildScheduleSelectionPayload = ({
   allocation,
   next,
 }: {
   allocation: AllocationScheduleContext;
   next: AllocationEditRange;
-}): DayOverridePatch => {
+}): ScheduleSelectionPayload => {
+  const isBaseHoursEdit = isFullAllocationRangeEdit({
+    allocation,
+    next,
+  });
+
+  if (
+    isBaseHoursEdit &&
+    next.hoursPerDay !== allocation.allocationHoursPerDay
+  ) {
+    return {
+      allocationHoursPerDay: next.hoursPerDay,
+      dayOverrides: [],
+      deletedDayOverrides: [],
+    };
+  }
+
   const currentHoursByDate = buildEffectiveHoursByDate(allocation);
   const desiredHoursByDate = new Map(currentHoursByDate);
   const normalizedNextRange = normalizeRange(next.startDate, next.endDate);
@@ -150,9 +188,8 @@ export const buildScheduleSelectionOverridePatch = ({
     desiredHoursByDate.set(date, next.hoursPerDay);
   }
 
-  return buildDayOverrideDiff(
-    currentHoursByDate,
-    desiredHoursByDate,
-    allocation,
-  );
+  return {
+    allocationHoursPerDay: allocation.allocationHoursPerDay,
+    ...buildDayOverrideDiff(currentHoursByDate, desiredHoursByDate, allocation),
+  };
 };

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleDateSelectionField.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleDateSelectionField.tsx
@@ -66,7 +66,7 @@ function ScheduleDateSelectionField({
         </div>
 
         {showInlineRecurrenceHelper ? (
-          <p className="shrink-0 text-sm text-ink-gray-4">
+          <p className="shrink-0 text-sm text-ink-gray-4 px-3.5">
             {recurrenceHelperText}
           </p>
         ) : (
@@ -75,7 +75,7 @@ function ScheduleDateSelectionField({
       </div>
 
       {recurrenceHelperText && !showInlineRecurrenceHelper ? (
-        <p className="pl-0.5 text-sm text-ink-gray-4">{recurrenceHelperText}</p>
+        <p className="text-sm text-ink-gray-4">{recurrenceHelperText}</p>
       ) : null}
 
       {error ? <ErrorMessage message={error} /> : null}

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -16,7 +16,7 @@ import {
  */
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { propagationModeLabels } from "@/pages/allocations/constants";
-import { buildScheduleSelectionOverridePatch } from "@/pages/allocations/overrideUtils";
+import { buildScheduleSelectionPayload } from "@/pages/allocations/overrideUtils";
 import ScheduleDateSelectionField from "./components/scheduleDateSelectionField";
 import ScheduleHoursPerDayField from "./components/scheduleHoursPerDayField";
 import ScheduleSummaryTable from "./components/scheduleSummaryTable";
@@ -174,8 +174,8 @@ function EditScheduleModal({
         override: safeValues.override,
         schedule: value.schedule,
       });
-      const patch = draft.selection
-        ? buildScheduleSelectionOverridePatch({
+      const schedulePayload = draft.selection
+        ? buildScheduleSelectionPayload({
             allocation: allocationContext,
             next: {
               startDate: draft.selection.startDate,
@@ -183,7 +183,11 @@ function EditScheduleModal({
               hoursPerDay: draft.hoursPerDay,
             },
           })
-        : { dayOverrides: [], deletedDayOverrides: [] };
+        : {
+            allocationHoursPerDay: allocationContext.allocationHoursPerDay,
+            dayOverrides: [],
+            deletedDayOverrides: [],
+          };
 
       try {
         setSubmitting(true);
@@ -197,14 +201,14 @@ function EditScheduleModal({
             customer: initialValues.customer ?? "",
             allocation_start_date: allocationContext.allocationStartDate,
             allocation_end_date: allocationContext.allocationEndDate,
-            hours_allocated_per_day: allocationContext.allocationHoursPerDay,
+            hours_allocated_per_day: schedulePayload.allocationHoursPerDay,
             include_weekends: true,
             is_billable: Number(initialValues.isBillable ?? true),
             status: initialValues.isTentative ? "Tentative" : "Confirmed",
             note: initialValues.note ?? "",
           },
-          day_overrides: patch.dayOverrides,
-          deleted_day_overrides: patch.deletedDayOverrides,
+          day_overrides: schedulePayload.dayOverrides,
+          deleted_day_overrides: schedulePayload.deletedDayOverrides,
         });
         await onSuccess?.({
           ...(safeValues.employeeId
@@ -245,10 +249,10 @@ function EditScheduleModal({
     ],
   );
 
-  const overridePatch = useMemo(
+  const schedulePayload = useMemo(
     () =>
       allocationContext && scheduleDraft.selection
-        ? buildScheduleSelectionOverridePatch({
+        ? buildScheduleSelectionPayload({
             allocation: allocationContext,
             next: {
               startDate: scheduleDraft.selection.startDate,
@@ -256,12 +260,19 @@ function EditScheduleModal({
               hoursPerDay: scheduleDraft.hoursPerDay,
             },
           })
-        : { dayOverrides: [], deletedDayOverrides: [] },
-    [allocationContext, scheduleDraft],
+        : {
+            allocationHoursPerDay:
+              allocationContext?.allocationHoursPerDay ?? defaultHoursPerDay,
+            dayOverrides: [],
+            deletedDayOverrides: [],
+          },
+    [allocationContext, defaultHoursPerDay, scheduleDraft],
   );
-  const hasOverrideChange =
-    overridePatch.dayOverrides.length > 0 ||
-    overridePatch.deletedDayOverrides.length > 0;
+  const hasScheduleChange =
+    schedulePayload.dayOverrides.length > 0 ||
+    schedulePayload.deletedDayOverrides.length > 0 ||
+    schedulePayload.allocationHoursPerDay !==
+      allocationContext?.allocationHoursPerDay;
 
   useEffect(() => {
     if (!open) {
@@ -308,7 +319,7 @@ function EditScheduleModal({
                 label="Save changes"
                 onClick={() => form.handleSubmit()}
                 loading={submitting}
-                disabled={!hasOverrideChange || isSubmitting || submitting}
+                disabled={!hasScheduleChange || isSubmitting || submitting}
               />
             )}
           </form.Subscribe>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
 Fix Edit Schedule so full-allocation schedule edits update the allocation’s base hours instead of creating per-day overrides.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Previously, changing an allocation from 8h/day to 4h/day across the entire allocation range saved the change as day overrides while leaving hours_allocated_per_day as 8. Reopening Edit Allocation or
  Edit Schedule then still showed 8h/day from the base allocation value.
- This change makes full-range schedule edits update hours_allocated_per_day directly. Partial schedule edits continue to use day overrides.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/30dc03e2-6fea-4213-b47e-590bcfcb077e



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1678