### PR TITLE
QA Fix: Allow Resubmitting Partially Approved, Rejected, and Partially Rejected Timesheets

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
@@ -7,6 +7,7 @@ import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
 import {
   WeekRow as BaseWeekRow,
   ApprovalStatusMap,
+  approvalStatusCanSubmitMap,
   totalHoursThemeMap,
 } from "@next-pms/design-system/components";
 import { getTodayDate, prettyDate } from "@next-pms/design-system/date";
@@ -100,6 +101,9 @@ export const WeekRow = ({
       : `· ${approvalPendingCount} pending ${
           approvalPendingCount === 1 ? "approval" : "approvals"
         }`;
+  const approvalStatus = status ? ApprovalStatusMap[status] : "none";
+  const canSubmitForApproval =
+    !isReadOnlyWeek && approvalStatusCanSubmitMap[approvalStatus];
 
   return (
     <Accordion.Root
@@ -121,15 +125,11 @@ export const WeekRow = ({
                 dates={formattedDates}
                 totalHours={floatToTime(weekData.total, 2)}
                 totalHoursTheme={totalHoursThemeMap[weekData.isExtended]}
-                status={status ? ApprovalStatusMap[status] : "none"}
+                status={approvalStatus}
                 badgeLabel={pendingApprovalLabel}
                 collapsed={collapsed}
                 onButtonClick={() =>
-                  !isReadOnlyWeek &&
-                  status &&
-                  ApprovalStatusMap[status] === "not-submitted"
-                    ? onButtonClick?.()
-                    : undefined
+                  canSubmitForApproval ? onButtonClick?.() : undefined
                 }
               />
             </div>
@@ -142,7 +142,7 @@ export const WeekRow = ({
             totalTimeEntries: weekData.totalTimeEntries,
             totalTimeEntriesInHours: weekData.totalTimeEntriesInHours,
             dailyWorkingHours: weekData.dailyWorkingHours,
-            status: status ? ApprovalStatusMap[status] : "none",
+            status: approvalStatus,
           })}
         </Accordion.Panel>
       </Accordion.Item>

--- a/frontend/packages/design-system/src/components/timesheet/index.ts
+++ b/frontend/packages/design-system/src/components/timesheet/index.ts
@@ -15,6 +15,7 @@ export {
   ApprovalStatusLabelMap,
   ApprovalStatusDisplayLabelMap,
   ApprovalStatusMap,
+  approvalStatusActionLabelMap,
   approvalStatusCanSubmitMap,
   taskStatusMap,
 } from "./rows/constants";

--- a/frontend/packages/design-system/src/components/timesheet/index.ts
+++ b/frontend/packages/design-system/src/components/timesheet/index.ts
@@ -15,5 +15,6 @@ export {
   ApprovalStatusLabelMap,
   ApprovalStatusDisplayLabelMap,
   ApprovalStatusMap,
+  approvalStatusCanSubmitMap,
   taskStatusMap,
 } from "./rows/constants";

--- a/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
@@ -83,6 +83,16 @@ export const ApprovalStatusMap: Record<
   None: "none",
 };
 
+export const approvalStatusCanSubmitMap: Record<ApprovalStatusType, boolean> = {
+  "not-submitted": true,
+  approved: false,
+  rejected: true,
+  "approval-pending": false,
+  "partially-approved": true,
+  "partially-rejected": true,
+  none: false,
+};
+
 export const taskStatusMap: Record<string, TaskStatusType> = {
   Open: "open",
   Working: "working",

--- a/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
@@ -93,6 +93,15 @@ export const approvalStatusCanSubmitMap: Record<ApprovalStatusType, boolean> = {
   none: false,
 };
 
+export const approvalStatusActionLabelMap: Partial<
+  Record<ApprovalStatusType, string>
+> = {
+  "not-submitted": "Submit for approval",
+  rejected: "Resubmit for approval",
+  "partially-approved": "Resubmit for approval",
+  "partially-rejected": "Resubmit for approval",
+};
+
 export const taskStatusMap: Record<string, TaskStatusType> = {
   Open: "open",
   Working: "working",

--- a/frontend/packages/design-system/src/components/timesheet/rows/week/weekRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/week/weekRow.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import React from "react";
-import { Badge, Button } from "@rtcamp/frappe-ui-react";
+import { Badge, Button, Tooltip } from "@rtcamp/frappe-ui-react";
 import { SmallDown } from "@rtcamp/frappe-ui-react/icons";
 
 /**
@@ -17,6 +17,7 @@ import {
   type ApprovalStatusType,
   approvalStatusTheme,
   approvalStatusIcon,
+  approvalStatusActionLabelMap,
 } from "../constants";
 
 export interface WeekRowProps {
@@ -58,6 +59,9 @@ export const WeekRow: React.FC<WeekRowProps> = ({
   className,
 }) => {
   const isStatusNone = status === "none";
+  const actionLabel =
+    approvalStatusActionLabelMap[status] ??
+    ApprovalStatusDisplayLabelMap[status];
 
   return (
     <div
@@ -129,28 +133,29 @@ export const WeekRow: React.FC<WeekRowProps> = ({
 
       <div className="flex items-center justify-end w-12 shrink-0 h-7 whitespace-nowrap">
         {!isStatusNone ? (
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onButtonClick?.();
-            }}
-            className={cn(
-              buttonVariants({
-                status,
-                thisWeek,
-                variant: approvalStatusIcon[status]?.variant,
-                collapsed,
-              }),
-            )}
-            variant={approvalStatusIcon[status]?.variant}
-            size="sm"
-            icon={() => {
-              const IconComponent = approvalStatusIcon[status]?.icon;
-              return IconComponent ? <IconComponent size={16} /> : null;
-            }}
-            aria-label="Submit week"
-            title={ApprovalStatusDisplayLabelMap[status]}
-          />
+          <Tooltip text={actionLabel}>
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onButtonClick?.();
+              }}
+              className={cn(
+                buttonVariants({
+                  status,
+                  thisWeek,
+                  variant: approvalStatusIcon[status]?.variant,
+                  collapsed,
+                }),
+              )}
+              variant={approvalStatusIcon[status]?.variant}
+              size="sm"
+              icon={() => {
+                const IconComponent = approvalStatusIcon[status]?.icon;
+                return IconComponent ? <IconComponent size={16} /> : null;
+              }}
+              aria-label={actionLabel}
+            />
+          </Tooltip>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
- Allow Resubmitting Partially Approved, Rejected, and Partially Rejected Timesheets
- Added tooltips to the buttons to indicate that the timesheets can be resubmitted.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/f671ebd0-1db8-4608-824e-b6294d8c47a8



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1575