### PR TITLE
fix: team allocation entries and project view for open projects

### DIFF
--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -421,7 +421,6 @@ def _get_resource_management_team_view_data(
         dates[-1].get("end_date"),
         is_billable=is_billable,
         allocation_status=allocation_status,
-        is_need_fetch_all_weeks=not need_hours_summary,
     )
     resource_allocation_data = attach_extra_entries(resource_allocation_data)
 

--- a/next_pms/resource_management/api/utils/helpers.py
+++ b/next_pms/resource_management/api/utils/helpers.py
@@ -388,6 +388,9 @@ def filter_project_list(
 
     conditions = []
 
+    # Closed projects (Completed / Cancelled) are excluded from the resource view.
+    conditions.append(["status", "not in", ["Completed", "Cancelled"]])
+
     if ids:
         conditions.append(["name", "in", ids])
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -13,17 +13,10 @@ def get_allocation_list_for_employee_for_given_range(
     end_date: str | datetime.date,
     is_billable: list | int | None = None,
     allocation_status: list | None = None,
-    is_need_fetch_all_weeks: bool = False,
 ) -> list[dict]:
     """Return Resource Allocation records for a list of employees or projects.
 
-    Supports two fetching strategies controlled by `is_need_fetch_all_weeks`:
-
-    - is_need_fetch_all_weeks=True: fetches ALL allocations for the given employees/
-      projects with no date filter. `start_date` and `end_date` are ignored.
-
-    - is_need_fetch_all_weeks=False (default): fetches only allocations that overlap
-      the [start_date, end_date] window.
+    Fetches only allocations that overlap the [start_date, end_date] window.
 
     Args:
         columns (list[str]): Fields to SELECT from the Resource Allocation doctype.
@@ -31,17 +24,13 @@ def get_allocation_list_for_employee_for_given_range(
             `values` against.
         values (list): List of employee IDs or project names to filter by.
             Returns [] immediately if empty.
-        start_date (str | datetime.date): Range start. Ignored when
-            `is_need_fetch_all_weeks` is True.
-        end_date (str | datetime.date): Range end. Ignored when
-            `is_need_fetch_all_weeks` is True.
+        start_date (str | datetime.date): Range start.
+        end_date (str | datetime.date): Range end.
         is_billable (list | int | None): Billable filter. Use ``[0]``, ``[1]``, or ``[0, 1]``.
             Legacy callers may pass ``0`` or ``1``; ``-1`` means no filter. ``None`` or
             ``[]`` also skips the filter. Defaults to None.
         allocation_status (list | None): Status values to match, e.g. ``["Confirmed", "Tentative"]``.
             ``None`` or ``[]`` skips the filter. Defaults to None.
-        is_need_fetch_all_weeks (bool): When True, skips the date range filter and
-            returns all allocations for the given employees/projects. Defaults to False.
 
     Returns:
         ```py
@@ -68,27 +57,6 @@ def get_allocation_list_for_employee_for_given_range(
     """
     if not values:
         return []
-
-    if is_need_fetch_all_weeks:
-        filters = {}
-
-        if value_key == "employee":
-            filters["employee"] = ["in", values]
-        else:
-            filters["project"] = ["in", values]
-
-        billable_values = _normalize_is_billable_filter(is_billable)
-        if billable_values:
-            filters["is_billable"] = ["in", billable_values]
-        if allocation_status:
-            filters["status"] = ["in", allocation_status]
-
-        return frappe.db.get_all(
-            "Resource Allocation",
-            filters=filters,
-            fields=columns,
-            order_by="employee_name, allocation_start_date, allocation_end_date",
-        )
 
     ResourceAllocation = frappe.qb.DocType("Resource Allocation")
     filter_column = ResourceAllocation.employee if value_key == "employee" else ResourceAllocation.project

--- a/next_pms/tests/resource_management/api/test_project_view.py
+++ b/next_pms/tests/resource_management/api/test_project_view.py
@@ -1,0 +1,332 @@
+import json
+
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.resource_management.api.project import get_resource_management_project_view_data
+
+WRITE_USER = "pv.write@example.com"
+READ_ONLY_USER = "pv.readonly@example.com"
+
+# A Monday, so the derived window is [2026-06-15, 2026-06-28] for max_week=2.
+DATE = "2026-06-15"
+WINDOW_START = "2026-06-15"
+WINDOW_END = "2026-06-28"
+
+
+class _ProjectViewBase(IntegrationTestCase):
+    """Shared fixture factories for the project-view endpoint tests.
+
+    All filter assertions run as a write user (Projects User role); the endpoint blanks
+    every filter except project_name for non-write callers.
+    """
+
+    @classmethod
+    def _make_user(cls, email, projects_user=False):
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                    "user_type": "System User",
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        if projects_user:
+            frappe.get_doc("User", email).add_roles("Projects User")
+        return email
+
+    @classmethod
+    def _make_employee(cls, employee_name, user_id=None):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": employee_name,
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                # The rtcamp Employee doc-event derives leave_approver from reports_to
+                # when left blank and errors on a None reports_to; set it up front.
+                "leave_approver": "Administrator",
+                "user_id": user_id,
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _make_customer(cls, customer_name):
+        existing = frappe.db.get_value("Customer", {"customer_name": customer_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": customer_name,
+                    "customer_type": "Company",
+                    "default_currency": frappe.get_cached_value("Company", cls.company, "default_currency"),
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project_type(cls, project_type):
+        if not frappe.db.exists("Project Type", project_type):
+            frappe.get_doc({"doctype": "Project Type", "project_type": project_type}).insert(ignore_permissions=True)
+        return project_type
+
+    @classmethod
+    def _make_project(
+        cls,
+        project_name,
+        customer,
+        status="Open",
+        billing_type="Non-Billable",
+        project_type=None,
+        project_manager=None,
+        tags=(),
+    ):
+        doc = frappe.get_doc(
+            {
+                "doctype": "Project",
+                "project_name": project_name,
+                "company": cls.company,
+                "customer": customer,
+                "custom_billing_type": billing_type,
+                "status": status,
+            }
+        )
+        if project_type:
+            doc.project_type = project_type
+        if project_manager:
+            doc.custom_project_manager = project_manager
+        doc.insert(ignore_permissions=True)
+        for tag in tags:
+            doc.add_tag(tag)
+        return doc.name
+
+    @classmethod
+    def _make_allocation(cls, employee, project, start, end, is_billable=0, status="Confirmed"):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Resource Allocation",
+                    "employee": employee,
+                    "project": project,
+                    "allocation_start_date": start,
+                    "allocation_end_date": end,
+                    "hours_allocated_per_day": 8,
+                    "status": status,
+                    "is_billable": is_billable,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def _call(self, user=WRITE_USER, **kwargs):
+        frappe.set_user(user)
+        return get_resource_management_project_view_data(date=DATE, **kwargs)
+
+    def _entry(self, result, project_id):
+        return next(entry for entry in result["data"] if entry["name"] == project_id)
+
+    def _project_ids(self, result):
+        return {entry["name"] for entry in result["data"]}
+
+
+class TestProjectViewProjectListFilters(_ProjectViewBase):
+    """Which projects the project view returns — filter_project_list branches."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(WRITE_USER, projects_user=True)
+
+        # Read-only user only clears the endpoint's role gate via the Employee role.
+        cls.read_only_user = cls._make_user(READ_ONLY_USER)
+        cls._make_employee("PV Readonly", user_id=cls.read_only_user)
+
+        cls.pm_a = cls._make_user("pv.pm.a@example.com")
+        cls.pm_b = cls._make_user("pv.pm.b@example.com")
+        cls.type_ext = cls._make_project_type("QA External")
+        cls.type_int = cls._make_project_type("QA Internal")
+
+        # A scope customer carries most single-attribute-varying projects so filters can
+        # be ANDed with customer=[C_main] to isolate the fixtures from the rest of the DB.
+        cls.c_main = cls._make_customer("PV Main Customer")
+        cls.c_other = cls._make_customer("PV Other Customer")
+
+        cls.p_alpha = cls._make_project(
+            "PV Alpha Portal",
+            cls.c_main,
+            billing_type="Time and Material",
+            project_type=cls.type_ext,
+            project_manager=cls.pm_a,
+            tags=["pv-tag-a"],
+        )
+        cls.p_beta = cls._make_project(
+            "PV Beta Portal",
+            cls.c_main,
+            billing_type="Fixed Cost",
+            project_type=cls.type_int,
+            project_manager=cls.pm_b,
+            tags=["pv-tag-b"],
+        )
+        cls.p_completed = cls._make_project("PV Gamma Portal", cls.c_main, status="Completed")
+        cls.p_cancelled = cls._make_project("PV Delta Portal", cls.c_main, status="Cancelled")
+        cls.p_other = cls._make_project("PV Epsilon Portal", cls.c_other)
+
+        frappe.clear_cache()
+
+    def test_closed_projects_excluded(self):
+        result = self._call(customer=self.c_main)
+        self.assertEqual(self._project_ids(result), {self.p_alpha, self.p_beta})
+        self.assertEqual(result["total_count"], 2)
+
+    def test_project_name_like(self):
+        result = self._call(project_name="Alpha Portal")
+        self.assertEqual(self._project_ids(result), {self.p_alpha})
+
+    def test_customer_single_and_multi(self):
+        single = self._call(customer=self.c_other)
+        self.assertEqual(self._project_ids(single), {self.p_other})
+
+        both = self._call(customer=json.dumps([self.c_main, self.c_other]))
+        self.assertEqual(both["total_count"], 3)  # 2 open under c_main + 1 under c_other
+        self.assertEqual(self._project_ids(both), {self.p_alpha, self.p_beta, self.p_other})
+
+    def test_billing_type(self):
+        result = self._call(customer=self.c_main, billing_type=json.dumps(["Fixed Cost"]))
+        self.assertEqual(self._project_ids(result), {self.p_beta})
+
+    def test_project_type(self):
+        result = self._call(customer=self.c_main, project_type=json.dumps([self.type_ext]))
+        self.assertEqual(self._project_ids(result), {self.p_alpha})
+
+    def test_project_manager(self):
+        result = self._call(customer=self.c_main, project_manager=json.dumps([self.pm_b]))
+        self.assertEqual(self._project_ids(result), {self.p_beta})
+
+    def test_tag(self):
+        result = self._call(tag=json.dumps(["pv-tag-a"]))
+        self.assertEqual(self._project_ids(result), {self.p_alpha})
+
+    def test_project_id_short_circuits_dedicated_but_keeps_status_exclusion(self):
+        # A closed project passed via project_id is still dropped by the status filter,
+        # and the dedicated project_name filter is ignored when project_id is set.
+        result = self._call(
+            project_id=json.dumps([self.p_alpha, self.p_completed]),
+            project_name="no-such-name",
+        )
+        self.assertEqual(self._project_ids(result), {self.p_alpha})
+
+    def test_composite_filter_operators(self):
+        eq = self._call(filters=json.dumps([["customer", "=", self.c_main], ["project_name", "like", "Beta"]]))
+        self.assertEqual(self._project_ids(eq), {self.p_beta})
+
+        neq = self._call(filters=json.dumps([["customer", "=", self.c_main], ["project_name", "not like", "Beta"]]))
+        self.assertEqual(self._project_ids(neq), {self.p_alpha})
+
+    def test_pagination(self):
+        page1 = self._call(customer=self.c_main, page_length=1, start=0)
+        self.assertEqual(len(page1["data"]), 1)
+        self.assertEqual(page1["total_count"], 2)
+        self.assertTrue(page1["has_more"])
+
+        page2 = self._call(customer=self.c_main, page_length=1, start=1)
+        self.assertEqual(len(page2["data"]), 1)
+        self.assertEqual(page2["total_count"], 2)
+        self.assertFalse(page2["has_more"])
+
+    def test_non_write_user_ignores_filters_except_name(self):
+        # customer=[c_other] would exclude p_alpha (under c_main) if honored; a read-only
+        # caller must ignore it and still return p_alpha via the name filter.
+        result = self._call(user=READ_ONLY_USER, customer=self.c_other, project_name="Alpha Portal")
+        self.assertFalse(result["permissions"]["write"])
+        self.assertIn(self.p_alpha, self._project_ids(result))
+
+
+class TestProjectViewAllocationFilters(_ProjectViewBase):
+    """The per-project allocation breakdown — allocation query branches.
+
+    These filters change which allocations appear (project_allocations), not which
+    projects are returned.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(WRITE_USER, projects_user=True)
+        cls.customer = cls._make_customer("PV Alloc Customer")
+        cls.project = cls._make_project("PV Alloc Portal", cls.customer)
+        cls.employee = cls._make_employee("PV Alloc Employee")
+
+        # In-window allocations.
+        cls.a_billable = cls._make_allocation(
+            cls.employee, cls.project, WINDOW_START, "2026-06-19", is_billable=1, status="Confirmed"
+        )
+        cls.a_nonbillable = cls._make_allocation(
+            cls.employee, cls.project, "2026-06-16", "2026-06-20", is_billable=0, status="Tentative"
+        )
+        # End == window start: inclusive overlap keeps it.
+        cls.a_boundary = cls._make_allocation(
+            cls.employee, cls.project, "2026-06-10", WINDOW_START, is_billable=1, status="Confirmed"
+        )
+        # Out-of-window allocations that must be excluded.
+        cls.a_before = cls._make_allocation(
+            cls.employee, cls.project, "2026-06-01", "2026-06-07", is_billable=1, status="Confirmed"
+        )
+        cls.a_after = cls._make_allocation(
+            cls.employee, cls.project, "2026-07-01", "2026-07-05", is_billable=0, status="Tentative"
+        )
+
+        frappe.clear_cache()
+
+    def _allocation_names(self, **kwargs):
+        result = self._call(project_id=json.dumps([self.project]), **kwargs)
+        return set(self._entry(result, self.project)["project_allocations"].keys())
+
+    def test_out_of_window_allocations_excluded(self):
+        names = self._allocation_names()
+        self.assertEqual(names, {self.a_billable, self.a_nonbillable, self.a_boundary})
+        self.assertNotIn(self.a_before, names)
+        self.assertNotIn(self.a_after, names)
+
+    def test_is_billable_one_keeps_only_billable(self):
+        names = self._allocation_names(is_billable="1")
+        self.assertEqual(names, {self.a_billable, self.a_boundary})
+
+    def test_is_billable_zero_is_honored(self):
+        # 0 must be a real filter, not swallowed like the -1/None "no filter" sentinel.
+        names = self._allocation_names(is_billable="0")
+        self.assertEqual(names, {self.a_nonbillable})
+
+    def test_allocation_status_filter(self):
+        confirmed = self._allocation_names(allocation_status=json.dumps(["Confirmed"]))
+        self.assertEqual(confirmed, {self.a_billable, self.a_boundary})
+
+        tentative = self._allocation_names(allocation_status=json.dumps(["Tentative"]))
+        self.assertEqual(tentative, {self.a_nonbillable})
+
+    def test_allocation_filters_do_not_drop_the_project(self):
+        # Even a status that matches nothing in-window leaves the project in the payload.
+        result = self._call(
+            project_id=json.dumps([self.project]), is_billable="0", allocation_status=json.dumps(["Confirmed"])
+        )
+        self.assertIn(self.project, self._project_ids(result))
+        self.assertEqual(self._entry(result, self.project)["project_allocations"], {})

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -150,3 +150,342 @@ class TestTeamViewTagFilter(IntegrationTestCase):
         self.assertFalse(permissions["write"])
         self.assertEqual(names, ["Aarav Sharma", "Diya Sharma", "Kabir Sharma", "Meera Sharma"])
         self.assertEqual(total_count, 4)
+
+
+# A Monday, so the derived window is [2026-06-15, 2026-06-28] for max_week=2.
+TEAM_DATE = "2026-06-15"
+TEAM_WINDOW_START = "2026-06-15"
+
+FILTER_WRITE_USER = "tv.write@example.com"
+FILTER_READ_ONLY_USER = "tv.readonly@example.com"
+
+
+class _TeamViewBase(IntegrationTestCase):
+    """Shared fixture factories for the team-view filter tests.
+
+    Filter assertions run as a write user (Projects User role); the endpoint blanks every
+    filter except employee_name for non-write callers.
+    """
+
+    @classmethod
+    def _make_user(cls, email, projects_user=False):
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                    "user_type": "System User",
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        if projects_user:
+            frappe.get_doc("User", email).add_roles("Projects User")
+        return email
+
+    @classmethod
+    def _make_master(cls, doctype, name_field, name):
+        if not frappe.db.exists(doctype, name):
+            frappe.get_doc({"doctype": doctype, name_field: name}).insert(ignore_permissions=True)
+        return name
+
+    @classmethod
+    def _make_employee(
+        cls,
+        employee_name,
+        user_id=None,
+        designation=None,
+        business_unit=None,
+        reports_to=None,
+        skills=(),
+    ):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": employee_name,
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                "leave_approver": "Administrator",
+                "user_id": user_id,
+                "designation": designation,
+                "custom_business_unit": business_unit,
+                "reports_to": reports_to,
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        if skills:
+            # Employee Skill Map is named by employee, so its Employee Skill children carry
+            # the employee id as their parent — which is what get_employees_by_skills reads.
+            for skill_name, _ in skills:
+                cls._make_master("Skill", "skill_name", skill_name)
+            frappe.get_doc(
+                {
+                    "doctype": "Employee Skill Map",
+                    "employee": employee.name,
+                    "employee_skills": [
+                        {"skill": skill_name, "proficiency": proficiency} for skill_name, proficiency in skills
+                    ],
+                }
+            ).insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _make_customer(cls, customer_name):
+        existing = frappe.db.get_value("Customer", {"customer_name": customer_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": customer_name,
+                    "customer_type": "Company",
+                    "default_currency": frappe.get_cached_value("Company", cls.company, "default_currency"),
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project(cls, project_name, customer):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": project_name,
+                    "company": cls.company,
+                    "customer": customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_allocation(cls, employee, project, start, end, is_billable=0, status="Confirmed"):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Resource Allocation",
+                    "employee": employee,
+                    "project": project,
+                    "allocation_start_date": start,
+                    "allocation_end_date": end,
+                    "hours_allocated_per_day": 8,
+                    "status": status,
+                    "is_billable": is_billable,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def _call(self, user=FILTER_WRITE_USER, **kwargs):
+        frappe.set_user(user)
+        return get_resource_management_team_view_data(date=TEAM_DATE, **kwargs)
+
+    def _names(self, result):
+        return sorted(employee["employee_name"] for employee in result["employees"])
+
+
+class TestTeamViewEmployeeFilters(_TeamViewBase):
+    """Which employees the team view returns — filter_employees + skill/id resolution."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
+        cls.read_only_user = cls._make_user(FILTER_READ_ONLY_USER)
+        # Read-only employee is not "Tvf"-named, so it never appears in the scoped assertions.
+        cls._make_employee("Tv Readonly", user_id=cls.read_only_user)
+
+        cls.bu_alpha = cls._make_master("Business Unit", "business_unit_name", "Tvf BU Alpha")
+        cls.bu_beta = cls._make_master("Business Unit", "business_unit_name", "Tvf BU Beta")
+        cls.desig_alpha = cls._make_master("Designation", "designation_name", "Tvf Desig Alpha")
+        cls.desig_beta = cls._make_master("Designation", "designation_name", "Tvf Desig Beta")
+
+        cls.mgr = cls._make_employee("Tvf Mgr", designation=cls.desig_beta, business_unit=cls.bu_beta)
+        cls.alpha = cls._make_employee(
+            "Tvf Alpha", designation=cls.desig_alpha, business_unit=cls.bu_alpha, skills=[("TvfPython", 0.8)]
+        )
+        cls.beta = cls._make_employee(
+            "Tvf Beta",
+            designation=cls.desig_beta,
+            business_unit=cls.bu_beta,
+            reports_to=cls.mgr,
+            skills=[("TvfReact", 0.7)],
+        )
+        cls.gamma = cls._make_employee(
+            "Tvf Gamma",
+            designation=cls.desig_alpha,
+            business_unit=cls.bu_alpha,
+            reports_to=cls.mgr,
+            skills=[("TvfPython", 0.6), ("TvfReact", 0.9)],
+        )
+
+        frappe.clear_cache()
+
+    def test_employee_name_like(self):
+        result = self._call(employee_name="Tvf Alpha")
+        self.assertEqual(self._names(result), ["Tvf Alpha"])
+
+    def test_designation(self):
+        result = self._call(employee_name="Tvf", designation=json.dumps([self.desig_alpha]))
+        self.assertEqual(self._names(result), ["Tvf Alpha", "Tvf Gamma"])
+
+    def test_business_unit(self):
+        result = self._call(employee_name="Tvf", business_unit=json.dumps([self.bu_beta]))
+        self.assertEqual(self._names(result), ["Tvf Beta", "Tvf Mgr"])
+
+    def test_reports_to(self):
+        result = self._call(employee_name="Tvf", reports_to=json.dumps([self.mgr]))
+        self.assertEqual(self._names(result), ["Tvf Beta", "Tvf Gamma"])
+
+    def test_employee_id(self):
+        result = self._call(employee_id=json.dumps([self.alpha, self.beta]))
+        self.assertEqual(self._names(result), ["Tvf Alpha", "Tvf Beta"])
+
+    def test_employee_id_takes_priority_over_skills(self):
+        result = self._call(
+            employee_id=json.dumps([self.alpha]),
+            skills=json.dumps([{"name": "TvfPython", "operator": ">=", "proficiency": 0.5}]),
+        )
+        self.assertEqual(self._names(result), ["Tvf Alpha"])
+
+    def test_skills_param(self):
+        result = self._call(
+            employee_name="Tvf",
+            skills=json.dumps([{"name": "TvfReact", "operator": ">=", "proficiency": 0.5}]),
+        )
+        self.assertEqual(self._names(result), ["Tvf Beta", "Tvf Gamma"])
+
+    def test_composite_filter_designation_operators(self):
+        eq = self._call(filters=json.dumps([["designation", "=", self.desig_alpha], ["employee_name", "like", "Tvf"]]))
+        self.assertEqual(self._names(eq), ["Tvf Alpha", "Tvf Gamma"])
+
+        neq = self._call(
+            filters=json.dumps([["designation", "!=", self.desig_alpha], ["employee_name", "like", "Tvf"]])
+        )
+        self.assertEqual(self._names(neq), ["Tvf Beta", "Tvf Mgr"])
+
+    def test_composite_filter_skills(self):
+        result = self._call(filters=json.dumps([["skills", "=", "TvfPython"], ["employee_name", "like", "Tvf"]]))
+        self.assertEqual(self._names(result), ["Tvf Alpha", "Tvf Gamma"])
+
+    def test_pagination(self):
+        page1 = self._call(employee_name="Tvf", page_length=2, start=0)
+        self.assertEqual(len(page1["employees"]), 2)
+        self.assertEqual(page1["total_count"], 4)
+        self.assertTrue(page1["has_more"])
+
+        page2 = self._call(employee_name="Tvf", page_length=2, start=2)
+        self.assertEqual(len(page2["employees"]), 2)
+        self.assertEqual(page2["total_count"], 4)
+        self.assertFalse(page2["has_more"])
+
+    def test_non_write_user_ignores_filters_except_name(self):
+        # business_unit=[bu_alpha] would drop Beta/Mgr if honored; a read-only caller must
+        # ignore it and return all four Tvf employees via the name filter.
+        result = self._call(user=FILTER_READ_ONLY_USER, employee_name="Tvf", business_unit=json.dumps([self.bu_alpha]))
+        self.assertFalse(result["permissions"]["write"])
+        self.assertEqual(self._names(result), ["Tvf Alpha", "Tvf Beta", "Tvf Gamma", "Tvf Mgr"])
+
+
+class TestTeamViewAllocationFilters(_TeamViewBase):
+    """Allocation-driven narrowing — is_billable / allocation_status / date window.
+
+    These narrow the employee set to those with a matching in-window allocation before
+    pagination (team.py). Employee sets are scoped with employee_id for determinism.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
+        cls.customer = cls._make_customer("TV Alloc Customer")
+        cls.project = cls._make_project("TV Alloc Portal", cls.customer)
+
+        cls.emp_billable = cls._make_employee("Tva Billable")
+        cls.emp_nonbillable = cls._make_employee("Tva Nonbillable")
+        cls.emp_out = cls._make_employee("Tva OutOfWindow")
+
+        cls._make_allocation(
+            cls.emp_billable, cls.project, TEAM_WINDOW_START, "2026-06-19", is_billable=1, status="Confirmed"
+        )
+        cls._make_allocation(
+            cls.emp_nonbillable, cls.project, "2026-06-16", "2026-06-20", is_billable=0, status="Tentative"
+        )
+        # Billable but entirely after the window — must not qualify the employee.
+        cls._make_allocation(cls.emp_out, cls.project, "2026-07-01", "2026-07-05", is_billable=1, status="Confirmed")
+
+        cls.all_ids = json.dumps([cls.emp_billable, cls.emp_nonbillable, cls.emp_out])
+        frappe.clear_cache()
+
+    def test_is_billable_one_only_in_window(self):
+        result = self._call(employee_id=self.all_ids, is_billable=json.dumps([1]))
+        self.assertEqual(self._names(result), ["Tva Billable"])
+
+    def test_is_billable_zero_is_honored(self):
+        # A [0] filter must narrow to non-billable, not be treated as "no filter".
+        result = self._call(employee_id=self.all_ids, is_billable=json.dumps([0]))
+        self.assertEqual(self._names(result), ["Tva Nonbillable"])
+
+    def test_allocation_status_filter(self):
+        confirmed = self._call(employee_id=self.all_ids, allocation_status=json.dumps(["Tentative"]))
+        self.assertEqual(self._names(confirmed), ["Tva Nonbillable"])
+
+    def test_no_matching_allocation_returns_empty(self):
+        result = self._call(employee_id=json.dumps([self.emp_nonbillable]), is_billable=json.dumps([1]))
+        self.assertEqual(result["employees"], [])
+        self.assertEqual(result["total_count"], 0)
+        self.assertFalse(result["has_more"])
+
+
+class TestTeamViewHoursSummaryShape(_TeamViewBase):
+    """The need_hours_summary response-shape switch."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
+        cls.customer = cls._make_customer("TV Hours Customer")
+        cls.project = cls._make_project("TV Hours Portal", cls.customer)
+        cls.employee = cls._make_employee("Tvh Employee")
+        cls._make_allocation(cls.employee, cls.project, TEAM_WINDOW_START, "2026-06-19", is_billable=1)
+        cls.only = json.dumps([cls.employee])
+        frappe.clear_cache()
+
+    def test_flat_grid_shape(self):
+        result = self._call(employee_id=self.only, need_hours_summary=False)
+        for key in (
+            "employees",
+            "resource_allocations",
+            "leaves",
+            "customer",
+            "total_count",
+            "has_more",
+            "permissions",
+        ):
+            self.assertIn(key, result)
+        self.assertNotIn("data", result)
+
+    def test_hours_summary_shape(self):
+        result = self._call(employee_id=self.only, need_hours_summary=True)
+        for key in ("data", "customer", "total_count", "has_more", "permissions"):
+            self.assertIn(key, result)
+        entry = next(row for row in result["data"] if row["name"] == self.employee)
+        self.assertIn("all_dates_data", entry)
+        self.assertIn("all_week_data", entry)

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -5,6 +5,17 @@ from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
 
 from next_pms.resource_management.api.team import get_resource_management_team_view_data
+from next_pms.timesheet.api.app import has_bu_field
+
+
+def _business_unit_available():
+    """True only when the rtcamp Business Unit doctype + custom_business_unit field exist.
+
+    The Business Unit doctype ships with the rtcamp app, which is not installed in CI,
+    so fixtures and assertions that touch it must be skipped there.
+    """
+    return bool(has_bu_field())
+
 
 EMPLOYEE_TAGS = {
     "Aarav Sharma": ["python", "react"],
@@ -310,8 +321,12 @@ class TestTeamViewEmployeeFilters(_TeamViewBase):
         # Read-only employee is not "Tvf"-named, so it never appears in the scoped assertions.
         cls._make_employee("Tv Readonly", user_id=cls.read_only_user)
 
-        cls.bu_alpha = cls._make_master("Business Unit", "business_unit_name", "Tvf BU Alpha")
-        cls.bu_beta = cls._make_master("Business Unit", "business_unit_name", "Tvf BU Beta")
+        cls.has_business_unit = _business_unit_available()
+        if cls.has_business_unit:
+            cls.bu_alpha = cls._make_master("Business Unit", "business_unit_name", "Tvf BU Alpha")
+            cls.bu_beta = cls._make_master("Business Unit", "business_unit_name", "Tvf BU Beta")
+        else:
+            cls.bu_alpha = cls.bu_beta = None
         cls.desig_alpha = cls._make_master("Designation", "designation_name", "Tvf Desig Alpha")
         cls.desig_beta = cls._make_master("Designation", "designation_name", "Tvf Desig Beta")
 
@@ -345,6 +360,8 @@ class TestTeamViewEmployeeFilters(_TeamViewBase):
         self.assertEqual(self._names(result), ["Tvf Alpha", "Tvf Gamma"])
 
     def test_business_unit(self):
+        if not self.has_business_unit:
+            self.skipTest("Business Unit doctype / custom_business_unit field not installed")
         result = self._call(employee_name="Tvf", business_unit=json.dumps([self.bu_beta]))
         self.assertEqual(self._names(result), ["Tvf Beta", "Tvf Mgr"])
 
@@ -397,6 +414,8 @@ class TestTeamViewEmployeeFilters(_TeamViewBase):
     def test_non_write_user_ignores_filters_except_name(self):
         # business_unit=[bu_alpha] would drop Beta/Mgr if honored; a read-only caller must
         # ignore it and return all four Tvf employees via the name filter.
+        if not self.has_business_unit:
+            self.skipTest("Business Unit doctype / custom_business_unit field not installed")
         result = self._call(user=FILTER_READ_ONLY_USER, employee_name="Tvf", business_unit=json.dumps([self.bu_alpha]))
         self.assertFalse(result["permissions"]["write"])
         self.assertEqual(self._names(result), ["Tvf Alpha", "Tvf Beta", "Tvf Gamma", "Tvf Mgr"])
@@ -464,7 +483,13 @@ class TestTeamViewHoursSummaryShape(_TeamViewBase):
         cls.customer = cls._make_customer("TV Hours Customer")
         cls.project = cls._make_project("TV Hours Portal", cls.customer)
         cls.employee = cls._make_employee("Tvh Employee")
-        cls._make_allocation(cls.employee, cls.project, TEAM_WINDOW_START, "2026-06-19", is_billable=1)
+        # In-window allocation ([2026-06-15, 2026-06-28]) and one entirely after it.
+        cls.in_window_alloc = cls._make_allocation(
+            cls.employee, cls.project, TEAM_WINDOW_START, "2026-06-19", is_billable=1
+        )
+        cls.out_of_window_alloc = cls._make_allocation(
+            cls.employee, cls.project, "2026-07-01", "2026-07-05", is_billable=1
+        )
         cls.only = json.dumps([cls.employee])
         frappe.clear_cache()
 
@@ -481,6 +506,14 @@ class TestTeamViewHoursSummaryShape(_TeamViewBase):
         ):
             self.assertIn(key, result)
         self.assertNotIn("data", result)
+
+    def test_flat_grid_excludes_out_of_window_allocations(self):
+        # #1677 regression: the flat grid must only return allocations overlapping the
+        # derived window, not every allocation for the employee ("fetch all weeks").
+        result = self._call(employee_id=self.only, need_hours_summary=False)
+        alloc_names = {allocation["name"] for allocation in result["resource_allocations"]}
+        self.assertIn(self.in_window_alloc, alloc_names)
+        self.assertNotIn(self.out_of_window_alloc, alloc_names)
 
     def test_hours_summary_shape(self):
         result = self._call(employee_id=self.only, need_hours_summary=True)


### PR DESCRIPTION
## Description

*  Closed projects (`Completed` and `Cancelled`) are now excluded from the resource view by default in the project filtering logic.
* The `get_allocation_list_for_employee_for_given_range` function is simplified to always filter allocations by the provided date range, removing the `is_need_fetch_all_weeks` parameter and its associated logic. The docstring and implementation are updated to reflect this. 
* Adds extensive integration tests for the project view endpoint, covering project list filtering, allocation breakdowns, pagination, filter combinations, and user permissions. These tests ensure correctness of the new filtering logic and allocation visibility.
* Adds a helper to conditionally skip tests that depend on the presence of the `Business Unit` doctype, improving test reliability across different environments.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1677 