### PR TITLE
QA Fix: Add icons and clear task on project change in add time modal

### DIFF
--- a/frontend/packages/app/src/hooks/useProjectLookup.ts
+++ b/frontend/packages/app/src/hooks/useProjectLookup.ts
@@ -29,6 +29,8 @@ interface UseProjectLookupOptions {
   revalidateOnFocus?: boolean;
   /** Keeps the current selection visible when it is not in the latest results. */
   selectedOption?: ProjectLookupOption | null;
+  /** Formats the mapped project option */
+  formatOption?: (option: ProjectLookupOption) => ProjectLookupOption;
 }
 
 /**
@@ -41,6 +43,7 @@ export const useProjectLookup = ({
   query,
   revalidateOnFocus,
   selectedOption,
+  formatOption,
 }: UseProjectLookupOptions) => {
   return useRemoteLookup<
     ProjectLookupResult,
@@ -70,6 +73,7 @@ export const useProjectLookup = ({
       value: project.name,
       customer: project.customer,
     }),
+    formatOption,
     selectedOption,
   });
 };

--- a/frontend/packages/app/src/hooks/useRemoteLookup.ts
+++ b/frontend/packages/app/src/hooks/useRemoteLookup.ts
@@ -50,6 +50,8 @@ interface UseRemoteLookupOptions<
   getItems: (message: TMessage | undefined) => TItem[];
   /** Maps each backend item into a combobox option shape. */
   mapOption: (item: TItem) => TOption;
+  /** Formats the mapped option */
+  formatOption?: (option: TOption) => TOption;
   /** Preserves the current selection when it is missing from the latest page. */
   selectedOption?: TOption | TOption[] | null;
 }
@@ -68,6 +70,7 @@ export const useRemoteLookup = <TMessage, TItem, TOption extends LookupOption>({
   params,
   getItems,
   mapOption,
+  formatOption,
   selectedOption,
 }: UseRemoteLookupOptions<TMessage, TItem, TOption>) => {
   const debouncedQuery = useDebounce(query, debounceMs);
@@ -82,11 +85,15 @@ export const useRemoteLookup = <TMessage, TItem, TOption extends LookupOption>({
   );
 
   const options = useMemo(() => {
-    const nextOptions = getItems(data?.message).map(mapOption);
+    const formatLookupOption = (option: TOption) =>
+      formatOption ? formatOption(option) : option;
+    const nextOptions = getItems(data?.message)
+      .map(mapOption)
+      .map(formatLookupOption);
     const selectedOptions = Array.isArray(selectedOption)
-      ? selectedOption
+      ? selectedOption.map(formatLookupOption)
       : selectedOption
-        ? [selectedOption]
+        ? [formatLookupOption(selectedOption)]
         : [];
 
     if (!selectedOptions.length) {
@@ -105,7 +112,7 @@ export const useRemoteLookup = <TMessage, TItem, TOption extends LookupOption>({
     }
 
     return [...missingSelectedOptions, ...nextOptions];
-  }, [data?.message, getItems, mapOption, selectedOption]);
+  }, [data?.message, formatOption, getItems, mapOption, selectedOption]);
 
   return {
     options,

--- a/frontend/packages/app/src/hooks/useTaskLookup.ts
+++ b/frontend/packages/app/src/hooks/useTaskLookup.ts
@@ -65,6 +65,7 @@ export const useTaskLookup = ({
       value: task.name,
       projectId: task.project,
       projectName: task.project_name,
+      status: task.status,
     }),
     formatOption,
     selectedOption,

--- a/frontend/packages/app/src/hooks/useTaskLookup.ts
+++ b/frontend/packages/app/src/hooks/useTaskLookup.ts
@@ -5,6 +5,7 @@ type TaskLookupItem = {
   project: string;
   project_name: string;
   subject: string;
+  status: string;
 };
 
 type TaskLookupResult = {
@@ -14,6 +15,7 @@ type TaskLookupResult = {
 export type TaskLookupOption = LookupOption & {
   projectId: string;
   projectName: string;
+  status?: string;
 };
 
 interface UseTaskLookupOptions {
@@ -29,6 +31,8 @@ interface UseTaskLookupOptions {
   query: string;
   /** Keeps the current selection visible when it is not in the latest results. */
   selectedOption?: TaskLookupOption | null;
+  /** Formats the mapped task option */
+  formatOption?: (option: TaskLookupOption) => TaskLookupOption;
 }
 
 /**
@@ -41,6 +45,7 @@ export const useTaskLookup = ({
   projectId,
   query,
   selectedOption,
+  formatOption,
 }: UseTaskLookupOptions) => {
   return useRemoteLookup<TaskLookupResult, TaskLookupItem, TaskLookupOption>({
     shouldFetch,
@@ -61,6 +66,7 @@ export const useTaskLookup = ({
       projectId: task.project,
       projectName: task.project_name,
     }),
+    formatOption,
     selectedOption,
   });
 };

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -231,7 +231,12 @@ const AddTime = ({
                   openOnFocus
                   onSearchChange={setProjectSearch}
                   onChange={(val) => {
-                    field.handleChange(val as string);
+                    const nextProject = val as string;
+                    if (nextProject !== field.state.value) {
+                      form.setFieldValue("task", "");
+                      setTaskSearch("");
+                    }
+                    field.handleChange(nextProject);
                   }}
                 />
                 {!field.state.meta.isValid && (

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -113,6 +113,7 @@ const AddTime = ({
   );
 
   const selectedProject = useStore(form.store, (state) => state.values.project);
+  const selectedTask = useStore(form.store, (state) => state.values.task);
   const selectedDate = useStore(form.store, (state) => state.values.date);
   const selectedProjectOption = project
     ? {
@@ -120,14 +121,15 @@ const AddTime = ({
         value: project,
       }
     : null;
-  const selectedTaskOption = task
-    ? {
-        label: taskLabel || task,
-        value: task,
-        projectId: project,
-        projectName: projectLabel || project,
-      }
-    : null;
+  const selectedTaskOption =
+    task && selectedTask === task
+      ? {
+          label: taskLabel || task,
+          value: task,
+          projectId: project,
+          projectName: projectLabel || project,
+        }
+      : null;
 
   useEffect(() => {
     if (!open) {

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { useCallback, useEffect, useState } from "react";
+import { TaskStatus, taskStatusMap } from "@next-pms/design-system/components";
 import {
   DatePicker,
   Dialog,
@@ -12,7 +13,7 @@ import {
   TextEditor,
   DurationInput,
 } from "@rtcamp/frappe-ui-react";
-import { Calendar } from "@rtcamp/frappe-ui-react/icons";
+import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm, useStore } from "@tanstack/react-form";
 import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
@@ -149,6 +150,10 @@ const AddTime = ({
       pageSize: 20,
       query: projectSearch,
       selectedOption: selectedProjectOption,
+      formatOption: (option) => ({
+        ...option,
+        icon: <Folder className="size-4 shrink-0 text-ink-gray-7" />,
+      }),
     });
 
   const { options: taskOptions, isLoading: isTaskLookupLoading } =
@@ -158,6 +163,12 @@ const AddTime = ({
       projectId: selectedProject || undefined,
       query: taskSearch,
       selectedOption: selectedTaskOption,
+      formatOption: (option) => ({
+        ...option,
+        icon: (
+          <TaskStatus status={taskStatusMap[option.status ?? ""] ?? "open"} />
+        ),
+      }),
     });
 
   const handleCalendarSelectionChange = useCallback(

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -101,6 +101,7 @@ const AddEmployeeTime = ({
   );
 
   const selectedProject = useStore(form.store, (state) => state.values.project);
+  const selectedTask = useStore(form.store, (state) => state.values.task);
   const selectedProjectOption = project
     ? {
         label: projectLabel || project,
@@ -113,14 +114,15 @@ const AddEmployeeTime = ({
         value: employeeId,
       }
     : null;
-  const selectedTaskOption = task
-    ? {
-        label: taskLabel || task,
-        value: task,
-        projectId: project,
-        projectName: projectLabel || project,
-      }
-    : null;
+  const selectedTaskOption =
+    task && selectedTask === task
+      ? {
+          label: taskLabel || task,
+          value: task,
+          projectId: project,
+          projectName: projectLabel || project,
+        }
+      : null;
 
   useEffect(() => {
     if (!open) {

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { useCallback, useEffect, useState } from "react";
+import { TaskStatus, taskStatusMap } from "@next-pms/design-system/components";
 import {
   DatePicker,
   Dialog,
@@ -12,7 +13,7 @@ import {
   TextEditor,
   DurationInput,
 } from "@rtcamp/frappe-ui-react";
-import { Calendar } from "@rtcamp/frappe-ui-react/icons";
+import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm, useStore } from "@tanstack/react-form";
 import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
@@ -150,6 +151,10 @@ const AddEmployeeTime = ({
       pageSize: 20,
       query: projectSearch,
       selectedOption: selectedProjectOption,
+      formatOption: (option) => ({
+        ...option,
+        icon: <Folder className="size-4 shrink-0 text-ink-gray-7" />,
+      }),
     });
 
   const { options: taskOptions, isLoading: isTaskLookupLoading } =
@@ -159,6 +164,12 @@ const AddEmployeeTime = ({
       projectId: selectedProject || undefined,
       query: taskSearch,
       selectedOption: selectedTaskOption,
+      formatOption: (option) => ({
+        ...option,
+        icon: (
+          <TaskStatus status={taskStatusMap[option.status ?? ""] ?? "open"} />
+        ),
+      }),
     });
 
   return (

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -233,7 +233,12 @@ const AddEmployeeTime = ({
                   openOnFocus
                   onSearchChange={setProjectSearch}
                   onChange={(val) => {
-                    field.handleChange(val as string);
+                    const nextProject = val as string;
+                    if (nextProject !== field.state.value) {
+                      form.setFieldValue("task", "");
+                      setTaskSearch("");
+                    }
+                    field.handleChange(nextProject);
                   }}
                 />
                 {!field.state.meta.isValid && (


### PR DESCRIPTION
## Description

- Clears the task field when the project field is modified or changed.
- Added icons for the Project and Task fields.

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Updated the `useRemoteLookup` hook to support a `formatOption` callback. This allows individual lookups to modify or extend the mapped option object without changing the default mapping logic. It provides a flexible way to customize lookup options where needed while avoiding changes to the shared hook that could affect other usages.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/ca92b5cf-0e9d-4029-aa7a-a19c49140ec4



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1585 #1576