### PR TITLE
UAT issues in dashboards

### DIFF
--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -34,12 +34,14 @@ import { useUser } from "@/providers/user";
 
 const Sidebar = () => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
   const notifications = useNotifications(({ state }) => state.notifications);
+  const isNotificationsOpen = useNotifications(({ state }) => state.isTrayOpen);
   const markAsViewed = useNotifications(({ actions }) => actions.markAsViewed);
   const markAllAsViewed = useNotifications(
     ({ actions }) => actions.markAllAsViewed,
   );
+  const openTray = useNotifications(({ actions }) => actions.openTray);
+  const closeTray = useNotifications(({ actions }) => actions.closeTray);
 
   const { theme, setTheme } = useTheme();
   const navigate = useNavigate();
@@ -268,7 +270,7 @@ const Sidebar = () => {
                 icon: Notifications,
                 to: "",
                 isActive: false,
-                onClick: () => setIsNotificationsOpen(true),
+                onClick: openTray,
               },
               {
                 label: "Search",
@@ -325,7 +327,9 @@ const Sidebar = () => {
 
       <NotificationTray
         open={isNotificationsOpen}
-        onOpenChange={setIsNotificationsOpen}
+        onOpenChange={(open) => {
+          if (!open) closeTray();
+        }}
         notifications={notifications}
         offsetClassName={isSidebarCollapsed ? "left-12" : "left-60"}
         onMarkAllRead={markAllAsViewed}

--- a/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
@@ -38,7 +38,10 @@ export default function LeadershipDashboard() {
           ]}
         />
       </Header>
-      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-5 space-y-6 max-w-[1200px] mx-auto">
+      <div
+        role="main"
+        className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-5 space-y-6 max-w-[1200px] mx-auto"
+      >
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex min-w-0 flex-col gap-2">
             <h2 className="text-2xl font-semibold text-ink-gray-8">

--- a/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
@@ -38,7 +38,7 @@ export default function LeadershipDashboard() {
           ]}
         />
       </Header>
-      <div className="flex-1 min-h-0 overflow-y-auto p-5 space-y-6 max-w-[1200px] mx-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-5 space-y-6 max-w-[1200px] mx-auto">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex min-w-0 flex-col gap-2">
             <h2 className="text-2xl font-semibold text-ink-gray-8">
@@ -49,7 +49,7 @@ export default function LeadershipDashboard() {
 
         <section
           aria-label="Leadership dashboard"
-          className="grid grid-cols-12 gap-3 overflow-y-auto scrollbar-thin"
+          className="grid grid-cols-12 gap-3"
         >
           <WidgetCard className="col-span-4">
             <LeadershipKpiCard

--- a/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useState } from "react";
 import { Breadcrumbs } from "@rtcamp/frappe-ui-react";
 
 /**
@@ -13,6 +14,7 @@ import WidgetCard from "../widget/components/card";
 import ForecastBreakdownCard from "../widget/forecast-breakdown";
 import HeatmapCard from "../widget/heatmap";
 import LeadershipKpiCard from "../widget/kpi-cards";
+import { getDefaultKpiMonth } from "../widget/kpi-cards/useLeadershipKpi";
 import NotificationsCard from "../widget/notificationsCard";
 import LiveStatCard from "../widget/stat-cards";
 import UtilisedTimeCard from "../widget/utilization";
@@ -24,6 +26,7 @@ export default function LeadershipDashboard() {
   }));
 
   const firstName = (employeeName || userName).trim().split(" ")[0] || "there";
+  const [kpiMonth, setKpiMonth] = useState(getDefaultKpiMonth);
 
   return (
     <main>
@@ -49,13 +52,25 @@ export default function LeadershipDashboard() {
           className="grid grid-cols-12 gap-3 overflow-y-auto scrollbar-thin"
         >
           <WidgetCard className="col-span-4">
-            <LeadershipKpiCard kpikey={"revenue"} />
+            <LeadershipKpiCard
+              kpikey={"revenue"}
+              month={kpiMonth}
+              onMonthChange={setKpiMonth}
+            />
           </WidgetCard>
           <WidgetCard className="col-span-4">
-            <LeadershipKpiCard kpikey={"cost"} />
+            <LeadershipKpiCard
+              kpikey={"cost"}
+              month={kpiMonth}
+              onMonthChange={setKpiMonth}
+            />
           </WidgetCard>
           <WidgetCard className="col-span-4">
-            <LeadershipKpiCard kpikey={"profit_margin"} />
+            <LeadershipKpiCard
+              kpikey={"profit_margin"}
+              month={kpiMonth}
+              onMonthChange={setKpiMonth}
+            />
           </WidgetCard>
           <WidgetCard className="h-[300px] col-span-8 p-4">
             <HeatmapCard />

--- a/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/leadership/index.tsx
@@ -29,7 +29,7 @@ export default function LeadershipDashboard() {
   const [kpiMonth, setKpiMonth] = useState(getDefaultKpiMonth);
 
   return (
-    <main>
+    <>
       <Header>
         <Breadcrumbs
           items={[
@@ -38,7 +38,7 @@ export default function LeadershipDashboard() {
           ]}
         />
       </Header>
-      <div className="flex flex-col gap-6 overflow-y-auto p-5 max-w-[1200px] mx-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto p-5 space-y-6 max-w-[1200px] mx-auto">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex min-w-0 flex-col gap-2">
             <h2 className="text-2xl font-semibold text-ink-gray-8">
@@ -92,6 +92,6 @@ export default function LeadershipDashboard() {
           </WidgetCard>
         </section>
       </div>
-    </main>
+    </>
   );
 }

--- a/frontend/packages/app/src/pages/dashboard/widget/heatmap/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/heatmap/index.tsx
@@ -5,13 +5,7 @@ import { useMemo, useState } from "react";
 import { MultiSelect } from "@rtcamp/frappe-ui-react";
 import type { MultiSelectOption } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
-import {
-  endOfMonth,
-  format,
-  parseISO,
-  startOfMonth,
-  subMonths,
-} from "date-fns";
+import { addWeeks, endOfWeek, format, parseISO, startOfWeek } from "date-fns";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
@@ -23,6 +17,8 @@ import type { AllocationHeatmapResponse, RoleAllocationWeek } from "./types";
 export type HeatmapCellState = "full" | "partial" | "none";
 
 const API_DATE_FORMAT = "yyyy-MM-dd";
+const WEEK_COUNT = 16;
+const WEEK_OPTIONS = { weekStartsOn: 1 } as const; // Monday, matches backend
 
 const STATE_BG: Record<HeatmapCellState, string> = {
   full: "bg-surface-gray-3",
@@ -50,10 +46,13 @@ export default function HeatmapCard() {
   const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
 
   const args = useMemo(() => {
-    const now = new Date();
+    const start = startOfWeek(new Date(), WEEK_OPTIONS);
     return {
-      from_date: format(startOfMonth(subMonths(now, 3)), API_DATE_FORMAT),
-      to_date: format(endOfMonth(subMonths(now, 1)), API_DATE_FORMAT),
+      from_date: format(start, API_DATE_FORMAT),
+      to_date: format(
+        endOfWeek(addWeeks(start, WEEK_COUNT - 1), WEEK_OPTIONS),
+        API_DATE_FORMAT,
+      ),
     };
   }, []);
 
@@ -163,7 +162,7 @@ export default function HeatmapCard() {
           </table>
         )}
       </div>
-      <div className="flex shrink-0 justify-center gap-8">
+      <div className="flex shrink-0 justify-center gap-8 mt-1">
         {LEGEND.map((item) => (
           <div key={item.label} className="flex items-center gap-1.5">
             <span

--- a/frontend/packages/app/src/pages/dashboard/widget/heatmap/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/heatmap/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { MultiSelect } from "@rtcamp/frappe-ui-react";
 import type { MultiSelectOption } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
@@ -19,6 +19,47 @@ export type HeatmapCellState = "full" | "partial" | "none";
 const API_DATE_FORMAT = "yyyy-MM-dd";
 const WEEK_COUNT = 16;
 const WEEK_OPTIONS = { weekStartsOn: 1 } as const; // Monday, matches backend
+
+// Designations matching any of these entries are pre-selected on first load.
+const DEFAULT_ROLES = [
+  "L1 - Software Engineer",
+  "L2 - Software Engineer",
+  "L3 - Senior Software Engineer",
+  "L4 - Senior Software Engineer",
+  "L5 - Senior Software Engineer",
+  "L6 - Senior Software Engineer",
+  "L7 - Engineering Manager",
+  "L8 - Engineering Manager",
+  "L7 - Staff Engineer",
+  "L8 - Principal Engineer",
+  "L1 - Quality Engineer",
+  "L2 - Quality Engineer",
+  "L3 - Senior Quality Engineer",
+  "L4 - Senior Quality Engineer",
+  "L5 - Senior Quality Engineer",
+  "L6 - Quality Engineering Manager",
+  "L1 - Project Coordinator",
+  "L2 - Project Manager",
+  "L3 - Project Manager",
+  "L4 - Senior Project Manager",
+  "L5 - Senior Project Manager",
+  "L6 - Senior Project Manager",
+  "L7 - Principal Project Manager",
+  "L1 - Technical Support Engineer",
+  "L2 - Technical Support Engineer",
+  "L3 - Senior Technical Support Engineer",
+  "L4 - Senior Technical Support Engineer",
+  "L5 - Technical Support Engineer Manager",
+  "L1 - Systems Engineer",
+  "L2 - Systems Engineer",
+  "L3 - Senior Systems Engineer",
+  "L4 - Senior Systems Engineer",
+  "L5 - Senior Systems Engineer",
+  "L6 - Systems Engineering Manager",
+  "L5 - Senior Growth Engineer",
+  "L2 - Growth Engineer",
+  "L1 - Growth Engineer",
+];
 
 const STATE_BG: Record<HeatmapCellState, string> = {
   full: "bg-surface-gray-3",
@@ -79,6 +120,22 @@ export default function HeatmapCard() {
       else groups.push({ label, span: 1 });
     }
     return groups;
+  }, [data]);
+
+  const defaultsApplied = useRef(false);
+  useEffect(() => {
+    if (defaultsApplied.current) return;
+    const roles = data?.message.roles;
+    if (!roles) return;
+    defaultsApplied.current = true;
+    const defaults = roles
+      .map((role) => role.designation)
+      .filter((designation) =>
+        DEFAULT_ROLES.some((keyword) =>
+          designation.toLowerCase().includes(keyword.toLowerCase()),
+        ),
+      );
+    if (defaults.length) setSelectedRoles(defaults);
   }, [data]);
 
   if (isLoading || !data) return <HeatmapCardSkeleton />;

--- a/frontend/packages/app/src/pages/dashboard/widget/kpi-cards/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/kpi-cards/index.tsx
@@ -20,10 +20,14 @@ const KPI_LABELS: Record<keyof LeadershipKPIResponse["message"], string> = {
 
 export default function LeadershipKpiCard({
   kpikey,
+  month,
+  onMonthChange,
 }: {
   kpikey: keyof LeadershipKPIResponse["message"];
+  month: string;
+  onMonthChange: (month: string) => void;
 }) {
-  const { month, setMonth, data, isLoading } = useLeadershipKpi(kpikey);
+  const { data, isLoading } = useLeadershipKpi(kpikey, month);
 
   if (isLoading) return <KpiCardSkeleton />;
 
@@ -35,7 +39,7 @@ export default function LeadershipKpiCard({
         </span>
         <MonthPicker
           value={month}
-          onChange={setMonth}
+          onChange={onMonthChange}
           inputIcon={SmallDown}
           className="h-auto! w-auto! justify-center! gap-0.5 bg-transparent! p-0! text-sm text-ink-gray-5! hover:bg-transparent!"
         />

--- a/frontend/packages/app/src/pages/dashboard/widget/kpi-cards/useLeadershipKpi.ts
+++ b/frontend/packages/app/src/pages/dashboard/widget/kpi-cards/useLeadershipKpi.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { endOfMonth, format, parse, startOfMonth, subMonths } from "date-fns";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
@@ -11,15 +11,16 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 import { LeadershipKPIResponse } from "./types";
 
 // MonthPicker emits and consumes this format, e.g. "May 2026".
-const MONTH_VALUE_FORMAT = "MMMM yyyy";
+export const MONTH_VALUE_FORMAT = "MMMM yyyy";
 const API_DATE_FORMAT = "yyyy-MM-dd";
 
-const getDefaultMonth = () =>
+export const getDefaultKpiMonth = () =>
   format(startOfMonth(subMonths(new Date(), 1)), MONTH_VALUE_FORMAT);
 
-export function useLeadershipKpi(key: keyof LeadershipKPIResponse["message"]) {
-  const [month, setMonth] = useState(getDefaultMonth);
-
+export function useLeadershipKpi(
+  key: keyof LeadershipKPIResponse["message"],
+  month: string,
+) {
   const args = useMemo(() => {
     const monthDate = parse(month, MONTH_VALUE_FORMAT, new Date());
     const prevMonthDate = subMonths(monthDate, 1);
@@ -36,5 +37,5 @@ export function useLeadershipKpi(key: keyof LeadershipKPIResponse["message"]) {
     args,
   );
 
-  return { month, setMonth, data: data?.message[key], isLoading, error };
+  return { data: data?.message[key], isLoading, error };
 }

--- a/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
@@ -16,6 +16,7 @@ export default function NotificationsCard() {
   const notifications = useNotifications(({ state }) => state.notifications);
   const isLoading = useNotifications(({ state }) => state.isLoading);
   const markAsViewed = useNotifications(({ actions }) => actions.markAsViewed);
+  const openTray = useNotifications(({ actions }) => actions.openTray);
 
   const handleClick = async (notification: NotificationEntry) => {
     await markAsViewed(notification.id);
@@ -28,15 +29,13 @@ export default function NotificationsCard() {
     <>
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="text-lg font-semibold text-ink-gray-8">Notifications</h3>
-        <a
-          href="/desk/nextpms-notifications"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="Open employee"
+        <button
+          type="button"
+          onClick={openTray}
           className="text-base text-ink-gray-8 hover:text-ink-gray-8"
         >
           See all
-        </a>
+        </button>
       </div>
       {!isLoading && notifications.length === 0 ? (
         <p className="py-10 text-center text-base text-ink-gray-4">

--- a/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
@@ -55,11 +55,11 @@ export default function NotificationsCard() {
                     event.shiftKey ||
                     event.button !== 0
                   ) {
-                    void markAsViewed(item.id);
+                    markAsViewed(item.id);
                     return;
                   }
                   event.preventDefault();
-                  void handleClick(item);
+                  handleClick(item);
                 }}
                 className="flex cursor-pointer items-start gap-2"
               >

--- a/frontend/packages/app/src/pages/dashboard/widget/stat-cards/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/stat-cards/index.tsx
@@ -6,6 +6,7 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
+import { ROUTES } from "@/lib/constant";
 import { StatCardSkeleton } from "./skeleton";
 import { StatCard } from "./statCard";
 import {
@@ -30,59 +31,59 @@ export default function StatCards() {
     isLoading: isMembersWithoutAllocationLoading,
   } = useFrappeGetCall<MembersWithoutAllocationResponse>(
     "next_pms.api.dashboard.get_members_without_allocation",
-    {
-      days: 30,
-    },
+    { days: 30 },
   );
 
   const { data: nonBillableHoursData, isLoading: isNonBillableHoursLoading } =
     useFrappeGetCall<NonBillableHoursResponse>(
       "next_pms.api.dashboard.get_non_billable_hours",
-      {
-        days: 30,
-      },
+      { days: 30 },
     );
 
   return (
-    <div className="w-full flex gap-3">
-      {isActiveProjectDataLoading ? (
-        <StatCardSkeleton />
-      ) : (
-        <StatCard
-          className="flex-1"
-          label="Active projects"
-          value={activeProjectData?.message ?? "-"}
-        />
-      )}
-      {isAtRiskProjectDataLoading ? (
-        <StatCardSkeleton />
-      ) : (
-        <StatCard
-          className="flex-1"
-          label="At risk project"
-          value={atRiskProjectData?.message ?? "-"}
-        />
-      )}
-      {isMembersWithoutAllocationLoading ? (
-        <StatCardSkeleton />
-      ) : (
-        <StatCard
-          className="flex-1"
-          label="Members without allocation"
-          subLabel="this month"
-          value={membersWithoutAllocationData?.message?.count ?? "-"}
-        />
-      )}
-      {isNonBillableHoursLoading ? (
-        <StatCardSkeleton />
-      ) : (
-        <StatCard
-          className="flex-1"
-          label="Non-billable hours logged"
-          subLabel="this month"
-          value={nonBillableHoursData?.message ?? "-"}
-        />
-      )}
+    <div className="flex flex-col gap-3 w-full">
+      <div className="flex gap-3">
+        {isActiveProjectDataLoading ? (
+          <StatCardSkeleton />
+        ) : (
+          <StatCard
+            className="flex-1"
+            label="Active projects"
+            value={activeProjectData?.message ?? "-"}
+            to={ROUTES.project + "?status=Open"}
+          />
+        )}
+        {isAtRiskProjectDataLoading ? (
+          <StatCardSkeleton />
+        ) : (
+          <StatCard
+            className="flex-1"
+            label="At risk project"
+            value={atRiskProjectData?.message ?? "-"}
+            to={ROUTES.project + "?rag=red"}
+          />
+        )}
+        {isMembersWithoutAllocationLoading ? (
+          <StatCardSkeleton />
+        ) : (
+          <StatCard
+            className="flex-1"
+            label="Members without allocation"
+            subLabel="this month"
+            value={membersWithoutAllocationData?.message?.count ?? "-"}
+          />
+        )}
+        {isNonBillableHoursLoading ? (
+          <StatCardSkeleton />
+        ) : (
+          <StatCard
+            className="flex-1"
+            label="Non-billable hours logged"
+            subLabel="this month"
+            value={nonBillableHoursData?.message ?? "-"}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/packages/app/src/pages/dashboard/widget/stat-cards/statCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/stat-cards/statCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { mergeClassNames } from "@next-pms/design-system";
 
 export type StatCardData = {
@@ -5,16 +6,21 @@ export type StatCardData = {
   value: string | number;
   subLabel?: string;
   className?: string;
+  to?: string;
 };
 
-export function StatCard({ label, value, subLabel, className }: StatCardData) {
-  return (
-    <div
-      className={mergeClassNames(
-        "flex flex-col gap-2 rounded-lg border border-outline-gray-1 bg-surface-cards p-3",
-        className,
-      )}
-    >
+const CARD_BASE =
+  "flex flex-col gap-2 rounded-lg border border-outline-gray-1 bg-surface-cards p-3";
+
+export function StatCard({
+  label,
+  value,
+  subLabel,
+  className,
+  to,
+}: StatCardData) {
+  const content = (
+    <>
       <span className="truncate text-base text-ink-gray-5">{label}</span>
       <div className="flex items-baseline gap-1">
         <span className="text-2xl font-medium text-ink-gray-8">{value}</span>
@@ -22,6 +28,23 @@ export function StatCard({ label, value, subLabel, className }: StatCardData) {
           <span className="truncate text-base text-ink-gray-5">{subLabel}</span>
         )}
       </div>
-    </div>
+    </>
   );
+
+  if (to) {
+    return (
+      <Link
+        to={to}
+        className={mergeClassNames(
+          CARD_BASE,
+          "hover:bg-surface-gray-1 transition-colors",
+          className,
+        )}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={mergeClassNames(CARD_BASE, className)}>{content}</div>;
 }

--- a/frontend/packages/app/src/pages/dashboard/widget/utilization/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/utilization/index.tsx
@@ -1,7 +1,10 @@
 /**
  * External dependencies.
  */
+import { useMemo, useState } from "react";
 import { mergeClassNames } from "@next-pms/design-system";
+import { MultiSelect } from "@rtcamp/frappe-ui-react";
+import type { MultiSelectOption } from "@rtcamp/frappe-ui-react";
 import { useFrappeGetCall } from "frappe-react-sdk";
 
 /**
@@ -12,14 +15,40 @@ import { UtilisationDonut } from "./utilisationDonut";
 import { UtilisedTimeCardSkeleton } from "./utilisedTimeCardSkeleton";
 
 export default function UtilisedTimeCard() {
+  const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+
   const { data, isLoading } = useFrappeGetCall<TimeUtilisationResponse>(
     "next_pms.api.dashboard.get_time_utilisation",
     { days: 30 },
   );
 
+  const roleOptions = useMemo<MultiSelectOption[]>(
+    () =>
+      (data?.message.roles ?? []).map((role) => ({
+        value: role.designation,
+        label: role.designation,
+      })),
+    [data],
+  );
+
   if (isLoading || !data) return <UtilisedTimeCardSkeleton />;
 
-  const { billable_hours, non_billable_hours, total_hours } = data.message;
+  const { roles } = data.message;
+  const visibleRoles = selectedRoles.length
+    ? roles.filter((role) => selectedRoles.includes(role.designation))
+    : roles;
+  const allRolesSelected =
+    selectedRoles.length === 0 || selectedRoles.length === roleOptions.length;
+
+  const billable_hours = visibleRoles.reduce(
+    (sum, r) => sum + r.billable_hours,
+    0,
+  );
+  const non_billable_hours = visibleRoles.reduce(
+    (sum, r) => sum + r.non_billable_hours,
+    0,
+  );
+  const total_hours = visibleRoles.reduce((sum, r) => sum + r.total_hours, 0);
   const billablePct =
     total_hours > 0 ? Math.round((billable_hours / total_hours) * 100) : 0;
   const nonBillablePct =
@@ -44,6 +73,19 @@ export default function UtilisedTimeCard() {
         <h3 className="text-lg font-semibold text-ink-gray-8">
           Utilised time in the past 30 days
         </h3>
+        <div className="w-44 shrink-0">
+          <MultiSelect
+            popupClassName="scrollbar-thin"
+            options={roleOptions}
+            value={selectedRoles}
+            triggerLabel={
+              allRolesSelected
+                ? "All roles"
+                : `${selectedRoles.length} role${selectedRoles.length === 1 ? "" : "s"} selected`
+            }
+            onChange={setSelectedRoles}
+          />
+        </div>
       </div>
       <div className="flex items-center gap-8">
         <UtilisationDonut

--- a/frontend/packages/app/src/pages/dashboard/widget/utilization/types.ts
+++ b/frontend/packages/app/src/pages/dashboard/widget/utilization/types.ts
@@ -1,7 +1,15 @@
+export interface TimeUtilisationRole {
+  designation: string;
+  billable_hours: number;
+  non_billable_hours: number;
+  total_hours: number;
+}
+
 export interface TimeUtilisationResponse {
   message: {
-    billable_hours: number;
-    non_billable_hours: number;
-    total_hours: number;
+    days: number;
+    start_date: string;
+    end_date: string;
+    roles: TimeUtilisationRole[];
   };
 }

--- a/frontend/packages/app/src/pages/dashboard/widget/utilization/utilisationDonut.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/utilization/utilisationDonut.tsx
@@ -23,7 +23,29 @@ export function UtilisationDonut({
   const total = segments.reduce((sum, segment) => sum + segment.value, 0);
 
   if (total <= 0) {
-    return null;
+    const circumference = 2 * Math.PI * radius;
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="shrink-0"
+        role="img"
+        aria-label="No utilisation data"
+      >
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={0}
+          className="text-surface-gray-3"
+        />
+      </svg>
+    );
   }
 
   const polar = (angleDeg: number) => {

--- a/frontend/packages/app/src/providers/notifications/index.ts
+++ b/frontend/packages/app/src/providers/notifications/index.ts
@@ -12,12 +12,18 @@ export interface NotificationsContextProps {
     isLoading: boolean;
     /** Number of notifications the user has not yet viewed. */
     unreadCount: number;
+    /** Whether the notification tray panel is open. */
+    isTrayOpen: boolean;
   };
   actions: {
     /** Marks a single notification as viewed. */
     markAsViewed: (id: string) => Promise<void>;
     /** Marks every unread notification as viewed. */
     markAllAsViewed: () => Promise<void>;
+    /** Opens the notification tray. */
+    openTray: () => void;
+    /** Closes the notification tray. */
+    closeTray: () => void;
   };
 }
 
@@ -26,10 +32,13 @@ export const NotificationsContext = createContext<NotificationsContextProps>({
     notifications: [],
     isLoading: false,
     unreadCount: 0,
+    isTrayOpen: false,
   },
   actions: {
     markAsViewed: () => Promise.resolve(),
     markAllAsViewed: () => Promise.resolve(),
+    openTray: () => undefined,
+    closeTray: () => undefined,
   },
 });
 

--- a/frontend/packages/app/src/providers/notifications/provider.tsx
+++ b/frontend/packages/app/src/providers/notifications/provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { FC, PropsWithChildren, useCallback, useMemo } from "react";
+import { FC, PropsWithChildren, useCallback, useMemo, useState } from "react";
 import type { NotificationEntry } from "@next-pms/design-system/components";
 import { formatDistanceToNow, parseISO } from "date-fns";
 import { useFrappeGetDocList, useFrappeUpdateDoc } from "frappe-react-sdk";
@@ -135,12 +135,25 @@ export const NotificationsProvider: FC<PropsWithChildren> = ({ children }) => {
     await mutate();
   }, [data, updateDoc, mutate]);
 
+  const [isTrayOpen, setIsTrayOpen] = useState(false);
+  const openTray = useCallback(() => setIsTrayOpen(true), []);
+  const closeTray = useCallback(() => setIsTrayOpen(false), []);
+
   const value = useMemo(
     () => ({
-      state: { notifications, isLoading, unreadCount },
-      actions: { markAsViewed, markAllAsViewed },
+      state: { notifications, isLoading, unreadCount, isTrayOpen },
+      actions: { markAsViewed, markAllAsViewed, openTray, closeTray },
     }),
-    [notifications, isLoading, unreadCount, markAsViewed, markAllAsViewed],
+    [
+      notifications,
+      isLoading,
+      unreadCount,
+      isTrayOpen,
+      markAsViewed,
+      markAllAsViewed,
+      openTray,
+      closeTray,
+    ],
   );
 
   return (

--- a/frontend/packages/design-system/src/components/calendar-timeline/calendarTimeline.tsx
+++ b/frontend/packages/design-system/src/components/calendar-timeline/calendarTimeline.tsx
@@ -113,7 +113,6 @@ const CalendarTimeline = ({
                 </div>
                 {dayEvents.map((event) => (
                   <EventChip
-                    key={event.id}
                     title={event.title}
                     subtitle={event.subtitle}
                     color={event.color}

--- a/frontend/packages/design-system/src/components/calendar-timeline/constants.ts
+++ b/frontend/packages/design-system/src/components/calendar-timeline/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_VISIBLE_DAYS = 14;
 export const WEEKEND_DAY_INDICES = [0, 6];
 
 export const eventChipVariants = cva(
-  "flex w-full flex-col gap-0.5 rounded-md py-0.5 pl-1 pr-2 text-left",
+  "flex w-full flex-col gap-0.5 rounded-md py-0.5 pl-1 pr-2 text-left cursor-pointer",
   {
     variants: {
       color: {

--- a/frontend/packages/design-system/src/components/calendar-timeline/eventChip.tsx
+++ b/frontend/packages/design-system/src/components/calendar-timeline/eventChip.tsx
@@ -16,7 +16,7 @@ interface EventChipProps {
 }
 
 const EventChip = ({ title, subtitle, color = "blue" }: EventChipProps) => (
-  <Tooltip text={title + "-" + subtitle}>
+  <Tooltip text={subtitle ? `${title} - ${subtitle}` : title}>
     <div className={eventChipVariants({ color })}>
       <p className={eventChipTitleVariants({ color })}>{title}</p>
       {subtitle && (

--- a/frontend/packages/design-system/src/components/calendar-timeline/eventChip.tsx
+++ b/frontend/packages/design-system/src/components/calendar-timeline/eventChip.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies.
  */
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import {
   eventChipSubtitleVariants,
   eventChipTitleVariants,
@@ -15,12 +16,14 @@ interface EventChipProps {
 }
 
 const EventChip = ({ title, subtitle, color = "blue" }: EventChipProps) => (
-  <div className={eventChipVariants({ color })}>
-    <p className={eventChipTitleVariants({ color })}>{title}</p>
-    {subtitle && (
-      <p className={eventChipSubtitleVariants({ color })}>{subtitle}</p>
-    )}
-  </div>
+  <Tooltip text={title + "-" + subtitle}>
+    <div className={eventChipVariants({ color })}>
+      <p className={eventChipTitleVariants({ color })}>{title}</p>
+      {subtitle && (
+        <p className={eventChipSubtitleVariants({ color })}>{subtitle}</p>
+      )}
+    </div>
+  </Tooltip>
 );
 
 export default EventChip;

--- a/next_pms/api/dashboard.py
+++ b/next_pms/api/dashboard.py
@@ -10,7 +10,7 @@ from frappe import only_for, whitelist
 from frappe.core.doctype.recorder.recorder import redis_cache
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Sum
-from frappe.utils import add_days, cint, flt, getdate, today
+from frappe.utils import add_days, cint, flt, get_datetime, getdate, today
 from pypika import Case
 from pypika.functions import Date
 
@@ -795,8 +795,12 @@ def _get_time_utilisation(days: int, role: str | None) -> dict:
         filters={"status": "Active"},
         fields=["designation"],
         pluck="designation",
+        distinct=True,
     )
     summary = {d: {"billable": 0.0, "non_billable": 0.0} for d in sorted(d for d in set(all_designations) if d)}
+
+    start_datetime = get_datetime(start_date)
+    end_datetime = get_datetime(add_days(end_date, 1))
 
     query = (
         frappe.qb.from_(TimesheetDetail)
@@ -809,10 +813,10 @@ def _get_time_utilisation(days: int, role: str | None) -> dict:
             TimesheetDetail.is_billable,
             Sum(TimesheetDetail.hours).as_("hours"),
         )
-        .where(Date(TimesheetDetail.from_time) >= start_date)
-        .where(Date(TimesheetDetail.from_time) <= end_date)
-        .where(Employee.designation.isnotnull())
+        .where(TimesheetDetail.from_time >= start_datetime)
+        .where(TimesheetDetail.from_time < end_datetime)
         .where(Employee.designation != "")
+        .where(Timesheet.custom_approval_status != "Rejected")
     )
 
     if role:

--- a/next_pms/api/dashboard.py
+++ b/next_pms/api/dashboard.py
@@ -752,7 +752,7 @@ def get_cost(cur_start, cur_end, prev_start, prev_end, client, project) -> tuple
 
 
 @whitelist(methods=["GET"])
-def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
+def get_time_utilisation(days: int = 30) -> dict:
     """Return billable and non-billable hours logged in the given window, grouped by designation.
 
     Parameters
@@ -761,9 +761,6 @@ def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
         Inclusive look-back window of calendar days ending today.
         For example, days=30 on 10 Jun covers 12 May through 10 Jun.
         Defaults to 30.
-    role : str, optional
-        Filter to a single designation. Defaults to None (all roles).
-
     Returns
     -------
     dict
@@ -778,11 +775,11 @@ def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
     if days < 1:
         frappe.throw(frappe._("days must be at least 1"))
 
-    return _get_time_utilisation(days, role)
+    return _get_time_utilisation(days)
 
 
 @redis_cache(ttl=21600)
-def _get_time_utilisation(days: int, role: str | None) -> dict:
+def _get_time_utilisation(days: int) -> dict:
     TimesheetDetail = DocType("Timesheet Detail")
     Timesheet = DocType("Timesheet")
     Employee = DocType("Employee")
@@ -814,9 +811,6 @@ def _get_time_utilisation(days: int, role: str | None) -> dict:
         .where(Employee.designation.isnotnull())
         .where(Employee.designation != "")
     )
-
-    if role:
-        query = query.where(Employee.designation == role)
 
     rows = query.groupby(Employee.designation, TimesheetDetail.is_billable).run(as_dict=True)
 

--- a/next_pms/api/dashboard.py
+++ b/next_pms/api/dashboard.py
@@ -762,7 +762,8 @@ def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
         For example, days=30 on 10 Jun covers 12 May through 10 Jun.
         Defaults to 30.
     role : str, optional
-        Filter to a single designation. Defaults to None (all roles).
+        When set, only that designation's hours are aggregated (other designations
+        are still returned with 0 hours). Defaults to None (all roles).
 
     Returns
     -------

--- a/next_pms/api/dashboard.py
+++ b/next_pms/api/dashboard.py
@@ -753,7 +753,7 @@ def get_cost(cur_start, cur_end, prev_start, prev_end, client, project) -> tuple
 
 @whitelist(methods=["GET"])
 def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
-    """Return total billable and non-billable hours logged across all timesheets in the given window.
+    """Return billable and non-billable hours logged in the given window, grouped by designation.
 
     Parameters
     ----------
@@ -762,14 +762,16 @@ def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
         For example, days=30 on 10 Jun covers 12 May through 10 Jun.
         Defaults to 30.
     role : str, optional
-        Filter by the timesheet employee's designation. Defaults to None (all roles).
+        Filter to a single designation. Defaults to None (all roles).
 
     Returns
     -------
     dict
-        billable_hours : float
-        non_billable_hours : float
-        total_hours : float
+        days : int
+        start_date : str
+        end_date : str
+        roles : list of dicts, each with designation, billable_hours,
+                non_billable_hours, total_hours
     """
     only_for(["Projects Manager", "Projects User", "System Manager"], message=True)
 
@@ -782,43 +784,64 @@ def get_time_utilisation(days: int = 30, role: str | None = None) -> dict:
 @redis_cache(ttl=21600)
 def _get_time_utilisation(days: int, role: str | None) -> dict:
     TimesheetDetail = DocType("Timesheet Detail")
-    since = add_days(today(), -(days - 1))
+    Timesheet = DocType("Timesheet")
+    Employee = DocType("Employee")
+    end_date = getdate(today())
+    start_date = getdate(add_days(end_date, -(days - 1)))
+
+    # Seed summary with every active designation so roles with zero activity still appear.
+    all_designations = frappe.get_all(
+        "Employee",
+        filters={"status": "Active"},
+        fields=["designation"],
+        pluck="designation",
+    )
+    summary = {d: {"billable": 0.0, "non_billable": 0.0} for d in sorted(d for d in set(all_designations) if d)}
 
     query = (
         frappe.qb.from_(TimesheetDetail)
+        .join(Timesheet)
+        .on(TimesheetDetail.parent == Timesheet.name)
+        .join(Employee)
+        .on(Timesheet.employee == Employee.name)
         .select(
+            Employee.designation,
             TimesheetDetail.is_billable,
-            Sum(TimesheetDetail.hours).as_("total_hours"),
+            Sum(TimesheetDetail.hours).as_("hours"),
         )
-        .where(Date(TimesheetDetail.from_time) >= since)
-        .where(Date(TimesheetDetail.from_time) <= today())
+        .where(Date(TimesheetDetail.from_time) >= start_date)
+        .where(Date(TimesheetDetail.from_time) <= end_date)
+        .where(Employee.designation.isnotnull())
+        .where(Employee.designation != "")
     )
 
     if role:
-        Timesheet = DocType("Timesheet")
-        Employee = DocType("Employee")
-        query = (
-            query.join(Timesheet)
-            .on(TimesheetDetail.parent == Timesheet.name)
-            .join(Employee)
-            .on(Timesheet.employee == Employee.name)
-            .where(Employee.designation == role)
-        )
+        query = query.where(Employee.designation == role)
 
-    rows = query.groupby(TimesheetDetail.is_billable).run(as_dict=True)
+    rows = query.groupby(Employee.designation, TimesheetDetail.is_billable).run(as_dict=True)
 
-    billable = 0.0
-    non_billable = 0.0
     for row in rows:
+        bucket = summary.setdefault(row.designation, {"billable": 0.0, "non_billable": 0.0})
         if row.is_billable:
-            billable = flt(row.total_hours)
+            bucket["billable"] += flt(row.hours)
         else:
-            non_billable = flt(row.total_hours)
+            bucket["non_billable"] += flt(row.hours)
+
+    roles = [
+        {
+            "designation": designation,
+            "billable_hours": flt(bucket["billable"], 2),
+            "non_billable_hours": flt(bucket["non_billable"], 2),
+            "total_hours": flt(bucket["billable"] + bucket["non_billable"], 2),
+        }
+        for designation, bucket in sorted(summary.items())
+    ]
 
     return {
-        "billable_hours": billable,
-        "non_billable_hours": non_billable,
-        "total_hours": billable + non_billable,
+        "days": days,
+        "start_date": start_date,
+        "end_date": end_date,
+        "roles": roles,
     }
 
 

--- a/next_pms/tests/test_dashboard.py
+++ b/next_pms/tests/test_dashboard.py
@@ -1,0 +1,177 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_to_date, get_datetime, today
+
+from next_pms.api.dashboard import _get_time_utilisation, get_time_utilisation
+
+DAYS = 7
+
+ENGINEER = "Time Utilisation Test Engineer"
+DESIGNER = "Time Utilisation Test Designer"
+IDLE_ROLE = "Time Utilisation Test QA"
+
+UNAUTHORISED_USER = "time-utilisation-unauthorised@example.com"
+
+
+class TestTimeUtilisation(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        for designation in (ENGINEER, DESIGNER, IDLE_ROLE):
+            if not frappe.db.exists("Designation", designation):
+                frappe.get_doc({"doctype": "Designation", "designation_name": designation}).insert(
+                    ignore_permissions=True
+                )
+
+        cls.end = get_datetime(today())
+        cls.window_start = add_to_date(cls.end, days=-(DAYS - 1))
+        cls.before_window = add_to_date(cls.window_start, days=-1)
+        cls.after_window = add_to_date(cls.end, days=1)
+
+        # Two engineers share a designation so we can check their hours get added together.
+        cls.engineer_1 = cls._make_employee("Engineer One", ENGINEER)
+        cls.engineer_2 = cls._make_employee("Engineer Two", ENGINEER)
+        cls.designer = cls._make_employee("Designer One", DESIGNER)
+        # Has a designation but never logs any time, to check it still shows up with zero hours.
+        cls._make_employee("Idle QA", IDLE_ROLE)
+        # Has no designation, to check their hours don't show up as a role.
+        cls.blank_designation_employee = cls._make_employee("No Designation", designation=None)
+
+        # engineer_1 logs 2h billable and 4h non-billable.
+        # engineer_2 logs 1h billable.
+        # Both share the ENGINEER designation, so it should total 3h billable and 4h non-billable.
+        cls._log_time(cls.engineer_1, cls.window_start, hours=2, is_billable=1)
+        cls._log_time(cls.engineer_1, add_to_date(cls.end, hours=23, minutes=59), hours=4, is_billable=0)
+        cls._log_time(cls.engineer_2, add_to_date(cls.window_start, days=2), hours=1, is_billable=1)
+
+        # Designer: 3h billable in the window.
+        cls._log_time(cls.designer, add_to_date(cls.window_start, days=3), hours=3, is_billable=1)
+
+        # 100h logged a day before the window starts and a day after it ends.
+        # These fall outside the range and should never be counted.
+        cls._log_time(cls.engineer_1, add_to_date(cls.before_window, hours=23, minutes=59), hours=100, is_billable=1)
+        cls._log_time(cls.engineer_1, cls.after_window, hours=100, is_billable=1)
+
+        # 5h logged by the employee with no designation. Should not appear as a role.
+        cls._log_time(cls.blank_designation_employee, add_to_date(cls.window_start, days=1), hours=5, is_billable=1)
+
+        # 6h on a rejected timesheet. Should be excluded from the designer's totals.
+        cls.rejected_timesheet = cls._log_time(
+            cls.designer, add_to_date(cls.window_start, days=1), hours=6, is_billable=1
+        )
+        frappe.db.set_value("Timesheet", cls.rejected_timesheet, "custom_approval_status", "Rejected")
+
+        frappe.clear_cache()
+
+    @classmethod
+    def _make_employee(cls, employee_name, designation):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": employee_name,
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                # Skips an rtcamp Employee doc-event that errors while deriving
+                # leave_approver from reports_to when both are left blank.
+                "leave_approver": "Administrator",
+            }
+        )
+        if designation:
+            employee.designation = designation
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _log_time(cls, employee, from_time, hours, is_billable):
+        timesheet = frappe.get_doc(
+            {
+                "doctype": "Timesheet",
+                "employee": employee,
+                "note": "",
+                "time_logs": [
+                    {
+                        "description": "Time utilisation test entry",
+                        "from_time": from_time,
+                        "to_time": add_to_date(from_time, hours=hours),
+                        "hours": hours,
+                        "is_billable": is_billable,
+                    }
+                ],
+            }
+        )
+        timesheet.flags.ignore_validate = True
+        timesheet.insert(ignore_permissions=True)
+        return timesheet.name
+
+    def setUp(self):
+        _get_time_utilisation.clear_cache()
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def _roles_by_designation(self, days=DAYS, role=None):
+        result = _get_time_utilisation(days, role)
+        return {r["designation"]: r for r in result["roles"]}
+
+    def test_sums_hours_per_designation_across_employees(self):
+        roles = self._roles_by_designation()
+        engineer = roles[ENGINEER]
+        self.assertEqual(engineer["billable_hours"], 3)
+        self.assertEqual(engineer["non_billable_hours"], 4)
+        self.assertEqual(engineer["total_hours"], 7)
+
+    def test_designation_with_zero_activity_still_appears(self):
+        roles = self._roles_by_designation()
+        self.assertIn(IDLE_ROLE, roles)
+        self.assertEqual(roles[IDLE_ROLE]["billable_hours"], 0)
+        self.assertEqual(roles[IDLE_ROLE]["non_billable_hours"], 0)
+        self.assertEqual(roles[IDLE_ROLE]["total_hours"], 0)
+
+    def test_hours_outside_window_are_excluded(self):
+        roles = self._roles_by_designation()
+        self.assertEqual(roles[ENGINEER]["total_hours"], 7)
+
+    def test_blank_designation_is_not_a_role(self):
+        roles = self._roles_by_designation()
+        self.assertNotIn("", roles)
+        self.assertNotIn(None, roles)
+
+    def test_rejected_timesheet_is_excluded(self):
+        roles = self._roles_by_designation()
+        # Only the 3h accepted entry should count; the 6h "Rejected" one must not.
+        self.assertEqual(roles[DESIGNER]["billable_hours"], 3)
+        self.assertEqual(roles[DESIGNER]["total_hours"], 3)
+
+    def test_role_filter_only_aggregates_hours_for_that_designation(self):
+        roles = self._roles_by_designation(role=DESIGNER)
+        self.assertEqual(roles[DESIGNER]["billable_hours"], 3)
+        self.assertEqual(roles[DESIGNER]["total_hours"], 3)
+        self.assertEqual(roles[ENGINEER]["total_hours"], 0)
+
+    def test_days_below_one_is_rejected(self):
+        with self.assertRaises(frappe.ValidationError):
+            get_time_utilisation(days=0)
+
+    def test_unauthorised_user_is_denied(self):
+        if not frappe.db.exists("User", UNAUTHORISED_USER):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": UNAUTHORISED_USER,
+                    "first_name": "Unauthorised",
+                    "user_type": "System User",
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        frappe.set_user(UNAUTHORISED_USER)
+        with self.assertRaises(frappe.PermissionError):
+            get_time_utilisation(days=DAYS)


### PR DESCRIPTION
## Description

Resolves UAT issues in dashboard pages listed in #1673 

- “See all” in the widget should open the notification tray.
- Add roles dropdown to utilize time.
- Bind date selection in kpi cards.
- Active project counts link to project list page
- At risk count should link to project list page
- Calendar adds a tool tip for displaying in full title.
- Dashboard should be scrollable.
- Heatmap card should have set of default roles selected
- Default first week should be current week, and forward

## Relevant Technical Choices

- Updates api get_time_utilisation api to respond with roles.

<!-- For Code Reviewers: Please describe your changes. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

addresses #1669, Partially addresses #1673 