### PR TITLE
QA Fix: Allocation page sidebar sticky behavior on Safari

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttGrid.tsx
@@ -92,7 +92,7 @@ const GanttGridInner: React.FC<{
       )}
 
       <table
-        className="relative border-separate border-spacing-0"
+        className="relative table-fixed border-separate border-spacing-0"
         style={{ width: headerWidth + columnCount * columnWidth }}
       >
         <thead className="sticky top-0 z-30">
@@ -101,7 +101,12 @@ const GanttGridInner: React.FC<{
             <th
               rowSpan={2}
               className="sticky left-0 z-35 bg-surface-white text-lg text-ink-gray-7 border border-l-0 border-outline-gray-1 font-medium text-start p-3 pl-4.25"
-              style={{ width: headerWidth, height: HEADER_HEIGHT }}
+              style={{
+                width: headerWidth,
+                minWidth: headerWidth,
+                maxWidth: headerWidth,
+                height: HEADER_HEIGHT,
+              }}
             >
               {rowHeaderLabel}
             </th>

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -24,6 +24,7 @@ export interface GanttMemberItemProps {
   onToggle?: () => void;
   className?: string;
   style?: CSSProperties;
+  contentHeight?: number;
 }
 
 export function GanttMemberItem({
@@ -35,6 +36,7 @@ export function GanttMemberItem({
   onToggle,
   className,
   style,
+  contentHeight = CELL_HEIGHT,
 }: GanttMemberItemProps) {
   const { members, expandedRows, toggleRow, headerWidth, hasRoleAccess } =
     useGanttStore((s) => ({
@@ -66,72 +68,81 @@ export function GanttMemberItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               className,
             )}
             style={{
-              height: CELL_HEIGHT,
               width: headerWidth,
+              minWidth: headerWidth,
+              maxWidth: headerWidth,
               ...style,
             }}
           />
         }
       >
-        <button
-          type="button"
-          disabled={!canExpand}
-          onClick={() => handleToggle?.()}
-          className={cn("flex items-center w-full shrink-0", {
-            "cursor-default!": !canExpand,
-          })}
-          aria-expanded={canExpand ? isExpanded : undefined}
+        <div
+          className="overflow-hidden transition-[height] duration-200 ease-in-out"
+          style={{ height: contentHeight }}
         >
-          <div className="flex flex-col gap-1 w-full min-w-0">
-            <div className="flex gap-1 justify-between items-center w-full">
-              <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
-                {showChevron ? (
-                  <RightChevron
-                    className={cn(
-                      "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-8",
-                      { "opacity-0 pointer-events-none": !canExpand },
-                      { "rotate-90": isExpanded },
-                    )}
+          <button
+            type="button"
+            disabled={!canExpand}
+            onClick={() => handleToggle?.()}
+            className={cn(
+              "flex h-full w-full shrink-0 items-center gap-2 overflow-hidden",
+              {
+                "cursor-default!": !canExpand,
+              },
+            )}
+            aria-expanded={canExpand ? isExpanded : undefined}
+          >
+            <div className="flex flex-col gap-1 w-full min-w-0">
+              <div className="flex gap-1 justify-between items-center w-full">
+                <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
+                  {showChevron ? (
+                    <RightChevron
+                      className={cn(
+                        "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-8",
+                        { "opacity-0 pointer-events-none": !canExpand },
+                        { "rotate-90": isExpanded },
+                      )}
+                    />
+                  ) : null}
+                  <Avatar
+                    size="xs"
+                    shape="circle"
+                    image={member.image}
+                    label={member.name}
                   />
-                ) : null}
-                <Avatar
-                  size="xs"
-                  shape="circle"
-                  image={member.image}
-                  label={member.name}
-                />
-                <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
-                  {member.name}
-                </span>
+                  <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
+                    {member.name}
+                  </span>
+                </div>
+                {member.badge && (
+                  <Badge
+                    className=""
+                    label={member.badge}
+                    size="sm"
+                    variant="subtle"
+                    theme="gray"
+                  />
+                )}
               </div>
-              {member.badge && (
-                <Badge
-                  className=""
-                  label={member.badge}
-                  size="sm"
-                  variant="subtle"
-                  theme="gray"
-                />
-              )}
+              <div
+                className={cn(
+                  "flex overflow-hidden flex-1 items-center w-full min-w-0",
+                  showChevron ? "pl-11" : "pl-6",
+                )}
+              >
+                {member.designation && (
+                  <span className="text-sm truncate text-ink-gray-6">
+                    {member.designation}
+                  </span>
+                )}
+              </div>
             </div>
-            <div
-              className={cn(
-                "flex overflow-hidden flex-1 items-center w-full min-w-0",
-                showChevron ? "pl-11" : "pl-6",
-              )}
-            >
-              {member.designation && (
-                <span className="text-sm truncate text-ink-gray-6">
-                  {member.designation}
-                </span>
-              )}
-            </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </PreviewCard.Trigger>
       <PreviewCard.Portal>
         <PreviewCard.Positioner

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -89,7 +89,7 @@ export function GanttMemberItem({
             disabled={!canExpand}
             onClick={() => handleToggle?.()}
             className={cn(
-              "flex h-full w-full shrink-0 items-center gap-2 overflow-hidden",
+              "flex h-full w-full shrink-0 items-center overflow-hidden",
               {
                 "cursor-default!": !canExpand,
               },

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -62,6 +62,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
         canExpand={false}
         showChevron={false}
         className="pl-8 pr-3"
+        contentHeight={animatedRowHeight}
         style={{
           height: animatedRowHeight,
           width: headerWidth,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -123,33 +123,35 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
           aria-hidden={!isExpanded}
         >
           <th
-            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
+            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,
+              maxWidth: headerWidth,
               height: addProjectRowHeight,
               borderBottomWidth: isExpanded ? undefined : 0,
               borderRightWidth: isExpanded ? undefined : 0,
             }}
           >
-            <button
-              type="button"
-              onClick={() =>
-                onAddAllocation?.({
-                  employeeId: member.id,
-                  employeeName: member.name,
-                })
-              }
-              tabIndex={isExpanded ? undefined : -1}
-              className="w-full flex items-center gap-2 text-base font-medium text-ink-gray-8 overflow-hidden"
+            <div
+              className="overflow-hidden transition-[height] duration-200 ease-in-out"
+              style={{ height: addProjectRowHeight }}
             >
-              {isExpanded ? (
-                <>
-                  <AddMd className="size-4 shrink-0" />
-                  <span className="truncate">Add project</span>
-                </>
-              ) : null}
-            </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onAddAllocation?.({
+                    employeeId: member.id,
+                    employeeName: member.name,
+                  })
+                }
+                tabIndex={isExpanded ? undefined : -1}
+                className="flex h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8"
+              >
+                <AddMd className="size-4 shrink-0" />
+                <span className="truncate">Add project</span>
+              </button>
+            </div>
           </th>
           {weeks.map((_, i) => (
             <td

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -70,7 +70,7 @@ export function GanttProjectItem({
             disabled={!canExpand}
             onClick={() => onToggle?.()}
             className={cn(
-              "flex h-full w-full shrink-0 items-center gap-2 overflow-hidden",
+              "flex h-full w-full shrink-0 items-center overflow-hidden",
               {
                 "cursor-default!": !canExpand,
               },

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -9,6 +9,7 @@ import { Folder, RightChevron } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
+import { CELL_HEIGHT } from "./constants";
 import GanttProjectHoverCard from "./ganttProjectHoverCard";
 import type { Project } from "./types";
 import { mergeClassNames as cn } from "../../utils";
@@ -21,6 +22,7 @@ export interface GanttProjectItemProps extends Project {
   onToggle?: () => void;
   className?: string;
   style?: CSSProperties;
+  contentHeight?: number;
 }
 
 export function GanttProjectItem({
@@ -39,6 +41,7 @@ export function GanttProjectItem({
   onToggle,
   className,
   style,
+  contentHeight = CELL_HEIGHT,
 }: GanttProjectItemProps) {
   const subtext = [dateRange, client].filter(Boolean).join(" · ");
 
@@ -50,7 +53,7 @@ export function GanttProjectItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               showChevron ? "pl-3" : "pl-8",
               className,
             )}
@@ -58,50 +61,63 @@ export function GanttProjectItem({
           />
         }
       >
-        <button
-          type="button"
-          disabled={!canExpand}
-          onClick={() => onToggle?.()}
-          className={cn("flex items-center w-full shrink-0", {
-            "cursor-default!": !canExpand,
-          })}
-          aria-expanded={canExpand ? isExpanded : undefined}
+        <div
+          className="overflow-hidden transition-[height] duration-200 ease-in-out"
+          style={{ height: contentHeight }}
         >
-          <div className="flex flex-col gap-1 w-full min-w-0">
-            <div className="flex gap-1 justify-between items-center w-full">
-              <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
-                {showChevron ? (
-                  <RightChevron
-                    className={cn(
-                      "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-8",
-                      { "opacity-0 pointer-events-none": !canExpand },
-                      { "rotate-90": isExpanded },
-                    )}
+          <button
+            type="button"
+            disabled={!canExpand}
+            onClick={() => onToggle?.()}
+            className={cn(
+              "flex h-full w-full shrink-0 items-center gap-2 overflow-hidden",
+              {
+                "cursor-default!": !canExpand,
+              },
+            )}
+            aria-expanded={canExpand ? isExpanded : undefined}
+          >
+            <div className="flex flex-col gap-1 w-full min-w-0">
+              <div className="flex gap-1 justify-between items-center w-full">
+                <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
+                  {showChevron ? (
+                    <RightChevron
+                      className={cn(
+                        "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-8",
+                        { "opacity-0 pointer-events-none": !canExpand },
+                        { "rotate-90": isExpanded },
+                      )}
+                    />
+                  ) : null}
+                  <Folder className="size-4 shrink-0" />
+                  <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
+                    {name}
+                  </span>
+                </div>
+                {badge && (
+                  <Badge
+                    label={badge}
+                    size="sm"
+                    variant="subtle"
+                    theme="gray"
                   />
-                ) : null}
-                <Folder className="size-4 shrink-0" />
-                <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
-                  {name}
-                </span>
+                )}
               </div>
-              {badge && (
-                <Badge label={badge} size="sm" variant="subtle" theme="gray" />
-              )}
+              <div
+                className={cn(
+                  "flex overflow-hidden flex-1 items-center w-full min-w-0",
+                  showChevron ? "pl-11" : "pl-6",
+                )}
+              >
+                {subtext && (
+                  <span className="text-sm truncate text-ink-gray-6">
+                    {subtext}
+                  </span>
+                )}
+              </div>
             </div>
-            <div
-              className={cn(
-                "flex overflow-hidden flex-1 items-center w-full min-w-0",
-                showChevron ? "pl-11" : "pl-6",
-              )}
-            >
-              {subtext && (
-                <span className="text-sm truncate text-ink-gray-6">
-                  {subtext}
-                </span>
-              )}
-            </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </PreviewCard.Trigger>
       <PreviewCard.Portal>
         <PreviewCard.Positioner

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
@@ -68,10 +68,12 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
         canExpand={false}
         showChevron={false}
         showHoverCard={false}
+        contentHeight={animatedRowHeight}
         style={{
           height: animatedRowHeight,
           width: headerWidth,
           minWidth: headerWidth,
+          maxWidth: headerWidth,
           borderBottomWidth: isExpanded ? undefined : 0,
           borderRightWidth: isExpanded ? undefined : 0,
         }}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -86,6 +86,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
             height: CELL_HEIGHT,
             width: headerWidth,
             minWidth: headerWidth,
+            maxWidth: headerWidth,
           }}
         />
         {weeks.map((week, index) => (
@@ -142,34 +143,36 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
           aria-hidden={!isExpanded}
         >
           <th
-            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle flex items-center gap-2 w-full overflow-hidden transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
+            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,
+              maxWidth: headerWidth,
               height: addMemberRowHeight,
               borderBottomWidth: isExpanded ? undefined : 0,
               borderRightWidth: isExpanded ? undefined : 0,
             }}
           >
-            <button
-              type="button"
-              onClick={() =>
-                onAddAllocation?.({
-                  projectId: project.id,
-                  projectName: project.name,
-                  customerName: project.client,
-                })
-              }
-              tabIndex={isExpanded ? undefined : -1}
-              className="w-full flex items-center gap-2 text-base font-medium text-ink-gray-8 overflow-hidden"
+            <div
+              className="overflow-hidden transition-[height] duration-200 ease-in-out"
+              style={{ height: addMemberRowHeight }}
             >
-              {isExpanded ? (
-                <>
-                  <AddMd className="size-4 shrink-0" />
-                  <span className="truncate">Add member</span>
-                </>
-              ) : null}
-            </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onAddAllocation?.({
+                    projectId: project.id,
+                    projectName: project.name,
+                    customerName: project.client,
+                  })
+                }
+                tabIndex={isExpanded ? undefined : -1}
+                className="flex h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8"
+              >
+                <AddMd className="size-4 shrink-0" />
+                <span className="truncate">Add member</span>
+              </button>
+            </div>
           </th>
           {weeks.map((week, index) => (
             <td


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes the Allocation page sidebar sticky behavior on Safari, where `th` elements do not work correctly when `sticky` and `flex` are used together on the same element. This worked correctly in Chrome and Firefox but failed in Safari.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/00d6f962-da9f-4cde-993d-b7aec3dea6bb



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially Fixes #1681