### PR TITLE
Render Gantt child rows conditionally on expansion for Allocation pages

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -24,6 +24,7 @@ interface GanttMemberRowProps {
   isExpanded: boolean;
   canManageAllocations: boolean;
   canEditAllocations: boolean;
+  onTransitionEnd?: React.TransitionEventHandler<HTMLTableRowElement>;
 }
 
 export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
@@ -32,6 +33,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
   isExpanded,
   canManageAllocations,
   canEditAllocations,
+  onTransitionEnd,
 }) => {
   const { weeks, daysPerWeek, columnWidth, headerWidth, onAddAllocation } =
     useGanttStore((s) => ({
@@ -55,6 +57,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
       onPointerDown={(e) => overlayRef.current?.handleRowPointerDown(e)}
       onPointerMove={(e) => overlayRef.current?.handleRowPointerMove(e)}
       onPointerLeave={() => overlayRef.current?.clearHoveredSlot()}
+      onTransitionEnd={onTransitionEnd}
     >
       <GanttMemberItem
         member={member}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -17,7 +17,7 @@ import { GanttMemberItem } from "./ganttMemberItem";
 import { GanttProjectRow } from "./ganttProjectRow";
 import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
-import { useAnimatedPresence } from "./hooks/useAnimatedPresence";
+import { useCollapsiblePresence } from "./hooks/useCollapsiblePresence";
 import { mergeClassNames as cn } from "../../utils";
 
 interface GanttMemberRowsProps {
@@ -53,7 +53,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
   }));
 
   const overlayRef = useRef<RowAllocationOverlayHandle | null>(null);
-  const childRowsPresence = useAnimatedPresence(isExpanded, {
+  const childRowsPresence = useCollapsiblePresence(isExpanded, {
     durationMs: 200,
   });
 

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -17,6 +17,7 @@ import { GanttMemberItem } from "./ganttMemberItem";
 import { GanttProjectRow } from "./ganttProjectRow";
 import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
+import { useAnimatedPresence } from "./hooks/useAnimatedPresence";
 import { mergeClassNames as cn } from "../../utils";
 
 interface GanttMemberRowsProps {
@@ -52,13 +53,17 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
   }));
 
   const overlayRef = useRef<RowAllocationOverlayHandle | null>(null);
+  const childRowsPresence = useAnimatedPresence(isExpanded, {
+    durationMs: 200,
+  });
 
   if (!member) return null;
 
   const canManageAllocations = hasRoleAccess && Boolean(onAddAllocation);
   const canEditAllocations = hasRoleAccess && Boolean(onEditAllocation);
   const memberRowKey = `member-${memberInd}`;
-  const addProjectRowHeight = isExpanded ? ADD_PROJECT_ROW_HEIGHT : 0;
+  const childRowsVisible = childRowsPresence.isVisible;
+  const addProjectRowHeight = childRowsVisible ? ADD_PROJECT_ROW_HEIGHT : 0;
   return (
     <React.Fragment>
       {/* Member row */}
@@ -104,23 +109,29 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
       </tr>
 
       {/* Project child rows */}
-      {member.projects?.map((_, projectIndex) => (
-        <GanttProjectRow
-          key={`${memberInd}-project-${projectIndex}`}
-          member={member}
-          memberInd={memberInd}
-          projectInd={projectIndex}
-          isExpanded={isExpanded}
-          canManageAllocations={canManageAllocations}
-          canEditAllocations={canEditAllocations}
-        />
-      ))}
+      {childRowsPresence.shouldRender
+        ? member.projects?.map((_, projectIndex) => (
+            <GanttProjectRow
+              key={`${memberInd}-project-${projectIndex}`}
+              member={member}
+              memberInd={memberInd}
+              projectInd={projectIndex}
+              isExpanded={childRowsVisible}
+              canManageAllocations={canManageAllocations}
+              canEditAllocations={canEditAllocations}
+              onTransitionEnd={childRowsPresence.onTransitionEnd}
+            />
+          ))
+        : null}
 
       {/* Add project row */}
-      {canManageAllocations && (
+      {canManageAllocations && childRowsPresence.shouldRender && (
         <tr
-          className={cn("touch-pan-y", { "pointer-events-none": !isExpanded })}
-          aria-hidden={!isExpanded}
+          className={cn("touch-pan-y", {
+            "pointer-events-none": !childRowsVisible,
+          })}
+          aria-hidden={!childRowsVisible}
+          onTransitionEnd={childRowsPresence.onTransitionEnd}
         >
           <th
             className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
@@ -129,8 +140,8 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
               minWidth: headerWidth,
               maxWidth: headerWidth,
               height: addProjectRowHeight,
-              borderBottomWidth: isExpanded ? undefined : 0,
-              borderRightWidth: isExpanded ? undefined : 0,
+              borderBottomWidth: childRowsVisible ? undefined : 0,
+              borderRightWidth: childRowsVisible ? undefined : 0,
             }}
           >
             <div
@@ -145,7 +156,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
                     employeeName: member.name,
                   })
                 }
-                tabIndex={isExpanded ? undefined : -1}
+                tabIndex={childRowsVisible ? undefined : -1}
                 className="flex h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8"
               >
                 <AddMd className="size-4 shrink-0" />
@@ -159,7 +170,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
               colSpan={daysPerWeek}
               className={cn(
                 "overflow-hidden transition-[height] duration-200 ease-in-out",
-                { "border-r border-b border-outline-gray-1": isExpanded },
+                { "border-r border-b border-outline-gray-1": childRowsVisible },
               )}
               style={{ height: addProjectRowHeight }}
             />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
@@ -25,6 +25,7 @@ interface GanttProjectRowProps {
   isExpanded: boolean;
   canManageAllocations: boolean;
   canEditAllocations: boolean;
+  onTransitionEnd?: React.TransitionEventHandler<HTMLTableRowElement>;
 }
 
 export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
@@ -34,6 +35,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
   isExpanded,
   canManageAllocations,
   canEditAllocations,
+  onTransitionEnd,
 }) => {
   const { weeks, daysPerWeek, columnWidth, headerWidth, onAddAllocation } =
     useGanttStore((s) => ({
@@ -61,6 +63,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
       onPointerDown={(e) => overlayRef.current?.handleRowPointerDown(e)}
       onPointerMove={(e) => overlayRef.current?.handleRowPointerMove(e)}
       onPointerLeave={() => overlayRef.current?.clearHoveredSlot()}
+      onTransitionEnd={onTransitionEnd}
     >
       <GanttProjectItem
         {...project}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -17,7 +17,7 @@ import { GanttMemberRow } from "./ganttMemberRow";
 import { GanttProjectItem } from "./ganttProjectItem";
 import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
-import { useAnimatedPresence } from "./hooks/useAnimatedPresence";
+import { useCollapsiblePresence } from "./hooks/useCollapsiblePresence";
 import { mergeClassNames as cn } from "../../utils";
 
 interface GanttProjectRowsProps {
@@ -55,7 +55,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
   }));
 
   const overlayRef = useRef<RowAllocationOverlayHandle | null>(null);
-  const childRowsPresence = useAnimatedPresence(isExpanded, {
+  const childRowsPresence = useCollapsiblePresence(isExpanded, {
     durationMs: 200,
   });
 

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -17,6 +17,7 @@ import { GanttMemberRow } from "./ganttMemberRow";
 import { GanttProjectItem } from "./ganttProjectItem";
 import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
+import { useAnimatedPresence } from "./hooks/useAnimatedPresence";
 import { mergeClassNames as cn } from "../../utils";
 
 interface GanttProjectRowsProps {
@@ -54,6 +55,9 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
   }));
 
   const overlayRef = useRef<RowAllocationOverlayHandle | null>(null);
+  const childRowsPresence = useAnimatedPresence(isExpanded, {
+    durationMs: 200,
+  });
 
   if (!project) return null;
 
@@ -61,7 +65,8 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
   const canManageAllocations = hasRoleAccess && Boolean(onAddAllocation);
   const canEditAllocations = hasRoleAccess && Boolean(onEditAllocation);
   const canExpand = hasMembers || canManageAllocations;
-  const addMemberRowHeight = isExpanded ? ADD_PROJECT_ROW_HEIGHT : 0;
+  const childRowsVisible = childRowsPresence.isVisible;
+  const addMemberRowHeight = childRowsVisible ? ADD_PROJECT_ROW_HEIGHT : 0;
   const projectSummaryRowKey = `project-summary-${project.id ?? project.name}`;
 
   return (
@@ -124,23 +129,29 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
         </GanttRowOverlayCell>
       </tr>
 
-      {project.members?.map((member) => {
-        return (
-          <GanttMemberRow
-            key={member.id ?? member.name}
-            project={project}
-            member={member}
-            isExpanded={isExpanded}
-            canManageAllocations={canManageAllocations}
-            canEditAllocations={canEditAllocations}
-          />
-        );
-      })}
+      {childRowsPresence.shouldRender
+        ? project.members?.map((member) => {
+            return (
+              <GanttMemberRow
+                key={member.id ?? member.name}
+                project={project}
+                member={member}
+                isExpanded={childRowsVisible}
+                canManageAllocations={canManageAllocations}
+                canEditAllocations={canEditAllocations}
+                onTransitionEnd={childRowsPresence.onTransitionEnd}
+              />
+            );
+          })
+        : null}
 
-      {canManageAllocations && (
+      {canManageAllocations && childRowsPresence.shouldRender && (
         <tr
-          className={cn("touch-pan-y", { "pointer-events-none": !isExpanded })}
-          aria-hidden={!isExpanded}
+          className={cn("touch-pan-y", {
+            "pointer-events-none": !childRowsVisible,
+          })}
+          aria-hidden={!childRowsVisible}
+          onTransitionEnd={childRowsPresence.onTransitionEnd}
         >
           <th
             className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
@@ -149,8 +160,8 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
               minWidth: headerWidth,
               maxWidth: headerWidth,
               height: addMemberRowHeight,
-              borderBottomWidth: isExpanded ? undefined : 0,
-              borderRightWidth: isExpanded ? undefined : 0,
+              borderBottomWidth: childRowsVisible ? undefined : 0,
+              borderRightWidth: childRowsVisible ? undefined : 0,
             }}
           >
             <div
@@ -166,7 +177,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
                     customerName: project.client,
                   })
                 }
-                tabIndex={isExpanded ? undefined : -1}
+                tabIndex={childRowsVisible ? undefined : -1}
                 className="flex h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8"
               >
                 <AddMd className="size-4 shrink-0" />
@@ -180,7 +191,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
               colSpan={daysPerWeek}
               className={cn(
                 "overflow-hidden transition-[height] duration-200 ease-in-out",
-                { "border-r border-b border-outline-gray-1": isExpanded },
+                { "border-r border-b border-outline-gray-1": childRowsVisible },
               )}
               style={{ height: addMemberRowHeight }}
             />

--- a/frontend/packages/design-system/src/components/gantt-view/hooks/useAnimatedPresence.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/hooks/useAnimatedPresence.ts
@@ -1,0 +1,89 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TransitionEvent } from "react";
+
+interface UseAnimatedPresenceOptions {
+  durationMs: number;
+  exitBufferMs?: number;
+}
+
+/**
+ * Keeps collapsible rows mounted only while they are visible or animating.
+ *
+ * - opening mounts the rows at their collapsed height, waits for layout to
+ *   commit, then marks them visible so the height transition can run.
+ * - closing keeps the rows mounted while they animate to zero height.
+ * - after the height transition ends, the rows are removed from the DOM.
+ */
+export function useAnimatedPresence(
+  open: boolean,
+  { durationMs, exitBufferMs = 50 }: UseAnimatedPresenceOptions,
+) {
+  const [shouldRender, setShouldRender] = useState(open);
+  const [isVisible, setIsVisible] = useState(open);
+  const frameRef = useRef<number | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  const clearScheduledWork = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const finishExit = useCallback(() => {
+    if (open) return;
+    clearScheduledWork();
+    setShouldRender(false);
+  }, [clearScheduledWork, open]);
+
+  const onTransitionEnd = useCallback(
+    (event: TransitionEvent<HTMLElement>) => {
+      if (event.propertyName !== "height") return;
+      finishExit();
+    },
+    [finishExit],
+  );
+
+  useEffect(() => {
+    clearScheduledWork();
+
+    if (open) {
+      setShouldRender(true);
+      // Wait two frames so newly mounted rows first paint at height 0;
+      // then the visible state can transition them to their expanded height.
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = requestAnimationFrame(() => {
+          frameRef.current = null;
+          setIsVisible(true);
+        });
+      });
+      return;
+    }
+
+    setIsVisible(false);
+    if (!shouldRender) {
+      return;
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = null;
+      setShouldRender(false);
+    }, durationMs + exitBufferMs);
+  }, [clearScheduledWork, durationMs, exitBufferMs, open, shouldRender]);
+
+  useEffect(() => clearScheduledWork, [clearScheduledWork]);
+
+  return {
+    shouldRender,
+    isVisible,
+    onTransitionEnd,
+  };
+}

--- a/frontend/packages/design-system/src/components/gantt-view/hooks/useCollapsiblePresence.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/hooks/useCollapsiblePresence.ts
@@ -47,9 +47,13 @@ export function useCollapsiblePresence(
   const onTransitionEnd = useCallback(
     (event: TransitionEvent<HTMLElement>) => {
       if (event.propertyName !== "height") return;
+      // If the transition was interrupted, don't finish the exit yet.
+      if (durationMs > 0 && event.elapsedTime * 1000 < durationMs - 16) {
+        return;
+      }
       finishExit();
     },
-    [finishExit],
+    [durationMs, finishExit],
   );
 
   useEffect(() => {

--- a/frontend/packages/design-system/src/components/gantt-view/hooks/useCollapsiblePresence.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/hooks/useCollapsiblePresence.ts
@@ -4,7 +4,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { TransitionEvent } from "react";
 
-interface UseAnimatedPresenceOptions {
+interface UseCollapsiblePresenceOptions {
   durationMs: number;
   exitBufferMs?: number;
 }
@@ -17,9 +17,9 @@ interface UseAnimatedPresenceOptions {
  * - closing keeps the rows mounted while they animate to zero height.
  * - after the height transition ends, the rows are removed from the DOM.
  */
-export function useAnimatedPresence(
+export function useCollapsiblePresence(
   open: boolean,
-  { durationMs, exitBufferMs = 50 }: UseAnimatedPresenceOptions,
+  { durationMs, exitBufferMs = 50 }: UseCollapsiblePresenceOptions,
 ) {
   const [shouldRender, setShouldRender] = useState(open);
   const [isVisible, setIsVisible] = useState(open);


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
Render Gantt child rows only while they are expanded or actively animating.

Previously, collapsed child rows stayed mounted at zero height, which preserved the collapse animation but still rendered all nested row components, allocation bars, overlays, and popover triggers. This change keeps the same expand/collapse animation behavior while removing collapsed child rows from the DOM after the exit transition completes.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Added `useCollapsiblePresence` hook to keep collapsed child rows out of the DOM while still allowing smooth expand/collapse animations. The hook keeps rows mounted during the animation, then removes them after collapse completes.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially Fixes #1695