### PR TITLE
QA Fix: Fix visibility of holidays on timesheets

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/timeOffRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/timeOffRow.tsx
@@ -42,6 +42,7 @@ export const TimeOffRow = ({
       totalTimeEntries.push({
         time: hour === 0 ? "" : floatToTime(hour, 2),
         holiday: Boolean(holiday),
+        holidayDescription: holiday?.description,
       });
     }
 

--- a/frontend/packages/app/src/components/timesheet-row/components/row/timeOffRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/timeOffRow.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useMemo } from "react";
-import { floatToTime } from "@next-pms/design-system";
+import { floatToTime, stripTags } from "@next-pms/design-system";
 import { TimeOffRow as BaseTimeOffRow } from "@next-pms/design-system/components";
 
 /**
@@ -42,7 +42,7 @@ export const TimeOffRow = ({
       totalTimeEntries.push({
         time: hour === 0 ? "" : floatToTime(hour, 2),
         holiday: Boolean(holiday),
-        holidayDescription: holiday?.description,
+        holidayDescription: stripTags(holiday?.description ?? ""),
       });
     }
 

--- a/frontend/packages/app/src/components/timesheet-row/components/row/timeOffRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/timeOffRow.tsx
@@ -8,7 +8,7 @@ import { TimeOffRow as BaseTimeOffRow } from "@next-pms/design-system/components
 /**
  * Internal dependencies
  */
-import { LeaveProps } from "@/types/timesheet";
+import { calculateLeaveHours } from "@/lib/utils";
 import type { TimeOffRowProps } from "./types";
 
 /**
@@ -17,66 +17,42 @@ import type { TimeOffRowProps } from "./types";
  *
  * @param {Array} props.dates - Array of date strings for the week.
  * @param {Array} props.leaves - Array of leave objects for the week.
- * @param {Array} props.holidayList - Array of holiday date strings for the week.
+ * @param {Array} props.holidays - Array of holiday objects for the week.
  * @param {number} props.expectedHours - Expected working hours for the day.
  */
 export const TimeOffRow = ({
   dates,
   leaves,
-  holidayList,
+  holidays,
   expectedHours,
   ...rest
 }: TimeOffRowProps) => {
   const timeOffData = useMemo(() => {
     let totalHours = 0;
     const totalTimeEntries = [];
+    let hasVisibleHoliday = false;
 
     for (const date of dates) {
-      let hour = 0;
-      const data = leaves.filter((data: LeaveProps) => {
-        return date >= data.from_date && date <= data.to_date;
-      });
+      const holiday = holidays.find((holiday) => holiday.holiday_date === date);
+      const hour = calculateLeaveHours(leaves, date, expectedHours, holiday);
+      hasVisibleHoliday =
+        hasVisibleHoliday || Boolean(holiday && !holiday.weekly_off);
 
-      if (holidayList.includes(date)) {
-        const is_lwp = data.some((item: LeaveProps) => item.is_lwp);
-        if (is_lwp) {
-          hour = expectedHours;
-          totalHours += hour;
-          totalTimeEntries.push({
-            time: hour === 0 ? "" : floatToTime(hour, 2),
-            holiday: true,
-          });
-          continue;
-        }
-        totalTimeEntries.push({
-          time: "",
-          holiday: true,
-        });
-        continue;
-      }
-
-      for (const item of data) {
-        if (
-          item.half_day &&
-          item.half_day_date &&
-          item.half_day_date === date
-        ) {
-          hour += expectedHours / 2;
-        } else {
-          hour += expectedHours;
-        }
-      }
       totalHours += hour;
       totalTimeEntries.push({
         time: hour === 0 ? "" : floatToTime(hour, 2),
-        holiday: false,
+        holiday: Boolean(holiday),
       });
     }
 
-    return { totalHours: floatToTime(totalHours, 2), totalTimeEntries };
-  }, [dates, leaves, holidayList, expectedHours]);
+    return {
+      totalHours: floatToTime(totalHours, 2),
+      totalTimeEntries,
+      hasVisibleHoliday,
+    };
+  }, [dates, leaves, holidays, expectedHours]);
 
-  if (timeOffData.totalHours === "00:00") {
+  if (timeOffData.totalHours === "00:00" && !timeOffData.hasVisibleHoliday) {
     return <></>;
   }
 

--- a/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
@@ -116,6 +116,6 @@ export interface TimeOffRowProps extends Omit<
 > {
   dates: string[];
   leaves: Array<LeaveProps>;
-  holidayList: Array<string>;
+  holidays: Array<HolidayProp>;
   expectedHours: number;
 }

--- a/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
@@ -11,7 +11,6 @@ import {
  * Internal dependencies
  */
 import { useImportedTasks } from "@/hooks/useImportedTasks";
-import { getHolidayList } from "@/lib/utils";
 import { useTimesheetOutletContext } from "@/pages/timesheet/outletContext";
 import { usePersonalTimesheet } from "@/pages/timesheet/personal/context";
 import { WorkingFrequency } from "@/types";
@@ -60,7 +59,6 @@ export const PersonalTimesheetRow = ({
   hideLikeButton,
 }: PersonalTimesheetRowProps) => {
   const { openAddTimeDialog } = useTimesheetOutletContext();
-  const holidayList = getHolidayList(holidays);
 
   // Get liked tasks from context
   const likedTaskData = usePersonalTimesheet(
@@ -186,7 +184,7 @@ export const PersonalTimesheetRow = ({
               className="pl-7.5 mt-3"
               dates={dates}
               leaves={leaves}
-              holidayList={holidayList}
+              holidays={holidays}
               expectedHours={dailyWorkingHours}
             />
           </>

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -10,7 +10,6 @@ import {
 /**
  * Internal dependencies
  */
-import { getHolidayList } from "@/lib/utils";
 import { useTimesheetOutletContext } from "@/pages/timesheet/outletContext";
 import type { WorkingFrequency } from "@/types";
 import type { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
@@ -56,12 +55,10 @@ export const TeamTimesheetRow = ({
   const teamMembersData = useMemo(() => {
     return teamMembers.map((member) => {
       const projects = groupTasksByProject(member.tasks);
-      const holidayList = getHolidayList(member.holidays);
 
       return {
         ...member,
         projects,
-        holidayList,
       };
     });
   }, [teamMembers]);
@@ -156,7 +153,7 @@ export const TeamTimesheetRow = ({
                       className="pl-13.5"
                       dates={dates}
                       leaves={member.leaves}
-                      holidayList={member.holidayList}
+                      holidays={member.holidays}
                       expectedHours={dailyWorkingHours}
                     />
                   </>

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -491,6 +491,10 @@ export const calculateLeaveHours = (
   daily_working_hours: number,
   holiday: HolidayProp | undefined,
 ) => {
+  if (holiday && !holiday.weekly_off) {
+    return daily_working_hours;
+  }
+
   return leaves.reduce((total, leave) => {
     if (date >= leave.from_date && date <= leave.to_date) {
       if (!leave.is_lwp && holiday?.weekly_off) {

--- a/frontend/packages/design-system/src/components/timesheet/rows/timeOff/timeOffRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/timeOff/timeOffRow.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { TimeOff } from "@rtcamp/frappe-ui-react/icons";
 
 /**
@@ -12,7 +13,11 @@ export interface TimeOffRowProps {
   /** Label for the time-off row. */
   label?: string;
   /** Array of time-off entries for each day of the week. */
-  timeOffEntries: { time: string; holiday: boolean }[];
+  timeOffEntries: {
+    time: string;
+    holiday: boolean;
+    holidayDescription?: string;
+  }[];
   /** Total time-off hours logged for the week. */
   totalHours?: string;
   /** Optional icon to display next to the label. */
@@ -46,10 +51,13 @@ export const TimeOffRow: React.FC<TimeOffRowProps> = ({
         </span>
         <span className="min-w-0 text-base font-medium truncate">{label}</span>
       </div>
-      {timeOffEntries.map((timeOffEntry, index) => {
-        return (
+      {timeOffEntries.map((timeOffEntry, index) => (
+        <Tooltip
+          key={index}
+          text={timeOffEntry.holidayDescription ?? ""}
+          disabled={!timeOffEntry.holidayDescription}
+        >
           <div
-            key={index}
             className={cn(
               "shrink-0 flex justify-end items-center text-base whitespace-nowrap w-16 h-7 px-2 py-1.5 lining-nums tabular-nums",
               timeOffEntry.holiday ? "text-ink-gray-4" : "text-ink-gray-6",
@@ -61,8 +69,8 @@ export const TimeOffRow: React.FC<TimeOffRowProps> = ({
               <span>{timeOffEntry.time}</span>
             )}
           </div>
-        );
-      })}
+        </Tooltip>
+      ))}
 
       <div className="shrink-0 flex justify-end items-center text-base text-end font-medium text-ink-amber-4 whitespace-nowrap w-16 h-7 px-2 py-1.5 lining-nums tabular-nums">
         <span>{totalHours}</span>


### PR DESCRIPTION
## Description

 Fixed holiday handling in personal and team timesheet rows.

The issue was that holiday data was present in the API response, but the frontend reduced holidays to only date strings and the Time-off row used separate logic from the total row. Because of that, holidays with `weekly_off: 0` were hidden.

Also adds a tooltip for holidays.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

<img width="1392" height="252" alt="Screenshot 2026-07-03 at 2 07 22 PM" src="https://github.com/user-attachments/assets/85719dca-1457-48a2-a0b0-d52143585af7" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1689 