### PR TITLE
QA Fix: Add timeoff row to project timesheet

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
@@ -16,6 +16,7 @@ import type { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
 import { MemberRow } from "./components/row/memberRow";
 import { ProjectRow } from "./components/row/projectRow";
 import { TaskRow } from "./components/row/taskRow";
+import { TimeOffRow } from "./components/row/timeOffRow";
 import { WeekRow } from "./components/row/weekRow";
 import { mergeProjectMemberTasks } from "./utils";
 
@@ -133,6 +134,14 @@ export const ProjectTimesheetRow = ({
                             hideLikeButton={true}
                           />
                         ))}
+                        <TimeOffRow
+                          label="Time-off"
+                          className="pl-19.5"
+                          dates={dates}
+                          leaves={member.leaves}
+                          holidays={member.holidays}
+                          expectedHours={dailyWorkingHours}
+                        />
                       </>
                     )}
                   </MemberRow>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds a Time Off row to the Project Timesheet, allowing users to see where allocated hours are coming from and providing better visibility into time off alongside project allocations.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1392" height="412" alt="Screenshot 2026-07-03 at 1 20 30 AM" src="https://github.com/user-attachments/assets/669ed417-bd63-40f2-9d22-eaac06baf815" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1657