### PR TITLE
fix: date-fns missing import

### DIFF
--- a/frontend/packages/app/src/components/task-log/personalTaskLog.tsx
+++ b/frontend/packages/app/src/components/task-log/personalTaskLog.tsx
@@ -63,6 +63,7 @@ const PersonalTaskLog: React.FC<PersonalTaskLogProps> = ({
       const err = parseFrappeErrorMsg(error);
       toast.error(err);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [error]);
 
   const handleDateRangeChange = (value: string | undefined) => {

--- a/frontend/packages/app/src/components/task-log/teamTaskLog.tsx
+++ b/frontend/packages/app/src/components/task-log/teamTaskLog.tsx
@@ -58,6 +58,7 @@ const TeamTaskLog: React.FC<TeamTaskLogProps> = ({
       const err = parseFrappeErrorMsg(error);
       toast.error(err);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [error]);
 
   const handleDateRangeChange = (value: string | undefined) => {

--- a/frontend/packages/app/src/components/taskPopover.tsx
+++ b/frontend/packages/app/src/components/taskPopover.tsx
@@ -8,13 +8,7 @@ import {
   mergeClassNames as cn,
   floatToTime,
 } from "@next-pms/design-system/utils";
-import { Badge } from "@rtcamp/frappe-ui-react";
 import TaskBadges from "./taskBadges";
-
-type BadgeItem = {
-  icon: React.ReactNode;
-  text: string;
-};
 
 export type TaskPopoverProps = {
   label: string;

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -15,6 +15,8 @@ import {
   getISOWeekYear,
   getISOWeeksInYear,
   parse,
+  parseISO,
+  isToday,
 } from "date-fns";
 import { Error as FrappeError } from "frappe-js-sdk/lib/frappe_app/types";
 import { twMerge } from "tailwind-merge";

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/create-touchpoint/index.tsx
@@ -143,6 +143,7 @@ export function CreateTouchpointModal({
 
   useEffect(() => {
     setOwnerSearch(isEditMode && item ? (item.owner?.fullName ?? "") : "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   return (


### PR DESCRIPTION
## Description
- Re-adds missing date fns imports

## Additional Information:
- Not sure why the imports were removed, but I suspect they were removed by rtBot - not sure how it got pass the lint checks. Also for some reason the missing imports do not break the build?

## Screenshot/Screencast
<img width="2072" height="1138" alt="image" src="https://github.com/user-attachments/assets/37a8fd6c-0321-48f2-8c64-a962894eb862" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1604