### PR TITLE
QA Fix: Weekly approval modal

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -43,7 +43,7 @@ const ApprovalPopup = () => {
           <p className="text-base text-ink-gray-5">{dateRange}</p>
         </div>
         <div className="flex items-center gap-3">
-          <span className="text-lg font-medium text-ink-green-4">
+          <span className="text-lg font-medium text-ink-green-4 tabular-nums lining-nums">
             {floatToTime(totalHours, 2, 2)}
           </span>
           <Dialog.Close className="hover:bg-surface-gray-2 rounded">
@@ -71,7 +71,7 @@ const ApprovalPopup = () => {
                   </span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className="text-lg font-medium text-ink-green-4">
+                  <span className="text-lg font-medium text-ink-green-4 tabular-nums lining-nums">
                     {floatToTime(dayGroup.totalHours, 2, 2)}
                   </span>
                   <div
@@ -115,6 +115,7 @@ const ApprovalPopup = () => {
           label="Approve"
           iconLeft={() => <Success size={16} className="text-ink-white" />}
           onClick={handleApproveSubmit}
+          className="bg-surface-green-5"
         />
       </div>
     </Dialog.Popup>

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -68,6 +68,11 @@ const ApprovalPopup = () => {
                   <SmallDown className="h-4 w-4 text-ink-gray-5 transition-transform duration-200 -rotate-90 group-data-panel-open:rotate-0" />
                   <span className="text-base font-medium text-ink-gray-8">
                     {dayGroup.day}
+                    {dayGroup.leaveLabel ? (
+                      <span className="text-ink-gray-5">
+                        {` · ${dayGroup.leaveLabel}`}
+                      </span>
+                    ) : null}
                   </span>
                 </div>
                 <div className="flex items-center gap-3">

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -24,6 +24,7 @@ const ApprovalPopup = () => {
     avatarUrl,
     dateRange,
     totalHours,
+    isReadOnly,
     groupedByDay,
     checkedDays,
     handleDayCheckChange,
@@ -85,6 +86,7 @@ const ApprovalPopup = () => {
                   >
                     <Checkbox
                       value={checkedDays.has(dayGroup.day)}
+                      disabled={isReadOnly}
                       onChange={(checked) =>
                         handleDayCheckChange(dayGroup.day, checked)
                       }
@@ -97,6 +99,7 @@ const ApprovalPopup = () => {
                   <EntryRow
                     key={entry.timesheetId}
                     entry={entry}
+                    readOnly={isReadOnly}
                     onSave={handleTimesheetUpdate}
                   />
                 ))}
@@ -112,15 +115,18 @@ const ApprovalPopup = () => {
           variant="solid"
           label="Reject"
           iconLeft={() => <CloseCircle size={16} className="text-ink-white" />}
+          disabled={isReadOnly}
           onClick={handleReject}
+          className={isReadOnly ? "text-ink-white" : undefined}
         />
         <Button
           theme="green"
           variant="solid"
           label="Approve"
           iconLeft={() => <Success size={16} className="text-ink-white" />}
+          disabled={isReadOnly}
           onClick={handleApproveSubmit}
-          className="bg-surface-green-5"
+          className={isReadOnly ? "text-ink-white" : "bg-surface-green-5"}
         />
       </div>
     </Dialog.Popup>

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -32,7 +32,7 @@ const ApprovalPopup = () => {
     handleReject,
   } = useWeeklyApproval();
   return (
-    <Dialog.Popup className="fixed right-0 top-0 w-112 h-[calc(100vh-20px)] m-2.5 z-101 bg-surface-modal rounded-xl shadow-xl flex flex-col">
+    <Dialog.Popup className="fixed right-0 top-0 max-w-120 w-full h-[calc(100vh-20px)] m-2.5 z-101 bg-surface-modal rounded-xl shadow-xl flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-3.5 py-4 border-b border-outline-gray-modals">
         <div className="flex items-center gap-3">

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -92,22 +92,29 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
               {entry.taskName}
             </p>
             <p className="text-xs text-ink-gray-5">{entry.projectName}</p>
-            <TextEditor
-              content={description}
-              onChange={(val) => {
-                setDescription(val);
-                setDescriptionError(null);
-              }}
-              fixedMenu={false}
-              placeholder="Comment"
-              editorClass="px-2 h-24 prose-sm overflow-auto scrollbar-thin bg-white border rounded-md border-outline-gray-2"
-            />
+            <div className="flex flex-col gap-2 mt-3">
+              <DurationInput
+                snap="smooth"
+                variant="outline"
+                value={hours}
+                onChange={setHours}
+              />
+              <TextEditor
+                content={description}
+                onChange={(val) => {
+                  setDescription(val);
+                  setDescriptionError(null);
+                }}
+                fixedMenu={false}
+                placeholder="Comment"
+                editorClass="px-2 h-24 prose-sm overflow-auto scrollbar-thin bg-white border rounded-md border-outline-gray-2"
+              />
+            </div>
             {descriptionError ? (
               <ErrorMessage message={descriptionError} />
             ) : null}
           </div>
         </div>
-        <DurationInput value={hours} onChange={setHours} />
 
         <div className="flex flex-col gap-2">
           <Button

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -21,6 +21,7 @@ import type { TimesheetEntry } from "./types";
 
 interface EntryRowProps {
   entry: TimesheetEntry;
+  readOnly?: boolean;
   onSave: (
     timesheetId: string,
     taskId: string,
@@ -31,17 +32,22 @@ interface EntryRowProps {
   ) => void;
 }
 
-const EntryRow = ({ entry, onSave }: EntryRowProps) => {
+const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const [description, setDescription] = useState(entry.description);
   const [hours, setHours] = useState(entry.hours);
   const [descriptionError, setDescriptionError] = useState<string | null>(null);
   const [isHovered, setIsHovered] = useState(false);
+  const isReadOnly = readOnly || entry.docstatus === 1;
 
   const handleEdit = useCallback(() => {
+    if (isReadOnly) {
+      return;
+    }
+
     setDescriptionError(null);
     setIsEditing(true);
-  }, []);
+  }, [isReadOnly]);
 
   const handleCancel = useCallback(() => {
     setDescription(entry.description);
@@ -76,7 +82,7 @@ const EntryRow = ({ entry, onSave }: EntryRowProps) => {
     onSave,
   ]);
 
-  if (isEditing) {
+  if (isEditing && !isReadOnly) {
     return (
       <div className="px-3.5 py-4 flex gap-3 border-b border-outline-gray-modals last:border-b-0 ">
         <TaskStatus status={entry.status} />
@@ -149,7 +155,9 @@ const EntryRow = ({ entry, onSave }: EntryRowProps) => {
       <Button
         className={cn(
           "m-0 size-fit hover:bg-surface-white transition-opacity",
-          isHovered ? "opacity-100" : "opacity-0 pointer-events-none",
+          !isReadOnly && isHovered
+            ? "opacity-100"
+            : "opacity-0 pointer-events-none",
         )}
         variant="ghost"
         icon={() => <EditAlt size={16} className="text-ink-gray-7" />}

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -146,9 +146,9 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
           />
         </div>
       </div>
-      <span className="relative size-fit text-base text-ink-gray-6 rounded-sm outline outline-offset-4 outline-outline-gray-modals">
-        {entry.isBillable ? (
-          <span className="block absolute z-10 -bottom-0.5 left-1/2 w-1 h-1 rounded-full bg-surface-amber-3 transform -translate-x-1/2"></span>
+      <span className="relative size-fit text-base text-ink-gray-6 rounded-sm outline outline-offset-6 outline-outline-gray-modals">
+        {!entry.isBillable ? (
+          <span className="block absolute z-10 -bottom-1 left-1/2 w-1 h-1 rounded-full bg-surface-amber-3 transform -translate-x-1/2"></span>
         ) : null}
         {floatToTime(entry.hours, 2, 2)}
       </span>

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { useState, useCallback } from "react";
-import { floatToTime } from "@next-pms/design-system";
+import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
 import { TaskStatus } from "@next-pms/design-system/components";
 import { stripTags } from "@next-pms/design-system/utils";
 import {
@@ -36,6 +36,7 @@ const EntryRow = ({ entry, onSave }: EntryRowProps) => {
   const [description, setDescription] = useState(entry.description);
   const [hours, setHours] = useState(entry.hours);
   const [descriptionError, setDescriptionError] = useState<string | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
 
   const handleEdit = useCallback(() => {
     setDescriptionError(null);
@@ -121,7 +122,11 @@ const EntryRow = ({ entry, onSave }: EntryRowProps) => {
   }
 
   return (
-    <div className="px-3.5 py-4 flex gap-3 border-b border-outline-gray-modals last:border-b-0 group">
+    <div
+      className="px-3.5 py-4 flex gap-3 border-b border-outline-gray-modals last:border-b-0"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <TaskStatus status={entry.status} />
       <div className="flex-1 min-w-0">
         <div className="space-y-1">
@@ -142,7 +147,10 @@ const EntryRow = ({ entry, onSave }: EntryRowProps) => {
         {floatToTime(entry.hours, 2, 2)}
       </span>
       <Button
-        className="m-0 size-fit hover:bg-surface-white opacity-0 group-hover:opacity-100 transition-opacity"
+        className={cn(
+          "m-0 size-fit hover:bg-surface-white transition-opacity",
+          isHovered ? "opacity-100" : "opacity-0 pointer-events-none",
+        )}
         variant="ghost"
         icon={() => <EditAlt size={16} className="text-ink-gray-7" />}
         onClick={handleEdit}

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -165,12 +165,14 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
       </span>
       <Button
         className={cn(
-          "m-0 size-fit hover:bg-surface-white transition-opacity",
+          "m-0 size-fit hover:bg-surface-white transition-opacity focus-visible:opacity-100 focus-visible:pointer-events-auto",
           !isReadOnly && isHovered
             ? "opacity-100"
             : "opacity-0 pointer-events-none",
         )}
         variant="ghost"
+        label="Edit time entry"
+        disabled={isReadOnly}
         icon={() => <EditAlt size={16} className="text-ink-gray-7" />}
         onClick={handleEdit}
       />

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -88,10 +88,12 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
         <TaskStatus status={entry.status} />
         <div className="flex-1 min-w-0">
           <div className="space-y-1">
-            <p className="text-base font-medium text-ink-gray-7">
+            <p className="text-base font-medium text-ink-gray-7 truncate">
               {entry.taskName}
             </p>
-            <p className="text-xs text-ink-gray-5">{entry.projectName}</p>
+            <p className="text-xs text-ink-gray-5 truncate">
+              {entry.projectName}
+            </p>
             <div className="flex flex-col gap-2 mt-3">
               <DurationInput
                 snap="smooth"
@@ -143,10 +145,12 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
       <TaskStatus status={entry.status} />
       <div className="flex-1 min-w-0">
         <div className="space-y-1">
-          <p className="text-base font-medium text-ink-gray-7">
+          <p className="text-base font-medium text-ink-gray-7 truncate">
             {entry.taskName}
           </p>
-          <p className="text-xs text-ink-gray-5">{entry.projectName}</p>
+          <p className="text-xs text-ink-gray-5 truncate">
+            {entry.projectName}
+          </p>
           <StaticTextEditor
             editorClass="prose-sm text-ink-gray-7 mt-3"
             content={entry.description}

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/index.tsx
@@ -25,7 +25,7 @@ const WeeklyApprovalContent = () => {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 bg-black/50 backdrop-blur-sm z-100" />
+        <Dialog.Backdrop className="dialog-backdrop fixed inset-0 bg-black-overlay-200 backdrop-filter backdrop-blur-md z-100" />
         {currentView === "approval" ? <ApprovalPopup /> : <RejectionPopup />}
       </Dialog.Portal>
     </Dialog.Root>

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/provider.tsx
@@ -35,6 +35,7 @@ export interface WeeklyApprovalContextValue {
   avatarUrl: string;
   dateRange: string;
   totalHours: number;
+  isReadOnly: boolean;
   rejectionError: string | null;
   groupedByDay: GroupedDay[];
   checkedDays: Set<string>;
@@ -111,6 +112,9 @@ export const WeeklyApprovalProvider = ({
     [timesheetData.entries],
   );
   const totalHours = timesheetData.totalHours;
+  const isReadOnly =
+    timesheetData.status === "Approved" ||
+    timesheetData.status === "Processing Timesheet";
   const dateRange = timesheetData.dateRange;
   const employeeName = employeeData?.employee_name || "";
   const avatarUrl = employeeData?.image || "";
@@ -120,17 +124,24 @@ export const WeeklyApprovalProvider = ({
     setCheckedDays(new Set(groupedByDay.map((dayGroup) => dayGroup.day)));
   }
 
-  const handleDayCheckChange = useCallback((day: string, checked: boolean) => {
-    setCheckedDays((prev) => {
-      const newSet = new Set(prev);
-      if (checked) {
-        newSet.add(day);
-      } else {
-        newSet.delete(day);
+  const handleDayCheckChange = useCallback(
+    (day: string, checked: boolean) => {
+      if (isReadOnly) {
+        return;
       }
-      return newSet;
-    });
-  }, []);
+
+      setCheckedDays((prev) => {
+        const newSet = new Set(prev);
+        if (checked) {
+          newSet.add(day);
+        } else {
+          newSet.delete(day);
+        }
+        return newSet;
+      });
+    },
+    [isReadOnly],
+  );
 
   const getCheckedDates = useCallback(() => {
     return groupedByDay
@@ -139,10 +150,14 @@ export const WeeklyApprovalProvider = ({
   }, [groupedByDay, checkedDays]);
 
   const handleReject = useCallback(() => {
+    if (isReadOnly) {
+      return;
+    }
+
     setRejectionError(null);
     mutate();
     setCurrentView("rejection");
-  }, [mutate]);
+  }, [isReadOnly, mutate]);
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -164,6 +179,10 @@ export const WeeklyApprovalProvider = ({
       parent: string,
       day: string,
     ) => {
+      if (isReadOnly) {
+        return;
+      }
+
       try {
         const res = await updateTimesheet({
           name: timesheetId,
@@ -181,10 +200,14 @@ export const WeeklyApprovalProvider = ({
         toast.error(message);
       }
     },
-    [updateTimesheet, employee, toast, mutate],
+    [isReadOnly, updateTimesheet, employee, toast, mutate],
   );
 
   const handleApproveSubmit = useCallback(async () => {
+    if (isReadOnly) {
+      return;
+    }
+
     const dates = getCheckedDates();
     try {
       const res = await approveOrRejectTimesheet({
@@ -203,6 +226,7 @@ export const WeeklyApprovalProvider = ({
     getCheckedDates,
     approveOrRejectTimesheet,
     employee,
+    isReadOnly,
     toast,
     mutate,
     handleOpenChange,
@@ -210,6 +234,10 @@ export const WeeklyApprovalProvider = ({
 
   const handleRejectionSubmit = useCallback(
     async (reason: string) => {
+      if (isReadOnly) {
+        return;
+      }
+
       const dates = getCheckedDates();
       try {
         setRejectionError(null);
@@ -230,6 +258,7 @@ export const WeeklyApprovalProvider = ({
       getCheckedDates,
       approveOrRejectTimesheet,
       employee,
+      isReadOnly,
       toast,
       mutate,
       handleOpenChange,
@@ -248,6 +277,7 @@ export const WeeklyApprovalProvider = ({
       avatarUrl,
       dateRange,
       totalHours,
+      isReadOnly,
       rejectionError,
       groupedByDay,
       checkedDays,
@@ -267,6 +297,7 @@ export const WeeklyApprovalProvider = ({
       avatarUrl,
       dateRange,
       totalHours,
+      isReadOnly,
       rejectionError,
       groupedByDay,
       checkedDays,

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
@@ -1,4 +1,6 @@
 import { TaskStatusType } from "@next-pms/design-system/components";
+import type { WorkingFrequency } from "@/types";
+import type { HolidayProp, LeaveProps } from "@/types/timesheet";
 
 export type ModalView = "approval" | "rejection";
 
@@ -12,6 +14,7 @@ export type WeeklyApprovalProps = {
 export interface GroupedDay {
   day: string;
   totalHours: number;
+  leaveLabel?: string;
   entries: TimesheetEntry[];
 }
 
@@ -28,6 +31,8 @@ export interface TimesheetEntry {
   parent: string;
   status: TaskStatusType;
   isBillable: boolean;
+  leaveHours: number;
+  leaveLabel?: string;
 }
 
 export interface TaskDataEntry {
@@ -71,9 +76,9 @@ export interface WeekData {
 export interface TimesheetApiResponse {
   message: {
     working_hour: number;
-    working_frequency: string;
-    leaves: unknown[];
-    holidays: unknown[];
+    working_frequency: WorkingFrequency;
+    leaves: LeaveProps[];
+    holidays: HolidayProp[];
     data: Record<string, WeekData>;
   };
 }

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
@@ -31,6 +31,7 @@ export interface TimesheetEntry {
   parent: string;
   status: TaskStatusType;
   isBillable: boolean;
+  docstatus: number;
   leaveHours: number;
   leaveLabel?: string;
 }

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -66,7 +66,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
   const weeklyData = response?.message?.data;
 
   if (!weeklyData) {
-    return { dateRange: "", totalHours: 0, entries };
+    return { dateRange: "", totalHours: 0, status: "", entries };
   }
 
   const thisWeek = Object.values(weeklyData)[0];
@@ -111,6 +111,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
           parent: entry.parent,
           status: task.status.toLowerCase() as TaskStatusType,
           isBillable: Boolean(task.is_billable),
+          docstatus: entry.docstatus,
           leaveHours,
           leaveLabel:
             leaveHours > 0 ? getLeaveLabelForDate(leaves, date) : undefined,
@@ -127,6 +128,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
   return {
     dateRange: thisWeekDateRange,
     totalHours: Object.values(weeklyData)[0].total_hours + displayedLeaveHours,
+    status: thisWeek.status,
     entries,
   };
 };

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -29,8 +29,10 @@ const formatDay = (dateTimeStr: string): string => {
   return `${weekday}, ${month} ${day}`;
 };
 
-const getLeaveLabel = (leave: LeaveProps): string => {
-  if (!leave.half_day) {
+const getLeaveLabel = (leave: LeaveProps, date: string): string => {
+  const isHalfDayLeave = leave.half_day && leave.half_day_date === date;
+
+  if (!isHalfDayLeave) {
     return "Full day off";
   }
 
@@ -51,7 +53,7 @@ const getLeaveLabelForDate = (
 ): string | undefined => {
   const labels = leaves
     .filter((leave) => date >= leave.from_date && date <= leave.to_date)
-    .map(getLeaveLabel);
+    .map((leave) => getLeaveLabel(leave, date));
 
   const uniqueLabels = [...new Set(labels)];
   return uniqueLabels.length > 0 ? uniqueLabels.join(", ") : undefined;

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -7,6 +7,8 @@ import { TaskStatusType } from "@next-pms/design-system/components";
  * Internal Dependencies
  */
 
+import { calculateLeaveHours, expectatedHours } from "@/lib/utils";
+import type { LeaveProps } from "@/types/timesheet";
 import type { TimesheetEntry, TimesheetApiResponse, GroupedDay } from "./types";
 
 /**
@@ -27,6 +29,34 @@ const formatDay = (dateTimeStr: string): string => {
   return `${weekday}, ${month} ${day}`;
 };
 
+const getLeaveLabel = (leave: LeaveProps): string => {
+  if (!leave.half_day) {
+    return "Full day off";
+  }
+
+  const half = leave.custom_first_halfsecond_half?.trim().toLowerCase();
+  if (half === "first half") {
+    return "First half off";
+  }
+  if (half === "second half") {
+    return "Second half off";
+  }
+
+  return "Half day off";
+};
+
+const getLeaveLabelForDate = (
+  leaves: LeaveProps[],
+  date: string,
+): string | undefined => {
+  const labels = leaves
+    .filter((leave) => date >= leave.from_date && date <= leave.to_date)
+    .map(getLeaveLabel);
+
+  const uniqueLabels = [...new Set(labels)];
+  return uniqueLabels.length > 0 ? uniqueLabels.join(", ") : undefined;
+};
+
 /**
  * Converts the timesheet API response into a flat array of entries.
  * Each entry contains taskName, projectName, hours, and description.
@@ -42,10 +72,32 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
   const thisWeek = Object.values(weeklyData)[0];
   const thisWeekTasks = Object.values(thisWeek.tasks);
   const thisWeekDateRange = Object.keys(weeklyData)[0];
+  const leaves = response?.message?.leaves ?? [];
+  const holidays = response?.message?.holidays ?? [];
+  const displayedLeaveHoursByDate = new Map<string, number>();
+  const dailyWorkingHours = expectatedHours(
+    response?.message?.working_hour ?? 0,
+    response?.message?.working_frequency ?? "Per Day",
+  );
 
   thisWeekTasks.forEach((task) => {
     if (task.data && Array.isArray(task.data)) {
       task.data.forEach((entry) => {
+        const date = extractDate(entry.from_time);
+        const holiday = holidays.find(
+          (holiday) => holiday.holiday_date === date,
+        );
+        const leaveHours = calculateLeaveHours(
+          leaves,
+          date,
+          dailyWorkingHours,
+          holiday,
+        );
+
+        if (leaveHours > 0) {
+          displayedLeaveHoursByDate.set(date, leaveHours);
+        }
+
         entries.push({
           timesheetId: entry.name,
           taskId: task.name,
@@ -55,18 +107,26 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
           hours: entry.hours,
           description: entry.description,
           day: formatDay(entry.from_time),
-          date: extractDate(entry.from_time),
+          date,
           parent: entry.parent,
           status: task.status.toLowerCase() as TaskStatusType,
           isBillable: Boolean(task.is_billable),
+          leaveHours,
+          leaveLabel:
+            leaveHours > 0 ? getLeaveLabelForDate(leaves, date) : undefined,
         });
       });
     }
   });
 
+  const displayedLeaveHours = [...displayedLeaveHoursByDate.values()].reduce(
+    (total, hours) => total + hours,
+    0,
+  );
+
   return {
     dateRange: thisWeekDateRange,
-    totalHours: Object.values(weeklyData)[0].total_hours,
+    totalHours: Object.values(weeklyData)[0].total_hours + displayedLeaveHours,
     entries,
   };
 };
@@ -78,7 +138,8 @@ export const groupEntriesByDay = (entries: TimesheetEntry[]): GroupedDay[] => {
     if (!acc[entry.day]) {
       acc[entry.day] = {
         day: entry.day,
-        totalHours: 0,
+        totalHours: entry.leaveHours,
+        leaveLabel: entry.leaveLabel,
         entries: [],
       };
     }

--- a/frontend/packages/app/src/types/timesheet.ts
+++ b/frontend/packages/app/src/types/timesheet.ts
@@ -48,6 +48,7 @@ export interface LeaveProps {
   half_day_date: string;
   leave_type: string;
   is_lwp: boolean;
+  custom_first_halfsecond_half?: string | null;
 }
 
 export interface DynamicKey {

--- a/next_pms/api/dashboard.py
+++ b/next_pms/api/dashboard.py
@@ -1022,21 +1022,26 @@ def _get_employees_on_leave(manager_employee: str) -> list:
     Employee = DocType("Employee")
     User = DocType("User")
 
-    return (
+    has_first_half_column = frappe.db.has_column("Leave Application", "custom_first_halfsecond_half")
+
+    select_fields = [
+        LeaveApplication.employee,
+        LeaveApplication.employee_name,
+        LeaveApplication.from_date,
+        LeaveApplication.to_date,
+        LeaveApplication.half_day,
+        User.user_image,
+    ]
+    if has_first_half_column:
+        select_fields.append(LeaveApplication.custom_first_halfsecond_half)
+
+    results = (
         frappe.qb.from_(LeaveApplication)
         .join(Employee)
         .on(Employee.name == LeaveApplication.employee)
         .left_join(User)
         .on(User.name == Employee.user_id)
-        .select(
-            LeaveApplication.employee,
-            LeaveApplication.employee_name,
-            LeaveApplication.from_date,
-            LeaveApplication.to_date,
-            LeaveApplication.half_day,
-            LeaveApplication.custom_first_halfsecond_half,
-            User.user_image,
-        )
+        .select(*select_fields)
         .where(LeaveApplication.docstatus == 1)
         .where(LeaveApplication.status == "Approved")
         .where(LeaveApplication.to_date >= frappe.utils.today())
@@ -1044,6 +1049,12 @@ def _get_employees_on_leave(manager_employee: str) -> list:
         .orderby(LeaveApplication.from_date)
         .run(as_dict=True)
     )
+
+    if not has_first_half_column:
+        for row in results:
+            row["custom_first_halfsecond_half"] = None
+
+    return results
 
 
 @whitelist(methods=["GET"])

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -200,6 +200,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
                 "total_leave_days": 3.0,
                 "name": "HR-LAP-00001",
                 "leave_type": "Casual Leave",
+                "custom_first_halfsecond_half": None,
                 "is_lwp": 0,
             },
         ]
@@ -219,6 +220,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
                 "total_leave_days": 3.0,
                 "name": "HR-LAP-00001",
                 "leave_type": "Casual Leave",
+                "custom_first_halfsecond_half": None,
                 "is_lwp": 0,
             },
             {
@@ -230,6 +232,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
                 "total_leave_days": 0.5,
                 "name": "HR-LAP-00002",
                 "leave_type": "Sick Leave",
+                "custom_first_halfsecond_half": "First Half",
                 "is_lwp": 0,
             },
         ]
@@ -255,6 +258,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
             LeaveApplication.total_leave_days,
             LeaveApplication.name,
             LeaveApplication.leave_type,
+            LeaveApplication.custom_first_halfsecond_half,
             LeaveType.is_lwp,
         )
     )

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -245,22 +245,27 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
     LeaveApplication = frappe.qb.DocType("Leave Application")
     LeaveType = frappe.qb.DocType("Leave Type")
 
+    has_first_half_column = frappe.db.has_column("Leave Application", "custom_first_halfsecond_half")
+
+    select_fields = [
+        LeaveApplication.employee,
+        LeaveApplication.from_date,
+        LeaveApplication.to_date,
+        LeaveApplication.half_day,
+        LeaveApplication.half_day_date,
+        LeaveApplication.total_leave_days,
+        LeaveApplication.name,
+        LeaveApplication.leave_type,
+        LeaveType.is_lwp,
+    ]
+    if has_first_half_column:
+        select_fields.append(LeaveApplication.custom_first_halfsecond_half)
+
     query = (
         frappe.qb.from_(LeaveApplication)
         .join(LeaveType)
         .on(LeaveApplication.leave_type == LeaveType.name)
-        .select(
-            LeaveApplication.employee,
-            LeaveApplication.from_date,
-            LeaveApplication.to_date,
-            LeaveApplication.half_day,
-            LeaveApplication.half_day_date,
-            LeaveApplication.total_leave_days,
-            LeaveApplication.name,
-            LeaveApplication.leave_type,
-            LeaveApplication.custom_first_halfsecond_half,
-            LeaveType.is_lwp,
-        )
+        .select(*select_fields)
     )
     if isinstance(employee, tuple):
         query = query.where(LeaveApplication.employee.isin(employee))
@@ -276,6 +281,10 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
     )
 
     results = query.run(as_dict=True)
+
+    if not has_first_half_column:
+        for row in results:
+            row["custom_first_halfsecond_half"] = None
 
     return results
 


### PR DESCRIPTION
## Description

* Fixed an issue where the Edit button remained visible after hovering out in Safari.
* Fixed the Approve button color.
* Display the Time Off label based on the leave type.
* Prevent editing of already approved time entries.
* Disabled the Approve and Reject actions when the entire week is already approved.
* Fixed the inverted non-billable indicator.
* Fixed an issue where long task names overlapped the Duration Input.


<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* Updated the backend API to return the leave type, allowing the frontend to determine whether the leave is for the first half, second half, or a full day.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1125" height="806" alt="Screenshot 2026-07-03 at 5 06 06 PM" src="https://github.com/user-attachments/assets/0ea469ab-6291-4808-8d9f-04f15a6095d0" />
<img width="1125" height="806" alt="Screenshot 2026-07-03 at 5 06 26 PM" src="https://github.com/user-attachments/assets/34388c1b-1b7e-4a8c-b252-67d822da3136" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1641 #1571 #1582