### PR TITLE
QA Fix: Hide links in hovercards based on user access in allocation pages

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
@@ -14,19 +14,32 @@ import {
  * Internal dependencies.
  */
 import type { Member, ProjectMember } from "./types";
+import { mergeClassNames as cn } from "../../utils";
 
 interface GanttMemberHoverCardProps {
   member: Member | ProjectMember;
+  canOpenEmployee?: boolean;
 }
 
-function GanttMemberHoverCard({ member }: GanttMemberHoverCardProps) {
+function GanttMemberHoverCard({
+  member,
+  canOpenEmployee = false,
+}: GanttMemberHoverCardProps) {
   const hasDetails =
     member.department || member.rate || member.capacity || member.manager;
+  const employeeHref =
+    canOpenEmployee && member.id
+      ? `/desk/employee/${encodeURIComponent(member.id)}`
+      : undefined;
 
   return (
     <div className="flex flex-col gap-3 p-3 w-60 rounded-xl shadow-2xl bg-surface-modal">
       {/* Header */}
-      <div className="flex justify-between items-start">
+      <div
+        className={cn("flex items-start", {
+          "justify-between": employeeHref,
+        })}
+      >
         <div className="flex gap-2 items-center min-w-0">
           <div className="shrink-0">
             <Avatar
@@ -47,9 +60,9 @@ function GanttMemberHoverCard({ member }: GanttMemberHoverCardProps) {
             )}
           </div>
         </div>
-        {member.id && (
+        {employeeHref && (
           <a
-            href={`/desk/employee/${encodeURIComponent(member.id)}`}
+            href={employeeHref}
             target="_blank"
             rel="noreferrer"
             aria-label="Open employee"

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -152,7 +152,10 @@ export function GanttMemberItem({
           sideOffset={-42}
         >
           <PreviewCard.Popup className="outline-none">
-            <GanttMemberHoverCard member={member} />
+            <GanttMemberHoverCard
+              member={member}
+              canOpenEmployee={hasRoleAccess}
+            />
           </PreviewCard.Popup>
         </PreviewCard.Positioner>
       </PreviewCard.Portal>

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
@@ -15,12 +15,17 @@ import {
  */
 import type { Project } from "./types";
 import { formatHours } from "./utils";
+import { mergeClassNames as cn } from "../../utils";
 
 interface GanttProjectHoverCardProps {
   project: Project;
+  canOpenProject?: boolean;
 }
 
-function GanttProjectHoverCard({ project }: GanttProjectHoverCardProps) {
+function GanttProjectHoverCard({
+  project,
+  canOpenProject = false,
+}: GanttProjectHoverCardProps) {
   const dateRange = project.projectDateRange ?? project.dateRange;
   const weeklyCapacityLabel =
     project.weeklyCapacity !== undefined
@@ -31,19 +36,27 @@ function GanttProjectHoverCard({ project }: GanttProjectHoverCardProps) {
     dateRange ||
     weeklyCapacityLabel ||
     project.projectManager;
+  const projectHref =
+    canOpenProject && project.id
+      ? `/next-pms/projects/${encodeURIComponent(project.id)}`
+      : undefined;
 
   return (
     <div className="flex flex-col gap-3 p-3 w-72 rounded-xl shadow-2xl bg-surface-modal">
-      <div className="flex justify-between items-start gap-3">
+      <div
+        className={cn("flex items-start gap-3", {
+          "justify-between": projectHref,
+        })}
+      >
         <div className="flex gap-2 items-center min-w-0">
           <Folder className="size-4 text-ink-gray-8 shrink-0" />
           <span className="text-base font-medium truncate text-ink-gray-7">
             {project.name}
           </span>
         </div>
-        {project.id && (
+        {projectHref && (
           <a
-            href={`/next-pms/projects/${encodeURIComponent(project.id)}`}
+            href={projectHref}
             target="_blank"
             rel="noreferrer"
             aria-label="Open project"

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -19,6 +19,7 @@ export interface GanttProjectItemProps extends Project {
   canExpand?: boolean;
   showChevron?: boolean;
   showHoverCard?: boolean;
+  hasRoleAccess?: boolean;
   onToggle?: () => void;
   className?: string;
   style?: CSSProperties;
@@ -38,6 +39,7 @@ export function GanttProjectItem({
   canExpand = false,
   showChevron = true,
   showHoverCard = true,
+  hasRoleAccess = false,
   onToggle,
   className,
   style,
@@ -137,6 +139,7 @@ export function GanttProjectItem({
                 projectManager,
                 weeklyCapacity,
               }}
+              canOpenProject={hasRoleAccess}
             />
           </PreviewCard.Popup>
         </PreviewCard.Positioner>

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -82,6 +82,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
           canExpand={canExpand}
           isExpanded={isExpanded}
           showChevron={true}
+          hasRoleAccess={hasRoleAccess}
           onToggle={() => {
             if (canExpand) {
               toggleRow(projectInd);


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
- Hide links in member and project card based on user access

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

<img width="449" height="195" alt="Screenshot 2026-07-03 at 6 25 00 PM" src="https://github.com/user-attachments/assets/7e580ce2-9a98-4e7b-b655-e7a71c5503ca" />
<img width="520" height="205" alt="Screenshot 2026-07-03 at 6 25 14 PM" src="https://github.com/user-attachments/assets/34d8a8ff-a2f2-49e2-aaea-39bf3549b489" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1683 