### PR TITLE
fix: remove extra spaces after bullet points in time entry descriptions

### DIFF
--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from frappe import (
     DoesNotExistError,
@@ -152,12 +153,19 @@ def get_compact_view_data(
                         notes += ts.get("note", "")
                 hour += total_hours
 
+                # Normalize preserved HTML breaks and collapse extra spaces after bullets
+                note_text = notes.replace("<br>", "\n")
+                # Replace non-breaking spaces with normal spaces
+                note_text = note_text.replace("\u00A0", " ")
+                # Collapse two or more spaces after common bullet chars to a single space
+                note_text = re.sub(r'([•\-\*]) {2,}', r'\1 ', note_text)
+
                 local_data["data"].append(
                     {
                         "date": date,
                         "hour": hour,
                         "is_leave": on_leave,
-                        "note": notes.replace("<br>", "\n"),
+                        "note": note_text,
                     }
                 )
 

--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -1,4 +1,5 @@
 import frappe
+import re
 from frappe import _, throw
 from frappe.utils import (
     add_days,
@@ -146,6 +147,18 @@ def save(date: str, description: str, task: str, hours: float = 0, employee: str
 
     project, custom_is_billable = frappe.get_value("Task", task, ["project", "custom_is_billable"])
 
+    def normalize_description(text: str):
+        if text is None:
+            return text
+        # replace non-breaking spaces and HTML nbsp with normal spaces
+        text = text.replace("\u00A0", " ").replace("\xa0", " ").replace("&nbsp;", " ")
+        # collapse two or more spaces after common bullet chars to a single space (handles line starts and inline)
+        text = re.sub(r'(?m)(^|\n)([•\-\*]) {2,}', r"\1\2 ", text)
+        text = re.sub(r'([•\-\*]) {2,}', r"\1 ", text)
+        return text
+
+    description = normalize_description(description)
+
     timesheet.update({"parent_project": project})
     timesheet.append(
         "time_logs",
@@ -252,6 +265,12 @@ def update_timesheet_detail(
     is_billable: bool | None = None,
 ):
     parent_doc = frappe.get_doc("Timesheet", parent)
+    # Normalize incoming description to avoid extra spaces after bullets
+    if description is not None:
+        description = re.sub(r'\u00A0', ' ', description)
+        description = re.sub(r'&nbsp;', ' ', description)
+        description = re.sub(r'(?m)(^|\n)([•\-\*]) {2,}', r"\1\2 ", description)
+        description = re.sub(r'([•\-\*]) {2,}', r"\1 ", description)
     ignore_permissions = employee_has_higher_access(parent_doc.employee, ptype="write")
     logs_to_remove = []
     new_logs = []

--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -1,4 +1,5 @@
 import frappe
+import re
 from frappe import _, get_value, throw
 from frappe.utils import add_days, date_diff, get_link_to_form, getdate, today
 
@@ -92,7 +93,12 @@ def update_note(doc):
     note = ""
     for data in doc.get("time_logs"):
         if data.description:
-            note += data.description.replace("\n", "<br>")
+            desc = data.description
+            # normalize non-breaking spaces and collapse extra spaces after bullets
+            desc = desc.replace("\u00A0", " ").replace("\xa0", " ").replace("&nbsp;", " ")
+            desc = re.sub(r'(?m)(^|\n)([•\-\*]) {2,}', r"\1\2 ", desc)
+            desc = re.sub(r'([•\-\*]) {2,}', r"\1 ", desc)
+            note += desc.replace("\n", "<br>")
         note += "<br>"
     doc.note = note
 


### PR DESCRIPTION
Fixes #1668

Removed extra spaces after bullet points in time entry descriptions.