### PR TITLE
fix: unify "Clear all" across composite and simple filters (Timesheet + Allocations)

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/context.ts
+++ b/frontend/packages/app/src/pages/allocations/project/context.ts
@@ -28,6 +28,7 @@ export interface AllocationsProjectContextProps {
     setDuration: (value: AllocationsDuration) => void;
     setAllocationsType: (value: string[]) => void;
     setCompositeFilters: (value: FilterCondition[]) => void;
+    handleClearAllFilters: () => void;
     loadMore: () => void;
     handlePrevious: () => void;
     handleNext: () => void;
@@ -55,6 +56,7 @@ export const AllocationsProjectContext =
       setDuration: () => null,
       setAllocationsType: () => null,
       setCompositeFilters: () => null,
+      handleClearAllFilters: () => null,
       loadMore: () => null,
       handlePrevious: () => null,
       handleNext: () => null,

--- a/frontend/packages/app/src/pages/allocations/project/provider.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/provider.tsx
@@ -148,6 +148,17 @@ export function AllocationsProjectProvider({
     [updateSearchParams],
   );
 
+  const handleClearAllFilters = useCallback(
+    () =>
+      updateSearchParams({
+        [SEARCH_PARAM_KEY]: undefined,
+        [DURATION_PARAM_KEY]: undefined,
+        [ALLOCATION_TYPE_PARAM_KEY]: undefined,
+        [COMPOSITE_FILTERS_PARAM_KEY]: undefined,
+      }),
+    [updateSearchParams],
+  );
+
   const handlePrevious = useCallback(() => {
     updateSearchParams({
       [DATE_PARAM_KEY]: format(
@@ -196,6 +207,7 @@ export function AllocationsProjectProvider({
         setDuration,
         setAllocationsType,
         setCompositeFilters,
+        handleClearAllFilters,
         loadMore,
         handlePrevious,
         handleNext,
@@ -218,6 +230,7 @@ export function AllocationsProjectProvider({
       setDuration,
       setAllocationsType,
       setCompositeFilters,
+      handleClearAllFilters,
       loadMore,
       handlePrevious,
       handleNext,

--- a/frontend/packages/app/src/pages/allocations/project/subHeader.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/subHeader.tsx
@@ -20,7 +20,11 @@ import {
 import { useDebounce } from "@/hooks/useDebounce";
 import { useGuardedAction } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { useUser } from "@/providers/user";
-import { durationOptions, navigationButtonAriaLabels } from "../constants";
+import {
+  DEFAULT_DURATION,
+  durationOptions,
+  navigationButtonAriaLabels,
+} from "../constants";
 import {
   projectAllocationFilters,
   projectAllocationsTypeOptions,
@@ -47,6 +51,9 @@ export function SubHeader() {
   const setCompositeFilters = useAllocationsProject(
     ({ actions }) => actions.setCompositeFilters,
   );
+  const handleClearAllFilters = useAllocationsProject(
+    ({ actions }) => actions.handleClearAllFilters,
+  );
   const handlePrevious = useAllocationsProject(
     ({ actions }) => actions.handlePrevious,
   );
@@ -59,6 +66,11 @@ export function SubHeader() {
   const roles = useUser(({ state }) => state.roles);
   const showFilters =
     roles.includes("Projects Manager") || roles.includes("Projects User");
+
+  const externalFilterCount =
+    (search !== "" ? 1 : 0) +
+    (duration !== DEFAULT_DURATION ? 1 : 0) +
+    (allocationsType.length > 0 ? 1 : 0);
 
   const [searchInput, setSearchInput] = useState(search);
   const [isAllocationTypeOpen, setIsAllocationTypeOpen] = useState(false);
@@ -154,6 +166,13 @@ export function SubHeader() {
             fields={projectAllocationFilters}
             value={compositeFilters}
             onChange={(value) => guard(() => setCompositeFilters(value))}
+            externalFilterCount={externalFilterCount}
+            onClearAll={() =>
+              guard(() => {
+                setSearchInput("");
+                handleClearAllFilters();
+              })
+            }
           />
         ) : null}
       </div>

--- a/frontend/packages/app/src/pages/allocations/team/context.ts
+++ b/frontend/packages/app/src/pages/allocations/team/context.ts
@@ -30,6 +30,7 @@ export interface AllocationsTeamContextProps {
     setDesignation: (value: string[]) => void;
     setAllocationsType: (value: string[]) => void;
     setCompositeFilters: (value: FilterCondition[]) => void;
+    handleClearAllFilters: () => void;
     loadMore: () => void;
     handlePrevious: () => void;
     handleNext: () => void;
@@ -59,6 +60,7 @@ export const AllocationsTeamContext =
       setDesignation: () => null,
       setAllocationsType: () => null,
       setCompositeFilters: () => null,
+      handleClearAllFilters: () => null,
       loadMore: () => null,
       handlePrevious: () => null,
       handleNext: () => null,

--- a/frontend/packages/app/src/pages/allocations/team/provider.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/provider.tsx
@@ -167,6 +167,18 @@ export function AllocationsTeamProvider({
     [updateSearchParams],
   );
 
+  const handleClearAllFilters = useCallback(
+    () =>
+      updateSearchParams({
+        [SEARCH_PARAM_KEY]: undefined,
+        [DESIGNATION_PARAM_KEY]: undefined,
+        [DURATION_PARAM_KEY]: undefined,
+        [ALLOCATION_TYPE_PARAM_KEY]: undefined,
+        [COMPOSITE_FILTERS_PARAM_KEY]: undefined,
+      }),
+    [updateSearchParams],
+  );
+
   const handlePrevious = useCallback(() => {
     updateSearchParams({
       [DATE_PARAM_KEY]: format(
@@ -217,6 +229,7 @@ export function AllocationsTeamProvider({
         setDesignation,
         setAllocationsType,
         setCompositeFilters,
+        handleClearAllFilters,
         loadMore,
         handlePrevious,
         handleNext,
@@ -241,6 +254,7 @@ export function AllocationsTeamProvider({
       setDesignation,
       setAllocationsType,
       setCompositeFilters,
+      handleClearAllFilters,
       loadMore,
       handlePrevious,
       handleNext,

--- a/frontend/packages/app/src/pages/allocations/team/subHeader.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/subHeader.tsx
@@ -23,7 +23,11 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { useDesignationLookup } from "@/hooks/useDesignationLookup";
 import { useGuardedAction } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { useUser } from "@/providers/user";
-import { durationOptions, navigationButtonAriaLabels } from "../constants";
+import {
+  DEFAULT_DURATION,
+  durationOptions,
+  navigationButtonAriaLabels,
+} from "../constants";
 import { teamAllocationFilters, teamAllocationsTypeOptions } from "./constants";
 import { useAllocationsTeam } from "./context";
 
@@ -49,6 +53,9 @@ export function SubHeader() {
   const setCompositeFilters = useAllocationsTeam(
     ({ actions }) => actions.setCompositeFilters,
   );
+  const handleClearAllFilters = useAllocationsTeam(
+    ({ actions }) => actions.handleClearAllFilters,
+  );
   const handlePrevious = useAllocationsTeam(
     ({ actions }) => actions.handlePrevious,
   );
@@ -62,6 +69,12 @@ export function SubHeader() {
   }));
   const showFilters =
     roles.includes("Projects Manager") || roles.includes("Projects User");
+
+  const externalFilterCount =
+    (search !== "" ? 1 : 0) +
+    (designation.length > 0 ? 1 : 0) +
+    (duration !== DEFAULT_DURATION ? 1 : 0) +
+    (allocationsType.length > 0 ? 1 : 0);
 
   const [searchInput, setSearchInput] = useState(search);
   const [designationQuery, setDesignationQuery] = useState("");
@@ -229,6 +242,13 @@ export function SubHeader() {
             value={compositeFilters}
             onChange={(value) => guard(() => setCompositeFilters(value))}
             triggerClassName="text-ink-gray-7"
+            externalFilterCount={externalFilterCount}
+            onClearAll={() =>
+              guard(() => {
+                setSearchInput("");
+                handleClearAllFilters();
+              })
+            }
           />
         ) : null}
       </div>

--- a/frontend/packages/app/src/pages/timesheet/hooks/useTimesheetFilters.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useTimesheetFilters.ts
@@ -134,6 +134,17 @@ export function useTimesheetFilters({
     [updateSearchParams],
   );
 
+  const resetAll = useCallback(
+    () =>
+      updateSearchParams({
+        [SEARCH_PARAM_KEY]: undefined,
+        [APPROVAL_PARAM_KEY]: undefined,
+        [REPORTS_TO_PARAM_KEY]: undefined,
+        [COMPOSITE_FILTERS_PARAM_KEY]: undefined,
+      }),
+    [updateSearchParams],
+  );
+
   return {
     filters: {
       search,
@@ -145,5 +156,6 @@ export function useTimesheetFilters({
     setApprovalStatus,
     setReportsTo,
     setCompositeFilters,
+    resetAll,
   };
 }

--- a/frontend/packages/app/src/pages/timesheet/personal/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/personal/context.ts
@@ -29,6 +29,7 @@ export interface PersonalTimesheetContextProps {
     handleSearchChange: (value: string) => void;
     handleApprovalStatusChange: (value?: ApprovalStatusType | null) => void;
     handleCompositeFilterChange: (value: FilterCondition[]) => void;
+    handleClearAllFilters: () => void;
     refetchLikedTasks: () => void;
   };
 }
@@ -61,6 +62,7 @@ export const PersonalTimesheetContext =
       handleSearchChange: () => null,
       handleApprovalStatusChange: () => null,
       handleCompositeFilterChange: () => null,
+      handleClearAllFilters: () => null,
       refetchLikedTasks: () => null,
     },
   });

--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -52,6 +52,9 @@ export const PersonalTimesheetTable = () => {
   const handleCompositeFilterChange = usePersonalTimesheet(
     ({ actions }) => actions.handleCompositeFilterChange,
   );
+  const handleClearAllFilters = usePersonalTimesheet(
+    ({ actions }) => actions.handleClearAllFilters,
+  );
   const { employeeId } = useUser(({ state }) => ({
     employeeId: state.employeeId,
   }));
@@ -65,6 +68,9 @@ export const PersonalTimesheetTable = () => {
     compositeFilters.some(
       (filter) => filter.fieldCategory === "Task" || filter.field === "subject",
     );
+
+  const externalFilterCount =
+    (filters.search !== "" ? 1 : 0) + (filters.approvalStatus ? 1 : 0);
 
   return (
     <div className="w-full flex-1 min-h-0 py-3.5 px-5 relative">
@@ -87,6 +93,8 @@ export const PersonalTimesheetTable = () => {
             fields={personalTimesheetFilters}
             value={compositeFilters}
             onChange={handleCompositeFilterChange}
+            externalFilterCount={externalFilterCount}
+            onClearAll={handleClearAllFilters}
           />
           <Button icon={() => <DotHorizontal size={16} />} />
         </div>

--- a/frontend/packages/app/src/pages/timesheet/personal/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/provider.tsx
@@ -19,10 +19,15 @@ import { useTimesheetFilters } from "../hooks/useTimesheetFilters";
 export const PersonalTimesheetProvider: FC<PropsWithChildren> = ({
   children,
 }) => {
-  const { filters, setSearch, setApprovalStatus, setCompositeFilters } =
-    useTimesheetFilters({
-      includeApprovalStatus: true,
-    });
+  const {
+    filters,
+    setSearch,
+    setApprovalStatus,
+    setCompositeFilters,
+    resetAll,
+  } = useTimesheetFilters({
+    includeApprovalStatus: true,
+  });
   const debouncedSearch = useDebounce(filters.search, 400);
 
   const { employeeId } = useUser(({ state }) => ({
@@ -80,6 +85,7 @@ export const PersonalTimesheetProvider: FC<PropsWithChildren> = ({
         handleSearchChange: setSearch,
         handleApprovalStatusChange: setApprovalStatus,
         handleCompositeFilterChange: setCompositeFilters,
+        handleClearAllFilters: resetAll,
         refetchLikedTasks,
       },
     }),
@@ -97,6 +103,7 @@ export const PersonalTimesheetProvider: FC<PropsWithChildren> = ({
       setSearch,
       setApprovalStatus,
       setCompositeFilters,
+      resetAll,
       refetchLikedTasks,
     ],
   );

--- a/frontend/packages/app/src/pages/timesheet/project/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/context.ts
@@ -59,6 +59,7 @@ export interface ProjectTimesheetContextProps {
     loadData: () => void;
     handleSearchChange: (value: string) => void;
     handleCompositeFilterChange: (value: FilterCondition[]) => void;
+    handleClearAllFilters: () => void;
   };
 }
 
@@ -78,6 +79,7 @@ export const ProjectTimesheetContext =
       loadData: () => null,
       handleSearchChange: () => null,
       handleCompositeFilterChange: () => null,
+      handleClearAllFilters: () => null,
     },
   });
 

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -37,8 +37,13 @@ export const ProjectTimesheetTable = () => {
   const handleCompositeFilterChange = useProjectTimesheet(
     ({ actions }) => actions.handleCompositeFilterChange,
   );
+  const handleClearAllFilters = useProjectTimesheet(
+    ({ actions }) => actions.handleClearAllFilters,
+  );
 
   const isFilteredDataLoading = isFilterRequest && isLoadingProjectData;
+
+  const externalFilterCount = filters.search !== "" ? 1 : 0;
 
   return (
     <div className="w-full flex-1 min-h-0 py-3.5 px-5 relative">
@@ -55,6 +60,8 @@ export const ProjectTimesheetTable = () => {
             fields={projectTimesheetFilters}
             value={compositeFilters}
             onChange={handleCompositeFilterChange}
+            externalFilterCount={externalFilterCount}
+            onClearAll={handleClearAllFilters}
           />
           <Button icon={() => <DotHorizontal size={16} />} />
         </div>

--- a/frontend/packages/app/src/pages/timesheet/project/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/provider.tsx
@@ -28,7 +28,8 @@ export const ProjectTimesheetProvider: FC<PropsWithChildren> = ({
   children,
 }) => {
   const toast = useToasts();
-  const { filters, setSearch, setCompositeFilters } = useTimesheetFilters();
+  const { filters, setSearch, setCompositeFilters, resetAll } =
+    useTimesheetFilters();
   const debouncedSearch = useDebounce(filters.search, 400);
 
   // Only pass complete filter conditions to the data hook so that selecting a
@@ -98,6 +99,7 @@ export const ProjectTimesheetProvider: FC<PropsWithChildren> = ({
         loadData,
         handleSearchChange: setSearch,
         handleCompositeFilterChange: setCompositeFilters,
+        handleClearAllFilters: resetAll,
       },
     }),
     [
@@ -110,6 +112,7 @@ export const ProjectTimesheetProvider: FC<PropsWithChildren> = ({
       filters.compositeFilters,
       setSearch,
       setCompositeFilters,
+      resetAll,
     ],
   );
 

--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -42,6 +42,7 @@ export interface TeamTimesheetContextProps {
     handleApprovalStatusChange: (value?: ApprovalStatusType | null) => void;
     handleReportsToChange: (value: string | null) => void;
     handleCompositeFilterChange: (value: FilterCondition[]) => void;
+    handleClearAllFilters: () => void;
   };
 }
 
@@ -64,6 +65,7 @@ export const TeamTimesheetContext = createContext<TeamTimesheetContextProps>({
     handleApprovalStatusChange: () => null,
     handleReportsToChange: () => null,
     handleCompositeFilterChange: () => null,
+    handleClearAllFilters: () => null,
   },
 });
 

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -33,6 +33,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
     setApprovalStatus,
     setReportsTo,
     setCompositeFilters,
+    resetAll,
   } = useTimesheetFilters({
     includeApprovalStatus: true,
     includeReportsTo: true,
@@ -129,6 +130,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
         handleApprovalStatusChange: setApprovalStatus,
         handleReportsToChange: setReportsTo,
         handleCompositeFilterChange: setCompositeFilters,
+        handleClearAllFilters: resetAll,
       },
     }),
     [
@@ -143,6 +145,7 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       setApprovalStatus,
       setReportsTo,
       setCompositeFilters,
+      resetAll,
     ],
   );
 

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -53,8 +53,16 @@ export const TeamTimesheetTable = () => {
   const handleCompositeFilterChange = useTeamTimesheet(
     ({ actions }) => actions.handleCompositeFilterChange,
   );
+  const handleClearAllFilters = useTeamTimesheet(
+    ({ actions }) => actions.handleClearAllFilters,
+  );
 
   const isFilteredDataLoading = isFilterRequest && isLoadingTeamData;
+
+  const externalFilterCount =
+    (filters.search !== "" ? 1 : 0) +
+    (filters.approvalStatus ? 1 : 0) +
+    (filters.reportsTo ? 1 : 0);
 
   return (
     <div className="w-full flex-1 min-h-0 py-3.5 px-5 relative">
@@ -102,6 +110,8 @@ export const TeamTimesheetTable = () => {
             fields={teamTimesheetFilters}
             value={compositeFilters}
             onChange={handleCompositeFilterChange}
+            externalFilterCount={externalFilterCount}
+            onClearAll={handleClearAllFilters}
           />
           <Button icon={() => <DotHorizontal size={16} />} />
         </div>


### PR DESCRIPTION
## Description
- frappe-ui-react's Filter component now supports externalFilterCount and onClearAll, so it can account for standalone "simple" filters it doesn't own.
- Wired this into Timesheet (Personal/Team/Project): "Clear all" now also resets search, approval status, and reports-to.
- Wired this into Allocations (Team/Project): "Clear all" now also resets search, duration, allocation type, and designation.

## Screenshot/Screencast

https://github.com/user-attachments/assets/a39b201f-b20a-4899-92f0-2f8400ea8738

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1600