### PR TITLE
QA Fix: Remove scrollbars on timesheet pages.

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -120,7 +120,7 @@ export const PersonalTimesheetTable = () => {
               hasMore={!isFilterRequest && hasMoreWeeks}
               verticalLodMore={loadData}
               className={cn(
-                "relative w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable] opacity-100",
+                "relative w-full h-[calc(100%-var(--spacing)*7)] overflow-auto no-scrollbar opacity-100",
                 {
                   "opacity-50 transition-opacity duration-150":
                     isFilteredDataLoading,

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -72,7 +72,7 @@ export const ProjectTimesheetTable = () => {
           hasMore={hasMore}
           verticalLodMore={loadData}
           className={cn(
-            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable] opacity-100",
+            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto no-scrollbar opacity-100",
             {
               "opacity-50 transition-opacity duration-150":
                 isFilteredDataLoading,

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -119,7 +119,7 @@ export const TeamTimesheetTable = () => {
           hasMore={hasMore}
           verticalLodMore={loadMore}
           className={cn(
-            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto scrollbar [scrollbar-gutter:stable] opacity-100",
+            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto no-scrollbar opacity-100",
             {
               "opacity-50 transition-opacity duration-150":
                 isFilteredDataLoading,


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR removes scrollbars on timesheet pagess.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
> This issue is caused by a change introduced in macOS 26. The default behavior of the "Show scroll bars" setting ("Automatically based on mouse or trackpad") was changed to hide scrollbars across the operating system, including in web browsers, and use overlay scrollbars instead.
> Overlay scrollbars are only visible while scrolling, which is why they overlap the content.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/47c43e4a-413b-43f4-a0b9-ed46e2ee3f9e



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1574