### PR TITLE
Reduce memory usage on allocation pages

### DIFF
--- a/frontend/packages/app/src/components/infiniteScroll.tsx
+++ b/frontend/packages/app/src/components/infiniteScroll.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 
+import { useEffect, useRef } from "react";
 import { mergeClassNames as cn } from "@next-pms/design-system";
 import { useInfiniteScroll } from "@next-pms/hooks";
 import { Skeleton } from "@rtcamp/frappe-ui-react";
@@ -19,15 +20,23 @@ const InfiniteScroll = ({
   className,
   skeletonClassName,
   count = 1,
+  scrollResetKey,
 }: InfiniteScrollProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const verticalLoderRef = useInfiniteScroll({
     isLoading: isLoading,
     hasMore: hasMore,
     next: () => verticalLodMore(),
   });
 
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+  }, [scrollResetKey]);
+
   return (
-    <div className={className}>
+    <div ref={containerRef} className={className}>
       {children}
       {(isLoading || hasMore) && (
         <div

--- a/frontend/packages/app/src/components/types.ts
+++ b/frontend/packages/app/src/components/types.ts
@@ -23,6 +23,7 @@ export interface InfiniteScrollProps {
   className?: string;
   skeletonClassName?: string;
   count?: number;
+  scrollResetKey?: string | number;
 }
 
 export interface TaskIndicatorProps {

--- a/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
@@ -31,6 +31,9 @@ export const AllocationsProjectTable = () => {
   const hasMore = useAllocationsProject(({ state }) => state.hasMore);
   const projects = useAllocationsProject(({ state }) => state.projects);
   const anchorDate = useAllocationsProject(({ state }) => state.anchorDate);
+  const querySignature = useAllocationsProject(
+    ({ state }) => state.querySignature,
+  );
   const loadMore = useAllocationsProject(({ actions }) => actions.loadMore);
 
   const ganttRef = useUnsavedChangesSource();
@@ -58,6 +61,7 @@ export const AllocationsProjectTable = () => {
             isLoading={isQueryLoading || isNextPageLoading}
             hasMore={hasMore}
             verticalLodMore={loadMore}
+            scrollResetKey={querySignature}
             className={cn("w-full h-full overflow-auto no-scrollbar", {
               "opacity-50 transition-opacity duration-150 pointer-events-none":
                 isRefreshingVisibleGrid,

--- a/frontend/packages/app/src/pages/allocations/project/context.ts
+++ b/frontend/packages/app/src/pages/allocations/project/context.ts
@@ -16,6 +16,7 @@ export interface AllocationsProjectContextProps {
     isQueryLoading: boolean;
     isNextPageLoading: boolean;
     hasMore: boolean;
+    querySignature: string;
     search: string;
     duration: AllocationsDuration;
     allocationsType: string[];
@@ -43,6 +44,7 @@ export const AllocationsProjectContext =
       isQueryLoading: false,
       isNextPageLoading: false,
       hasMore: true,
+      querySignature: "",
       search: "",
       duration: "this-quarter",
       allocationsType: [],

--- a/frontend/packages/app/src/pages/allocations/project/layout.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/layout.tsx
@@ -4,6 +4,7 @@
 import { Outlet } from "react-router-dom";
 import { Button } from "@rtcamp/frappe-ui-react";
 import { AddSm } from "@rtcamp/frappe-ui-react/icons";
+import { SWRConfig } from "swr";
 
 /**
  * Internal dependencies.
@@ -51,11 +52,13 @@ function ProjectAllocationsLayoutContent() {
 
 function ProjectAllocationsLayout() {
   return (
-    <UnsavedChangesProvider>
-      <AllocationsProjectProvider>
-        <ProjectAllocationsLayoutContent />
-      </AllocationsProjectProvider>
-    </UnsavedChangesProvider>
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <UnsavedChangesProvider>
+        <AllocationsProjectProvider>
+          <ProjectAllocationsLayoutContent />
+        </AllocationsProjectProvider>
+      </UnsavedChangesProvider>
+    </SWRConfig>
   );
 }
 

--- a/frontend/packages/app/src/pages/allocations/project/provider.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/provider.tsx
@@ -77,6 +77,7 @@ export function AllocationsProjectProvider({
     hasMore,
     isQueryLoading,
     isNextPageLoading,
+    querySignature,
     loadMore,
     refresh,
   } = useAllocationsProjectData({
@@ -184,6 +185,7 @@ export function AllocationsProjectProvider({
         isQueryLoading,
         isNextPageLoading,
         hasMore,
+        querySignature,
         search: searchParam,
         duration,
         allocationsType,
@@ -208,6 +210,7 @@ export function AllocationsProjectProvider({
       isQueryLoading,
       isNextPageLoading,
       hasMore,
+      querySignature,
       searchParam,
       duration,
       allocationsType,

--- a/frontend/packages/app/src/pages/allocations/project/useAllocationsProjectData.ts
+++ b/frontend/packages/app/src/pages/allocations/project/useAllocationsProjectData.ts
@@ -32,6 +32,7 @@ type UseAllocationsProjectDataResult = {
   hasMore: boolean;
   isQueryLoading: boolean;
   isNextPageLoading: boolean;
+  querySignature: string;
   loadMore: () => void;
   refresh: (projectIds?: string[]) => Promise<void>;
 };
@@ -39,6 +40,8 @@ type UseAllocationsProjectDataResult = {
 type ProjectAllocationCallResponse = {
   message?: ProjectAllocationResponse;
 };
+
+const QUERY_SIGNATURE_PREFIX = "project-allocations:";
 
 export function useAllocationsProjectData({
   anchorDate,
@@ -79,9 +82,8 @@ export function useAllocationsProjectData({
     hasBillable === hasNonBillable ? null : JSON.stringify(hasBillable ? 1 : 0);
   const querySignature = useMemo(
     () =>
-      hashString(
+      `${QUERY_SIGNATURE_PREFIX}${hashString(
         [
-          "project-allocations",
           requestDate,
           String(maxWeek),
           search,
@@ -89,7 +91,7 @@ export function useAllocationsProjectData({
           isBillableParam ?? "",
           filtersParam ?? "",
         ].join(":"),
-      ),
+      )}`,
     [
       allocationStatusParam,
       filtersParam,
@@ -157,6 +159,9 @@ export function useAllocationsProjectData({
       errorRetryCount: 0,
       onError: (error) => {
         toast.error(parseFrappeErrorMsg(error as FrappeError));
+      },
+      cacheCleanup: {
+        signaturePrefix: QUERY_SIGNATURE_PREFIX,
       },
     },
   );
@@ -251,6 +256,7 @@ export function useAllocationsProjectData({
     hasMore,
     isQueryLoading,
     isNextPageLoading,
+    querySignature,
     loadMore,
     refresh,
   };

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -31,6 +31,9 @@ export const AllocationsTeamTable = () => {
   const hasMore = useAllocationsTeam(({ state }) => state.hasMore);
   const members = useAllocationsTeam(({ state }) => state.members);
   const anchorDate = useAllocationsTeam(({ state }) => state.anchorDate);
+  const querySignature = useAllocationsTeam(
+    ({ state }) => state.querySignature,
+  );
   const loadMore = useAllocationsTeam(({ actions }) => actions.loadMore);
 
   const ganttRef = useUnsavedChangesSource();
@@ -60,6 +63,7 @@ export const AllocationsTeamTable = () => {
             isLoading={isQueryLoading || isNextPageLoading}
             hasMore={hasMore}
             verticalLodMore={loadMore}
+            scrollResetKey={querySignature}
             className={cn("w-full h-full overflow-auto no-scrollbar", {
               "opacity-50 transition-opacity duration-150 pointer-events-none":
                 isRefreshingVisibleGrid,

--- a/frontend/packages/app/src/pages/allocations/team/context.ts
+++ b/frontend/packages/app/src/pages/allocations/team/context.ts
@@ -16,6 +16,7 @@ export interface AllocationsTeamContextProps {
     isQueryLoading: boolean;
     isNextPageLoading: boolean;
     hasMore: boolean;
+    querySignature: string;
     designation: string[];
     search: string;
     duration: AllocationsDuration;
@@ -45,6 +46,7 @@ export const AllocationsTeamContext =
       isQueryLoading: false,
       isNextPageLoading: false,
       hasMore: true,
+      querySignature: "",
       search: "",
       duration: "this-quarter",
       allocationsType: [],

--- a/frontend/packages/app/src/pages/allocations/team/layout.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/layout.tsx
@@ -4,6 +4,7 @@
 import { Outlet } from "react-router-dom";
 import { Button } from "@rtcamp/frappe-ui-react";
 import { AddSm } from "@rtcamp/frappe-ui-react/icons";
+import { SWRConfig } from "swr";
 
 /**
  * Internal dependencies.
@@ -51,11 +52,13 @@ function AllocationsTeamLayoutContent() {
 
 function AllocationsTeamLayout() {
   return (
-    <UnsavedChangesProvider>
-      <AllocationsTeamProvider>
-        <AllocationsTeamLayoutContent />
-      </AllocationsTeamProvider>
-    </UnsavedChangesProvider>
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <UnsavedChangesProvider>
+        <AllocationsTeamProvider>
+          <AllocationsTeamLayoutContent />
+        </AllocationsTeamProvider>
+      </UnsavedChangesProvider>
+    </SWRConfig>
   );
 }
 

--- a/frontend/packages/app/src/pages/allocations/team/provider.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/provider.tsx
@@ -85,6 +85,7 @@ export function AllocationsTeamProvider({
     hasMore,
     isQueryLoading,
     isNextPageLoading,
+    querySignature,
     loadMore,
     refresh,
   } = useAllocationsTeamData({
@@ -203,6 +204,7 @@ export function AllocationsTeamProvider({
         isQueryLoading,
         isNextPageLoading,
         hasMore,
+        querySignature,
         search: searchParam,
         designation,
         duration,
@@ -229,6 +231,7 @@ export function AllocationsTeamProvider({
       isNextPageLoading,
       isQueryLoading,
       hasMore,
+      querySignature,
       searchParam,
       duration,
       designation,

--- a/frontend/packages/app/src/pages/allocations/team/useAllocationsTeamData.ts
+++ b/frontend/packages/app/src/pages/allocations/team/useAllocationsTeamData.ts
@@ -33,6 +33,7 @@ type UseAllocationsTeamDataResult = {
   hasMore: boolean;
   isQueryLoading: boolean;
   isNextPageLoading: boolean;
+  querySignature: string;
   loadMore: () => void;
   refresh: (employeeIds?: string[]) => Promise<void>;
 };
@@ -40,6 +41,8 @@ type UseAllocationsTeamDataResult = {
 type TeamAllocationCallResponse = {
   message?: TeamAllocationResponse;
 };
+
+const QUERY_SIGNATURE_PREFIX = "team-allocations:";
 
 export function useAllocationsTeamData({
   anchorDate,
@@ -92,9 +95,8 @@ export function useAllocationsTeamData({
       : JSON.stringify(hasBillable ? [1] : [0]);
   const querySignature = useMemo(
     () =>
-      hashString(
+      `${QUERY_SIGNATURE_PREFIX}${hashString(
         [
-          "team-allocations",
           requestDate,
           String(maxWeek),
           search,
@@ -103,7 +105,7 @@ export function useAllocationsTeamData({
           isBillableParam ?? "",
           filtersParam ?? "",
         ].join(":"),
-      ),
+      )}`,
     [
       allocationStatusParam,
       designationParam,
@@ -175,6 +177,9 @@ export function useAllocationsTeamData({
       errorRetryCount: 0,
       onError: (error) => {
         toast.error(parseFrappeErrorMsg(error as FrappeError));
+      },
+      cacheCleanup: {
+        signaturePrefix: QUERY_SIGNATURE_PREFIX,
       },
     },
   );
@@ -270,6 +275,7 @@ export function useAllocationsTeamData({
     hasMore,
     isQueryLoading,
     isNextPageLoading,
+    querySignature,
     loadMore,
     refresh,
   };

--- a/frontend/packages/hooks/src/usePagination.ts
+++ b/frontend/packages/hooks/src/usePagination.ts
@@ -2,16 +2,51 @@
 /**
  * External dependencies.
  */
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { FrappeContext, FrappeConfig } from "frappe-react-sdk";
+import { useSWRConfig, type Cache } from "swr";
 import useSWRInfinite, {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
+  unstable_serialize,
 } from "swr/infinite";
 
 export type PaginationKey = readonly [cacheKey: string, pageIndex: number];
+
 type PaginationParams = Record<string, unknown> & {
   page_length: number;
+};
+
+type PaginationOptions<T = any, E = any> = SWRInfiniteConfiguration<T, E> & {
+  /** Optional cleanup of cached pages for this query prefix. */
+  cacheCleanup?: { signaturePrefix: string };
+};
+
+/**
+ * Extract the signature from a cached entry. SWR keeps the original key args
+ * in `_k`: [signature, pageIndex].
+ */
+const signatureOf = (entry: unknown): string | undefined => {
+  const keyArgs = (entry as { _k?: unknown } | null | undefined)?._k;
+  return Array.isArray(keyArgs) && typeof keyArgs[0] === "string"
+    ? keyArgs[0]
+    : undefined;
+};
+
+/**
+ * Delete all cached pages for a given prefix, except those of `keep`. Also
+ * delete the metadata entry for each deleted signature.
+ */
+const deletePages = (cache: Cache, prefix: string, keep: string) => {
+  for (const key of Array.from(cache.keys())) {
+    const signature = signatureOf(cache.get(key));
+    if (signature?.startsWith(prefix) && signature !== keep) {
+      cache.delete(key);
+      cache.delete(
+        unstable_serialize((pageIndex: number) => [signature, pageIndex]),
+      );
+    }
+  }
 };
 
 /**
@@ -20,37 +55,47 @@ type PaginationParams = Record<string, unknown> & {
  * @param method - name of the method to call (will be dotted path e.g. "frappe.client.get_list")
  * @param getKey - A function that accepts the index and previous page data, and returns the key for that page
  * @param params - Request params for every page. Must include `page_length` so the hook can derive the `start` offset.
- * @param options - Optional useSWRInfinite configuration
+ * @param options - Optional useSWRInfinite configuration, plus `cacheCleanup` (see PaginationOptions)
  *
  * @typeParam T - Type of the data returned by the method
+ * @typeParam E - Type of the error returned by the method
  * @typeParam P - Type of the request params. Must extend `PaginationParams`.
  * @returns The `useSWRInfinite` response for the paginated request. `data` is an array of page responses.
  */
 export const usePagination = <
   T = any,
+  E = any,
   P extends PaginationParams = PaginationParams,
 >(
   method: string,
   getKey: (index: number, previousPageData: T | null) => PaginationKey | null,
   params: P,
-  options?: SWRInfiniteConfiguration,
-): SWRInfiniteResponse<T, Error> => {
+  options?: PaginationOptions<T, E>,
+): SWRInfiniteResponse<T, E> => {
   const { call } = useContext(FrappeContext) as FrappeConfig;
+  const { cache } = useSWRConfig();
+  const { cacheCleanup, ...swrOptions } = options ?? {};
+  const prefix = cacheCleanup?.signaturePrefix;
+  const signature = getKey(0, null)?.[0];
 
-  const swrResult = useSWRInfinite<T, Error>(
+  const result = useSWRInfinite<T, E>(
     getKey,
-    ([, pageIndex]: PaginationKey) => {
-      return call.get<T>(method, {
+    ([, pageIndex]: PaginationKey) =>
+      call.get<T>(method, {
         ...params,
         start: pageIndex * params.page_length,
-      });
-    },
-    {
-      ...options,
-    },
+      }),
+    swrOptions,
   );
 
-  return {
-    ...swrResult,
-  };
+  // Once the active query settles, drop the cached pages of previous queries.
+  // They are kept until then so keepPreviousData can show them while loading.
+  const settled = !result.isLoading && !result.error;
+  useEffect(() => {
+    if (prefix && signature && settled) {
+      deletePages(cache, prefix, signature);
+    }
+  }, [cache, prefix, signature, settled]);
+
+  return result;
 };


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR reduces memory usage on the Team and Project allocation pages.

Previously, both pages paginated heavy Gantt data through `useSWRInfinite`. Because SWR does not provide built-in cache eviction, every filter, search, or date-navigation change created a new query whose pages remained in the SWR cache indefinitely. During long allocation browsing sessions, this could accumulate hundreds of cached pages until the page was fully reloaded.

Now, cached data is cleared when filters or date navigation change, and also when the page unmounts.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Each allocation page now has its own SWR cache, which is fully dropped when the page unmounts. This ensures allocation data never outlives the page.
- While the page is mounted, cached pages from stale queries, such as previous filter, date, or search combinations, are deleted as soon as the active query finishes loading. Only the active query’s pages remain in memory.
- The list now scrolls back to the top when the query changes, instead of leaving the user deep in the previous scroll position. This prevents a large number of requests from being sent at once when filters, date navigation, or search values change after the user has scrolled significantly down the list.




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1695 