### PR TITLE
fix: add keyboard focus on edit icon for timesheet sidebar

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -142,7 +142,7 @@ const EntryRow = ({ entry, onSave }: EntryRowProps) => {
         {floatToTime(entry.hours, 2, 2)}
       </span>
       <Button
-        className="m-0 size-fit hover:bg-surface-white opacity-0 group-hover:opacity-100 transition-opacity"
+        className="m-0 size-fit hover:bg-surface-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
         variant="ghost"
         icon={() => <EditAlt size={16} className="text-ink-gray-7" />}
         onClick={handleEdit}


### PR DESCRIPTION
## Description

While navigating in the sidebar using keyboard, the edit icon was not visible but was being focused, added visibility to the icon on keyboard focus

## Testing Instructions

- Log in with account having Project Manager role.
- Open Timesheets page → Team.
- Open an employee timesheet in the sidebar.
- Use the Tab key to navigate through.
- Focus on the edit button.
- The edit icon should be visible when keyboard focuses on it


## Screenshot/Screencast


https://github.com/user-attachments/assets/017f3068-8f54-4b33-bb59-c0e111f95b94

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1653 