### PR TITLE
feat: validate resource allocation against cancelled projects and disabled customers

### DIFF
--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
@@ -66,7 +66,10 @@ class ResourceAllocation(Document):
             if is_active == "No":
                 frappe.throw(frappe._("Cannot allocate to inactive project {0}.").format(self.project))
 
-        if self.customer and (self.is_new() or self.has_value_changed("customer")):
+        # Customer is fetched from project.customer, so a project change can swap in a
+        # different (possibly disabled) customer without customer itself registering a
+        # change when both projects share the same customer. Re-check on project change too.
+        if self.customer and (self.is_new() or self.has_value_changed("customer") or self.has_value_changed("project")):
             if frappe.db.get_value("Customer", self.customer, "disabled"):
                 frappe.throw(frappe._("Cannot allocate to disabled customer {0}.").format(self.customer))
 

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
@@ -50,7 +50,25 @@ class ResourceAllocation(Document):
         if self.allocation_end_date < self.allocation_start_date:
             frappe.throw(frappe._("End date should be greater than or equal to start date"))
 
+        self.validate_project_and_customer()
         self.calculate_cost()
+
+    def validate_project_and_customer(self):
+        """Reject allocations pointed at a cancelled/inactive project or a disabled customer.
+
+        Only fires when the project/customer is newly set or changed, so an allocation
+        created while its project was valid stays editable if the project is later cancelled.
+        """
+        if self.project and (self.is_new() or self.has_value_changed("project")):
+            status, is_active = frappe.db.get_value("Project", self.project, ["status", "is_active"])
+            if status == "Cancelled":
+                frappe.throw(frappe._("Cannot allocate to cancelled project {0}.").format(self.project))
+            if is_active == "No":
+                frappe.throw(frappe._("Cannot allocate to inactive project {0}.").format(self.project))
+
+        if self.customer and (self.is_new() or self.has_value_changed("customer")):
+            if frappe.db.get_value("Customer", self.customer, "disabled"):
+                frappe.throw(frappe._("Cannot allocate to disabled customer {0}.").format(self.customer))
 
     def calculate_cost(self):
         """Calculate hourly_cost_rate and total_cost based on employee CTC."""

--- a/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
@@ -1,9 +1,165 @@
 # Copyright (c) 2024, rtCamp and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests.utils import FrappeTestCase
+import frappe
+from erpnext import get_default_company
+from frappe.exceptions import ValidationError
+from frappe.tests import IntegrationTestCase
+
+START_DATE = "2026-06-15"
+END_DATE = "2026-06-19"
 
 
-class TestResourceAllocation(FrappeTestCase):
-    pass
+class TestResourceAllocationValidation(IntegrationTestCase):
+    """Controller checks for Resource Allocation: entity state, date range, and cost calculation."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.employee = cls._make_employee("Ravi Kumar")
+        cls.customer = cls._make_customer("Globex")
+        cls.project = cls._make_project("Active Project", cls.customer)
+
+    @classmethod
+    def _make_employee(cls, employee_name):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": employee_name,
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                "leave_approver": "Administrator",
+                "ctc": 100000,
+                "salary_currency": "INR",
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _make_customer(cls, name, disabled=0):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": f"{name} {frappe.generate_hash(length=6)}",
+                    "customer_type": "Company",
+                    "custom_abbr": frappe.generate_hash(length=8).upper(),
+                    "default_currency": "INR",
+                    "disabled": disabled,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project(cls, name, customer):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": f"{name} {frappe.generate_hash(length=6)}",
+                    "company": cls.company,
+                    "customer": customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def _make_allocation_doc(self, project=None, customer=None, **overrides):
+        data = {
+            "doctype": "Resource Allocation",
+            "employee": self.employee,
+            "allocation_start_date": START_DATE,
+            "allocation_end_date": END_DATE,
+            "hours_allocated_per_day": 8,
+            "status": "Confirmed",
+            "is_billable": 0,
+        }
+        if project:
+            data["project"] = project
+        if customer:
+            data["customer"] = customer
+        data.update(overrides)
+        return frappe.get_doc(data)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def test_active_project_and_enabled_customer_saves(self):
+        doc = self._make_allocation_doc(project=self.project)
+        doc.insert(ignore_permissions=True)
+        self.assertTrue(frappe.db.exists("Resource Allocation", doc.name))
+
+    def test_cancelled_project_rejected(self):
+        project = self._make_project("Cancelled Project", self.customer)
+        frappe.db.set_value("Project", project, "status", "Cancelled")
+        doc = self._make_allocation_doc(project=project)
+        with self.assertRaises(ValidationError) as cm:
+            doc.insert(ignore_permissions=True)
+        self.assertIn("cancelled project", str(cm.exception).lower())
+
+    def test_inactive_project_rejected(self):
+        project = self._make_project("Inactive Project", self.customer)
+        frappe.db.set_value("Project", project, "is_active", "No")
+        doc = self._make_allocation_doc(project=project)
+        with self.assertRaises(ValidationError) as cm:
+            doc.insert(ignore_permissions=True)
+        self.assertIn("inactive project", str(cm.exception).lower())
+
+    def test_disabled_customer_rejected(self):
+        # No project, so the disabled customer is used directly (project.customer
+        # fetch_from would otherwise overwrite an explicit customer value).
+        customer = self._make_customer("Disabled Customer", disabled=1)
+        doc = self._make_allocation_doc(customer=customer)
+        with self.assertRaises(ValidationError) as cm:
+            doc.insert(ignore_permissions=True)
+        self.assertIn("disabled customer", str(cm.exception).lower())
+
+    def test_edit_unrelated_field_allowed_after_project_cancelled(self):
+        # An allocation valid at creation stays editable when its project is later
+        # cancelled, as long as the project/customer field itself does not change.
+        project = self._make_project("Later Cancelled", self.customer)
+        doc = self._make_allocation_doc(project=project)
+        doc.insert(ignore_permissions=True)
+
+        frappe.db.set_value("Project", project, "status", "Cancelled")
+
+        doc.reload()
+        doc.note = "Updated after cancellation"
+        doc.save(ignore_permissions=True)
+
+        self.assertEqual(
+            frappe.db.get_value("Resource Allocation", doc.name, "note"),
+            "Updated after cancellation",
+        )
+
+    def test_end_date_before_start_date_rejected(self):
+        doc = self._make_allocation_doc(project=self.project, allocation_end_date="2026-06-10")
+        with self.assertRaises(ValidationError) as cm:
+            doc.insert(ignore_permissions=True)
+        self.assertIn("end date", str(cm.exception).lower())
+
+    def test_same_start_and_end_date_allowed(self):
+        doc = self._make_allocation_doc(
+            project=self.project,
+            allocation_start_date=START_DATE,
+            allocation_end_date=START_DATE,
+        )
+        doc.insert(ignore_permissions=True)
+        self.assertTrue(frappe.db.exists("Resource Allocation", doc.name))
+
+    def test_total_cost_is_hourly_rate_times_allocated_hours(self):
+        doc = self._make_allocation_doc(project=self.project, total_allocated_hours=40)
+        doc.insert(ignore_permissions=True)
+        self.assertGreater(doc.hourly_cost_rate, 0)
+        self.assertEqual(doc.total_cost, doc.hourly_cost_rate * doc.total_allocated_hours)

--- a/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
@@ -6,7 +6,7 @@ from erpnext import get_default_company
 from frappe.exceptions import ValidationError
 from frappe.tests import IntegrationTestCase
 
-# All fixtures are created manually in setUpClass; skip the auto test-record.
+# All fixtures are created manually in setUpClass; skip the auto test-recordx.
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Employee", "Project", "Customer", "Currency"]
 
 START_DATE = "2026-06-15"
@@ -145,6 +145,26 @@ class TestResourceAllocationValidation(IntegrationTestCase):
             frappe.db.get_value("Resource Allocation", doc.name, "note"),
             "Updated after cancellation",
         )
+
+    def test_project_change_to_disabled_customer_rejected(self):
+        # Customer is fetched from project.customer. An allocation created under an
+        # enabled customer must be rejected when its project is switched to another
+        # project under the same customer after that customer is disabled — even
+        # though the customer field value itself does not change.
+        customer = self._make_customer("Shared Customer")
+        first_project = self._make_project("Shared Proj One", customer)
+        second_project = self._make_project("Shared Proj Two", customer)
+
+        doc = self._make_allocation_doc(project=first_project)
+        doc.insert(ignore_permissions=True)
+
+        frappe.db.set_value("Customer", customer, "disabled", 1)
+
+        doc.reload()
+        doc.project = second_project
+        with self.assertRaises(ValidationError) as cm:
+            doc.save(ignore_permissions=True)
+        self.assertIn("disabled customer", str(cm.exception).lower())
 
     def test_end_date_before_start_date_rejected(self):
         doc = self._make_allocation_doc(project=self.project, allocation_end_date="2026-06-10")

--- a/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
@@ -6,6 +6,9 @@ from erpnext import get_default_company
 from frappe.exceptions import ValidationError
 from frappe.tests import IntegrationTestCase
 
+# All fixtures are created manually in setUpClass; skip the auto test-record.
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Employee", "Project", "Customer", "Currency"]
+
 START_DATE = "2026-06-15"
 END_DATE = "2026-06-19"
 


### PR DESCRIPTION
## Description

* Added a new method `validate_project_and_customer` in `resource_allocation.py` to reject allocations if the associated project is cancelled/inactive or the customer is disabled. This validation only triggers when the project or customer is newly set or changed, allowing edits to existing allocations even if the project/customer is later deactivated.

* Replaced the old test class with a new `TestResourceAllocationValidation` integration test suite in `test_resource_allocation.py`. This suite:
  * Creates test fixtures for employees, customers, and projects.
  * Tests that allocations to cancelled/inactive projects or disabled customers are rejected.
  * Verifies that allocations remain editable after project/customer status changes, unless those fields are modified.
  * Checks date range validation and cost calculation logic.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1722 