### PR TITLE
feat: Timesheet Rejection Reason

### DIFF
--- a/next_pms/install.py
+++ b/next_pms/install.py
@@ -11,6 +11,28 @@ def after_install():
     create_default_risk_masters()
     setup_project_custom_fields()
     setup_project_target_hours_field()
+    setup_timesheet_rejection_reason_field()
+
+
+def setup_timesheet_rejection_reason_field():
+    from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+    create_custom_fields(
+        {
+            "Timesheet": [
+                {
+                    "fieldname": "custom_rejection_reason",
+                    "fieldtype": "Text Editor",
+                    "label": "Rejection Reason",
+                    "insert_after": "note",
+                    "depends_on": 'eval:doc.custom_approval_status=="Rejected"',
+                    "read_only": 1,
+                    "no_copy": 1,
+                    "module": "Timesheet",
+                },
+            ]
+        }
+    )
 
 
 def setup_project_target_hours_field():

--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -29,3 +29,4 @@ next_pms.next_projects.patches.setup_project_lifetime_value_fields
 next_pms.timesheet.patches.add_timesheet_detail_index
 next_pms.next_projects.patches.setup_project_target_hours_field
 next_pms.timesheet.patches.add_project_report_permissions
+next_pms.timesheet.patches.setup_timesheet_rejection_reason_field

--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -2,7 +2,7 @@ import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
 
-from next_pms.tests.utils import make_employee, make_holiday_list
+from next_pms.tests.utils import make_employee
 from next_pms.timesheet.api.team import _approve_or_reject_timesheet
 from next_pms.timesheet.api.timesheet import save as save_timesheet
 from next_pms.timesheet.api.timesheet import submit_for_approval
@@ -32,28 +32,6 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
 
         # Week start is read via frappe.db.get_default, not System Settings directly.
         frappe.db.set_default("first_day_of_the_week", "Monday")
-
-        # HRMS's leave-balance validation needs a holiday list resolvable for every
-        # employee; add a company-wide one unless another test already created it.
-        if not frappe.db.exists(
-            "Holiday List Assignment",
-            {"assigned_to": cls.company, "applicable_for": "Company", "docstatus": 1},
-        ):
-            holiday_list = make_holiday_list(
-                "Rejection Reason Test Company Holidays",
-                from_date="2026-01-01",
-                to_date="2026-12-31",
-                holiday_dates=[],
-            )
-            frappe.get_doc(
-                {
-                    "doctype": "Holiday List Assignment",
-                    "applicable_for": "Company",
-                    "assigned_to": cls.company,
-                    "holiday_list": holiday_list.name,
-                    "from_date": "2026-01-01",
-                }
-            ).insert(ignore_permissions=True).submit()
 
         cls.manager = make_employee(MANAGER_USER, company=cls.company, leave_approver="Administrator")
         cls.employee = make_employee(

--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -1,0 +1,196 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.tests.utils import make_employee, make_holiday_list
+from next_pms.timesheet.api.team import _approve_or_reject_timesheet
+from next_pms.timesheet.api.timesheet import save as save_timesheet
+from next_pms.timesheet.api.timesheet import submit_for_approval
+
+MANAGER_USER = "rejection-reason-test-manager@example.com"
+EMPLOYEE_USER = "rejection-reason-test-employee@example.com"
+
+CUSTOMER_NAME = "Rejection Reason Test Customer"
+PROJECT_NAME = "Rejection Reason Test Project"
+TASK_SUBJECT = "Rejection Reason Test Task"
+
+MON, TUE, WED, THU, FRI = "2026-09-07", "2026-09-08", "2026-09-09", "2026-09-10", "2026-09-11"
+WEEK_DATES = [MON, TUE, WED, THU, FRI]
+
+TUE_REASON = "Please add a task breakdown before resubmitting Tuesday's entry."
+THU_REASON = "Thursday's hours need the billable split corrected."
+
+
+class TestTimesheetRejectionReason(IntegrationTestCase):
+    """Reject two days of a submitted week, resubmit, then approve the whole week."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        currency = frappe.get_cached_value("Company", cls.company, "default_currency")
+
+        # Week start is read via frappe.db.get_default, not System Settings directly.
+        frappe.db.set_default("first_day_of_the_week", "Monday")
+
+        # HRMS's leave-balance validation needs a holiday list resolvable for every
+        # employee; add a company-wide one unless another test already created it.
+        if not frappe.db.exists(
+            "Holiday List Assignment",
+            {"assigned_to": cls.company, "applicable_for": "Company", "docstatus": 1},
+        ):
+            holiday_list = make_holiday_list(
+                "Rejection Reason Test Company Holidays",
+                from_date="2026-01-01",
+                to_date="2026-12-31",
+                holiday_dates=[],
+            )
+            frappe.get_doc(
+                {
+                    "doctype": "Holiday List Assignment",
+                    "applicable_for": "Company",
+                    "assigned_to": cls.company,
+                    "holiday_list": holiday_list.name,
+                    "from_date": "2026-01-01",
+                }
+            ).insert(ignore_permissions=True).submit()
+
+        cls.manager = make_employee(MANAGER_USER, company=cls.company, leave_approver="Administrator")
+        cls.employee = make_employee(
+            EMPLOYEE_USER, company=cls.company, reports_to=cls.manager, leave_approver="Administrator"
+        )
+
+        if not frappe.db.exists("Customer", {"customer_name": CUSTOMER_NAME}):
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": CUSTOMER_NAME,
+                    "customer_type": "Company",
+                    "default_currency": currency,
+                }
+            ).insert(ignore_permissions=True)
+        cls.customer = frappe.db.get_value("Customer", {"customer_name": CUSTOMER_NAME})
+
+        if not frappe.db.exists("Project", {"project_name": PROJECT_NAME}):
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": PROJECT_NAME,
+                    "company": cls.company,
+                    "customer": cls.customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            ).insert(ignore_permissions=True)
+        cls.project = frappe.db.get_value("Project", {"project_name": PROJECT_NAME})
+
+        if not frappe.db.exists("Task", {"subject": TASK_SUBJECT}):
+            frappe.get_doc({"doctype": "Task", "subject": TASK_SUBJECT, "project": cls.project}).insert(
+                ignore_permissions=True
+            )
+        cls.task = frappe.db.get_value("Task", {"subject": TASK_SUBJECT})
+
+        frappe.clear_cache()
+
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+        self.delete_test_week_timesheets()
+
+        # Create 5 daily draft timesheets and submit the whole week for approval.
+        for date in WEEK_DATES:
+            save_timesheet(
+                date=date,
+                description=f"Work logged on {date}",
+                task=self.task,
+                hours=2,
+                employee=self.employee,
+            )
+        submit_for_approval(start_date=MON, employee=self.employee, approver=self.manager)
+
+    def tearDown(self):
+        self.delete_test_week_timesheets()
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+    def delete_test_week_timesheets(self):
+        # _approve_or_reject_timesheet commits internally, so a previous run's data
+        # can survive a rollback. Start every test from a clean slate.
+        names = frappe.get_all(
+            "Timesheet",
+            filters={"employee": self.employee, "start_date": [">=", MON], "end_date": ["<=", FRI]},
+            pluck="name",
+        )
+        for name in names:
+            doc = frappe.get_doc("Timesheet", name)
+            if doc.docstatus == 1:
+                doc.cancel()
+            frappe.delete_doc("Timesheet", name, force=True, ignore_permissions=True)
+
+    def get_timesheets_by_date(self):
+        rows = frappe.get_all(
+            "Timesheet",
+            filters={
+                "employee": self.employee,
+                "start_date": [">=", MON],
+                "end_date": ["<=", FRI],
+                "docstatus": ["!=", 2],
+            },
+            fields=["name", "start_date", "custom_approval_status", "custom_rejection_reason", "docstatus"],
+        )
+        by_date = {str(row.start_date): row for row in rows}
+        self.assertEqual(len(by_date), 5, "expected exactly 5 daily timesheets for the test week")
+        return by_date
+
+    def decide_timesheets(self, status, dates, note=""):
+        drafts = frappe.get_all(
+            "Timesheet",
+            filters={
+                "employee": self.employee,
+                "start_date": [">=", MON],
+                "end_date": ["<=", FRI],
+                "docstatus": 0,
+            },
+            fields=["name", "start_date", "employee"],
+        )
+        _approve_or_reject_timesheet(timesheets=drafts, status=status, employee=self.employee, dates=dates, note=note)
+
+    def test_reject_resubmit_approve_lifecycle(self):
+        # Step 1 (done in setUp): all 5 days pending, no rejection reason yet.
+        by_date = self.get_timesheets_by_date()
+        for date in WEEK_DATES:
+            self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
+            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assertEqual(by_date[date].docstatus, 0)
+
+        # Step 2: reject Tuesday and Thursday, each with its own reason.
+        self.decide_timesheets("Rejected", [TUE], note=TUE_REASON)
+        self.decide_timesheets("Rejected", [THU], note=THU_REASON)
+
+        by_date = self.get_timesheets_by_date()
+        self.assertEqual(by_date[TUE].custom_approval_status, "Rejected")
+        self.assertEqual(by_date[TUE].custom_rejection_reason, TUE_REASON)
+        self.assertEqual(by_date[THU].custom_approval_status, "Rejected")
+        self.assertEqual(by_date[THU].custom_rejection_reason, THU_REASON)
+        for date in (MON, WED, FRI):
+            self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
+            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+
+        # Step 3: employee fixes things and resubmits the whole week. Status resets
+        # to pending, but the rejection reason is kept until the day is re-decided.
+        submit_for_approval(start_date=MON, employee=self.employee, approver=self.manager)
+
+        by_date = self.get_timesheets_by_date()
+        for date in WEEK_DATES:
+            self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
+            self.assertEqual(by_date[date].docstatus, 0)
+        self.assertEqual(by_date[TUE].custom_rejection_reason, TUE_REASON)
+        self.assertEqual(by_date[THU].custom_rejection_reason, THU_REASON)
+
+        # Step 4: manager approves the whole week; reasons are cleared on approval.
+        self.decide_timesheets("Approved", WEEK_DATES)
+
+        by_date = self.get_timesheets_by_date()
+        for date in WEEK_DATES:
+            self.assertEqual(by_date[date].custom_approval_status, "Approved")
+            self.assertEqual(by_date[date].docstatus, 1)
+            self.assertEqual(by_date[date].custom_rejection_reason or "", "")

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -551,6 +551,7 @@ def _approve_or_reject_timesheet(
         for timesheet in timesheets_to_process:
             doc = get_doc("Timesheet", timesheet.name)
             doc.custom_approval_status = status
+            doc.custom_rejection_reason = note if status == "Rejected" else ""
             doc.save(ignore_permissions=has_permission)
             if status == "Approved":
                 doc.submit()

--- a/next_pms/timesheet/patches/setup_timesheet_rejection_reason_field.py
+++ b/next_pms/timesheet/patches/setup_timesheet_rejection_reason_field.py
@@ -1,0 +1,5 @@
+from next_pms.install import setup_timesheet_rejection_reason_field
+
+
+def execute():
+    setup_timesheet_rejection_reason_field()


### PR DESCRIPTION
## Description

add a timesheet rejection reason field

## Relevant Technical Choices

1. when a timesheet is rejected, the employee is sent a mail with the rejection reason. we log it as a text field in the doctype now.

## Testing Instructions

1. reject a timesheet
2. go to the timesheet doc and see the reason

## Screenshot/Screencast

<img width="1277" height="593" alt="image" src="https://github.com/user-attachments/assets/8bcde4c6-291c-4ce5-ad54-65c1b3e37ea4" />

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1652 