### PR TITLE
QA Fix: Updating a filtered time entry reveals tasks excluded by the active search filter

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -73,7 +73,12 @@ const PersonalTimesheetGrid = () => {
           )}
 
           {Object.keys(timesheetData?.data).length == 0 ? (
-            <Typography className="flex items-center justify-center">
+            <Typography
+              className={cn("flex items-center justify-center", {
+                "opacity-50 transition-opacity duration-150":
+                  isFilteredDataLoading,
+              })}
+            >
               No data found
             </Typography>
           ) : (

--- a/frontend/packages/app/src/pages/timesheet/personal/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/provider.tsx
@@ -37,15 +37,6 @@ export const PersonalTimesheetProvider: FC<PropsWithChildren> = ({
     [filters.compositeFilters],
   );
 
-  const activeFilterKey = useMemo(
-    () =>
-      JSON.stringify({
-        search: filters.search,
-        approvalStatus: filters.approvalStatus ?? "",
-        compositeFilters: effectiveCompositeFilters,
-      }),
-    [filters.search, filters.approvalStatus, effectiveCompositeFilters],
-  );
   const {
     hasMoreWeeks,
     isLoadingPersonalData,
@@ -57,7 +48,6 @@ export const PersonalTimesheetProvider: FC<PropsWithChildren> = ({
     refetchLikedTasks,
   } = usePersonalTimesheetData({
     employeeId,
-    requestKey: activeFilterKey,
     search: filters.search,
     approvalStatus: filters.approvalStatus,
     compositeFilters: effectiveCompositeFilters,

--- a/frontend/packages/app/src/pages/timesheet/personal/usePersonalTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/personal/usePersonalTimesheetData.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { ApprovalStatusLabelMap } from "@next-pms/design-system/components";
 import { getFormatedDate, getTodayDate } from "@next-pms/design-system/date";
 import { type PaginationKey, usePagination } from "@next-pms/hooks";
@@ -65,15 +65,27 @@ const hasActiveFilters = (
   Boolean(approvalStatus) ||
   compositeFilters.length > 0;
 
-const getNextPageStartDate = (payload?: PersonalTimesheetPayload) => {
-  const weeks = Object.values(payload?.data ?? {});
-  const lastWeek = weeks.at(-1);
+const getNextPageStartDate = (
+  page: PersonalTimesheetCallResponse | null | undefined,
+  requestedStartDate: string | undefined,
+  weeksPerPage: number,
+) => {
+  const payload = page?.message;
+  const lastWeek = Object.values(payload?.data ?? {}).at(-1);
 
-  if (!lastWeek) {
-    return null;
+  if (lastWeek) {
+    return getFormatedDate(addDays(parseISO(lastWeek.start_date), -1));
   }
 
-  return getFormatedDate(addDays(parseISO(lastWeek.start_date), -1));
+  // A filtered window can come back empty while older matches exist
+  // (has_more), so skip one full window back from this page's request date.
+  if (payload?.has_more && requestedStartDate) {
+    return getFormatedDate(
+      addDays(parseISO(requestedStartDate), -(weeksPerPage * 7)),
+    );
+  }
+
+  return null;
 };
 
 const hasWeek = (
@@ -88,6 +100,10 @@ export function usePersonalTimesheetData({
   compositeFilters,
 }: UsePersonalTimesheetDataOptions): UsePersonalTimesheetDataResult {
   const toast = useToasts();
+  const pageStartDatesRef = useRef<{
+    dates: string[];
+    signature: string;
+  }>({ dates: [], signature: "" });
 
   const filtersAreActive = hasActiveFilters(
     search,
@@ -138,6 +154,10 @@ export function usePersonalTimesheetData({
       pageIndex: number,
       previousPageData: PersonalTimesheetCallResponse | null,
     ): PaginationKey<PersonalTimesheetPageParams> | null => {
+      if (pageStartDatesRef.current.signature !== querySignature) {
+        pageStartDatesRef.current = { dates: [], signature: querySignature };
+      }
+
       if (
         filtersAreActive &&
         previousPageData?.message &&
@@ -149,11 +169,17 @@ export function usePersonalTimesheetData({
       const pageStartDate =
         pageIndex === 0
           ? requestWeekDate
-          : getNextPageStartDate(previousPageData?.message);
+          : getNextPageStartDate(
+              previousPageData,
+              pageStartDatesRef.current.dates[pageIndex - 1],
+              weeksPerPage,
+            );
 
       if (!pageStartDate) {
         return null;
       }
+
+      pageStartDatesRef.current.dates[pageIndex] = pageStartDate;
 
       return [
         querySignature,
@@ -161,7 +187,7 @@ export function usePersonalTimesheetData({
         { start_date: pageStartDate },
       ] as const;
     },
-    [filtersAreActive, querySignature, requestWeekDate],
+    [filtersAreActive, querySignature, requestWeekDate, weeksPerPage],
   );
 
   const {
@@ -222,16 +248,29 @@ export function usePersonalTimesheetData({
     );
   }, [payloads]);
 
-  const lastPayload = payloads.at(-1);
-  const hasDateRangeFilter = Boolean(startDate);
+  const nextPageStartDate = getNextPageStartDate(
+    pages.at(-1),
+    pageStartDatesRef.current.dates[pages.length - 1],
+    weeksPerPage,
+  );
+  const emptySkipLimit = addDays(
+    parseISO(
+      Object.values(timesheetData.data).at(-1)?.start_date ?? requestWeekDate,
+    ),
+    -365,
+  );
   const hasMoreWeeks = filtersAreActive
-    ? !hasDateRangeFilter && Boolean(lastPayload?.has_more)
+    ? Boolean(
+        !startDate &&
+        nextPageStartDate &&
+        parseISO(nextPageStartDate) > emptySkipLimit &&
+        payloads.at(-1)?.has_more,
+      )
     : true;
   const isInitialLoad = isLoading && pages.length === 0;
   const isFilterRequest = isLoading && pages.length > 0;
-  const isNextPageLoading =
-    !isLoading && isValidating && typeof pages[size - 1] === "undefined";
-  const isLoadingPersonalData = isLoading || isNextPageLoading;
+  const isLoadingPersonalData =
+    isLoading || (isValidating && typeof pages[size - 1] === "undefined");
 
   const refreshPageForWeek = useCallback(
     async (weekKey: string) => {

--- a/frontend/packages/app/src/pages/timesheet/personal/usePersonalTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/personal/usePersonalTimesheetData.ts
@@ -1,26 +1,31 @@
 /**
  * External dependencies.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { ApprovalStatusLabelMap } from "@next-pms/design-system/components";
 import { getFormatedDate, getTodayDate } from "@next-pms/design-system/date";
+import { type PaginationKey, usePagination } from "@next-pms/hooks";
 import { useToasts } from "@rtcamp/frappe-ui-react";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
-import { addDays } from "date-fns";
+import { addDays, parseISO } from "date-fns";
+import type { FrappeError } from "frappe-react-sdk";
 import { useFrappeEventListener, useFrappeGetCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
 import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
-import { buildCompositeFilters, parseFrappeErrorMsg } from "@/lib/utils";
+import {
+  buildCompositeFilters,
+  hashString,
+  parseFrappeErrorMsg,
+} from "@/lib/utils";
 import type { DataProp, TaskDataProps } from "@/types/timesheet";
 import { initialTimesheetData } from "./context";
 import { addWeekLabels, mergeTimesheetData } from "./utils";
 
 type UsePersonalTimesheetDataOptions = {
   employeeId: string;
-  requestKey: string;
   search: string;
   approvalStatus?: keyof typeof ApprovalStatusLabelMap;
   compositeFilters: FilterCondition[];
@@ -37,6 +42,20 @@ type UsePersonalTimesheetDataResult = {
   refetchLikedTasks: () => void;
 };
 
+type PersonalTimesheetPayload = DataProp & {
+  has_more?: boolean;
+};
+
+type PersonalTimesheetCallResponse = {
+  message?: PersonalTimesheetPayload;
+};
+
+type PersonalTimesheetPageParams = {
+  start_date: string;
+};
+
+const QUERY_SIGNATURE_PREFIX = "personal-timesheet:";
+
 const hasActiveFilters = (
   search: string,
   approvalStatus: keyof typeof ApprovalStatusLabelMap | undefined,
@@ -46,21 +65,30 @@ const hasActiveFilters = (
   Boolean(approvalStatus) ||
   compositeFilters.length > 0;
 
+const getNextPageStartDate = (payload?: PersonalTimesheetPayload) => {
+  const weeks = Object.values(payload?.data ?? {});
+  const lastWeek = weeks.at(-1);
+
+  if (!lastWeek) {
+    return null;
+  }
+
+  return getFormatedDate(addDays(parseISO(lastWeek.start_date), -1));
+};
+
+const hasWeek = (
+  payload: PersonalTimesheetPayload | undefined,
+  weekKey: string,
+) => Object.prototype.hasOwnProperty.call(payload?.data ?? {}, weekKey);
+
 export function usePersonalTimesheetData({
   employeeId,
-  requestKey,
   search,
   approvalStatus,
   compositeFilters,
 }: UsePersonalTimesheetDataOptions): UsePersonalTimesheetDataResult {
   const toast = useToasts();
-  const [weekDate, setWeekDate] = useState(getTodayDate());
-  const [hasMoreWeeks, setHasMoreWeeks] = useState(true);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
-  const [timesheetData, setTimesheetData] = useState(initialTimesheetData);
-  const [resolvedRequestKey, setResolvedRequestKey] = useState(requestKey);
 
-  const isFilterRequest = requestKey !== resolvedRequestKey;
   const filtersAreActive = hasActiveFilters(
     search,
     approvalStatus,
@@ -70,97 +98,229 @@ export function usePersonalTimesheetData({
     () => buildCompositeFilters(compositeFilters),
     [compositeFilters],
   );
-  const requestWeekDate =
-    startDate ?? (isFilterRequest ? getTodayDate() : weekDate);
 
-  useEffect(() => {
-    if (!isFilterRequest) {
-      return;
-    }
+  const requestWeekDate = startDate ?? getTodayDate();
+  const weeksPerPage = maxWeek ?? NUMBER_OF_WEEKS_TO_FETCH;
+  const approvalStatusParam = approvalStatus
+    ? ApprovalStatusLabelMap[approvalStatus]
+    : null;
+  const filtersParam = useMemo(
+    () => JSON.stringify(frappeFilters),
+    [frappeFilters],
+  );
 
-    setHasMoreWeeks(true);
-    setWeekDate(startDate ?? getTodayDate());
-  }, [isFilterRequest, startDate]);
+  const querySignature = useMemo(
+    () =>
+      `${QUERY_SIGNATURE_PREFIX}${hashString(
+        JSON.stringify({
+          employeeId,
+          requestWeekDate,
+          maxWeek: weeksPerPage,
+          search,
+          approvalStatus: approvalStatusParam ?? "",
+          filters: filtersParam,
+          skipEmptyWeeks: filtersAreActive,
+        }),
+      )}`,
+    [
+      approvalStatusParam,
+      employeeId,
+      filtersAreActive,
+      filtersParam,
+      weeksPerPage,
+      requestWeekDate,
+      search,
+    ],
+  );
 
-  const { data, isLoading, error } = useFrappeGetCall(
+  const getKey = useCallback(
+    (
+      pageIndex: number,
+      previousPageData: PersonalTimesheetCallResponse | null,
+    ): PaginationKey<PersonalTimesheetPageParams> | null => {
+      if (
+        filtersAreActive &&
+        previousPageData?.message &&
+        !previousPageData.message.has_more
+      ) {
+        return null;
+      }
+
+      const pageStartDate =
+        pageIndex === 0
+          ? requestWeekDate
+          : getNextPageStartDate(previousPageData?.message);
+
+      if (!pageStartDate) {
+        return null;
+      }
+
+      return [
+        querySignature,
+        pageIndex,
+        { start_date: pageStartDate },
+      ] as const;
+    },
+    [filtersAreActive, querySignature, requestWeekDate],
+  );
+
+  const {
+    data: paginatedData,
+    isLoading,
+    isValidating,
+    size,
+    setSize,
+    mutate,
+  } = usePagination<PersonalTimesheetCallResponse>(
     "next_pms.timesheet.api.timesheet.get_timesheet_data",
+    getKey,
     {
       employee: employeeId,
-      start_date: requestWeekDate,
-      max_week: maxWeek ?? NUMBER_OF_WEEKS_TO_FETCH,
+      max_week: weeksPerPage,
       search,
-      approval_status: approvalStatus
-        ? ApprovalStatusLabelMap[approvalStatus]
-        : null,
-      filters: JSON.stringify(frappeFilters),
+      approval_status: approvalStatusParam,
+      filters: filtersParam,
       skip_empty_weeks: filtersAreActive,
     },
+    {
+      revalidateOnFocus: false,
+      revalidateAll: false,
+      revalidateFirstPage: false,
+      keepPreviousData: true,
+      persistSize: false,
+      shouldRetryOnError: false,
+      errorRetryCount: 0,
+      onError: (err) => {
+        toast.error(parseFrappeErrorMsg(err as FrappeError));
+      },
+    },
   );
+
   const { data: likedTasksResponse, mutate: refetchLikedTasks } =
     useFrappeGetCall("next_pms.timesheet.api.task.get_liked_tasks");
 
-  useEffect(() => {
-    if (!data?.message) {
-      return;
-    }
+  const pages = useMemo(() => paginatedData ?? [], [paginatedData]);
+  const payloads = useMemo(
+    () =>
+      pages
+        .map((page) => page.message)
+        .filter((payload): payload is PersonalTimesheetPayload =>
+          Boolean(payload),
+        ),
+    [pages],
+  );
 
-    const labeledData = addWeekLabels(data.message);
+  const timesheetData = useMemo(() => {
+    return (
+      payloads.reduce<DataProp | null>((currentData, payload) => {
+        const labeledPayload = addWeekLabels(payload);
 
-    setTimesheetData((currentData) =>
-      isFilterRequest || Object.keys(currentData.data).length === 0
-        ? labeledData
-        : mergeTimesheetData(currentData, labeledData),
+        return currentData
+          ? mergeTimesheetData(currentData, labeledPayload)
+          : labeledPayload;
+      }, null) ?? initialTimesheetData
     );
-    setHasMoreWeeks(filtersAreActive ? (data.message.has_more ?? false) : true);
-    setIsInitialLoad(false);
-    setResolvedRequestKey(requestKey);
-  }, [data, filtersAreActive, isFilterRequest, requestKey]);
+  }, [payloads]);
 
-  useEffect(() => {
-    if (!error || !isFilterRequest) {
-      return;
-    }
+  const lastPayload = payloads.at(-1);
+  const hasDateRangeFilter = Boolean(startDate);
+  const hasMoreWeeks = filtersAreActive
+    ? !hasDateRangeFilter && Boolean(lastPayload?.has_more)
+    : true;
+  const isInitialLoad = isLoading && pages.length === 0;
+  const isFilterRequest = isLoading && pages.length > 0;
+  const isNextPageLoading =
+    !isLoading && isValidating && typeof pages[size - 1] === "undefined";
+  const isLoadingPersonalData = isLoading || isNextPageLoading;
 
-    setResolvedRequestKey(requestKey);
-  }, [error, isFilterRequest, requestKey]);
+  const refreshPageForWeek = useCallback(
+    async (weekKey: string) => {
+      try {
+        if (!paginatedData?.length) {
+          return;
+        }
 
-  useEffect(() => {
-    if (!error) {
-      return;
-    }
+        const pagesToRevalidate = new Set<number>();
 
-    const err = parseFrappeErrorMsg(error);
-    toast.error(err);
-  }, [error, toast]);
+        paginatedData.forEach((page, index) => {
+          if (hasWeek(page.message, weekKey)) {
+            pagesToRevalidate.add(index);
+          }
+        });
 
-  useFrappeEventListener(`timesheet_update::${employeeId}`, (payload) => {
-    const updatedData = addWeekLabels(payload.message);
-    const key = Object.keys(updatedData.data)[0];
+        if (!pagesToRevalidate.size) {
+          return;
+        }
 
-    setTimesheetData((currentData) => {
-      if (!Object.prototype.hasOwnProperty.call(currentData.data, key)) {
-        return currentData;
+        await mutate(paginatedData, {
+          revalidate: (_pageData, pageKey) => {
+            return (
+              Array.isArray(pageKey) &&
+              typeof pageKey[1] === "number" &&
+              pagesToRevalidate.has(pageKey[1])
+            );
+          },
+        });
+      } catch {
+        return;
+      }
+    },
+    [mutate, paginatedData],
+  );
+
+  const mergeRealtimePayload = useCallback(
+    (payload: PersonalTimesheetPayload, weekKey: string) => {
+      if (!paginatedData?.length) {
+        return;
       }
 
-      return mergeTimesheetData(currentData, updatedData);
-    });
+      const updatedData = addWeekLabels(payload);
+      let changed = false;
+      const nextPages = paginatedData.map((page) => {
+        if (!page.message || !hasWeek(page.message, weekKey)) {
+          return page;
+        }
+
+        changed = true;
+
+        return {
+          ...page,
+          message: mergeTimesheetData(page.message, updatedData),
+        };
+      });
+
+      if (changed) {
+        void mutate(nextPages, { revalidate: false });
+      }
+    },
+    [mutate, paginatedData],
+  );
+
+  useFrappeEventListener(`timesheet_update::${employeeId}`, (payload) => {
+    const updatedPayload = payload.message as PersonalTimesheetPayload;
+    const key = Object.keys(updatedPayload?.data ?? {})[0];
+
+    if (!key) {
+      return;
+    }
+
+    if (filtersAreActive) {
+      void refreshPageForWeek(key);
+      return;
+    }
+
+    mergeRealtimePayload(updatedPayload, key);
   });
 
   const loadData = useCallback(() => {
-    if (!hasMoreWeeks || isLoading) return;
+    if (!hasMoreWeeks || isLoadingPersonalData) return;
 
-    const weeks = timesheetData.data;
-    if (Object.keys(weeks).length === 0) return;
-
-    const lastKey = Object.keys(weeks).pop();
-    if (!lastKey) return;
-
-    setWeekDate(getFormatedDate(addDays(weeks[lastKey].start_date, -1)));
-  }, [hasMoreWeeks, isLoading, timesheetData.data]);
+    void setSize((current) => current + 1);
+  }, [hasMoreWeeks, isLoadingPersonalData, setSize]);
 
   return {
     hasMoreWeeks,
-    isLoadingPersonalData: isLoading,
+    isLoadingPersonalData,
     isInitialLoad,
     isFilterRequest,
     timesheetData,

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -58,7 +58,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
   return (
     <div
       className={cn(
-        "flex justify-between items-center px-1 py-2 w-full border-b transition-colors border-outline-gray-1",
+        "flex justify-between items-center px-1 py-2 w-full border-b transition-colors border-outline-gray-1 cursor-pointer",
         className,
       )}
     >

--- a/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
@@ -45,7 +45,7 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({
   return (
     <div
       className={cn(
-        "flex items-center border-b border-outline-gray-1 transition-colors w-full justify-between px-1 py-2",
+        "flex items-center border-b border-outline-gray-1 transition-colors w-full justify-between px-1 py-2 cursor-pointer",
         className,
       )}
     >

--- a/frontend/packages/hooks/src/usePagination.ts
+++ b/frontend/packages/hooks/src/usePagination.ts
@@ -11,10 +11,14 @@ import useSWRInfinite, {
   unstable_serialize,
 } from "swr/infinite";
 
-export type PaginationKey = readonly [cacheKey: string, pageIndex: number];
+export type PaginationKey<TPageParams = Record<string, unknown>> = readonly [
+  cacheKey: string,
+  pageIndex: number,
+  pageParams?: TPageParams,
+];
 
 type PaginationParams = Record<string, unknown> & {
-  page_length: number;
+  page_length?: number;
 };
 
 type PaginationOptions<T = any, E = any> = SWRInfiniteConfiguration<T, E> & {
@@ -54,7 +58,9 @@ const deletePages = (cache: Cache, prefix: string, keep: string) => {
  *
  * @param method - name of the method to call (will be dotted path e.g. "frappe.client.get_list")
  * @param getKey - A function that accepts the index and previous page data, and returns the key for that page
- * @param params - Request params for every page. Must include `page_length` so the hook can derive the `start` offset.
+ * @param params - Request params for every page. When `page_length` is present,
+ * the hook derives an offset `start` value. A key may include page-specific
+ * params as the third tuple item to support cursor based pagination.
  * @param options - Optional useSWRInfinite configuration, plus `cacheCleanup` (see PaginationOptions)
  *
  * @typeParam T - Type of the data returned by the method
@@ -66,9 +72,13 @@ export const usePagination = <
   T = any,
   E = any,
   P extends PaginationParams = PaginationParams,
+  TPageParams extends object = Record<string, unknown>,
 >(
   method: string,
-  getKey: (index: number, previousPageData: T | null) => PaginationKey | null,
+  getKey: (
+    index: number,
+    previousPageData: T | null,
+  ) => PaginationKey<TPageParams> | null,
   params: P,
   options?: PaginationOptions<T, E>,
 ): SWRInfiniteResponse<T, E> => {
@@ -80,11 +90,18 @@ export const usePagination = <
 
   const result = useSWRInfinite<T, E>(
     getKey,
-    ([, pageIndex]: PaginationKey) =>
-      call.get<T>(method, {
+    ([, pageIndex, pageParams]: PaginationKey<TPageParams>) => {
+      const offsetParams =
+        params.page_length === undefined
+          ? {}
+          : { start: pageIndex * params.page_length };
+
+      return call.get<T>(method, {
         ...params,
-        start: pageIndex * params.page_length,
-      }),
+        ...offsetParams,
+        ...pageParams,
+      });
+    },
     swrOptions,
   );
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
Fixes the personal timesheet filtered update issue where saving a time entry could reveal tasks excluded by the active search/filter.

The personal timesheet now fetches data through paginated SWR pages keyed by the active query and page start_date, instead of maintaining a manually merged request state. When a realtime timesheet update arrives while filters are active, the UI revalidates the affected loaded page instead of merging the unfiltered realtime payload from the backend.

Other:
- Adds cursor pointer to the member and project timesheet rows

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
  - Extended `usePagination` to support optional page-specific params in the pagination key, while preserving existing offset-based behavior.
  - Realtime handling now distinguishes filtered and unfiltered views:
      - Filtered views revalidate the page containing the updated week.
      - Unfiltered views still merge the pushed payload directly.
- Caps filtered requests to one year. The backend can return empty data while still setting `has_more: true`, this can lead to an infinite request loop. Limiting requests to one year prevents this scenario same is done in team and project timesheet pages.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/6d87facc-c4c1-4c34-874c-efd88166569b



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1598