### PR TITLE
QA Fix: Submit timesheet button overlaps while scrolling and affects user experience

### DIFF
--- a/frontend/packages/app/src/components/infiniteScroll.tsx
+++ b/frontend/packages/app/src/components/infiniteScroll.tsx
@@ -2,7 +2,8 @@
  * External dependencies.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ScrollArea } from "@base-ui/react/scroll-area";
 import { mergeClassNames as cn } from "@next-pms/design-system";
 import { useInfiniteScroll } from "@next-pms/hooks";
 import { Skeleton } from "@rtcamp/frappe-ui-react";
@@ -21,13 +22,26 @@ const InfiniteScroll = ({
   skeletonClassName,
   count = 1,
   scrollResetKey,
+  showScrollbar = true,
+  scrollbarVisibility = "always",
+  scrollbarVariant = "classic",
+  enableScrollArea = false,
 }: InfiniteScrollProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [containerElement, setContainerElement] =
+    useState<HTMLDivElement | null>(null);
+  const observerRoot = enableScrollArea || className ? containerElement : null;
   const verticalLoderRef = useInfiniteScroll({
     isLoading: isLoading,
     hasMore: hasMore,
     next: () => verticalLodMore(),
+    root: observerRoot,
   });
+
+  const handleViewportRef = useCallback((element: HTMLDivElement | null) => {
+    containerRef.current = element;
+    setContainerElement(element);
+  }, []);
 
   useEffect(() => {
     if (containerRef.current) {
@@ -35,8 +49,8 @@ const InfiniteScroll = ({
     }
   }, [scrollResetKey]);
 
-  return (
-    <div ref={containerRef} className={className}>
+  const content = (
+    <>
       {children}
       {(isLoading || hasMore) && (
         <div
@@ -54,7 +68,59 @@ const InfiniteScroll = ({
           ))}
         </div>
       )}
-    </div>
+    </>
+  );
+
+  if (!enableScrollArea) {
+    return (
+      <div ref={handleViewportRef} className={className}>
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea.Root className={cn("relative h-full w-full", className)}>
+      <ScrollArea.Viewport
+        ref={handleViewportRef}
+        className={cn("h-full w-full", {
+          "w-[calc(100%-var(--spacing)*1.5)]":
+            showScrollbar && scrollbarVariant === "classic",
+          "h-[calc(100%-var(--spacing)*1.5)]":
+            showScrollbar && scrollbarVariant === "classic",
+        })}
+      >
+        <ScrollArea.Content className="min-h-full">
+          {content}
+        </ScrollArea.Content>
+      </ScrollArea.Viewport>
+      {showScrollbar ? (
+        <>
+          <ScrollArea.Scrollbar
+            className={cn(
+              "z-20 flex w-1.5 cursor-pointer justify-center bg-transparent",
+              scrollbarVisibility === "hover"
+                ? "opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100"
+                : "opacity-100 animate-fade-in",
+            )}
+          >
+            <ScrollArea.Thumb className="w-full cursor-pointer rounded-[54px] bg-surface-gray-4" />
+          </ScrollArea.Scrollbar>
+          <ScrollArea.Scrollbar
+            orientation="horizontal"
+            className={cn(
+              "z-20 flex h-1.5 cursor-pointer items-center bg-transparent",
+              scrollbarVisibility === "hover"
+                ? "opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100"
+                : "opacity-100 animate-fade-in",
+            )}
+          >
+            <ScrollArea.Thumb className="h-full cursor-pointer rounded-[54px] bg-surface-gray-4" />
+          </ScrollArea.Scrollbar>
+          <ScrollArea.Corner className="bg-transparent" />
+        </>
+      ) : null}
+    </ScrollArea.Root>
   );
 };
 

--- a/frontend/packages/app/src/components/types.ts
+++ b/frontend/packages/app/src/components/types.ts
@@ -24,6 +24,10 @@ export interface InfiniteScrollProps {
   skeletonClassName?: string;
   count?: number;
   scrollResetKey?: string | number;
+  showScrollbar?: boolean;
+  scrollbarVisibility?: "always" | "hover";
+  scrollbarVariant?: "classic" | "overlay";
+  enableScrollArea?: boolean;
 }
 
 export interface TaskIndicatorProps {

--- a/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
@@ -62,7 +62,9 @@ export const AllocationsProjectTable = () => {
             hasMore={hasMore}
             verticalLodMore={loadMore}
             scrollResetKey={querySignature}
-            className={cn("w-full h-full overflow-auto no-scrollbar", {
+            enableScrollArea
+            showScrollbar={false}
+            className={cn("w-full h-full", {
               "opacity-50 transition-opacity duration-150 pointer-events-none":
                 isRefreshingVisibleGrid,
             })}

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -64,7 +64,9 @@ export const AllocationsTeamTable = () => {
             hasMore={hasMore}
             verticalLodMore={loadMore}
             scrollResetKey={querySignature}
-            className={cn("w-full h-full overflow-auto no-scrollbar", {
+            enableScrollArea
+            showScrollbar={false}
+            className={cn("w-full h-full", {
               "opacity-50 transition-opacity duration-150 pointer-events-none":
                 isRefreshingVisibleGrid,
             })}

--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -82,13 +82,14 @@ const PersonalTimesheetGrid = () => {
               hasMore={!isFilterRequest && hasMoreWeeks}
               verticalLodMore={loadData}
               className={cn(
-                "relative w-full h-[calc(100%-var(--spacing)*7)] overflow-auto no-scrollbar opacity-100",
+                "relative w-full h-[calc(100%-var(--spacing)*7)] opacity-100",
                 {
                   "opacity-50 transition-opacity duration-150":
                     isFilteredDataLoading,
                 },
               )}
               count={NUMBER_OF_WEEKS_TO_FETCH}
+              enableScrollArea
             >
               <div className="min-w-225">
                 {Object.entries(timesheetData.data).map(

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -41,14 +41,11 @@ const ProjectTimesheetGrid = () => {
           isLoading={isLoadingProjectData}
           hasMore={hasMore}
           verticalLodMore={loadData}
-          className={cn(
-            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto no-scrollbar opacity-100",
-            {
-              "opacity-50 transition-opacity duration-150":
-                isFilteredDataLoading,
-            },
-          )}
+          className={cn("w-full h-[calc(100%-var(--spacing)*7)] opacity-100", {
+            "opacity-50 transition-opacity duration-150": isFilteredDataLoading,
+          })}
           count={NUMBER_OF_WEEKS_TO_FETCH}
+          enableScrollArea
         >
           <div className="min-w-225">
             {weekGroups.map((week, index) => {

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -71,14 +71,11 @@ const TeamTimesheetGrid = () => {
           isLoading={isLoadingTeamData}
           hasMore={hasMore}
           verticalLodMore={loadMore}
-          className={cn(
-            "w-full h-[calc(100%-var(--spacing)*7)] overflow-auto no-scrollbar opacity-100",
-            {
-              "opacity-50 transition-opacity duration-150":
-                isFilteredDataLoading,
-            },
-          )}
+          className={cn("w-full h-[calc(100%-var(--spacing)*7)] opacity-100", {
+            "opacity-50 transition-opacity duration-150": isFilteredDataLoading,
+          })}
           count={NUMBER_OF_WEEKS_TO_FETCH}
+          enableScrollArea
         >
           <div className="min-w-225">
             {weekGroups.map((week, index) => {

--- a/frontend/packages/hooks/src/useInfiniteScroll.ts
+++ b/frontend/packages/hooks/src/useInfiniteScroll.ts
@@ -38,9 +38,9 @@ function useInfiniteScroll({
 
   const observerRef = useCallback(
     (element: HTMLElement | null) => {
-      if (!element) return;
-
       observer.current?.disconnect();
+
+      if (!element) return;
 
       observer.current = new IntersectionObserver(
         ([entry]) => {
@@ -53,12 +53,12 @@ function useInfiniteScroll({
           root,
           rootMargin,
           threshold,
-        }
+        },
       );
 
       observer.current.observe(element);
     },
-    [hasMore, next, threshold, root, rootMargin]
+    [hasMore, next, threshold, root, rootMargin],
   );
   if (!isLoading) {
     isFetchingRef.current = false;


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
 This PR fixes the timesheet scrollbar overlap issue by replacing native scrollbar behavior with an opt-in Base UI scroll area for timesheet views.

This avoids OS/browser overlay scrollbars covering timesheet row actions while keeping scrolling available and visually consistent.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
 - Added opt-in Base UI ScrollArea support to the shared InfiniteScroll component.
 - Timesheet pages now use the Base UI scroll area instead of native `overflow-auto no-scrollbar` handling.
 - Added classic scrollbar gutter reservation so content does not shift or get covered by overlay scrollbars.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


https://github.com/user-attachments/assets/2d5f4309-6d71-4f79-b5e5-f746fc13ee6b





## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1574