### PR TITLE
fix: allow selecting half day date

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-leave/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-leave/index.tsx
@@ -59,6 +59,7 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
       fromDate: getTodayDate(),
       toDate: getTodayDate(),
       leaveDuration: LEAVE_DURATION[0] as string,
+      halfDayDate: "",
       leaveType: "",
       reason: "",
     },
@@ -87,7 +88,11 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
           to_date: value.toDate,
           leave_type: value.leaveType,
           half_day,
-          half_day_date: half_day ? value.fromDate : undefined,
+          half_day_date: half_day
+            ? value.fromDate !== value.toDate
+              ? value.halfDayDate
+              : value.fromDate
+            : undefined,
           custom_first_halfsecond_half,
         };
         await createDoc("Leave Application", data);
@@ -260,6 +265,58 @@ const AddLeave = ({ open = false, onOpenChange }: LeaveTimeProps) => {
               </>
             );
           }}
+        />
+
+        <form.Subscribe
+          selector={(state) => [
+            state.values.fromDate,
+            state.values.toDate,
+            state.values.leaveDuration,
+          ]}
+          children={([fromDate, toDate, leaveDuration]) =>
+            leaveDuration !== "full-day" &&
+            fromDate !== toDate && (
+              <form.Field
+                name="halfDayDate"
+                children={(field) => {
+                  return (
+                    <div className="flex flex-col space-y-1.5">
+                      <label className="block text-base text-ink-gray-5 mb-1.5">
+                        Half Day Date
+                      </label>
+                      <DatePicker
+                        label="Half Day Date"
+                        onChange={(val) => field.handleChange(val as string)}
+                        placeholder="Half day date"
+                        value={field.state.value}
+                      >
+                        {({ displayValue }) => {
+                          return (
+                            <div className="w-full h-8 relative flex items-center border border-outline-gray-2 px-2.5 py-2 rounded">
+                              <input
+                                readOnly
+                                type="text"
+                                id="half-day-date"
+                                value={displayValue}
+                                className="w-full text-base text-ink-gray-7"
+                                placeholder="Select half day date"
+                              />
+                              <Calendar className="size-4" />
+                            </div>
+                          );
+                        }}
+                      </DatePicker>
+                      {!field.state.meta.isValid && (
+                        <ErrorMessage
+                          message={field.state.meta.errors[0]?.message}
+                        />
+                      )}
+                    </div>
+                  );
+                }}
+              />
+            )
+          }
         />
 
         <form.Field

--- a/frontend/packages/app/src/pages/timesheet/components/add-leave/schema.ts
+++ b/frontend/packages/app/src/pages/timesheet/components/add-leave/schema.ts
@@ -1,34 +1,61 @@
 import { z } from "zod";
 import { LEAVE_DURATION } from "./types";
 
-export const addLeaveFormSchema = z.object({
-  fromDate: z
-    .string({
-      required_error: "Please select from date.",
-    })
-    .trim()
-    .min(1, { message: "Please select from date." }),
-  toDate: z
-    .string({
-      required_error: "Please select to date.",
-    })
-    .trim()
-    .min(1, { message: "Please select to date." }),
-  leaveDuration: z.enum(LEAVE_DURATION, {
-    required_error: "Please select leave duration.",
-  }),
-  leaveType: z
-    .string({
-      required_error: "Please select leave type.",
-    })
-    .trim()
-    .min(1, { message: "Please select leave type." }),
-  reason: z
-    .string({
-      required_error: "Please enter a reason.",
-    })
-    .trim()
-    .min(1, { message: "Please enter a reason." }),
-});
+export const addLeaveFormSchema = z
+  .object({
+    fromDate: z
+      .string({
+        required_error: "Please select from date.",
+      })
+      .trim()
+      .min(1, { message: "Please select from date." }),
+    toDate: z
+      .string({
+        required_error: "Please select to date.",
+      })
+      .trim()
+      .min(1, { message: "Please select to date." }),
+    leaveDuration: z.enum(LEAVE_DURATION, {
+      required_error: "Please select leave duration.",
+    }),
+    halfDayDate: z.string().trim(),
+    leaveType: z
+      .string({
+        required_error: "Please select leave type.",
+      })
+      .trim()
+      .min(1, { message: "Please select leave type." }),
+    reason: z
+      .string({
+        required_error: "Please enter a reason.",
+      })
+      .trim()
+      .min(1, { message: "Please enter a reason." }),
+  })
+  .superRefine((value, ctx) => {
+    if (value.leaveDuration === "full-day" || value.fromDate === value.toDate) {
+      return;
+    }
+
+    if (!value.halfDayDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["halfDayDate"],
+        message: "Please select half day date.",
+      });
+      return;
+    }
+
+    if (
+      value.halfDayDate < value.fromDate ||
+      value.halfDayDate > value.toDate
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["halfDayDate"],
+        message: "Half day date must be between from date and to date.",
+      });
+    }
+  });
 
 export type AddLeaveFormValues = z.infer<typeof addLeaveFormSchema>;

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/index.tsx
@@ -60,6 +60,7 @@ const AddEmployeeLeave = ({
       fromDate: getTodayDate(),
       toDate: getTodayDate(),
       leaveDuration: LEAVE_DURATION[0] as string,
+      halfDayDate: "",
       leaveType: "",
       reason: "",
     },
@@ -89,7 +90,11 @@ const AddEmployeeLeave = ({
           to_date: value.toDate,
           leave_type: value.leaveType,
           half_day,
-          half_day_date: half_day ? value.fromDate : undefined,
+          half_day_date: half_day
+            ? value.fromDate !== value.toDate
+              ? value.halfDayDate
+              : value.fromDate
+            : undefined,
           custom_first_halfsecond_half,
         };
         await createDoc("Leave Application", data);
@@ -299,6 +304,58 @@ const AddEmployeeLeave = ({
               </>
             );
           }}
+        />
+
+        <form.Subscribe
+          selector={(state) => [
+            state.values.fromDate,
+            state.values.toDate,
+            state.values.leaveDuration,
+          ]}
+          children={([fromDate, toDate, leaveDuration]) =>
+            leaveDuration !== "full-day" &&
+            fromDate !== toDate && (
+              <form.Field
+                name="halfDayDate"
+                children={(field) => {
+                  return (
+                    <div className="flex flex-col space-y-1.5">
+                      <label className="block text-base text-ink-gray-5 mb-1.5">
+                        Half Day Date
+                      </label>
+                      <DatePicker
+                        label="Half Day Date"
+                        onChange={(val) => field.handleChange(val as string)}
+                        placeholder="Half day date"
+                        value={field.state.value}
+                      >
+                        {({ displayValue }) => {
+                          return (
+                            <div className="flex relative items-center py-2 w-full h-8 rounded border border-outline-gray-2 px-2.5">
+                              <input
+                                readOnly
+                                type="text"
+                                id="half-day-date"
+                                value={displayValue}
+                                className="w-full text-base text-ink-gray-7"
+                                placeholder="Select half day date"
+                              />
+                              <Calendar className="size-4" />
+                            </div>
+                          );
+                        }}
+                      </DatePicker>
+                      {!field.state.meta.isValid && (
+                        <ErrorMessage
+                          message={field.state.meta.errors[0]?.message}
+                        />
+                      )}
+                    </div>
+                  );
+                }}
+              />
+            )
+          }
         />
 
         <form.Field

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/schema.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-leave/schema.ts
@@ -1,40 +1,67 @@
 import { z } from "zod";
 import { LEAVE_DURATION } from "./types";
 
-export const addLeaveFormSchema = z.object({
-  employeeId: z
-    .string({
-      required_error: "Please select an employee.",
-    })
-    .trim()
-    .min(1, { message: "Please select an employee." }),
-  fromDate: z
-    .string({
-      required_error: "Please select from date.",
-    })
-    .trim()
-    .min(1, { message: "Please select from date." }),
-  toDate: z
-    .string({
-      required_error: "Please select to date.",
-    })
-    .trim()
-    .min(1, { message: "Please select to date." }),
-  leaveDuration: z.enum(LEAVE_DURATION, {
-    required_error: "Please select leave duration.",
-  }),
-  leaveType: z
-    .string({
-      required_error: "Please select leave type.",
-    })
-    .trim()
-    .min(1, { message: "Please select leave type." }),
-  reason: z
-    .string({
-      required_error: "Please enter a reason.",
-    })
-    .trim()
-    .min(1, { message: "Please enter a reason." }),
-});
+export const addLeaveFormSchema = z
+  .object({
+    employeeId: z
+      .string({
+        required_error: "Please select an employee.",
+      })
+      .trim()
+      .min(1, { message: "Please select an employee." }),
+    fromDate: z
+      .string({
+        required_error: "Please select from date.",
+      })
+      .trim()
+      .min(1, { message: "Please select from date." }),
+    toDate: z
+      .string({
+        required_error: "Please select to date.",
+      })
+      .trim()
+      .min(1, { message: "Please select to date." }),
+    leaveDuration: z.enum(LEAVE_DURATION, {
+      required_error: "Please select leave duration.",
+    }),
+    halfDayDate: z.string().trim(),
+    leaveType: z
+      .string({
+        required_error: "Please select leave type.",
+      })
+      .trim()
+      .min(1, { message: "Please select leave type." }),
+    reason: z
+      .string({
+        required_error: "Please enter a reason.",
+      })
+      .trim()
+      .min(1, { message: "Please enter a reason." }),
+  })
+  .superRefine((value, ctx) => {
+    if (value.leaveDuration === "full-day" || value.fromDate === value.toDate) {
+      return;
+    }
+
+    if (!value.halfDayDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["halfDayDate"],
+        message: "Please select half day date.",
+      });
+      return;
+    }
+
+    if (
+      value.halfDayDate < value.fromDate ||
+      value.halfDayDate > value.toDate
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["halfDayDate"],
+        message: "Half day date must be between from date and to date.",
+      });
+    }
+  });
 
 export type AddLeaveFormValues = z.infer<typeof addLeaveFormSchema>;


### PR DESCRIPTION
## Description

Adds date field to select what day to apply half day on.

## Relevant Technical Choices

- Half day date field only shows up when 
  - difference between from and to date is more than one day.
  - First half or second half is selected.


## Screenshot/Screencast

<img width="503" height="575" alt="Screenshot 2026-07-08 at 2 56 53 PM" src="https://github.com/user-attachments/assets/8e0a66ca-1d6d-41ea-a302-12ce253e7778" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1639