### PR TITLE
feat: sort project list by computed values and set currency

### DIFF
--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -100,7 +100,7 @@ const Sidebar = () => {
   }
 
   const personalTimesheet = {
-    label: "Personal",
+    label: "Timesheet",
     icon: Time,
     to: ROUTES["timesheet-personal"],
     isActive: pathname === ROUTES["timesheet-personal"],
@@ -134,6 +134,7 @@ const Sidebar = () => {
     roles.includes("Timesheet User") ||
     roles.includes("Projects Manager")
   ) {
+    timesheetItems[0].label = "Personal";
     timesheetItems.push(teamTimesheet);
     timesheetItems.push(projectTimesheet);
   }

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -107,6 +107,7 @@ export function ProjectListSubHeader() {
               },
               { field: "project_type", label: "Project type" },
               { field: "customer", label: "Client name" },
+              { field: "contract_end_date", label: "Contract end date" },
               { label: "Last Updated On", field: "modified" },
             ]}
           />

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -90,11 +90,10 @@ export function ProjectListSubHeader() {
             fields={[
               { field: "project_name", label: "Project name" },
               { field: "custom_project_phase", label: "Phase" },
-              { field: "total_billable_amount", label: "Total budget" },
-              {
-                field: "custom_percentage_estimated_profit",
-                label: "Profit margin",
-              },
+              { field: "burn_rate_per_week", label: "Burn rate/week" },
+              { field: "cost_burn_percent", label: "Cost burn" },
+              { field: "total_budget", label: "Total budget" },
+              { field: "profit_margin", label: "Profit margin" },
               { field: "expected_start_date", label: "Expected Start Date" },
               { field: "custom_next_milestone", label: "Next milestone" },
               { field: "expected_end_date", label: "Expected End Date" },

--- a/frontend/packages/app/src/pages/projects/list/columns.ts
+++ b/frontend/packages/app/src/pages/projects/list/columns.ts
@@ -77,5 +77,10 @@ export const PROJECT_LIST_COLUMNS = [
     width: "180px",
     sortField: "customer",
   },
-  { key: "contract_end_date", label: "Contract end date", width: "160px" },
+  {
+    key: "contract_end_date",
+    label: "Contract end date",
+    width: "160px",
+    sortField: "contract_end_date",
+  },
 ];

--- a/frontend/packages/app/src/pages/projects/list/columns.ts
+++ b/frontend/packages/app/src/pages/projects/list/columns.ts
@@ -11,19 +11,29 @@ export const PROJECT_LIST_COLUMNS = [
     width: "160px",
     sortField: "custom_project_phase",
   },
-  { key: "burn_rate_per_week", label: "Burn rate/week", width: "130px" },
-  { key: "cost_burn_percent", label: "Cost burn", width: "140px" },
+  {
+    key: "burn_rate_per_week",
+    label: "Burn rate/week",
+    width: "130px",
+    sortField: "burn_rate_per_week",
+  },
+  {
+    key: "cost_burn_percent",
+    label: "Cost burn",
+    width: "140px",
+    sortField: "cost_burn_percent",
+  },
   {
     key: "total_budget",
     label: "Total budget",
     width: "130px",
-    sortField: "total_billable_amount",
+    sortField: "total_budget",
   },
   {
     key: "profit_margin",
     label: "Profit margin",
     width: "120px",
-    sortField: "custom_percentage_estimated_profit",
+    sortField: "profit_margin",
   },
   {
     key: "start_date",

--- a/next_pms/next_projects/api/constant.py
+++ b/next_pms/next_projects/api/constant.py
@@ -33,6 +33,26 @@ TIMELINE_ITEM_FIELDS = [
     "actual_end_date",
 ]
 
+# Sort fields whose values are computed (not DB columns); handled via sort-key pagination
+COMPUTED_SORT_FIELDS = (
+    "burn_rate_per_week",
+    "cost_burn_percent",
+    "total_budget",
+    "profit_margin",
+)
+
+# Minimal Project columns needed to compute the values in COMPUTED_SORT_FIELDS
+SORT_KEY_FIELDS = [
+    "name",
+    "custom_billing_type",
+    "total_sales_amount",
+    "estimated_costing",
+    "total_costing_amount",
+    "total_billable_amount",
+    "custom_default_hourly_billing_rate",
+    "expected_start_date",
+]
+
 # Fields to fetch from Project doctype
 LIST_VIEW_FIELDS = [
     "name",

--- a/next_pms/next_projects/api/constant.py
+++ b/next_pms/next_projects/api/constant.py
@@ -39,6 +39,7 @@ COMPUTED_SORT_FIELDS = (
     "cost_burn_percent",
     "total_budget",
     "profit_margin",
+    "contract_end_date",
 )
 
 # Minimal Project columns needed to compute the values in COMPUTED_SORT_FIELDS
@@ -51,6 +52,9 @@ SORT_KEY_FIELDS = [
     "total_billable_amount",
     "custom_default_hourly_billing_rate",
     "expected_start_date",
+    "status",
+    "expected_end_date",
+    "actual_end_date",
 ]
 
 # Fields to fetch from Project doctype

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -130,11 +130,13 @@ def get_computed_sort_value(sort_field: str, project: dict, cost_forecasted_map:
         return (flt(project.get("total_costing_amount")) / total_budget) * 100
     if sort_field == "total_budget":
         return total_budget
-    return get_profit_margin(
-        total_budget,
-        flt(project.get("total_costing_amount")),
-        cost_forecasted_map.get(project.get("name"), 0),
-    )
+    if sort_field == "profit_margin":
+        return get_profit_margin(
+            total_budget,
+            flt(project.get("total_costing_amount")),
+            cost_forecasted_map.get(project.get("name"), 0),
+        )
+    return None
 
 
 def get_page_names_for_computed_sort(

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -12,9 +12,11 @@ from frappe.utils import cint, flt, getdate, today
 from next_pms.api.utils import error_logger
 from next_pms.next_projects.api.constant import (
     ALLOWED_ROLES,
+    COMPUTED_SORT_FIELDS,
     KANBAN_VIEW_FIELDS,
     LIST_VIEW_FIELDS,
     PROJECT_TRACKING_CACHE_KEY_PREFIX,
+    SORT_KEY_FIELDS,
     TASK_TRACKING_COMPLETED_STATUS,
     TASK_TRACKING_OPEN_STATUSES,
     TASK_TRACKING_TOTAL_STATUSES,
@@ -39,19 +41,24 @@ def get_total_budget(project: dict) -> float:
 
 
 def get_cost_forecasted(project_name: str) -> float:
-    """Sum of total_cost from ALL Resource Allocations for the project."""
+    """Sum of total_cost from ongoing/future Resource Allocations for the project.
+
+    Past allocations are excluded: their cost is already realized in the
+    project's total_costing_amount (cost_accrued) via timesheets.
+    """
     ResourceAllocation = frappe.qb.DocType("Resource Allocation")
     result = (
         frappe.qb.from_(ResourceAllocation)
         .select(Coalesce(Sum(ResourceAllocation.total_cost), 0).as_("total"))
         .where(ResourceAllocation.project == project_name)
+        .where(ResourceAllocation.allocation_end_date >= today())
         .run(as_dict=True)
     )
     return flt(result[0].total) if result else 0
 
 
 def get_cost_forecasted_map(project_names: list[str]) -> dict[str, float]:
-    """Fetch forecasted costs for multiple projects in a single grouped query."""
+    """Fetch forecasted costs (ongoing/future allocations only) for multiple projects in a single grouped query."""
     if not project_names:
         return {}
     ResourceAllocation = frappe.qb.DocType("Resource Allocation")
@@ -62,6 +69,7 @@ def get_cost_forecasted_map(project_names: list[str]) -> dict[str, float]:
             Coalesce(Sum(ResourceAllocation.total_cost), 0).as_("total"),
         )
         .where(ResourceAllocation.project.isin(project_names))
+        .where(ResourceAllocation.allocation_end_date >= today())
         .groupby(ResourceAllocation.project)
         .run(as_dict=True)
     )
@@ -98,6 +106,67 @@ def get_profit_margin(total_budget: float, cost_accrued: float, cost_forecasted:
     if total_budget <= 0:
         return 0
     return ((total_budget - (cost_accrued + cost_forecasted)) / total_budget) * 100
+
+
+def parse_order_by(order_by: str) -> tuple[str, str]:
+    """Return (field, direction) from the first clause of an order_by string."""
+    first_clause = (order_by or "").split(",")[0].strip()
+    parts = first_clause.split()
+    field = parts[0].strip("`") if parts else ""
+    direction = parts[1].lower() if len(parts) > 1 else "desc"
+    if direction not in ("asc", "desc"):
+        direction = "desc"
+    return field, direction
+
+
+def get_computed_sort_value(sort_field: str, project: dict, cost_forecasted_map: dict[str, float]) -> float | None:
+    total_budget = get_total_budget(project)
+    if sort_field == "burn_rate_per_week":
+        return get_burn_rate_per_week(project)
+    if sort_field == "cost_burn_percent":
+        # Mirrors the frontend cost-burn cell: cost_accrued / total_budget * 100
+        if total_budget <= 0:
+            return 0
+        return (flt(project.get("total_costing_amount")) / total_budget) * 100
+    if sort_field == "total_budget":
+        return total_budget
+    return get_profit_margin(
+        total_budget,
+        flt(project.get("total_costing_amount")),
+        cost_forecasted_map.get(project.get("name"), 0),
+    )
+
+
+def get_page_names_for_computed_sort(
+    sort_field: str,
+    sort_direction: str,
+    project_filters: list,
+    or_filters: dict | None,
+    start: int,
+    limit: int,
+) -> tuple[list[str], int]:
+    """
+    Sort-key pagination for computed fields: fetch only the component columns for
+    every matching project, compute the sort value in Python (same helpers used for
+    display), sort with nulls last, and return the page's names plus the total count.
+    """
+    rows = get_list(
+        "Project",
+        fields=SORT_KEY_FIELDS,
+        filters=project_filters,
+        or_filters=or_filters,
+        limit_page_length=0,
+        order_by="modified desc",
+    )
+
+    cost_forecasted_map = get_cost_forecasted_map([row.name for row in rows]) if sort_field == "profit_margin" else {}
+
+    valued = [(get_computed_sort_value(sort_field, row, cost_forecasted_map), row.name) for row in rows]
+    ranked = [entry for entry in valued if entry[0] is not None]
+    ranked.sort(key=lambda entry: entry[0], reverse=sort_direction == "desc")
+
+    ordered_names = [name for _, name in ranked] + [name for value, name in valued if value is None]
+    return ordered_names[start : start + limit], len(ordered_names)
 
 
 def get_end_date(project: dict) -> str | None:
@@ -244,23 +313,48 @@ def get_projects_view(
     # Select fields based on view
     fields = LIST_VIEW_FIELDS if view == "list" else KANBAN_VIEW_FIELDS
 
-    # Fetch projects
-    projects = get_list(
-        "Project",
-        fields=fields,
-        filters=project_filters,
-        or_filters=or_filters if or_filters else None,
-        limit_start=cint(start),
-        limit_page_length=cint(limit),
-        order_by=order_by,
-    )
+    sort_field, sort_direction = parse_order_by(order_by)
+    use_computed_sort = view == "list" and sort_field in COMPUTED_SORT_FIELDS
+    if sort_field in COMPUTED_SORT_FIELDS and not use_computed_sort:
+        order_by = "modified desc"
 
-    # Get total count
-    total_count = get_count(
-        "Project",
-        filters=project_filters,
-        or_filters=or_filters if or_filters else None,
-    )
+    if use_computed_sort:
+        page_names, total_count = get_page_names_for_computed_sort(
+            sort_field,
+            sort_direction,
+            project_filters,
+            or_filters if or_filters else None,
+            cint(start),
+            cint(limit),
+        )
+        projects = []
+        if page_names:
+            projects = get_list(
+                "Project",
+                fields=fields,
+                filters=[["name", "in", page_names]],
+                limit_page_length=0,
+            )
+            rank = {name: index for index, name in enumerate(page_names)}
+            projects.sort(key=lambda p: rank[p.name])
+    else:
+        # Fetch projects
+        projects = get_list(
+            "Project",
+            fields=fields,
+            filters=project_filters,
+            or_filters=or_filters if or_filters else None,
+            limit_start=cint(start),
+            limit_page_length=cint(limit),
+            order_by=order_by,
+        )
+
+        # Get total count
+        total_count = get_count(
+            "Project",
+            filters=project_filters,
+            or_filters=or_filters if or_filters else None,
+        )
 
     has_more = cint(start) + cint(limit) < total_count
 
@@ -724,7 +818,7 @@ def _get_project_tracking(project: str):
     task_counts = _get_task_counts(project)
     actual_cost_incurred = flt(p.total_costing_amount)
     total_forecasted_cost = get_cost_forecasted(project)
-    forecasted_cost_to_completion = max(0, total_forecasted_cost - actual_cost_incurred)
+    forecasted_cost_to_completion = max(0, total_forecasted_cost)
 
     contracts = None
     if has_hours_pool:

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import json
+from datetime import date
 from typing import Literal
 
 import frappe
@@ -119,7 +120,12 @@ def parse_order_by(order_by: str) -> tuple[str, str]:
     return field, direction
 
 
-def get_computed_sort_value(sort_field: str, project: dict, cost_forecasted_map: dict[str, float]) -> float | None:
+def get_computed_sort_value(
+    sort_field: str, project: dict, cost_forecasted_map: dict[str, float]
+) -> float | date | None:
+    if sort_field == "contract_end_date":
+        end_date = get_end_date(project)
+        return getdate(end_date) if end_date else None
     total_budget = get_total_budget(project)
     if sort_field == "burn_rate_per_week":
         return get_burn_rate_per_week(project)

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.json
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.json
@@ -149,7 +149,6 @@
   },
   {
    "fetch_from": "project.custom_currency",
-   "fetch_if_empty": 1,
    "fieldname": "currency",
    "fieldtype": "Link",
    "label": "Currency",

--- a/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/resource_allocation.py
@@ -50,9 +50,18 @@ class ResourceAllocation(Document):
         if self.allocation_end_date < self.allocation_start_date:
             frappe.throw(frappe._("End date should be greater than or equal to start date"))
 
+        self.set_project_currency()
         self.validate_no_overlap()
         self.validate_project_and_customer()
         self.calculate_cost()
+
+    def set_project_currency(self):
+        if not self.project:
+            return
+
+        project_currency = frappe.get_cached_value("Project", self.project, "custom_currency")
+        if project_currency:
+            self.currency = project_currency
 
     def validate_no_overlap(self):
         """Block a second allocation for the same employee + project whose date range

--- a/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
+++ b/next_pms/resource_management/doctype/resource_allocation/test_resource_allocation.py
@@ -23,6 +23,23 @@ class TestResourceAllocationValidation(IntegrationTestCase):
         cls.employee = cls._make_employee("Ravi Kumar")
         cls.customer = cls._make_customer("Globex")
         cls.project = cls._make_project("Active Project", cls.customer)
+        cls.projects_user = cls._make_user("meera.iyer@example.com", roles=["Projects User"])
+
+    @classmethod
+    def _make_user(cls, email, roles=None):
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                    "user_type": "System User",
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        if roles:
+            frappe.get_doc("User", email).add_roles(*roles)
+        return email
 
     @classmethod
     def _make_employee(cls, employee_name):
@@ -211,3 +228,44 @@ class TestResourceAllocationValidation(IntegrationTestCase):
         doc.insert(ignore_permissions=True)
         self.assertGreater(doc.hourly_cost_rate, 0)
         self.assertEqual(doc.total_cost, doc.hourly_cost_rate * doc.total_allocated_hours)
+
+    def test_currency_set_from_project_currency(self):
+        project = self._make_project("USD Project", self.customer)
+        frappe.db.set_value("Project", project, "custom_currency", "USD")
+
+        doc = self._make_allocation_doc(project=project)
+        doc.insert(ignore_permissions=True)
+
+        self.assertEqual(doc.currency, "USD")
+
+    def test_explicit_currency_overridden_by_project_currency(self):
+        # A currency arriving in the payload must not win over the project's
+        # currency (fetch_if_empty used to skip the fetch in that case).
+        project = self._make_project("USD Override Project", self.customer)
+        frappe.db.set_value("Project", project, "custom_currency", "USD")
+
+        doc = self._make_allocation_doc(project=project, currency="INR")
+        doc.insert(ignore_permissions=True)
+
+        self.assertEqual(doc.currency, "USD")
+
+    def test_currency_survives_permlevel_reset_for_projects_user(self):
+        # currency is a permlevel-2 field and Projects User only has permlevel-0
+        # write. On insert, validate_higher_perm_levels resets permlevel-2 fields
+        # AFTER the fetch_from fetch, so the fetched currency was wiped and the
+        # allocation saved with no currency. set_project_currency runs in
+        # validate(), after the reset, so the value must now survive.
+        project = self._make_project("Permlevel Project", self.customer)
+        frappe.db.set_value("Project", project, "custom_currency", "USD")
+
+        frappe.set_user(self.projects_user)
+        doc = self._make_allocation_doc(project=project)
+        doc.insert()
+
+        self.assertEqual(doc.currency, "USD")
+        self.assertEqual(frappe.db.get_value("Resource Allocation", doc.name, "currency"), "USD")
+
+    def test_currency_untouched_without_project(self):
+        doc = self._make_allocation_doc(customer=self.customer, currency="INR")
+        doc.insert(ignore_permissions=True)
+        self.assertEqual(doc.currency, "INR")

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -1,0 +1,123 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, today
+
+from next_pms.next_projects.api.project import get_projects_view
+
+# Unique marker so `search` scopes every call to this suite's fixtures only.
+FIXTURE_PREFIX = "CompSort"
+
+
+class TestGetProjectsViewComputedSort(IntegrationTestCase):
+    """get_projects_view sorts by computed fields (burn_rate_per_week,
+    cost_burn_percent, total_budget, profit_margin) via sort-key pagination:
+    correct order across page boundaries, nulls last in both directions.
+
+    Component amounts are written with db.set_value because they are
+    read-only/rollup columns on Project.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        # name -> (billing_type, sales, estimated, costing, rate, billable, start_days_ago)
+        # Derived values (cost_forecasted = 0, no allocations):
+        #   total_budget:      A 1000, B 2000, C 3000, D 0
+        #   cost_burn_percent: A 50,   B 25,   C 200,  D 0 (budget<=0 guard)
+        #   profit_margin:     A 50,   B 75,   C -100, D 0 (budget<=0 guard)
+        #   burn_rate/week:    A 700,  B None, C 1400, D None
+        fixture_rows = {
+            "A": ("Fixed Cost", 1000, 0, 500, 100, 700, 7),
+            "B": (None, 0, 2000, 500, 0, 0, 7),
+            "C": ("Fixed Cost", 3000, 0, 6000, 100, 2800, 14),
+            "D": (None, 0, 0, 100, 0, 0, None),
+        }
+        cls.projects = {}
+        for suffix, (billing_type, sales, estimated, costing, rate, billable, days_ago) in fixture_rows.items():
+            name = (
+                frappe.get_doc(
+                    {
+                        "doctype": "Project",
+                        "project_name": f"{FIXTURE_PREFIX} {suffix}",
+                        "company": cls.company,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+            frappe.db.set_value(
+                "Project",
+                name,
+                {
+                    "custom_billing_type": billing_type,
+                    "total_sales_amount": sales,
+                    "estimated_costing": estimated,
+                    "total_costing_amount": costing,
+                    "custom_default_hourly_billing_rate": rate,
+                    "total_billable_amount": billable,
+                    "expected_start_date": add_days(today(), -days_ago) if days_ago else None,
+                },
+                update_modified=False,
+            )
+            cls.projects[suffix] = name
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    def call(self, order_by, start=0, limit=20, view="list"):
+        return get_projects_view(
+            view=view,
+            search=FIXTURE_PREFIX,
+            start=start,
+            limit=limit,
+            order_by=order_by,
+        )
+
+    def fixture_order(self, result):
+        by_name = {name: suffix for suffix, name in self.projects.items()}
+        return [by_name[row["name"]] for row in result["data"]]
+
+    def test_cost_burn_percent_sort(self):
+        self.assertEqual(self.fixture_order(self.call("cost_burn_percent desc")), ["C", "A", "B", "D"])
+        self.assertEqual(self.fixture_order(self.call("cost_burn_percent asc")), ["D", "B", "A", "C"])
+
+    def test_total_budget_sort(self):
+        self.assertEqual(self.fixture_order(self.call("total_budget desc")), ["C", "B", "A", "D"])
+        self.assertEqual(self.fixture_order(self.call("total_budget asc")), ["D", "A", "B", "C"])
+
+    def test_profit_margin_sort(self):
+        self.assertEqual(self.fixture_order(self.call("profit_margin desc")), ["B", "A", "D", "C"])
+        self.assertEqual(self.fixture_order(self.call("profit_margin asc")), ["C", "D", "A", "B"])
+
+    def test_burn_rate_sort_nulls_last_both_directions(self):
+        desc = self.fixture_order(self.call("burn_rate_per_week desc"))
+        asc = self.fixture_order(self.call("burn_rate_per_week asc"))
+        self.assertEqual(desc[:2], ["C", "A"])
+        self.assertEqual(asc[:2], ["A", "C"])
+        self.assertEqual(set(desc[2:]), {"B", "D"})
+        self.assertEqual(set(asc[2:]), {"B", "D"})
+
+    def test_pagination_across_page_boundary(self):
+        page_one = self.call("cost_burn_percent desc", start=0, limit=2)
+        page_two = self.call("cost_burn_percent desc", start=2, limit=2)
+
+        self.assertEqual(page_one["total_count"], 4)
+        self.assertTrue(page_one["has_more"])
+        self.assertFalse(page_two["has_more"])
+        self.assertEqual(
+            self.fixture_order(page_one) + self.fixture_order(page_two),
+            ["C", "A", "B", "D"],
+        )
+
+    def test_stored_field_sort_unchanged(self):
+        result = self.call("project_name asc")
+        self.assertEqual(self.fixture_order(result), ["A", "B", "C", "D"])
+        self.assertEqual(result["total_count"], 4)
+
+    def test_kanban_falls_back_for_computed_field(self):
+        result = self.call("cost_burn_percent desc", view="kanban")
+        self.assertEqual(result["total_count"], 4)
+        self.assertIn("columns", result)

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -11,8 +11,9 @@ FIXTURE_PREFIX = "CompSort"
 
 class TestGetProjectsViewComputedSort(IntegrationTestCase):
     """get_projects_view sorts by computed fields (burn_rate_per_week,
-    cost_burn_percent, total_budget, profit_margin) via sort-key pagination:
-    correct order across page boundaries, nulls last in both directions.
+    cost_burn_percent, total_budget, profit_margin, contract_end_date) via
+    sort-key pagination: correct order across page boundaries, nulls last
+    in both directions.
 
     Component amounts are written with db.set_value because they are
     read-only/rollup columns on Project.
@@ -35,6 +36,15 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
             "C": ("Fixed Cost", 3000, 0, 6000, 100, 2800, 14),
             "D": (None, 0, 0, 100, 0, 0, None),
         }
+        # name -> (status, expected_end_in_days, actual_end_in_days)
+        # contract_end_date = actual_end_date when Completed/Cancelled, else expected_end_date:
+        #   A +10, B +5, C +20 (Completed, actual wins over expected +2), D None
+        end_date_rows = {
+            "A": (None, 10, None),
+            "B": (None, 5, None),
+            "C": ("Completed", 2, 20),
+            "D": (None, None, None),
+        }
         cls.projects = {}
         for suffix, (billing_type, sales, estimated, costing, rate, billable, days_ago) in fixture_rows.items():
             name = (
@@ -48,20 +58,21 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
                 .insert(ignore_permissions=True)
                 .name
             )
-            frappe.db.set_value(
-                "Project",
-                name,
-                {
-                    "custom_billing_type": billing_type,
-                    "total_sales_amount": sales,
-                    "estimated_costing": estimated,
-                    "total_costing_amount": costing,
-                    "custom_default_hourly_billing_rate": rate,
-                    "total_billable_amount": billable,
-                    "expected_start_date": add_days(today(), -days_ago) if days_ago else None,
-                },
-                update_modified=False,
-            )
+            status, end_in, actual_end_in = end_date_rows[suffix]
+            values = {
+                "custom_billing_type": billing_type,
+                "total_sales_amount": sales,
+                "estimated_costing": estimated,
+                "total_costing_amount": costing,
+                "custom_default_hourly_billing_rate": rate,
+                "total_billable_amount": billable,
+                "expected_start_date": add_days(today(), -days_ago) if days_ago else None,
+                "expected_end_date": add_days(today(), end_in) if end_in else None,
+                "actual_end_date": add_days(today(), actual_end_in) if actual_end_in else None,
+            }
+            if status:
+                values["status"] = status
+            frappe.db.set_value("Project", name, values, update_modified=False)
             cls.projects[suffix] = name
 
         frappe.set_user("Administrator")
@@ -99,6 +110,10 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         self.assertEqual(asc[:2], ["A", "C"])
         self.assertEqual(set(desc[2:]), {"B", "D"})
         self.assertEqual(set(asc[2:]), {"B", "D"})
+
+    def test_contract_end_date_sort(self):
+        self.assertEqual(self.fixture_order(self.call("contract_end_date desc")), ["C", "A", "B", "D"])
+        self.assertEqual(self.fixture_order(self.call("contract_end_date asc")), ["B", "A", "C", "D"])
 
     def test_pagination_across_page_boundary(self):
         page_one = self.call("cost_burn_percent desc", start=0, limit=2)


### PR DESCRIPTION
## Description

- Added backend support for sorting the project list view by computed fields (`burn_rate_per_week`, `cost_burn_percent`, `total_budget`, `profit_margin`) using sort-key pagination, ensuring correct ordering and pagination across page boundaries. 
- Introduced helpers to parse `order_by` clauses and compute sort values in Python, mirroring frontend calculations for consistency.
- Updated frontend project list columns and subheader to reflect new computed fields and correct sort field mappings.
- Ensured the `currency` field on `Resource Allocation` is always set from the linked project's `custom_currency` during validation, regardless of incoming payload or user permission resets. 
- Added tests to confirm correct currency assignment in various scenarios, including permission edge cases and explicit overrides. 
- Added integration tests for computed field sorting, verifying correct ordering, pagination, and null handling for all supported computed fields in the project list view.
- Refined cost forecast calculations to exclude past allocations, ensuring only ongoing and future costs are considered in forecasts.
- Minor bugfix in project tracking to ensure forecasted cost to completion is calculated correctly.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="237" height="194" alt="image" src="https://github.com/user-attachments/assets/2831799e-9bf3-4527-8964-6a91c5bb9537" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1337#issuecomment-4855147615