### PR TITLE
feat: timesheet api returns the rejected reason

### DIFF
--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
@@ -135,31 +137,32 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
     def collect_entries_by_parent(self, timesheet_details):
         """Both endpoints nest time entries the same way:
             timesheet_details[week]["tasks"][task]["data"] = [ {entry}, {entry}, ... ]
-        Each entry's "parent" is its Timesheet name. Here every day is its own
-        Timesheet, so flattening by parent gives one entry per day."""
-        entries_by_parent = {}
+        Each entry's "parent" is its Timesheet name. A Timesheet can hold several
+        entries, so group them into a list per parent rather than keeping only one."""
+        entries_by_parent = defaultdict(list)
         for week in timesheet_details.values():
             for task in week["tasks"].values():
                 for entry in task["data"]:
-                    entries_by_parent[entry["parent"]] = entry
+                    entries_by_parent[entry["parent"]].append(entry)
         return entries_by_parent
 
     def assert_entries_carry_fields(self, entries_by_parent, by_date):
-        # A rejected timesheet surfaces its rejection reason on every time entry.
-        tuesday = entries_by_parent[by_date[TUE].name]
-        self.assertEqual(tuesday["custom_approval_status"], "Rejected")
-        self.assertEqual(tuesday["custom_rejection_reason"], TUE_REASON)
+        def assert_day(date, status, reason):
+            # The approval fields come from the parent Timesheet, so every entry
+            # under that Timesheet must carry the same values.
+            entries = entries_by_parent[by_date[date].name]
+            self.assertTrue(entries, f"expected at least one time entry for {date}")
+            for entry in entries:
+                self.assertEqual(entry["custom_approval_status"], status)
+                self.assertEqual(entry["custom_rejection_reason"], reason)
 
+        # A rejected timesheet surfaces its rejection reason.
+        assert_day(TUE, "Rejected", TUE_REASON)
         # An approved timesheet has no rejection reason.
-        wednesday = entries_by_parent[by_date[WED].name]
-        self.assertEqual(wednesday["custom_approval_status"], "Approved")
-        self.assertIsNone(wednesday["custom_rejection_reason"])
-
+        assert_day(WED, "Approved", None)
         # A pending timesheet was never rejected, so it has no reason either.
         for date in (MON, THU, FRI):
-            entry = entries_by_parent[by_date[date].name]
-            self.assertEqual(entry["custom_approval_status"], "Approval Pending")
-            self.assertIsNone(entry["custom_rejection_reason"])
+            assert_day(date, "Approval Pending", None)
 
     def test_endpoints_expose_parent_approval_fields(self):
         # Reject Tuesday (with a reason) and approve Wednesday; the rest stay pending.

--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -3,9 +3,9 @@ from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
 
 from next_pms.tests.utils import make_employee
-from next_pms.timesheet.api.team import _approve_or_reject_timesheet
+from next_pms.timesheet.api.team import _approve_or_reject_timesheet, get_team_timesheet_data
+from next_pms.timesheet.api.timesheet import get_timesheet_data, submit_for_approval
 from next_pms.timesheet.api.timesheet import save as save_timesheet
-from next_pms.timesheet.api.timesheet import submit_for_approval
 
 MANAGER_USER = "rejection-reason-test-manager@example.com"
 EMPLOYEE_USER = "rejection-reason-test-employee@example.com"
@@ -131,6 +131,52 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             fields=["name", "start_date", "employee"],
         )
         _approve_or_reject_timesheet(timesheets=drafts, status=status, employee=self.employee, dates=dates, note=note)
+
+    def collect_entries_by_parent(self, timesheet_details):
+        """Both endpoints nest time entries the same way:
+            timesheet_details[week]["tasks"][task]["data"] = [ {entry}, {entry}, ... ]
+        Each entry's "parent" is its Timesheet name. Here every day is its own
+        Timesheet, so flattening by parent gives one entry per day."""
+        entries_by_parent = {}
+        for week in timesheet_details.values():
+            for task in week["tasks"].values():
+                for entry in task["data"]:
+                    entries_by_parent[entry["parent"]] = entry
+        return entries_by_parent
+
+    def assert_entries_carry_fields(self, entries_by_parent, by_date):
+        # A rejected timesheet surfaces its rejection reason on every time entry.
+        tuesday = entries_by_parent[by_date[TUE].name]
+        self.assertEqual(tuesday["custom_approval_status"], "Rejected")
+        self.assertEqual(tuesday["custom_rejection_reason"], TUE_REASON)
+
+        # An approved timesheet has no rejection reason.
+        wednesday = entries_by_parent[by_date[WED].name]
+        self.assertEqual(wednesday["custom_approval_status"], "Approved")
+        self.assertIsNone(wednesday["custom_rejection_reason"])
+
+        # A pending timesheet was never rejected, so it has no reason either.
+        for date in (MON, THU, FRI):
+            entry = entries_by_parent[by_date[date].name]
+            self.assertEqual(entry["custom_approval_status"], "Approval Pending")
+            self.assertIsNone(entry["custom_rejection_reason"])
+
+    def test_endpoints_expose_parent_approval_fields(self):
+        # Reject Tuesday (with a reason) and approve Wednesday; the rest stay pending.
+        self.decide_timesheets("Rejected", [TUE], note=TUE_REASON)
+        self.decide_timesheets("Approved", [WED])
+        # by_date maps each date -> its Timesheet row, so by_date[TUE].name is the
+        # parent name we look each entry up by.
+        by_date = self.get_timesheets_by_date()
+
+        # get_timesheet_data returns data[week]["tasks"][task]["data"][...]
+        personal = get_timesheet_data(employee=self.employee, start_date=MON, max_week=1)
+        self.assert_entries_carry_fields(self.collect_entries_by_parent(personal["data"]), by_date)
+
+        # get_team_timesheet_data nests one level deeper, under data[employee]["timesheet_details"].
+        team = get_team_timesheet_data(date=FRI, max_week=1, reports_to=self.manager)
+        team_details = team["data"][self.employee]["timesheet_details"]
+        self.assert_entries_carry_fields(self.collect_entries_by_parent(team_details), by_date)
 
     def test_reject_resubmit_approve_lifecycle(self):
         # Step 1 (done in setUp): all 5 days pending, no rejection reason yet.

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -551,7 +551,7 @@ def _approve_or_reject_timesheet(
         for timesheet in timesheets_to_process:
             doc = get_doc("Timesheet", timesheet.name)
             doc.custom_approval_status = status
-            doc.custom_rejection_reason = note if status == "Rejected" else ""
+            doc.custom_rejection_reason = note if status == "Rejected" else None
             doc.save(ignore_permissions=has_permission)
             if status == "Approved":
                 doc.submit()

--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -543,15 +543,18 @@ def get_timesheet(dates: list, employee: str, search: str | None = None, parsed_
     }
     ts_filters = build_filters(base_ts_filters, parsed_filters.get("Timesheet", []))
 
-    timesheet_names = frappe.get_all(
+    timesheets = frappe.get_all(
         "Timesheet",
         filters=ts_filters,
-        pluck="name",
+        fields=["name", "custom_approval_status", "custom_rejection_reason"],
         ignore_permissions=employee_has_higher_access(employee, ptype="read"),
     )
 
-    if not timesheet_names:
+    if not timesheets:
         return [data, total_hours]
+
+    timesheet_names = [ts.name for ts in timesheets]
+    ts_parent_map = {ts.name: ts for ts in timesheets}
 
     # Fetch all timesheet detail records with needed fields in one query
     base_detail_filters = {"parent": ["in", timesheet_names]}
@@ -629,7 +632,11 @@ def get_timesheet(dates: list, employee: str, search: str | None = None, parsed_
                 "exp_end_date": task["exp_end_date"] or "",
             }
 
-        data[task_name]["data"].append({field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS})
+        entry = {field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS}
+        parent_ts = ts_parent_map.get(log.get("parent"))
+        entry["custom_approval_status"] = parent_ts.get("custom_approval_status") if parent_ts else None
+        entry["custom_rejection_reason"] = parent_ts.get("custom_rejection_reason") if parent_ts else None
+        data[task_name]["data"].append(entry)
 
     return [data, total_hours]
 

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -675,9 +675,11 @@ def build_chunk_context(employees: list, dates: list, parsed_filters: dict, sear
             "total_hours",
             "note",
             "custom_approval_status",
+            "custom_rejection_reason",
             "custom_weekly_approval_status",
         ],
     )
+    ts_parent_map = {ts.name: ts for ts in all_timesheets}
 
     timesheet_map = defaultdict(list)
     emp_ts_by_start = defaultdict(lambda: defaultdict(list))
@@ -764,6 +766,7 @@ def build_chunk_context(employees: list, dates: list, parsed_filters: dict, sear
         "timesheet_map": timesheet_map,
         "emp_ts_by_start": emp_ts_by_start,
         "detail_by_parent": detail_by_parent,
+        "ts_parent_map": ts_parent_map,
         "task_details_dict": task_details_dict,
         "week_status_map": week_status_map,
         "overall_status_map": overall_status_map,
@@ -782,6 +785,7 @@ def build_employee_week_details(
     week_details = {}
     emp_ts_by_start = context["emp_ts_by_start"].get(employee_name, {})
     detail_by_parent = context["detail_by_parent"]
+    ts_parent_map = context["ts_parent_map"]
     task_details_dict = context["task_details_dict"]
     has_search_or_task_filters = context["has_search_or_task_filters"]
 
@@ -830,7 +834,11 @@ def build_employee_week_details(
                         "data": [],
                     }
 
-                tasks[task_name]["data"].append({field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS})
+                entry = {field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS}
+                parent_ts = ts_parent_map.get(ts_name)
+                entry["custom_approval_status"] = parent_ts.get("custom_approval_status") if parent_ts else None
+                entry["custom_rejection_reason"] = parent_ts.get("custom_rejection_reason") if parent_ts else None
+                tasks[task_name]["data"].append(entry)
 
         week_status = context["week_status_map"].get((employee_name, date_info["start_date"]), "Not Submitted")
         should_skip_empty = has_filters and skip_empty_weeks


### PR DESCRIPTION
## Description

timesheet api returns the rejected reason

## Relevant Technical Choices

added the response to both the endpoints `get_timesheet_data ` & `get_team_timesheet_data `.

## Testing Instructions

1. add a timesheet
2. reject with a reason and observe the api response

## Screenshot/Screencast

<img width="613" height="839" alt="image" src="https://github.com/user-attachments/assets/f7469bfe-4100-4b5d-be4f-c42cea1b484b" />
<img width="629" height="839" alt="image" src="https://github.com/user-attachments/assets/b425a498-e463-4be1-875f-a17948e9b584" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1741 