### PR TITLE
QA Fix: Enable filtering with `Like` and `Not Like` without `%` in composite filter

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -532,6 +532,31 @@ export const isCompleteFilterCondition = (f: FilterCondition): boolean => {
 };
 
 /**
+ * Normalizes the value of a "like" or "not like" filter condition by ensuring
+ * that it is wrapped in "%" wildcards, unless it already starts or ends with one.
+ */
+export const normalizeLikeFilterValue = (
+  operator: string,
+  value: FilterCondition["value"],
+) => {
+  if (!["like", "not like"].includes(operator) || typeof value !== "string") {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+
+  if (
+    !trimmedValue ||
+    trimmedValue.startsWith("%") ||
+    trimmedValue.endsWith("%")
+  ) {
+    return trimmedValue;
+  }
+
+  return `%${trimmedValue}%`;
+};
+
+/**
  * Builds native Frappe filters from the given composite filters.
  *
  * @param compositeFilters Array of FilterCondition objects.
@@ -546,7 +571,9 @@ export const buildFrappeFilters = (compositeFilters: FilterCondition[]) => {
       filter.fieldCategory,
       filter.field,
       filter.operator,
-      isNoValueOperator(filter.operator) ? null : filter.value,
+      isNoValueOperator(filter.operator)
+        ? null
+        : normalizeLikeFilterValue(filter.operator, filter.value),
     ]);
 };
 

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -539,7 +539,12 @@ export const normalizeLikeFilterValue = (
   operator: string,
   value: FilterCondition["value"],
 ) => {
-  if (!["like", "not like"].includes(operator) || typeof value !== "string") {
+  const normalizedOperator = operator.toLowerCase().trim();
+
+  if (
+    !["like", "not like"].includes(normalizedOperator) ||
+    typeof value !== "string"
+  ) {
     return value;
   }
 

--- a/frontend/packages/app/src/pages/allocations/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/utils.ts
@@ -14,6 +14,7 @@ import {
   expectatedHours,
   isCompleteFilterCondition,
   isNoValueOperator,
+  normalizeLikeFilterValue,
   pickAllowed,
 } from "@/lib/utils";
 import type { WorkingFrequency } from "@/types";
@@ -122,7 +123,9 @@ export function buildAllocationQueryFilters({
     filters.push([
       filter.field,
       filter.operator,
-      isNoValueOperator(filter.operator) ? null : (filter.value ?? null),
+      isNoValueOperator(filter.operator)
+        ? null
+        : (normalizeLikeFilterValue(filter.operator, filter.value) ?? null),
     ]);
   });
 

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/useRisksData.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/useRisksData.ts
@@ -11,6 +11,7 @@ import {
   hashString,
   isCompleteFilterCondition,
   isNoValueOperator,
+  normalizeLikeFilterValue,
 } from "@/lib/utils";
 import { useProjectDetail } from "@/pages/project-details/context";
 import type { RiskFilters, RiskItem, RiskSort, UserDetails } from "./types";
@@ -30,7 +31,9 @@ export function useRisksData(filters: RiskFilters, sort: RiskSort | null) {
       base.push([
         f.field,
         f.operator,
-        isNoValueOperator(f.operator) ? null : f.value,
+        isNoValueOperator(f.operator)
+          ? null
+          : normalizeLikeFilterValue(f.operator, f.value),
       ]);
     });
 

--- a/frontend/packages/app/src/pages/projects/utils.ts
+++ b/frontend/packages/app/src/pages/projects/utils.ts
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies.
  */
-import { isCompleteFilterCondition } from "@/lib/utils";
+import {
+  isCompleteFilterCondition,
+  normalizeLikeFilterValue,
+} from "@/lib/utils";
 import type { ProjectListFilters } from "./types";
 
 export const buildListFrappeFilters = (filters: ProjectListFilters) => {
@@ -18,7 +21,11 @@ export const buildListFrappeFilters = (filters: ProjectListFilters) => {
   if (filters.advanced) {
     filters.advanced.forEach((filter) => {
       if (isCompleteFilterCondition(filter)) {
-        out.push([filter.field, filter.operator, filter.value]);
+        out.push([
+          filter.field,
+          filter.operator,
+          normalizeLikeFilterValue(filter.operator, filter.value),
+        ]);
       }
     });
   }


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR updates composite filter behavior so `Like` and `Not Like` filters work as contains searches by default, matching how Frappe Desk handles filters.

Users no longer need to manually add `%` wildcards for normal partial matching. If a user does provide `%` at the start or end of the value, the entered pattern is preserved.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Added a shared `normalizeLikeFilterValue` helper that mirrors Frappe Desk behavior: it wraps string values with `%...%` for like / not like operators only when the value does not already start or end with `%`.

- Applied the helper across all composite filter serialization paths:
  - Timesheet filters
  - Allocation filters
  - Project list
  - Project risk advanced filters


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/94569cd5-dc26-4d08-a187-fc6f2d6a4bb9



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially Fixes #1633