### PR TITLE
fix: scope employee dropdown to project team and add tag filter

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -37,6 +37,7 @@ import { OverAllocationWarning } from "./overAllocationWarning";
 import { addAllocationFormSchema } from "./schema";
 import type { AddAllocationModalProps } from "./types";
 import { useOverAllocation } from "./useOverAllocation";
+import { useProjectTeamMemberIds } from "./useProjectTeamMemberIds";
 import { computeTotalHours } from "./utils";
 
 function AddAllocationModal({
@@ -235,6 +236,17 @@ function AddAllocationModal({
       selectedOption: selectedCustomerOption,
     });
 
+  const { memberIds: projectTeamMemberIds, isLoading: isProjectTeamLoading } =
+    useProjectTeamMemberIds({
+      projectId,
+      enabled: open,
+    });
+
+  const projectHasNoAssignedMembers =
+    Boolean(projectId) &&
+    !isProjectTeamLoading &&
+    projectTeamMemberIds.size === 0;
+
   const closeModal = useCallback(() => {
     onOpenChange(false);
     form.reset(mergedDefaultValues);
@@ -291,7 +303,7 @@ function AddAllocationModal({
   }, [open]);
 
   useEffect(() => {
-    if (isEmployeeLookupLoading || employeeSearch) {
+    if (isProjectTeamLoading) {
       return;
     }
 
@@ -300,21 +312,12 @@ function AddAllocationModal({
     }
     lastValidatedProjectIdRef.current = projectId;
 
-    const isEmployeeInProjectTeam = employeeOptions.some(
-      (option) => option.value === employeeId,
-    );
+    const isEmployeeInProjectTeam = projectTeamMemberIds.has(employeeId);
 
     if (projectId && employeeId && !isEmployeeInProjectTeam) {
       form.setFieldValue("employeeId", "");
     }
-  }, [
-    projectId,
-    employeeId,
-    employeeSearch,
-    employeeOptions,
-    isEmployeeLookupLoading,
-    form,
-  ]);
+  }, [projectId, employeeId, projectTeamMemberIds, isProjectTeamLoading, form]);
 
   const totalHours = computeTotalHours({
     hoursPerDay,
@@ -354,7 +357,7 @@ function AddAllocationModal({
           </label>
           <Combobox
             inputClassName="bg-surface-white h-8 border-outline-gray-2 text-ink-gray-7"
-            loading={isEmployeeLookupLoading}
+            loading={isEmployeeLookupLoading || isProjectTeamLoading}
             options={employeeOptions}
             searchValue={employeeSearch}
             placeholder="Select Employee"
@@ -362,6 +365,11 @@ function AddAllocationModal({
             disabled={isLockedAllocationMetadataEdit}
             onChange={(value) => field.handleChange(value as string)}
             onSearchChange={setEmployeeSearch}
+            emptyMessage={
+              projectHasNoAssignedMembers
+                ? "This project doesn't have any assigned team members"
+                : undefined
+            }
             openOnFocus
           />
           {!field.state.meta.isValid && (

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -71,12 +71,6 @@ function AddAllocationModal({
   );
 
   const allocationName = initialValues?.allocationName;
-  const selectedEmployeeOption = initialValues?.employeeId
-    ? {
-        label: initialValues.employeeLabel || initialValues.employeeId,
-        value: initialValues.employeeId,
-      }
-    : null;
   const selectedProjectOption = initialValues?.projectId
     ? {
         label: initialValues.projectLabel || initialValues.projectId,
@@ -194,7 +188,18 @@ function AddAllocationModal({
   });
 
   const projectId = useStore(form.store, (state) => state.values.projectId);
-  const lastValidatedProjectIdRef = useRef(projectId);
+  const employeeId = useStore(form.store, (state) => state.values.employeeId);
+  const lastValidatedProjectIdRef = useRef<string | undefined>(undefined);
+
+  const selectedEmployeeOption = employeeId
+    ? {
+        label:
+          employeeId === initialValues?.employeeId
+            ? initialValues.employeeLabel || employeeId
+            : employeeId,
+        value: employeeId,
+      }
+    : null;
 
   const { options: employeeOptions, isLoading: isEmployeeLookupLoading } =
     useEmployeeLookup({
@@ -276,7 +281,6 @@ function AddAllocationModal({
     form.store,
     (state) => state.values.includeWeekends,
   );
-  const employeeId = useStore(form.store, (state) => state.values.employeeId);
 
   const overAllocatedDays = useOverAllocation({
     employeeId,
@@ -294,6 +298,7 @@ function AddAllocationModal({
     }
 
     form.reset(mergedDefaultValues);
+    lastValidatedProjectIdRef.current = undefined;
   }, [form, mergedDefaultValues, open]);
 
   useEffect(() => {

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { mergeClassNames as cn } from "@next-pms/design-system";
 import { formatDateRange } from "@next-pms/design-system/date";
 import {
@@ -89,45 +89,6 @@ function AddAllocationModal({
         value: initialValues.customer,
       }
     : null;
-
-  const { options: employeeOptions, isLoading: isEmployeeLookupLoading } =
-    useEmployeeLookup({
-      shouldFetch: open,
-      pageSize: 20,
-      query: employeeSearch,
-      selectedOption: selectedEmployeeOption,
-      formatOption: (option) => ({
-        ...option,
-        icon: (
-          <Avatar
-            size="xs"
-            shape="circle"
-            image={option.image}
-            label={option.label}
-          />
-        ),
-      }),
-    });
-
-  const { options: projectOptions, isLoading: isProjectLookupLoading } =
-    useProjectLookup({
-      shouldFetch: open,
-      filters: [
-        ["status", "!=", "Cancelled"],
-        ["is_active", "=", "Yes"],
-      ],
-      pageSize: 20,
-      query: projectSearch,
-      selectedOption: selectedProjectOption,
-    });
-
-  const { options: customerOptions, isLoading: isCustomerLookupLoading } =
-    useCustomerLookup({
-      shouldFetch: open,
-      pageSize: 20,
-      query: customerSearch,
-      selectedOption: selectedCustomerOption,
-    });
 
   const mergedDefaultValues = useMemo(() => {
     const initialFormValues = {
@@ -231,6 +192,49 @@ function AddAllocationModal({
     },
   });
 
+  const projectId = useStore(form.store, (state) => state.values.projectId);
+  const lastValidatedProjectIdRef = useRef(projectId);
+
+  const { options: employeeOptions, isLoading: isEmployeeLookupLoading } =
+    useEmployeeLookup({
+      shouldFetch: open,
+      pageSize: 20,
+      query: employeeSearch,
+      projects: projectId ? [projectId] : undefined,
+      selectedOption: selectedEmployeeOption,
+      formatOption: (option) => ({
+        ...option,
+        icon: (
+          <Avatar
+            size="xs"
+            shape="circle"
+            image={option.image}
+            label={option.label}
+          />
+        ),
+      }),
+    });
+
+  const { options: projectOptions, isLoading: isProjectLookupLoading } =
+    useProjectLookup({
+      shouldFetch: open,
+      filters: [
+        ["status", "!=", "Cancelled"],
+        ["is_active", "=", "Yes"],
+      ],
+      pageSize: 20,
+      query: projectSearch,
+      selectedOption: selectedProjectOption,
+    });
+
+  const { options: customerOptions, isLoading: isCustomerLookupLoading } =
+    useCustomerLookup({
+      shouldFetch: open,
+      pageSize: 20,
+      query: customerSearch,
+      selectedOption: selectedCustomerOption,
+    });
+
   const closeModal = useCallback(() => {
     onOpenChange(false);
     form.reset(mergedDefaultValues);
@@ -286,6 +290,32 @@ function AddAllocationModal({
     setCustomerSearch("");
   }, [open]);
 
+  useEffect(() => {
+    if (isEmployeeLookupLoading || employeeSearch) {
+      return;
+    }
+
+    if (lastValidatedProjectIdRef.current === projectId) {
+      return;
+    }
+    lastValidatedProjectIdRef.current = projectId;
+
+    const isEmployeeInProjectTeam = employeeOptions.some(
+      (option) => option.value === employeeId,
+    );
+
+    if (projectId && employeeId && !isEmployeeInProjectTeam) {
+      form.setFieldValue("employeeId", "");
+    }
+  }, [
+    projectId,
+    employeeId,
+    employeeSearch,
+    employeeOptions,
+    isEmployeeLookupLoading,
+    form,
+  ]);
+
   const totalHours = computeTotalHours({
     hoursPerDay,
     recurrence,
@@ -304,6 +334,7 @@ function AddAllocationModal({
 
       form.setFieldValue("projectId", nextProjectId);
       setProjectSearch("");
+      setEmployeeSearch("");
 
       if (selectedProject?.customer) {
         form.setFieldValue("customer", selectedProject.customer);

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useProjectTeamMemberIds.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useProjectTeamMemberIds.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies.
+ */
+import { useMemo } from "react";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+interface UseProjectTeamMemberIdsOptions {
+  projectId: string;
+  enabled: boolean;
+}
+
+interface ProjectSidebarMembersResponse {
+  message?: {
+    members?: { employee: string }[];
+  };
+}
+
+/**
+ * Resolves the complete employee-id set for a project's team via the project
+ * sidebar endpoint (same source as the project "About" sidebar). Used to
+ * validate "is this employee on the project's team" without relying on the
+ * employee lookup dropdown's options, which are capped to a single page of
+ * results and therefore an unsafe/incomplete source for a membership check.
+ */
+export function useProjectTeamMemberIds({
+  projectId,
+  enabled,
+}: UseProjectTeamMemberIdsOptions) {
+  const { data, isLoading } = useFrappeGetCall<ProjectSidebarMembersResponse>(
+    "next_pms.next_projects.api.project.get_project_sidebar",
+    { project: projectId },
+    enabled && projectId ? undefined : false,
+  );
+
+  const memberIds = useMemo(
+    () =>
+      new Set((data?.message?.members ?? []).map((member) => member.employee)),
+    [data],
+  );
+
+  return { memberIds, isLoading };
+}

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useProjectTeamMemberIds.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useProjectTeamMemberIds.ts
@@ -29,7 +29,7 @@ export function useProjectTeamMemberIds({
   const { data, isLoading } = useFrappeGetCall<ProjectSidebarMembersResponse>(
     "next_pms.next_projects.api.project.get_project_sidebar",
     { project: projectId },
-    enabled && projectId ? undefined : false,
+    enabled && projectId ? undefined : null,
   );
 
   const memberIds = useMemo(

--- a/frontend/packages/app/src/pages/allocations/team/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/team/constants.ts
@@ -17,6 +17,11 @@ export const teamAllocationFilters: FilterField[] = [
     type: "string",
   },
   {
+    name: "tag",
+    label: "Tag",
+    type: "string",
+  },
+  {
     name: "business_unit",
     label: "Business Unit",
     type: "string",

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/projectRateModal/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/projectRateModal/index.tsx
@@ -75,6 +75,12 @@ export function ProjectRateModal({
       projects: [projectId],
     });
 
+  const projectHasNoAssignedMembers =
+    Boolean(projectId) &&
+    !isEmployeeLookupLoading &&
+    !employeeSearch &&
+    employeeOptions.length === 0;
+
   const employeeOptionsWithAvatars = useMemo(
     () =>
       employeeOptions.map((opt) => ({
@@ -145,6 +151,11 @@ export function ProjectRateModal({
                 value={field.state.value}
                 onChange={(value) => field.handleChange(value as string)}
                 onSearchChange={setEmployeeSearch}
+                emptyMessage={
+                  projectHasNoAssignedMembers
+                    ? "This project doesn't have any assigned team members"
+                    : undefined
+                }
                 openOnFocus
               />
               {!field.state.meta.isValid && (

--- a/next_pms/tests/timesheet/api/test_filter_employees.py
+++ b/next_pms/tests/timesheet/api/test_filter_employees.py
@@ -1,0 +1,126 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.timesheet.api import filter_employees
+
+SHARED_PROJECT_NAME = "Filter Employees Shared Project"
+EMPTY_PROJECT_NAME = "Filter Employees Empty Project"
+
+MEMBER_A_NAME = "FE Member Alpha"
+MEMBER_B_NAME = "FE Member Beta"
+MEMBER_A_USER = "fe.member.alpha@example.com"
+MEMBER_B_USER = "fe.member.beta@example.com"
+
+
+class TestFilterEmployeesMembership(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        cls.user_a = cls._make_user(MEMBER_A_USER)
+        cls.user_b = cls._make_user(MEMBER_B_USER)
+        cls.member_a = cls._make_employee(MEMBER_A_NAME, cls.user_a)
+        cls.member_b = cls._make_employee(MEMBER_B_NAME, cls.user_b)
+
+        # Shared project → member A only. Empty project → nobody.
+        cls.shared_project = cls._make_project(SHARED_PROJECT_NAME)
+        cls.empty_project = cls._make_project(EMPTY_PROJECT_NAME)
+        frappe.share.add("Project", cls.shared_project, cls.user_a, read=1)
+
+        frappe.clear_cache()
+
+    @classmethod
+    def _make_user(cls, email):
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                    "user_type": "System User",
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        return email
+
+    @classmethod
+    def _make_employee(cls, employee_name, user_id):
+        existing = frappe.db.get_value("Employee", {"employee_name": employee_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Employee",
+                    "naming_series": "EMP-",
+                    "first_name": employee_name,
+                    "company": cls.company,
+                    "gender": "Female",
+                    "date_of_birth": "1990-05-08",
+                    "date_of_joining": "2013-01-01",
+                    "status": "Active",
+                    "employment_type": "Intern",
+                    "leave_approver": "Administrator",
+                    "user_id": user_id,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project(cls, project_name):
+        existing = frappe.db.get_value("Project", {"project_name": project_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": project_name,
+                    "company": cls.company,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def _names(self, employees):
+        return {employee["name"] for employee in employees}
+
+    def _active_count(self):
+        return frappe.db.count("Employee", {"status": "Active"})
+
+    def test_project_with_no_shares_returns_empty(self):
+        employees, count = filter_employees(project=[self.empty_project], ignore_permissions=True)
+        self.assertEqual(employees, [])
+        self.assertEqual(count, 0)
+
+    def test_project_with_shares_returns_only_shared_employees(self):
+        employees, count = filter_employees(project=[self.shared_project], ignore_permissions=True)
+        self.assertEqual(self._names(employees), {self.member_a})
+        self.assertEqual(count, 1)
+
+    def test_no_membership_filter_returns_all_active(self):
+        employees, count = filter_employees(page_length=self._active_count(), ignore_permissions=True)
+        self.assertEqual(count, self._active_count())
+        self.assertIn(self.member_a, self._names(employees))
+        self.assertIn(self.member_b, self._names(employees))
+
+    def test_explicit_empty_ids_returns_empty(self):
+        employees, count = filter_employees(ids=[], ignore_permissions=True)
+        self.assertEqual(employees, [])
+        self.assertEqual(count, 0)
+
+    def test_ids_none_does_not_restrict(self):
+        _, count = filter_employees(ids=None, page_length=self._active_count(), ignore_permissions=True)
+        self.assertEqual(count, self._active_count())
+
+    def test_project_and_ids_are_unioned(self):
+        # shared_project → member A; ids → member B. Union = both.
+        employees, count = filter_employees(project=[self.shared_project], ids=[self.member_b], ignore_permissions=True)
+        self.assertEqual(self._names(employees), {self.member_a, self.member_b})
+        self.assertEqual(count, 2)

--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -70,13 +70,7 @@ def filter_employees(
         status (list | str | None): JSON-encoded list of statuses (e.g. ["Active"]).
             Defaults to None (no status filter unless set by caller).
         ids (list[str] | None): Explicit list of employee IDs to restrict results to.
-            Takes priority alongside other filters (ANDed). Defaults to None.
-            Note: `ids`, `project`, `user_group`, and `roles` are unioned together
-            (an employee matching any one of them is included) — if one of these
-            is provided but resolves to zero employees (e.g. a project with no
-            assigned team members), the result is still restricted to that empty
-            set rather than falling back to "no restriction" (see
-            `has_membership_filter` below).
+            Defaults to None.
         reports_to (list | str | None): Employee ID or JSON-encoded list of IDs; restricts
             to direct reports of any of the given managers. Defaults to None.
         business_unit (list | str | None): JSON-encoded list of business unit values
@@ -135,7 +129,7 @@ def filter_employees(
     # no assigned team members) still restricts the query to that empty set,
     # instead of silently skipping the "name in employee_ids" filter below and
     # returning every employee.
-    has_membership_filter = bool(ids)
+    has_membership_filter = ids is not None
     filters = {"status": ["in", ["Active"]]}
     or_filters = {}
 

--- a/next_pms/timesheet/api/__init__.py
+++ b/next_pms/timesheet/api/__init__.py
@@ -71,6 +71,12 @@ def filter_employees(
             Defaults to None (no status filter unless set by caller).
         ids (list[str] | None): Explicit list of employee IDs to restrict results to.
             Takes priority alongside other filters (ANDed). Defaults to None.
+            Note: `ids`, `project`, `user_group`, and `roles` are unioned together
+            (an employee matching any one of them is included) — if one of these
+            is provided but resolves to zero employees (e.g. a project with no
+            assigned team members), the result is still restricted to that empty
+            set rather than falling back to "no restriction" (see
+            `has_membership_filter` below).
         reports_to (list | str | None): Employee ID or JSON-encoded list of IDs; restricts
             to direct reports of any of the given managers. Defaults to None.
         business_unit (list | str | None): JSON-encoded list of business unit values
@@ -124,6 +130,12 @@ def filter_employees(
     if extra_fields:
         fields.extend(extra_fields)
     employee_ids = []
+    # Set whenever ids/project/user_group/roles is actually provided, so a
+    # filter that legitimately resolves to zero employees (e.g. a project with
+    # no assigned team members) still restricts the query to that empty set,
+    # instead of silently skipping the "name in employee_ids" filter below and
+    # returning every employee.
+    has_membership_filter = bool(ids)
     filters = {"status": ["in", ["Active"]]}
     or_filters = {}
 
@@ -180,6 +192,7 @@ def filter_employees(
         employee_ids.extend(ids)
 
     if project and len(project) > 0:
+        has_membership_filter = True
         project_employee = get_all(
             "DocShare",
             filters={"share_doctype": "Project", "share_name": ["IN", project]},
@@ -189,6 +202,7 @@ def filter_employees(
         employee_ids.extend(ids)
 
     if user_group and len(user_group) > 0:
+        has_membership_filter = True
         users = get_all("User Group Member", pluck="user", filters={"parent": ["in", user_group]})
         ids = [get_value("Employee", {"user_id": user}, cache=True) for user in users]
         employee_ids.extend(ids)
@@ -197,6 +211,7 @@ def filter_employees(
         roles = json.loads(roles)
 
     if roles and len(roles) > 0:
+        has_membership_filter = True
         user_ids = get_all(
             "Has Role",
             filters={"role": ["in", roles], "parenttype": "User", "parent": ["!=", "Administrator"]},
@@ -205,7 +220,7 @@ def filter_employees(
         ids = get_all("Employee", filters={"user_id": ["in", user_ids]}, pluck="name")
         employee_ids.extend(ids)
 
-    if len(employee_ids) > 0:
+    if has_membership_filter:
         filters["name"] = ["in", employee_ids]
 
     if ignore_default_filters:


### PR DESCRIPTION
## Description
Frontend
- Add a "Tag" filter option to the team allocation composite filter
- Scope the employee dropdown in the add/edit allocation modal to the selected project's shared members, instead of listing all employees
- Auto-clear the selected employee if it's no longer part of the newly selected project's team

Backend: 
- filter_employees no longer falls back to "all employees" on an empty membership filter

## Screenshot/Screencast
<img width="2034" height="718" alt="image" src="https://github.com/user-attachments/assets/bdb875e9-d477-4494-b3ce-4a6a6083c16d" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially Fixes: https://github.com/rtCamp/next-pms/issues/1755