### PR TITLE
fix: make progress bar segmented

### DIFF
--- a/frontend/packages/app/src/pages/project-details/about/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/about/index.tsx
@@ -117,10 +117,12 @@ function AboutThisProjectContent({ className }: { className: string }) {
             </div>
             <BudgetBurnBar
               value={sidebar.burn.cost_accrued}
+              primaryTooltip="Cost Accrued"
               secondaryValue={sidebar.burn.cost_forecasted}
+              secondaryTooltip="Cost Forcasted"
               markerValue={sidebar.burn.target_cost}
+              markerTooltip="Target Cost"
               maxValue={sidebar.burn.total_budget}
-              variant="burn"
             />
           </div>
         </Section>

--- a/frontend/packages/design-system/src/components/budget-burn-bar/index.tsx
+++ b/frontend/packages/design-system/src/components/budget-burn-bar/index.tsx
@@ -1,9 +1,18 @@
 import React from "react";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { cva } from "class-variance-authority";
+import { scale } from "./utils";
 import { mergeClassNames as cn } from "../../utils";
-import ProgressBar, { type ProgressBarSize } from "../progress-bar";
 
-const indicatorVariants = cva("", {
+const SIZE = {
+  sm: "h-1",
+  md: "h-2",
+  lg: "h-3",
+} as const;
+
+export type BudgetBurnBarSize = keyof typeof SIZE;
+
+const primarySegmentVariants = cva("rounded-full cursor-pointer", {
   variants: {
     tone: {
       burn: "bg-surface-green-5",
@@ -14,7 +23,7 @@ const indicatorVariants = cva("", {
   },
 });
 
-const secondaryVariants = cva("", {
+const secondarySegmentVariants = cva("rounded-full cursor-pointer", {
   variants: {
     tone: {
       burn: "bg-surface-green-3",
@@ -38,49 +47,98 @@ export type BudgetBurnBarProps = {
   secondaryValue?: number;
   maxValue?: number;
   markerValue?: number;
-  size?: ProgressBarSize;
-  variant?: BudgetBurnVariant;
+  primaryTooltip?: React.ReactNode;
+  secondaryTooltip?: React.ReactNode;
+  markerTooltip?: React.ReactNode;
+  size?: BudgetBurnBarSize;
   className?: string;
 };
 
+const SegmentTooltip = ({
+  content,
+  children,
+}: {
+  content?: React.ReactNode;
+  children: React.ReactElement;
+}) =>
+  content ? (
+    typeof content === "string" ? (
+      <Tooltip text={content}>{children}</Tooltip>
+    ) : (
+      <Tooltip body={content}>{children}</Tooltip>
+    )
+  ) : (
+    children
+  );
+
 const BudgetBurnBar: React.FC<BudgetBurnBarProps> = ({
   value,
-  secondaryValue,
+  secondaryValue = 0,
   maxValue = 100,
-  markerValue,
-  size,
-  variant = "tiered",
+  markerValue = 0,
+  primaryTooltip,
+  secondaryTooltip,
+  markerTooltip,
+  size = "md",
   className,
 }) => {
-  const percent = maxValue > 0 ? (value / maxValue) * 100 : 0;
-  const tone = variant === "tiered" ? budgetTier(percent) : "burn";
-  const marker =
-    markerValue !== undefined && markerValue > 0 && markerValue < maxValue
-      ? (markerValue / maxValue) * 100
-      : null;
+  const primaryPercent = scale(value, maxValue);
+  const secondaryPercent = scale(secondaryValue, maxValue);
+  const markerPercent = scale(markerValue, maxValue);
+
+  const tierPercent = scale(value + secondaryValue, markerValue || maxValue);
+
+  const tone = budgetTier(tierPercent);
 
   return (
     <div className={cn("relative w-full", className)}>
-      <ProgressBar
-        value={value}
-        secondaryValue={secondaryValue}
-        maxValue={maxValue}
-        size={size}
-        indicatorClassName={indicatorVariants({ tone })}
-        secondaryIndicatorClassName={secondaryVariants({ tone })}
-      />
-      {marker !== null && (
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={maxValue}
+        aria-valuenow={Math.max(0, Math.min(maxValue, value))}
+        className={cn(
+          "flex w-full items-stretch gap-px rounded-full bg-surface-gray-2",
+          SIZE[size],
+        )}
+      >
+        {primaryPercent > 0 && (
+          <SegmentTooltip content={primaryTooltip}>
+            <div
+              className={primarySegmentVariants({ tone })}
+              style={{ width: `${primaryPercent}%` }}
+            />
+          </SegmentTooltip>
+        )}
+        {secondaryPercent > 0 && (
+          <SegmentTooltip content={secondaryTooltip}>
+            <div
+              className={secondarySegmentVariants({ tone })}
+              style={{ width: `${secondaryPercent}%` }}
+            />
+          </SegmentTooltip>
+        )}
+      </div>
+      {markerPercent > 0 && (
         <>
           <span
             aria-hidden
             className="absolute bottom-[calc(100%+1px)] h-1 w-px -translate-x-1/2 bg-outline-gray-3"
-            style={{ left: `${marker}%` }}
+            style={{ left: `${markerPercent}%` }}
           />
           <span
             aria-hidden
             className="absolute top-[calc(100%+1px)] h-1 w-px -translate-x-1/2 bg-outline-gray-3"
-            style={{ left: `${marker}%` }}
+            style={{ left: `${markerPercent}%` }}
           />
+          {markerTooltip && (
+            <SegmentTooltip content={markerTooltip}>
+              <span
+                className="absolute -inset-y-1 w-1.5 -translate-x-1/2"
+                style={{ left: `${markerPercent}%` }}
+              />
+            </SegmentTooltip>
+          )}
         </>
       )}
     </div>

--- a/frontend/packages/design-system/src/components/budget-burn-bar/utils.ts
+++ b/frontend/packages/design-system/src/components/budget-burn-bar/utils.ts
@@ -1,0 +1,9 @@
+export const scale = (v: number, maxValue: number) => {
+  if (maxValue <= 0) {
+    return 0;
+  } else if (v > maxValue) {
+    return 100;
+  } else {
+    return (v / maxValue) * 100;
+  }
+};

--- a/frontend/packages/design-system/src/components/index.ts
+++ b/frontend/packages/design-system/src/components/index.ts
@@ -23,6 +23,7 @@ export {
 export {
   default as BudgetBurnBar,
   type BudgetBurnBarProps,
+  type BudgetBurnBarSize,
   type BudgetBurnVariant,
 } from "./budget-burn-bar";
 export {


### PR DESCRIPTION
## Description

- Makes budget burn bar used in sidebar and project list page segmented.
- Add tooltips ( only of about section ).
- Tiered behaviour( showing progress in red/amber/green ) now depends on target cost. Total budget will be used in case target cost is not set.

## Screenshot/Screencast

<img width="817" height="133" alt="Screenshot 2026-07-09 at 1 05 29 PM" src="https://github.com/user-attachments/assets/0c682c73-a59f-4bae-b443-61798bb9ba39" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1759