### PR TITLE
QA Fix: Allocation page issues

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -657,16 +657,22 @@ function AddAllocationModal({
                   <label className="block text-base text-ink-gray-5">
                     Repeat for
                   </label>
-                  <TextInput
-                    type="number"
-                    size="md"
-                    variant="outline"
-                    disabled={variant === "edit"}
-                    value={field.state.value ?? ""}
-                    onChange={(e) =>
-                      field.handleChange(Math.max(1, Number(e.target.value)))
-                    }
-                  />
+                  <div className="relative">
+                    <TextInput
+                      type="number"
+                      size="md"
+                      variant="outline"
+                      disabled={variant === "edit"}
+                      value={field.state.value ?? ""}
+                      onChange={(e) =>
+                        field.handleChange(Math.max(1, Number(e.target.value)))
+                      }
+                      inputClassName="pr-13"
+                    />
+                    <span className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-gray-5 text-sm">
+                      {field.state.value === 1 ? "week" : "weeks"}
+                    </span>
+                  </div>
                   {!field.state.meta.isValid && (
                     <ErrorMessage
                       message={field.state.meta.errors[0]?.message}

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/overAllocationWarning.tsx
@@ -36,11 +36,11 @@ export function OverAllocationWarning({
   );
 
   return (
-    <Accordion.Root className="bg-(--color-violet-50) rounded-lg overflow-hidden">
+    <Accordion.Root className="bg-(--color-violet-50) dark:bg-(--color-violet-900)/20 rounded-lg overflow-hidden">
       <Accordion.Item value="details">
         <Accordion.Header render={<div />}>
           <Accordion.Trigger className="w-full flex items-center gap-2 px-2.5 py-2 group">
-            <AlertTriangle className="size-4 shrink-0 text-(--color-violet-700)" />
+            <AlertTriangle className="size-4 shrink-0 text-ink-violet-4 bg-surface-v" />
             <p className="flex-1 min-w-0 text-xs text-ink-gray-8 text-left">
               This allocation causes over-allocation on {dayCount}{" "}
               {dayCount === 1 ? "day" : "days"} (+{formatHours(totalExcess)}{" "}
@@ -50,7 +50,7 @@ export function OverAllocationWarning({
           </Accordion.Trigger>
         </Accordion.Header>
         <Accordion.Panel className="accordion-panel">
-          <div className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8 max-h-24 overflow-y-scroll scrollbar-thin [scrollbar-gutter:stable]">
+          <div className="flex flex-col gap-1.5 px-2.5 pb-2 pl-8 max-h-24 overflow-y-scroll scrollbar-thin scrollbar-gutter-stable">
             {overAllocatedDays.map((day) => (
               <div key={day.date} className="flex items-center gap-2">
                 <span className="text-xs text-ink-gray-7">
@@ -58,7 +58,7 @@ export function OverAllocationWarning({
                 </span>
                 <span
                   className={cn(
-                    "bg-surface-violet-1 text-(--color-violet-700)",
+                    "bg-surface-violet-1 text-ink-violet-4",
                     "text-xs font-medium px-1.5 py-0.5 rounded-md",
                   )}
                 >

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -70,6 +70,7 @@ export function GanttAllocationBar({
 
   const left = allocation.barOffset + headerWidth;
   const { width, fullNumDays } = allocation;
+  const canResize = resizable && !allocation.recurrenceId;
   const [previewGeometry, setPreviewGeometry] = useState({ left, width });
   const [previewOpen, setPreviewOpen] = useState(false);
   const isModified =
@@ -317,13 +318,13 @@ export function GanttAllocationBar({
             billable={allocation.billable}
             showOutline={isModified}
             renderFloatingLabel={isModified ? renderFloatingLabel : undefined}
-            resizable={resizable}
+            resizable={canResize}
             snapUnitPx={columnWidth}
             tabIndex={0}
             minLeft={bounds.minLeft}
             maxRight={bounds.maxRight}
             onKeyDown={handleKeyDown}
-            onResizeEnd={handleResizeEnd}
+            onResizeEnd={canResize ? handleResizeEnd : undefined}
           />
         }
       />

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import React from "react";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { TimeOff } from "@rtcamp/frappe-ui-react/icons";
 import { cva, type VariantProps } from "class-variance-authority";
 
@@ -76,6 +77,7 @@ interface GanttBarProps
   onResizeEnd?: (geometry: GanttBarGeometry) => void;
   renderLabel?: (state: GanttBarRenderState) => React.ReactNode;
   renderFloatingLabel?: (state: GanttBarRenderState) => React.ReactNode;
+  showInlineLabel?: boolean;
   trailingLabel?: React.ReactNode;
   trailingLabelVariant?: GanttBarTrailingLabelVariant;
 }
@@ -98,6 +100,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
       onResizeEnd,
       renderLabel,
       renderFloatingLabel,
+      showInlineLabel = true,
       trailingLabel,
       trailingLabelVariant,
       onClick,
@@ -152,18 +155,20 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
           <CrosshatchLayer variant={variant ?? "allocation"} />
         )}
         {isTimeoff ? (
-          <>
-            <TimeOff
-              className="shrink-0 size-4 text-ink-gray-5"
-              size={16}
-              strokeWidth={1.5}
-            />
-            {label ? (
-              <span className="text-[13px] font-medium tracking-[0.02em] truncate">
-                {label}
-              </span>
-            ) : null}
-          </>
+          <Tooltip text={label}>
+            <div className="absolute inset-0 px-2.5 py-2 w-full flex items-center justify-center gap-1.5">
+              <TimeOff
+                className="shrink-0 size-4 text-ink-gray-5"
+                size={16}
+                strokeWidth={1.5}
+              />
+              {showInlineLabel && label ? (
+                <span className="text-[13px] font-medium tracking-[0.02em] truncate">
+                  {label}
+                </span>
+              ) : null}
+            </div>
+          </Tooltip>
         ) : (
           <>
             <span className="min-w-0 flex-1 overflow-hidden text-[13px] font-medium tracking-[0.02em] truncate">

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
@@ -51,12 +51,13 @@ export function GanttMemberSummaryBar({
   if (summary.type === "timeoff") {
     const leaveDays =
       differenceInCalendarDays(summary.endDate, summary.startDate) + 1;
-    const leaveLabel = leaveDays > 2 ? `${leaveDays} days` : "";
+    const leaveLabel = `${leaveDays} ${leaveDays === 1 ? "day" : "days"} off`;
 
     return (
       <GanttBar
         variant="timeoff"
         label={leaveLabel}
+        showInlineLabel={leaveDays > 1}
         left={left}
         width={width}
       />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -79,7 +79,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
           key={`${week}-${index}`}
           colSpan={daysPerWeek}
           className={cn(
-            "overflow-hidden transition-[height] duration-200 ease-in-out",
+            "overflow-hidden transition-[height] duration-200 ease-in-out bg-surface-gray-1/50",
             { "border-r border-outline-gray-1": isExpanded },
           )}
           style={{ height: animatedRowHeight }}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -169,7 +169,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
               key={i}
               colSpan={daysPerWeek}
               className={cn(
-                "overflow-hidden transition-[height] duration-200 ease-in-out",
+                "overflow-hidden transition-[height] duration-200 ease-in-out bg-surface-gray-1/50",
                 { "border-r border-b border-outline-gray-1": childRowsVisible },
               )}
               style={{ height: addProjectRowHeight }}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRow.tsx
@@ -86,7 +86,7 @@ export const GanttProjectRow: React.FC<GanttProjectRowProps> = ({
           key={i}
           colSpan={daysPerWeek}
           className={cn(
-            "overflow-hidden transition-[height] duration-200 ease-in-out",
+            "overflow-hidden transition-[height] duration-200 ease-in-out bg-surface-gray-1/50",
             { "border-r border-outline-gray-1": isExpanded },
           )}
           style={{ height: animatedRowHeight }}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -191,7 +191,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
               key={`${week}-${index}`}
               colSpan={daysPerWeek}
               className={cn(
-                "overflow-hidden transition-[height] duration-200 ease-in-out",
+                "overflow-hidden transition-[height] duration-200 ease-in-out bg-surface-gray-1/50",
                 { "border-r border-b border-outline-gray-1": childRowsVisible },
               )}
               style={{ height: addMemberRowHeight }}


### PR DESCRIPTION


## Description

<!-- What do we want to achieve with this PR? -->
* Added a **"week/weeks"** label to the **Repeat For** field in the Add Allocation modal to make it clear that the value represents the number of weeks, not days.
* Disabled resizing of recurring allocation bars, as resizing recurring allocations is already restricted in the Edit Allocation modal.
* Added a tooltip to the Time Off bar on the Allocation pages so users can view the full leave duration when the text is truncated.
* Added the missing background color to expanded allocation rows to match the design and improve the visibility of allocation bars in dark mode.
* Fixes dark mode colors for overallocation warning



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/21a93cc8-4bdb-43c4-8971-9d6b94fe3f8c



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1731 #1736 #1762