### PR TITLE
fix: label for project popover card

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
@@ -29,7 +29,7 @@ function GanttProjectHoverCard({
   const dateRange = project.projectDateRange ?? project.dateRange;
   const weeklyCapacityLabel =
     project.weeklyCapacity !== undefined
-      ? `${formatHours(project.weeklyCapacity)}h/week`
+      ? `${formatHours(project.weeklyCapacity)}h remaining`
       : undefined;
   const hasDetails =
     project.client ||


### PR DESCRIPTION
## Description
- Fixes label for project popover card - changes "### h/week" to "### h remaining"

## Screenshot/Screencast
<img width="1158" height="688" alt="image" src="https://github.com/user-attachments/assets/a48b0b09-83b9-4d41-b425-3710b64f481c" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially addresses #1763