### PR TITLE
fix: scroll allocations timeline back to current week on Today click

### DIFF
--- a/frontend/packages/app/src/components/infiniteScroll.tsx
+++ b/frontend/packages/app/src/components/infiniteScroll.tsx
@@ -46,6 +46,7 @@ const InfiniteScroll = ({
   useEffect(() => {
     if (containerRef.current) {
       containerRef.current.scrollTop = 0;
+      containerRef.current.scrollLeft = 0;
     }
   }, [scrollResetKey]);
 

--- a/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
@@ -34,6 +34,9 @@ export const AllocationsProjectTable = () => {
   const querySignature = useAllocationsProject(
     ({ state }) => state.querySignature,
   );
+  const todayResetKey = useAllocationsProject(
+    ({ state }) => state.todayResetKey,
+  );
   const loadMore = useAllocationsProject(({ actions }) => actions.loadMore);
 
   const ganttRef = useUnsavedChangesSource();
@@ -61,7 +64,7 @@ export const AllocationsProjectTable = () => {
             isLoading={isQueryLoading || isNextPageLoading}
             hasMore={hasMore}
             verticalLodMore={loadMore}
-            scrollResetKey={querySignature}
+            scrollResetKey={`${querySignature}:${todayResetKey}`}
             enableScrollArea
             showScrollbar={false}
             className={cn("w-full h-full", {

--- a/frontend/packages/app/src/pages/allocations/project/context.ts
+++ b/frontend/packages/app/src/pages/allocations/project/context.ts
@@ -17,6 +17,7 @@ export interface AllocationsProjectContextProps {
     isNextPageLoading: boolean;
     hasMore: boolean;
     querySignature: string;
+    todayResetKey: number;
     search: string;
     duration: AllocationsDuration;
     allocationsType: string[];
@@ -46,6 +47,7 @@ export const AllocationsProjectContext =
       isNextPageLoading: false,
       hasMore: true,
       querySignature: "",
+      todayResetKey: 0,
       search: "",
       duration: "this-quarter",
       allocationsType: [],

--- a/frontend/packages/app/src/pages/allocations/project/provider.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 import { format } from "date-fns";
@@ -42,6 +42,7 @@ export function AllocationsProjectProvider({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParam = searchParams.get(SEARCH_PARAM_KEY) ?? "";
+  const [todayResetKey, setTodayResetKey] = useState(0);
 
   const allocationTypeValues = useMemo(
     () => projectAllocationsTypeOptions.map((option) => option.value),
@@ -180,6 +181,7 @@ export function AllocationsProjectProvider({
 
   const handleToday = useCallback(() => {
     updateSearchParams({ [DATE_PARAM_KEY]: undefined });
+    setTodayResetKey((key) => key + 1);
   }, [updateSearchParams]);
 
   const handleRefresh = useCallback(
@@ -197,6 +199,7 @@ export function AllocationsProjectProvider({
         isNextPageLoading,
         hasMore,
         querySignature,
+        todayResetKey,
         search: searchParam,
         duration,
         allocationsType,
@@ -223,6 +226,7 @@ export function AllocationsProjectProvider({
       isNextPageLoading,
       hasMore,
       querySignature,
+      todayResetKey,
       searchParam,
       duration,
       allocationsType,

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -34,6 +34,7 @@ export const AllocationsTeamTable = () => {
   const querySignature = useAllocationsTeam(
     ({ state }) => state.querySignature,
   );
+  const todayResetKey = useAllocationsTeam(({ state }) => state.todayResetKey);
   const loadMore = useAllocationsTeam(({ actions }) => actions.loadMore);
 
   const ganttRef = useUnsavedChangesSource();
@@ -63,7 +64,7 @@ export const AllocationsTeamTable = () => {
             isLoading={isQueryLoading || isNextPageLoading}
             hasMore={hasMore}
             verticalLodMore={loadMore}
-            scrollResetKey={querySignature}
+            scrollResetKey={`${querySignature}:${todayResetKey}`}
             enableScrollArea
             showScrollbar={false}
             className={cn("w-full h-full", {

--- a/frontend/packages/app/src/pages/allocations/team/context.ts
+++ b/frontend/packages/app/src/pages/allocations/team/context.ts
@@ -17,6 +17,7 @@ export interface AllocationsTeamContextProps {
     isNextPageLoading: boolean;
     hasMore: boolean;
     querySignature: string;
+    todayResetKey: number;
     designation: string[];
     search: string;
     duration: AllocationsDuration;
@@ -48,6 +49,7 @@ export const AllocationsTeamContext =
       isNextPageLoading: false,
       hasMore: true,
       querySignature: "",
+      todayResetKey: 0,
       search: "",
       duration: "this-quarter",
       allocationsType: [],

--- a/frontend/packages/app/src/pages/allocations/team/provider.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 import { format } from "date-fns";
@@ -44,6 +44,7 @@ export function AllocationsTeamProvider({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParam = searchParams.get(SEARCH_PARAM_KEY) ?? "";
+  const [todayResetKey, setTodayResetKey] = useState(0);
 
   const allocationTypeValues = useMemo(
     () => teamAllocationsTypeOptions.map((option) => option.value),
@@ -200,6 +201,7 @@ export function AllocationsTeamProvider({
 
   const handleToday = useCallback(() => {
     updateSearchParams({ [DATE_PARAM_KEY]: undefined });
+    setTodayResetKey((key) => key + 1);
   }, [updateSearchParams]);
 
   const handleRefresh = useCallback(
@@ -217,6 +219,7 @@ export function AllocationsTeamProvider({
         isNextPageLoading,
         hasMore,
         querySignature,
+        todayResetKey,
         search: searchParam,
         designation,
         duration,
@@ -245,6 +248,7 @@ export function AllocationsTeamProvider({
       isQueryLoading,
       hasMore,
       querySignature,
+      todayResetKey,
       searchParam,
       duration,
       designation,


### PR DESCRIPTION
## Description
-  Clicking "Today" in the Project/Team Allocations timeline now scrolls the Gantt grid horizontally back into view, even when the anchor date param doesn't change (i.e. already viewing the current period).

## Screenshot/Screencast
https://github.com/user-attachments/assets/f382c01f-0d7a-4170-87ac-b3c57ea1bfbf

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1745