### PR TITLE
Enhancement: Expand all weeks by default on timesheet pages

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
@@ -3,7 +3,7 @@
  */
 import { useMemo, useState } from "react";
 import { Accordion } from "@base-ui/react/accordion";
-import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
+import { floatToTime } from "@next-pms/design-system";
 import {
   WeekRow as BaseWeekRow,
   ApprovalStatusMap,
@@ -111,7 +111,6 @@ export const WeekRow = ({
       onValueChange={(value) => {
         setCollapsed(value.length === 0);
       }}
-      className={cn(!collapsed && "mb-4")}
     >
       <Accordion.Item value="week" className="border-none">
         <Accordion.Trigger
@@ -136,14 +135,16 @@ export const WeekRow = ({
           )}
         />
         <Accordion.Panel className="pb-0 accordion-panel">
-          {children?.({
-            totalHours: floatToTime(weekData.total, 2),
-            totalHoursTheme: totalHoursThemeMap[weekData.isExtended],
-            totalTimeEntries: weekData.totalTimeEntries,
-            totalTimeEntriesInHours: weekData.totalTimeEntriesInHours,
-            dailyWorkingHours: weekData.dailyWorkingHours,
-            status: approvalStatus,
-          })}
+          <div className="pb-4">
+            {children?.({
+              totalHours: floatToTime(weekData.total, 2),
+              totalHoursTheme: totalHoursThemeMap[weekData.isExtended],
+              totalTimeEntries: weekData.totalTimeEntries,
+              totalTimeEntriesInHours: weekData.totalTimeEntriesInHours,
+              dailyWorkingHours: weekData.dailyWorkingHours,
+              status: approvalStatus,
+            })}
+          </div>
         </Accordion.Panel>
       </Accordion.Item>
     </Accordion.Root>

--- a/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
@@ -29,7 +29,6 @@ export type PersonalTimesheetRowProps = {
   holidays: Array<HolidayProp>;
   tasks: TaskProps;
   leaves: Array<LeaveProps>;
-  firstWeek: boolean;
   workingHour: number;
   disabled?: boolean;
   workingFrequency: WorkingFrequency;
@@ -48,7 +47,6 @@ export const PersonalTimesheetRow = ({
   holidays,
   tasks,
   leaves,
-  firstWeek,
   workingHour,
   workingFrequency,
   disabled,
@@ -110,7 +108,7 @@ export const PersonalTimesheetRow = ({
         status={status}
         className="pl-3"
         onButtonClick={onButtonClick}
-        collapsed={!firstWeek}
+        collapsed={false}
       >
         {({
           totalHours,

--- a/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
@@ -29,6 +29,7 @@ export type PersonalTimesheetRowProps = {
   holidays: Array<HolidayProp>;
   tasks: TaskProps;
   leaves: Array<LeaveProps>;
+  collapsed: boolean;
   workingHour: number;
   disabled?: boolean;
   workingFrequency: WorkingFrequency;
@@ -47,6 +48,7 @@ export const PersonalTimesheetRow = ({
   holidays,
   tasks,
   leaves,
+  collapsed,
   workingHour,
   workingFrequency,
   disabled,
@@ -108,7 +110,7 @@ export const PersonalTimesheetRow = ({
         status={status}
         className="pl-3"
         onButtonClick={onButtonClick}
-        collapsed={false}
+        collapsed={collapsed}
       >
         {({
           totalHours,

--- a/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
@@ -41,14 +41,12 @@ export type ProjectTimesheetProject = {
 export type ProjectTimesheetRowProps = {
   label?: string;
   dates: string[];
-  firstWeek: boolean;
   projects: ProjectTimesheetProject[];
 };
 
 export const ProjectTimesheetRow = ({
   label,
   dates,
-  firstWeek,
   projects,
 }: ProjectTimesheetRowProps) => {
   const { openAddTimeDialog } = useTimesheetOutletContext();
@@ -66,7 +64,7 @@ export const ProjectTimesheetRow = ({
         dates={dates}
         workingFrequency="Per Day"
         className="pl-3"
-        collapsed={!firstWeek}
+        collapsed={false}
         isReadOnlyWeek={true}
       >
         {() => (

--- a/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
@@ -41,12 +41,14 @@ export type ProjectTimesheetProject = {
 export type ProjectTimesheetRowProps = {
   label?: string;
   dates: string[];
+  collapsed: boolean;
   projects: ProjectTimesheetProject[];
 };
 
 export const ProjectTimesheetRow = ({
   label,
   dates,
+  collapsed,
   projects,
 }: ProjectTimesheetRowProps) => {
   const { openAddTimeDialog } = useTimesheetOutletContext();
@@ -64,7 +66,7 @@ export const ProjectTimesheetRow = ({
         dates={dates}
         workingFrequency="Per Day"
         className="pl-3"
-        collapsed={false}
+        collapsed={collapsed}
         isReadOnlyWeek={true}
       >
         {() => (

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -35,6 +35,7 @@ export type TeamMember = {
 type TeamTimesheetRowProps = {
   label?: string;
   dates: string[];
+  collapsed: boolean;
   teamMembers: TeamMember[];
   approvalPendingCount?: number;
   setSelectedTask?: (task: string) => void;
@@ -44,6 +45,7 @@ type TeamTimesheetRowProps = {
 export const TeamTimesheetRow = ({
   label,
   dates,
+  collapsed,
   teamMembers,
   approvalPendingCount,
   setSelectedTask,
@@ -68,7 +70,7 @@ export const TeamTimesheetRow = ({
         dates={dates}
         workingFrequency="Per Day"
         className="pl-3"
-        collapsed={false}
+        collapsed={collapsed}
         isReadOnlyWeek={true}
         approvalPendingCount={approvalPendingCount}
       >

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -35,7 +35,6 @@ export type TeamMember = {
 type TeamTimesheetRowProps = {
   label?: string;
   dates: string[];
-  firstWeek: boolean;
   teamMembers: TeamMember[];
   approvalPendingCount?: number;
   setSelectedTask?: (task: string) => void;
@@ -45,7 +44,6 @@ type TeamTimesheetRowProps = {
 export const TeamTimesheetRow = ({
   label,
   dates,
-  firstWeek,
   teamMembers,
   approvalPendingCount,
   setSelectedTask,
@@ -70,7 +68,7 @@ export const TeamTimesheetRow = ({
         dates={dates}
         workingFrequency="Per Day"
         className="pl-3"
-        collapsed={!firstWeek}
+        collapsed={false}
         isReadOnlyWeek={true}
         approvalPendingCount={approvalPendingCount}
       >

--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -133,7 +133,6 @@ const PersonalTimesheetGrid = () => {
                             holidays={timesheetData.holidays}
                             leaves={timesheetData.leaves}
                             tasks={value.tasks}
-                            firstWeek={index === 0}
                             disabled={value.status === "Approved"}
                             setSelectedTask={setSelectedTask}
                             onButtonClick={() =>

--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -133,6 +133,7 @@ const PersonalTimesheetGrid = () => {
                             holidays={timesheetData.holidays}
                             leaves={timesheetData.leaves}
                             tasks={value.tasks}
+                            collapsed={index >= 6}
                             disabled={value.status === "Approved"}
                             setSelectedTask={setSelectedTask}
                             onButtonClick={() =>

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -77,6 +77,7 @@ const ProjectTimesheetGrid = () => {
                     <ProjectTimesheetRow
                       label={week.label}
                       dates={week.dates}
+                      collapsed={index >= 6}
                       projects={week.projects}
                     />
                   </div>

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -77,7 +77,6 @@ const ProjectTimesheetGrid = () => {
                     <ProjectTimesheetRow
                       label={week.label}
                       dates={week.dates}
-                      firstWeek={index === 0}
                       projects={week.projects}
                     />
                   </div>

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -107,7 +107,6 @@ const TeamTimesheetGrid = () => {
                     <TeamTimesheetRow
                       label={week.label}
                       dates={week.dates}
-                      firstWeek={index === 0}
                       approvalPendingCount={week.approvalPendingCount}
                       setSelectedTask={setSelectedTask}
                       openWeeklyApproval={(employee, date) =>

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -107,6 +107,7 @@ const TeamTimesheetGrid = () => {
                     <TeamTimesheetRow
                       label={week.label}
                       dates={week.dates}
+                      collapsed={index >= 6}
                       approvalPendingCount={week.approvalPendingCount}
                       setSelectedTask={setSelectedTask}
                       openWeeklyApproval={(employee, date) =>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
  Expanded all week rows by default across personal, project, and team timesheet pages.

 Previously only the first/current week was expanded by default, while later weeks were collapsed. Since collapsed weeks take very little vertical space, infinite scroll could load many additional weeks on initial page load to fill the viewport. With visible weeks expanded by default, fewer weeks fit initially, reducing unnecessary data fetching while keeping the most relevant weeks visible for users.

Other:
- Moved the bottom margin from the wrapper to the panel. This makes the empty week collapse animation smoother and removes the need for additional conditional logic, as the panel is only rendered when the week is expanded.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/c89116cf-100a-41ab-ae46-60a62c57eb97



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1766