### PR TITLE
feat: compare project allocations with task estimates and timesheet hours

### DIFF
--- a/frontend/packages/app/src/app/pages/resource-management/components/resource-allocation-list/resourceAllocationCard.tsx
+++ b/frontend/packages/app/src/app/pages/resource-management/components/resource-allocation-list/resourceAllocationCard.tsx
@@ -173,6 +173,32 @@ export const ResourceAllocationCard = ({
               </Typography>
             </div>
           )}
+
+          {resourceAllocation.project_allocation !== undefined && (
+            <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-muted-foreground bg-gray-50/50 dark:bg-gray-900/30 p-2 rounded-md w-11/12">
+              <div className="flex justify-between">
+                <span>Allocation:</span>
+                <span className="font-semibold text-foreground">{resourceAllocation.project_allocation} hrs</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Planned Tasks:</span>
+                <span className="font-semibold text-foreground">{resourceAllocation.planned_task_effort} hrs</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Logged Hours:</span>
+                <span className="font-semibold text-foreground">{resourceAllocation.actual_logged_hours} hrs</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Allocation Gap:</span>
+                <span className={mergeClassNames(
+                  "font-semibold",
+                  (resourceAllocation.allocation_gap ?? 0) > 0 ? "text-yellow-600 dark:text-yellow-400" : "text-green-600 dark:text-green-400"
+                )}>
+                  {resourceAllocation.allocation_gap} hrs
+                </span>
+              </div>
+            </div>
+          )}
         </div>
         <div className=" absolute right-4 top-3 flex gap-1 cursor-pointer">
           {resourceAllocationPermission.write && (

--- a/frontend/packages/app/src/types/resource_management.ts
+++ b/frontend/packages/app/src/types/resource_management.ts
@@ -21,6 +21,10 @@ export type ResourceAllocationProps = {
   modified_by_avatar: string;
   modified: string;
   creation: string;
+  project_allocation?: number;
+  planned_task_effort?: number;
+  actual_logged_hours?: number;
+  allocation_gap?: number;
 };
 
 export interface ResourceCustomerObjectProps {

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -16,6 +16,7 @@ from next_pms.resource_management.api.utils.query import (
     get_allocation_list_for_employee_for_given_range,
     get_allocation_worked_hours_for_given_employee,
     get_allocation_worked_hours_for_given_projects,
+    get_allocation_task_and_logged_hours,
 )
 
 
@@ -64,6 +65,7 @@ def get_resource_management_project_view_data(
             "allocation_start_date",
             "allocation_end_date",
             "hours_allocated_per_day",
+            "total_allocated_hours",
             "project",
             "project_name",
             "customer",
@@ -78,7 +80,18 @@ def get_resource_management_project_view_data(
     )
 
     resource_allocation_map = {}
+    todo_assignments_cache = {}
     for resource_allocation in resource_allocation_data:
+        stats = get_allocation_task_and_logged_hours(
+            project=resource_allocation.project,
+            employee=resource_allocation.employee,
+            start_date=resource_allocation.allocation_start_date,
+            end_date=resource_allocation.allocation_end_date,
+            total_allocated_hours=resource_allocation.get("total_allocated_hours") or 0.0,
+            cache=todo_assignments_cache
+        )
+        resource_allocation.update(stats)
+
         if resource_allocation.project not in resource_allocation_map:
             resource_allocation_map[resource_allocation.project] = {}
         resource_allocation_map[resource_allocation.project][resource_allocation.name] = resource_allocation
@@ -179,6 +192,7 @@ def get_employees_resrouce_data_for_given_project(project: str, start_date: str,
             "allocation_start_date",
             "allocation_end_date",
             "hours_allocated_per_day",
+            "total_allocated_hours",
             "project",
             "project_name",
             "customer",
@@ -193,7 +207,18 @@ def get_employees_resrouce_data_for_given_project(project: str, start_date: str,
     )
 
     resource_allocation_map = {}
+    todo_assignments_cache = {}
     for resource_allocation in resource_allocation_data:
+        stats = get_allocation_task_and_logged_hours(
+            project=resource_allocation.project,
+            employee=resource_allocation.employee,
+            start_date=resource_allocation.allocation_start_date,
+            end_date=resource_allocation.allocation_end_date,
+            total_allocated_hours=resource_allocation.get("total_allocated_hours") or 0.0,
+            cache=todo_assignments_cache
+        )
+        resource_allocation.update(stats)
+
         if resource_allocation.employee not in resource_allocation_map:
             resource_allocation_map[resource_allocation.employee] = {}
         resource_allocation_map[resource_allocation.employee][resource_allocation.name] = resource_allocation

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -16,6 +16,7 @@ from next_pms.resource_management.api.utils.helpers import (
 from next_pms.resource_management.api.utils.query import (
     get_allocation_list_for_employee_for_given_range,
     get_employee_leaves,
+    get_allocation_task_and_logged_hours,
 )
 from next_pms.timesheet.api import filter_employees
 from next_pms.timesheet.api.employee import get_employee_working_hours
@@ -105,6 +106,7 @@ def get_resource_management_team_view_data(
             "allocation_start_date",
             "allocation_end_date",
             "hours_allocated_per_day",
+            "total_allocated_hours",
             "project",
             "project_name",
             "customer",
@@ -126,6 +128,7 @@ def get_resource_management_team_view_data(
     # Make the map of resource allocation data for given employee
     resource_allocation_map = {}
     user_info_cache = {}
+    todo_assignments_cache = {}
     for resource_allocation in resource_allocation_data:
         modified_by = resource_allocation.get("modified_by") or resource_allocation.get("created_by")
         if modified_by:
@@ -136,6 +139,17 @@ def get_resource_management_team_view_data(
                 }
             resource_allocation["modified_by_avatar"] = user_info_cache[modified_by]["avatar"]
             resource_allocation["modified_by"] = user_info_cache[modified_by]["full_name"]
+
+        stats = get_allocation_task_and_logged_hours(
+            project=resource_allocation.project,
+            employee=resource_allocation.employee,
+            start_date=resource_allocation.allocation_start_date,
+            end_date=resource_allocation.allocation_end_date,
+            total_allocated_hours=resource_allocation.get("total_allocated_hours") or 0.0,
+            cache=todo_assignments_cache
+        )
+        resource_allocation.update(stats)
+
         if resource_allocation.employee not in resource_allocation_map:
             resource_allocation_map[resource_allocation.employee] = []
         customer = add_customer_data_if_not_exists(customer, resource_allocation.customer)

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -235,3 +235,55 @@ def get_allocation_worked_hours_for_given_employee(project: str, employee: str, 
     ).run(as_dict=True)[0]
 
     return total_hours.get("time") or 0.0
+
+
+def get_allocation_task_and_logged_hours(project: str, employee: str, start_date: str, end_date: str, total_allocated_hours: float, cache: dict = None) -> dict:
+    from frappe.utils import getdate
+
+    project_allocation = total_allocated_hours or 0.0
+    actual_logged_hours = get_allocation_worked_hours_for_given_employee(project, employee, start_date, end_date)
+    planned_task_effort = 0.0
+
+    user_id = frappe.db.get_value("Employee", employee, "user_id")
+    if user_id:
+        if cache is not None and user_id in cache:
+            assigned_tasks = cache[user_id]
+        else:
+            assigned_tasks = frappe.get_all(
+                "ToDo",
+                filters={
+                    "reference_type": "Task",
+                    "allocated_to": user_id,
+                    "status": "Open",
+                },
+                pluck="reference_name"
+            )
+            if cache is not None:
+                cache[user_id] = assigned_tasks
+
+        if assigned_tasks:
+            tasks = frappe.get_all(
+                "Task",
+                filters={
+                    "name": ["in", assigned_tasks],
+                    "project": project,
+                    "status": ["not in", ["Closed", "Completed", "Cancelled"]],
+                },
+                fields=["expected_time", "exp_end_date"]
+            )
+
+            for task in tasks:
+                if task.exp_end_date:
+                    task_end_date = getdate(task.exp_end_date)
+                    if not (getdate(start_date) <= task_end_date <= getdate(end_date)):
+                        continue
+                planned_task_effort += task.expected_time or 0.0
+
+    allocation_gap = max(0.0, project_allocation - planned_task_effort)
+
+    return {
+        "project_allocation": project_allocation,
+        "planned_task_effort": planned_task_effort,
+        "actual_logged_hours": actual_logged_hours,
+        "allocation_gap": allocation_gap
+    }


### PR DESCRIPTION
Added a comparison breakdown on resource allocation cards to show:
- Project allocation (total hours allocated)
- Planned task effort (sum of expected hours for active tasks assigned to the employee)
- Actual logged hours (from timesheets)
- Allocation gap (allocation minus planned task effort)

This addresses #1740 so resource managers can see if an employee has enough tasks planned relative to their allocated project hours.

Changes made:
- Added a helper `get_allocation_task_and_logged_hours` in `query.py` to query active tasks assigned to the employee under the project using ToDo assignments, filter by the allocation date range, and calculate actual logged hours.
- Loaded `total_allocated_hours` and mapped these stats onto allocation results returned in the team and project view APIs (`team.py` and `project.py`).
- Added the fields to `ResourceAllocationProps` and rendered a simple 2-column grid in `ResourceAllocationCard` to display the stats.