### PR TITLE
Prevent unauthenticated bootstrap requests before login redirect

### DIFF
--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -50,12 +50,22 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   >(window.frappe?.boot?.has_industry || false);
 
   const { logout, isLoading: isAuthLoading, currentUser } = useFrappeAuth();
+  const isAuthenticated =
+    !isAuthLoading && !!currentUser && currentUser !== "Guest";
 
   const { data: appData, error: appDataError } = useFrappeGetCall(
     "next_pms.timesheet.api.app.get_data",
+    undefined,
+    isAuthenticated
+      ? ["next_pms.timesheet.api.app.get_data", currentUser]
+      : null,
   );
 
   useEffect(() => {
+    if (!appData) {
+      return;
+    }
+
     setRoles(appData?.message?.roles || []);
     setCurrencies(appData?.message?.currencies || []);
     setHasBuField(appData?.message?.has_business_unit || false);
@@ -64,17 +74,27 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const { data: employeeData, error: employeeDataError } = useFrappeGetCall(
     "next_pms.timesheet.api.employee.get_data",
+    undefined,
+    isAuthenticated
+      ? ["next_pms.timesheet.api.employee.get_data", currentUser]
+      : null,
   );
 
-  if (appDataError) {
-    throw new Error(parseFrappeErrorMsg(appDataError));
-  }
+  if (isAuthenticated) {
+    if (appDataError) {
+      throw new Error(parseFrappeErrorMsg(appDataError));
+    }
 
-  if (employeeDataError) {
-    throw new Error(parseFrappeErrorMsg(employeeDataError));
+    if (employeeDataError) {
+      throw new Error(parseFrappeErrorMsg(employeeDataError));
+    }
   }
 
   useEffect(() => {
+    if (!employeeData) {
+      return;
+    }
+
     setEmployeeId(employeeData?.message?.employee ?? "");
     setWorkingHours(
       employeeData?.message?.employee_working_detail?.working_hour ?? 8,

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import { Route, Outlet, Navigate, useNavigate } from "react-router-dom";
+import { Spinner } from "@next-pms/design-system/components";
 /**
  * Internal dependencies.
  */
@@ -201,7 +202,7 @@ const AuthenticatedRoute = () => {
   }));
 
   if (isUserLoading) {
-    return <></>;
+    return <Spinner isFull />;
   } else if (!currentUser || currentUser === "Guest") {
     window.location.replace("/login?redirect-to=/next-pms/timesheet");
   }
@@ -219,7 +220,7 @@ const RoleProtectedRoute = ({ allowedRoles }: { allowedRoles: Role[] }) => {
   }));
 
   if (isLoading) {
-    return <></>;
+    return <Spinner isFull />;
   }
 
   const hasAccess =

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { Route, Outlet, Navigate, useNavigate } from "react-router-dom";
+import { Route, Outlet, Navigate } from "react-router-dom";
 import { Spinner } from "@next-pms/design-system/components";
 /**
  * Internal dependencies.
@@ -205,15 +205,17 @@ const AuthenticatedRoute = () => {
     return <Spinner isFull />;
   } else if (!currentUser || currentUser === "Guest") {
     window.location.replace("/login?redirect-to=/next-pms/timesheet");
+    return <Spinner isFull />;
   }
 
   if (!isUserLoading && currentUser && currentUser !== "Guest") {
     return <Outlet />;
   }
+
+  return null;
 };
 
 const RoleProtectedRoute = ({ allowedRoles }: { allowedRoles: Role[] }) => {
-  const navigate = useNavigate();
   const { isLoading, roles } = useUser(({ state }) => ({
     isLoading: state.isLoading,
     roles: state.roles,
@@ -229,7 +231,7 @@ const RoleProtectedRoute = ({ allowedRoles }: { allowedRoles: Role[] }) => {
       : true;
 
   if (!hasAccess) {
-    navigate(ROUTES["not-found"]);
+    return <Navigate to={ROUTES["not-found"]} replace />;
   }
 
   return <Outlet />;

--- a/frontend/packages/design-system/src/components/error-fallback/index.tsx
+++ b/frontend/packages/design-system/src/components/error-fallback/index.tsx
@@ -41,7 +41,7 @@ class ErrorFallback extends Component<ErrorFallbackProp, ErrorFallbackState> {
 
     return hasError
       ? fallback || (
-          <div className="w-full h-full flex flex-col gap-1 justify-center items-center">
+          <div className="w-full h-full p-2 flex flex-col gap-1 justify-center items-center">
             <Typography variant="p" className="text-ink-gray-7 font-medium">
               Something went wrong
             </Typography>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
 Prevents logged-out users from briefly seeing the error fallback before being redirected to login.

The user provider now waits until auth is resolved and currentUser is a real authenticated user before calling the protected `app.get_data` and `employee.get_data` APIs. The authenticated route also shows the shared full-screen spinner while auth is loading instead of rendering a blank screen.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1768