### PR TITLE
fix: member status and business unit composite filter

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/constants.ts
+++ b/frontend/packages/app/src/pages/timesheet/constants.ts
@@ -126,6 +126,12 @@ export const teamTimesheetFilters: FilterField[] = [
       { label: "Suspended", value: "Suspended" },
       { label: "Left", value: "Left" },
     ],
+    // Default select operators (is/is_not/is_empty/is_not_empty) are not valid
+    // Frappe operators, and status is mandatory so empty checks are meaningless.
+    operators: [
+      { label: "is", value: "=" },
+      { label: "is not", value: "!=" },
+    ],
     type: "select",
   },
   {

--- a/next_pms/tests/timesheet/api/test_team_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_team_timesheet_data.py
@@ -7,7 +7,7 @@ from frappe.tests import IntegrationTestCase
 from next_pms.tests.utils import make_holiday_list
 from next_pms.timesheet.api.team import get_team_timesheet_data
 from next_pms.timesheet.api.timesheet import save as save_timesheet
-from next_pms.timesheet.api.utils import get_holidays
+from next_pms.timesheet.api.utils import get_holidays, sanitize_employee_conditions
 
 # build_aggregate_dates walks backward from `date`, so anchoring on the
 # Monday of W2 yields exactly [W1, W2] = [06-15..06-21, 06-22..06-28] for
@@ -463,3 +463,100 @@ class TestTeamTimesheetDataFilters(_TeamTimesheetDataBase):
         for emp in (self.r1, self.r2):
             self.assertEqual(len(with_skip["data"][emp]["timesheet_details"]), 1)
             self.assertEqual(len(without_skip["data"][emp]["timesheet_details"]), 2)
+
+
+LEFT_EMP_NAME = "Meera Joshi"
+BU_ALPHA_NAME = "Ttf BU Alpha"
+BU_BETA_NAME = "Ttf BU Beta"
+
+
+class TestTeamTimesheetDataEmployeeFilters(_TeamTimesheetDataBase):
+    """Employee-doctype composite filters — operators must survive to SQL instead of
+    being coerced into IN (status) or exact-match (business unit)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+
+        # Timesheet saved while Active, then flipped via db.set_value to skip
+        # HRMS's relieving-date validation.
+        cls.left_emp = cls._make_employee(LEFT_EMP_NAME, reports_to=cls.mgr)
+        cls._save(cls.left_emp, W1_MON, cls.task_alpha, 2, "left mon")
+        frappe.db.set_value("Employee", cls.left_emp, "status", "Left")
+
+        cls.has_business_unit = bool(frappe.db.exists("DocType", "Business Unit")) and frappe.get_meta(
+            "Employee"
+        ).has_field("custom_business_unit")
+        if cls.has_business_unit:
+            cls.bu_alpha = cls._make_business_unit(BU_ALPHA_NAME)
+            cls.bu_beta = cls._make_business_unit(BU_BETA_NAME)
+            frappe.db.set_value("Employee", cls.r1, "custom_business_unit", cls.bu_alpha)
+            frappe.db.set_value("Employee", cls.r2, "custom_business_unit", cls.bu_beta)
+
+        frappe.clear_cache()
+
+    @classmethod
+    def _make_business_unit(cls, business_unit_name):
+        existing = frappe.db.get_value("Business Unit", {"business_unit_name": business_unit_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc({"doctype": "Business Unit", "business_unit_name": business_unit_name})
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def _skip_without_business_unit(self):
+        if not self.has_business_unit:
+            self.skipTest("Business Unit doctype / custom_business_unit field not installed")
+
+    def test_status_equals_overrides_default_active_filter(self):
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Employee", "status", "=", "Left"]]),
+        )
+        self.assertEqual(list(res["data"].keys()), [self.left_emp])
+        self.assertEqual(res["total_count"], 1)
+
+    def test_status_not_equals_operator_preserved(self):
+        # Under the old IN coercion this returned the Active employees instead.
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Employee", "status", "!=", "Active"]]),
+        )
+        self.assertEqual(list(res["data"].keys()), [self.left_emp])
+        self.assertEqual(res["total_count"], 1)
+
+    def test_status_filter_without_match_returns_empty(self):
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Employee", "status", "=", "Suspended"]]),
+        )
+        self.assertEqual(res["data"], {})
+        self.assertEqual(res["total_count"], 0)
+        self.assertFalse(res["has_more"])
+
+    def test_business_unit_like_matches_wildcard(self):
+        self._skip_without_business_unit()
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Employee", "custom_business_unit", "like", "%BU Alph%"]]),
+        )
+        self.assertEqual(list(res["data"].keys()), [self.r1])
+        self.assertEqual(res["total_count"], 1)
+
+    def test_business_unit_not_like_excludes_match(self):
+        self._skip_without_business_unit()
+        # Only r2 qualifies: r1's BU matches the pattern, left_emp fails the
+        # default Active-only filter, r3 has no timesheets in the window.
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Employee", "custom_business_unit", "not like", "%BU Alph%"]]),
+        )
+        self.assertEqual(list(res["data"].keys()), [self.r2])
+        self.assertEqual(res["total_count"], 1)
+
+    def test_sanitize_drops_conditions_on_missing_meta_fields(self):
+        conditions = sanitize_employee_conditions([["status", "=", "Active"], ["field_missing_from_meta", "=", "x"]])
+        self.assertEqual(conditions, [["status", "=", "Active"]])

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -209,15 +209,10 @@ def _get_team_timesheet_data(
 
     parsed_filters = parse_filters(filters)
 
-    # get the employee status and business unit from the filters (drop down ui in frontend)
-    # this will be passed to the global employee filter so the pool of employees is narrowed down.
-    employee_status = None
-    employee_business_unit = None
-    for field, _operator, value in parsed_filters.get("Employee", []):
-        if field == "status":
-            employee_status = [value] if isinstance(value, str) else value
-        elif field == "custom_business_unit":
-            employee_business_unit = [value] if isinstance(value, str) else value
+    # Employee-level filters (status / business unit drop-downs in frontend) are
+    # passed through with their operators intact so the global employee filter
+    # narrows the pool with the same semantics the caller asked for (like, in, ...).
+    employee_conditions = parsed_filters.get("Employee", [])
 
     has_filters = bool(search or status_filter or any(parsed_filters.values()))
     dates, _ = build_aggregate_dates(date=date, max_week=max_week, has_filters=has_filters)
@@ -230,8 +225,7 @@ def _get_team_timesheet_data(
         parsed_filters=parsed_filters,
         search=search,
         timesheet_status=status_filter,
-        status=employee_status,
-        business_unit=employee_business_unit,
+        employee_conditions=employee_conditions,
     )
 
     if candidate_employee_ids == []:
@@ -334,8 +328,7 @@ def _get_team_timesheet_data(
             start=start,
             page_length=page_length,
             builder=build_team_employee_payload,
-            status=employee_status,
-            business_unit=employee_business_unit,
+            employee_conditions=employee_conditions,
         )
     else:
         # No filters (candidate_employee_ids is None here) — every employee

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -35,6 +35,7 @@ from .utils import (
     paginate_qualifying_employee_payloads,
     paginate_unfiltered_employee_payloads,
     parse_filters,
+    sanitize_employee_conditions,
 )
 
 
@@ -212,7 +213,10 @@ def _get_team_timesheet_data(
     # Employee-level filters (status / business unit drop-downs in frontend) are
     # passed through with their operators intact so the global employee filter
     # narrows the pool with the same semantics the caller asked for (like, in, ...).
-    employee_conditions = parsed_filters.get("Employee", [])
+    # Sanitized (and written back) before has_filters so a condition dropped for a
+    # missing meta field cannot flip the request into the filtered path.
+    employee_conditions = sanitize_employee_conditions(parsed_filters.get("Employee"))
+    parsed_filters["Employee"] = employee_conditions
 
     has_filters = bool(search or status_filter or any(parsed_filters.values()))
     dates, _ = build_aggregate_dates(date=date, max_week=max_week, has_filters=has_filters)

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -440,20 +440,38 @@ def get_matching_timesheet_employee_ids(
     return list({timesheet_by_name[parent].employee for parent in matched_parent_names if parent in timesheet_by_name})
 
 
+def employee_condition_kwargs(employee_conditions: list | None) -> dict:
+    """Build `filter_employees` kwargs that apply Employee-level [field, operator, value]
+    conditions with their operators intact (e.g. `like` stays a LIKE, not an IN).
+
+    An explicit status condition replaces the default Active-only filter, matching
+    the behaviour of `filter_employees`'s own `status` parameter. Conditions on
+    fields missing from the site's Employee meta (e.g. `custom_business_unit`
+    without the rtcamp customisation) are dropped instead of raising.
+    """
+    meta = frappe.get_meta("Employee")
+    conditions = [
+        [field, operator, value] for field, operator, value in employee_conditions or [] if meta.has_field(field)
+    ]
+    return {
+        "extra_conditions": conditions or None,
+        "ignore_default_filters": any(field == "status" for field, _operator, _value in conditions),
+    }
+
+
 def get_team_candidate_employee_ids(
     reports_to: str | None = None,
     dates: list | None = None,
     parsed_filters: dict | None = None,
     search: str | None = None,
     timesheet_status: list[str] | None = None,
-    status=None,
-    business_unit=None,
+    employee_conditions: list | None = None,
 ):
     if not dates:
         return []
 
     has_candidate_filters = bool(timesheet_status or search or any((parsed_filters or {}).values()))
-    if not has_candidate_filters and not status and not business_unit:
+    if not has_candidate_filters and not employee_conditions:
         return None
 
     employee_ids = get_matching_timesheet_employee_ids(
@@ -470,8 +488,7 @@ def get_team_candidate_employee_ids(
         start=0,
         reports_to=reports_to,
         ids=employee_ids,
-        status=status,
-        business_unit=business_unit,
+        **employee_condition_kwargs(employee_conditions),
     )
     if not filtered_count:
         return []
@@ -865,8 +882,7 @@ def paginate_qualifying_employee_payloads(
     start: int,
     page_length: int,
     builder,
-    status=None,
-    business_unit=None,
+    employee_conditions: list | None = None,
 ):
     selected = []
     total_count = 0
@@ -878,8 +894,7 @@ def paginate_qualifying_employee_payloads(
             start=employee_start,
             reports_to=reports_to,
             ids=employee_ids,
-            status=status,
-            business_unit=business_unit,
+            **employee_condition_kwargs(employee_conditions),
         )
         if not chunk:
             break

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -440,22 +440,29 @@ def get_matching_timesheet_employee_ids(
     return list({timesheet_by_name[parent].employee for parent in matched_parent_names if parent in timesheet_by_name})
 
 
-def employee_condition_kwargs(employee_conditions: list | None) -> dict:
-    """Build `filter_employees` kwargs that apply Employee-level [field, operator, value]
-    conditions with their operators intact (e.g. `like` stays a LIKE, not an IN).
+def sanitize_employee_conditions(employee_conditions: list | None) -> list:
+    """Drop conditions on fields missing from the site's Employee meta
+    (e.g. `custom_business_unit` without the rtcamp customisation) instead of raising.
 
-    An explicit status condition replaces the default Active-only filter, matching
-    the behaviour of `filter_employees`'s own `status` parameter. Conditions on
-    fields missing from the site's Employee meta (e.g. `custom_business_unit`
-    without the rtcamp customisation) are dropped instead of raising.
+    Callers must sanitize before deciding filtered-vs-unfiltered behaviour, so a
+    condition that will be dropped anyway cannot flip the request into the
+    filtered path.
     """
     meta = frappe.get_meta("Employee")
-    conditions = [
-        [field, operator, value] for field, operator, value in employee_conditions or [] if meta.has_field(field)
-    ]
+    return [[field, operator, value] for field, operator, value in employee_conditions or [] if meta.has_field(field)]
+
+
+def employee_condition_kwargs(employee_conditions: list | None) -> dict:
+    """Build `filter_employees` kwargs that apply Employee-level [field, operator, value]
+    conditions (already sanitized via `sanitize_employee_conditions`) with their
+    operators intact (e.g. `like` stays a LIKE, not an IN).
+
+    An explicit status condition replaces the default Active-only filter, matching
+    the behaviour of `filter_employees`'s own `status` parameter.
+    """
     return {
-        "extra_conditions": conditions or None,
-        "ignore_default_filters": any(field == "status" for field, _operator, _value in conditions),
+        "extra_conditions": employee_conditions or None,
+        "ignore_default_filters": any(field == "status" for field, _operator, _value in employee_conditions or []),
     }
 
 
@@ -887,6 +894,7 @@ def paginate_qualifying_employee_payloads(
     selected = []
     total_count = 0
     employee_start = 0
+    employee_filter_kwargs = employee_condition_kwargs(employee_conditions)
 
     while True:
         chunk, _ = filter_employees(
@@ -894,7 +902,7 @@ def paginate_qualifying_employee_payloads(
             start=employee_start,
             reports_to=reports_to,
             ids=employee_ids,
-            **employee_condition_kwargs(employee_conditions),
+            **employee_filter_kwargs,
         )
         if not chunk:
             break


### PR DESCRIPTION
## Description

* Refactored `team.py` and `utils.py` to pass all Employee-level filter conditions (with their original operators) as a list to the employee query logic, instead of extracting just status and business unit and converting operators. 
* Introduced the `employee_condition_kwargs` helper to build filter arguments, ensuring conditions are only applied to fields present in the Employee meta and that explicit status filters override the default "Active-only" filter.
* Updated all relevant internal function signatures and calls (`get_team_candidate_employee_ids`, `paginate_qualifying_employee_payloads`) to use the new `employee_conditions` parameter and logic. 
* Updated the `teamTimesheetFilters` definition so that the status filter only exposes valid Frappe operators (`=` and `!=`), removing empty checks and ensuring the frontend matches backend expectations.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1771 , #1772 