### PR TITLE
feat: make customer field read only in add allocation modal

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -19,7 +19,8 @@ import {
   useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { AlertTriangle, Calendar } from "@rtcamp/frappe-ui-react/icons";
-import { useForm, useStore } from "@tanstack/react-form";
+import { useForm } from "@tanstack/react-form";
+import { useSelector } from "@tanstack/react-store";
 import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
@@ -180,9 +181,12 @@ function AddAllocationModal({
     },
   });
 
-  const projectId = useStore(form.store, (state) => state.values.projectId);
-  const customerId = useStore(form.store, (state) => state.values.customer);
-  const employeeId = useStore(form.store, (state) => state.values.employeeId);
+  const projectId = useSelector(form.store, (state) => state.values.projectId);
+  const customerId = useSelector(form.store, (state) => state.values.customer);
+  const employeeId = useSelector(
+    form.store,
+    (state) => state.values.employeeId,
+  );
   const lastValidatedProjectIdRef = useRef<string | undefined>(undefined);
 
   const selectedCustomerOption = customerId
@@ -273,15 +277,21 @@ function AddAllocationModal({
     [closeModal, onOpenChange],
   );
 
-  const recurrence = useStore(form.store, (state) => state.values.recurrence);
-  const hoursPerDay = useStore(form.store, (state) => state.values.hoursPerDay);
-  const repeatFor = useStore(
+  const recurrence = useSelector(
+    form.store,
+    (state) => state.values.recurrence,
+  );
+  const hoursPerDay = useSelector(
+    form.store,
+    (state) => state.values.hoursPerDay,
+  );
+  const repeatFor = useSelector(
     form.store,
     (state) => state.values.repeatFor ?? 0,
   );
-  const fromDate = useStore(form.store, (state) => state.values.fromDate);
-  const toDate = useStore(form.store, (state) => state.values.toDate);
-  const includeWeekendsValue = useStore(
+  const fromDate = useSelector(form.store, (state) => state.values.fromDate);
+  const toDate = useSelector(form.store, (state) => state.values.toDate);
+  const includeWeekendsValue = useSelector(
     form.store,
     (state) => state.values.includeWeekends,
   );

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -53,7 +53,6 @@ function AddAllocationModal({
   const weekendEntriesAllowed: boolean = isWeekendEntryAllowed();
   const [employeeSearch, setEmployeeSearch] = useState("");
   const [projectSearch, setProjectSearch] = useState("");
-  const [customerSearch, setCustomerSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
   const isRecurringEdit =
@@ -76,12 +75,6 @@ function AddAllocationModal({
         label: initialValues.projectLabel || initialValues.projectId,
         value: initialValues.projectId,
         customer: initialValues.customer,
-      }
-    : null;
-  const selectedCustomerOption = initialValues?.customer
-    ? {
-        label: initialValues.customerLabel || initialValues.customer,
-        value: initialValues.customer,
       }
     : null;
 
@@ -188,8 +181,19 @@ function AddAllocationModal({
   });
 
   const projectId = useStore(form.store, (state) => state.values.projectId);
+  const customerId = useStore(form.store, (state) => state.values.customer);
   const employeeId = useStore(form.store, (state) => state.values.employeeId);
   const lastValidatedProjectIdRef = useRef<string | undefined>(undefined);
+
+  const selectedCustomerOption = customerId
+    ? {
+        label:
+          customerId === initialValues?.customer
+            ? initialValues.customerLabel || customerId
+            : customerId,
+        value: customerId,
+      }
+    : null;
 
   const selectedEmployeeOption = employeeId
     ? {
@@ -235,9 +239,9 @@ function AddAllocationModal({
 
   const { options: customerOptions, isLoading: isCustomerLookupLoading } =
     useCustomerLookup({
-      shouldFetch: open,
+      shouldFetch: open && Boolean(customerId),
       pageSize: 20,
-      query: customerSearch,
+      query: customerId,
       selectedOption: selectedCustomerOption,
     });
 
@@ -304,7 +308,6 @@ function AddAllocationModal({
   useEffect(() => {
     setEmployeeSearch("");
     setProjectSearch("");
-    setCustomerSearch("");
   }, [open]);
 
   useEffect(() => {
@@ -344,10 +347,7 @@ function AddAllocationModal({
       setProjectSearch("");
       setEmployeeSearch("");
 
-      if (selectedProject?.customer) {
-        form.setFieldValue("customer", selectedProject.customer);
-        setCustomerSearch("");
-      }
+      form.setFieldValue("customer", selectedProject?.customer ?? "");
     },
     [form, projectOptions],
   );
@@ -423,17 +423,11 @@ function AddAllocationModal({
           </label>
           <Combobox
             inputClassName="bg-surface-white h-8 border-outline-gray-2 text-ink-gray-7"
-            loading={isCustomerLookupLoading}
+            loading={isCustomerLookupLoading || isProjectLookupLoading}
             options={customerOptions}
-            searchValue={customerSearch}
             placeholder="Select Customer"
             value={field.state.value}
-            disabled={isLockedAllocationMetadataEdit}
-            onChange={(value) => {
-              field.handleChange(value as string);
-              setCustomerSearch("");
-            }}
-            onSearchChange={setCustomerSearch}
+            disabled
             openOnFocus
           />
           {!field.state.meta.isValid && (

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
@@ -17,10 +17,10 @@ export const addAllocationFormSchema = z
       .min(1, { message: "Please select a project." }),
     customer: z
       .string({
-        required_error: "Please select a customer.",
+        required_error: "This project doesn't have a customer set.",
       })
       .trim()
-      .min(1, { message: "Please select a customer." }),
+      .min(1, { message: "This project doesn't have a customer set." }),
     recurrence: z.enum(
       Object.keys(allocationRecurrenceLabels) as ["one-time", "recurring"],
     ),


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR makes the `Customer` field read-only in the Add Allocation modal. The field is automatically populated based on the selected project and displays an inline error if the project does not have a customer assigned.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/651c9671-a4ae-4456-a745-b557ef0ff8e9



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1730