### PR TITLE
fix: disable is generating button and remove useStore

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/reports/projectBoardField.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/reports/projectBoardField.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies.
+ */
+import { useEffect, useMemo } from "react";
+import { Select } from "@rtcamp/frappe-ui-react";
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal dependencies.
+ */
+import { Field } from "./field";
+
+interface ProjectBoardFieldProps {
+  repository: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function ProjectBoardField({
+  repository,
+  value,
+  onChange,
+}: ProjectBoardFieldProps) {
+  const { data: projectBoards } = useFrappeGetCall<{ message: string[] }>(
+    "next_pms.api.generate_pm_report.get_repository_project_boards",
+    { repository },
+    repository ? `get_repository_project_boards:${repository}` : null,
+  );
+
+  const options = useMemo(
+    () =>
+      (projectBoards?.message ?? []).map((board) => ({
+        label: board,
+        value: board,
+      })),
+    [projectBoards],
+  );
+
+  useEffect(() => {
+    onChange("");
+  }, [repository, onChange]);
+
+  return (
+    <Field label="Project Board" className="col-span-2">
+      <Select
+        variant="outline"
+        className="text-ink-gray-7"
+        value={value}
+        onChange={(selected) => onChange(selected ?? "")}
+        options={options}
+        disabled={options.length === 0}
+        placeholder="Select project board…"
+      />
+    </Field>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/reports/reportGenerationForm.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/reports/reportGenerationForm.tsx
@@ -9,15 +9,12 @@ import {
   DateRangePicker,
   Select,
   TextInput,
+  Tooltip,
   useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { Calendar } from "@rtcamp/frappe-ui-react/icons";
-import { useForm, useStore } from "@tanstack/react-form";
-import {
-  FrappeError,
-  useFrappeGetCall,
-  useFrappePostCall,
-} from "frappe-react-sdk";
+import { useForm } from "@tanstack/react-form";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
@@ -25,6 +22,7 @@ import {
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { getDurationPresets } from "./constants";
 import { Field } from "./field";
+import { ProjectBoardField } from "./projectBoardField";
 import { SlackChannelField } from "./slackChannelField";
 import { useProjectDetail } from "../../context";
 
@@ -54,6 +52,7 @@ export function ReportGenerationForm() {
   const reports = useProjectDetail(
     (state) => state.project?.custom_project_reports ?? [],
   );
+  const isReportGenerating = reports.at(-1)?.status === "Generating";
   const previousReportUrl = useMemo(() => {
     for (let index = reports.length - 1; index >= 0; index--) {
       if (reports[index].report_link) {
@@ -95,32 +94,6 @@ export function ReportGenerationForm() {
       }
     },
   });
-
-  const selectedRepository = useStore(
-    form.store,
-    (state) => state.values.githubRepository,
-  );
-
-  const { data: projectBoards } = useFrappeGetCall<{ message: string[] }>(
-    "next_pms.api.generate_pm_report.get_repository_project_boards",
-    { repository: selectedRepository },
-    selectedRepository
-      ? `get_repository_project_boards:${selectedRepository}`
-      : null,
-  );
-
-  const projectBoardOptions = useMemo(
-    () =>
-      (projectBoards?.message ?? []).map((board) => ({
-        label: board,
-        value: board,
-      })),
-    [projectBoards],
-  );
-
-  useEffect(() => {
-    form.setFieldValue("projectBoard", "");
-  }, [selectedRepository, form]);
 
   useEffect(() => {
     form.setFieldValue("driveLink", driveLink);
@@ -203,20 +176,19 @@ export function ReportGenerationForm() {
           )}
         />
 
-        <form.Field
-          name="projectBoard"
-          children={(field) => (
-            <Field label="Project Board" className="col-span-2">
-              <Select
-                variant="outline"
-                className="text-ink-gray-7"
-                value={field.state.value}
-                onChange={(value) => field.handleChange(value ?? "")}
-                options={projectBoardOptions}
-                disabled={projectBoardOptions.length === 0}
-                placeholder="Select project board…"
-              />
-            </Field>
+        <form.Subscribe
+          selector={(state) => state.values.githubRepository}
+          children={(selectedRepository) => (
+            <form.Field
+              name="projectBoard"
+              children={(field) => (
+                <ProjectBoardField
+                  repository={selectedRepository}
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                />
+              )}
+            />
           )}
         />
 
@@ -253,14 +225,21 @@ export function ReportGenerationForm() {
         <form.Subscribe
           selector={(state) => state.isSubmitting}
           children={(isSubmitting) => (
-            <Button
-              type="submit"
-              variant="solid"
-              loading={isSubmitting}
-              disabled={isSubmitting}
+            <Tooltip
+              text="A report is currently being generated"
+              disabled={!isReportGenerating}
             >
-              Generate Project Report
-            </Button>
+              <span>
+                <Button
+                  type="submit"
+                  variant="solid"
+                  loading={isSubmitting}
+                  disabled={isSubmitting || isReportGenerating}
+                >
+                  Generate Project Report
+                </Button>
+              </span>
+            </Tooltip>
           )}
         />
       </div>


### PR DESCRIPTION
## Description

- Disables project report generate button according to the status of last report.
- Remove use of depreciated hook 'useStore'. 


## Screenshot/Screencast

<img width="2019" height="1380" alt="Screenshot 2026-07-10 at 2 01 47 PM" src="https://github.com/user-attachments/assets/365e1d59-69b5-4b2c-9727-577471c43f97" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1735 