### PR TITLE
fix: comment implementation (project status update)

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/utils.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/utils.ts
@@ -42,6 +42,9 @@ export function mapNoteComment(comment: NoteComment): CommentNode {
     content: comment.comment,
     createdAt: comment.created_at,
     ownerId: comment.owner,
+    edited: comment?.edited,
+    deleted: comment?.deleted,
+    deletedAt: comment?.deleted_at,
     replies: (comment.replies ?? []).map(mapNoteComment),
   };
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/noteActions.tsx
@@ -17,6 +17,7 @@ import {
  */
 import { ROUTES } from "@/lib/constant";
 import { useProjectDetail } from "@/pages/project-details/context";
+import { useUser } from "@/providers/user";
 import { useNotes } from "./context";
 import { exportNote } from "./detail/utils";
 import type { Note } from "./types";
@@ -31,6 +32,10 @@ export function NoteActions({ note }: NoteActionsProps) {
   const togglePin = useNotes((s) => s.actions.togglePin);
   const openDeleteDialog = useNotes((s) => s.actions.openDeleteDialog);
   const isUpdating = useNotes((s) => s.state.isUpdating);
+  const currentUser = useUser((s) => s.state.currentUser);
+
+  // Deletion is author-only on the backend; hide the action for non-authors.
+  const isAuthor = Boolean(currentUser) && note.owner === currentUser;
 
   return (
     <span className="flex items-center" onClick={(e) => e.stopPropagation()}>
@@ -74,14 +79,18 @@ export function NoteActions({ note }: NoteActionsProps) {
             icon: <Export className="size-4 mr-2" />,
             onClick: () => exportNote(note),
           },
-          {
-            key: "delete",
-            label: "Delete",
-            theme: "red",
-            icon: <Delete className="size-4 mr-2" />,
-            disabled: isUpdating,
-            onClick: () => openDeleteDialog(note.name),
-          },
+          ...(isAuthor
+            ? [
+                {
+                  key: "delete",
+                  label: "Delete",
+                  theme: "red" as const,
+                  icon: <Delete className="size-4 mr-2" />,
+                  disabled: isUpdating,
+                  onClick: () => openDeleteDialog(note.name),
+                },
+              ]
+            : []),
         ]}
       />
     </span>

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/provider.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/provider.tsx
@@ -4,11 +4,7 @@
 import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useToasts } from "@rtcamp/frappe-ui-react";
-import {
-  FrappeError,
-  useFrappeDeleteDoc,
-  useFrappePostCall,
-} from "frappe-react-sdk";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
@@ -26,9 +22,11 @@ export function NotesProvider({ children }: PropsWithChildren) {
   const [isUpdating, setIsUpdating] = useState(false);
   const [deleteNoteName, setDeleteNoteName] = useState<string | null>(null);
   const [, setSearchParams] = useSearchParams();
-  const { deleteDoc } = useFrappeDeleteDoc();
   const { call: updateNote } = useFrappePostCall(
     "next_pms.timesheet.api.project_status_update.update_project_status_update",
+  );
+  const { call: deleteNoteCall } = useFrappePostCall(
+    "next_pms.timesheet.api.project_status_update.delete_project_status_update",
   );
   const toast = useToasts();
   const debouncedTitleInput = useDebounce(titleInput, 400);
@@ -62,7 +60,7 @@ export function NotesProvider({ children }: PropsWithChildren) {
     async (name: string) => {
       setIsUpdating(true);
       try {
-        await deleteDoc("Project Status Update", name);
+        await deleteNoteCall({ name });
         toast.success("Note deleted");
         await refresh();
         setSearchParams((prev) => {
@@ -75,7 +73,7 @@ export function NotesProvider({ children }: PropsWithChildren) {
         setIsUpdating(false);
       }
     },
-    [deleteDoc, refresh, toast, setSearchParams],
+    [deleteNoteCall, refresh, toast, setSearchParams],
   );
 
   const togglePin = useCallback(

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/types.ts
@@ -7,6 +7,9 @@ export type NoteComment = {
   reply_to: string | null;
   created_at: string;
   modified_at: string | null;
+  edited: boolean;
+  deleted: boolean;
+  deleted_at: string | null;
   owner: string;
   modified_by: string;
   reply_count: number;

--- a/frontend/packages/design-system/src/components/comments/commentItem.tsx
+++ b/frontend/packages/design-system/src/components/comments/commentItem.tsx
@@ -39,7 +39,8 @@ export function CommentItem({ comment, canReply }: CommentItemProps) {
   const isOwnedByViewer =
     Boolean(authorId) &&
     (comment.authorId === authorId || comment.ownerId === authorId);
-  const canManageComment = isOwnedByViewer || canManageAllComments;
+  const canManageComment =
+    (isOwnedByViewer || canManageAllComments) && !comment.deleted;
 
   const handleEdit = useCallback(
     async (value: string) => {
@@ -73,7 +74,11 @@ export function CommentItem({ comment, canReply }: CommentItemProps) {
             {comment.authorName}
           </span>
           <span className="shrink-0 text-base text-ink-gray-5">
-            added a comment
+            {comment.deleted
+              ? "deleted"
+              : comment.edited
+                ? "edited"
+                : "added a comment"}
           </span>
         </div>
         <span className="shrink-0 text-sm text-ink-gray-5">{timestamp}</span>
@@ -92,7 +97,11 @@ export function CommentItem({ comment, canReply }: CommentItemProps) {
       ) : (
         <div className="rounded-lg bg-surface-gray-1 px-3">
           <StaticTextEditor
-            content={comment.content}
+            content={
+              comment.deleted
+                ? "This comment has been deleted."
+                : comment.content
+            }
             editorClass="prose-sm text-ink-gray-7"
           />
         </div>

--- a/frontend/packages/design-system/src/components/comments/types.ts
+++ b/frontend/packages/design-system/src/components/comments/types.ts
@@ -6,6 +6,9 @@ export type CommentNode = {
   content: string;
   createdAt: string;
   ownerId?: string | null;
+  edited?: boolean;
+  deleted?: boolean;
+  deletedAt?: string | null;
   replies: CommentNode[];
 };
 

--- a/next_pms/next_pms/doctype/project_comments/project_comments.json
+++ b/next_pms/next_pms/doctype/project_comments/project_comments.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2025-08-25 12:22:30.110887",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -9,7 +10,10 @@
   "reply_to",
   "comment",
   "created_at",
-  "modified_at"
+  "modified_at",
+  "deleted",
+  "edited",
+  "deleted_at"
  ],
  "fields": [
   {
@@ -39,13 +43,32 @@
    "label": "Reply To",
    "options": "Project Comments",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "deleted",
+   "fieldtype": "Check",
+   "label": "Deleted"
+  },
+  {
+   "default": "0",
+   "fieldname": "edited",
+   "fieldtype": "Check",
+   "label": "Edited"
+  },
+  {
+   "depends_on": "eval:doc.deleted",
+   "fieldname": "deleted_at",
+   "fieldtype": "Datetime",
+   "label": "Deleted At",
+   "mandatory_depends_on": "eval:doc.deleted"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-15 23:06:14.064570",
+ "modified": "2026-07-10 15:36:43.566755",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Project Comments",

--- a/next_pms/next_pms/doctype/project_comments/project_comments.py
+++ b/next_pms/next_pms/doctype/project_comments/project_comments.py
@@ -16,6 +16,9 @@ class ProjectComments(Document):
 
         comment: DF.TextEditor | None
         created_at: DF.Datetime | None
+        deleted: DF.Check
+        deleted_at: DF.Datetime | None
+        edited: DF.Check
         modified_at: DF.Datetime | None
         parent: DF.Data
         parentfield: DF.Data

--- a/next_pms/next_pms/doctype/project_status_update/project_status_update.json
+++ b/next_pms/next_pms/doctype/project_status_update/project_status_update.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2025-08-25 12:12:22.154396",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -63,7 +64,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-11 20:45:23.893484",
+ "modified": "2026-07-15 16:08:24.682099",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Project Status Update",
@@ -83,8 +84,6 @@
    "write": 1
   },
   {
-   "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -92,8 +91,17 @@
    "report": 1,
    "role": "Projects Manager",
    "select": 1,
-   "share": 1,
-   "write": 1
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
+   "select": 1,
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/next_pms/next_pms/doctype/project_status_update_template/project_status_update_template.json
+++ b/next_pms/next_pms/doctype/project_status_update_template/project_status_update_template.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "autoname": "field:template_name",
  "creation": "2026-05-07 19:10:32.461670",
@@ -39,7 +40,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-08 13:28:02.096891",
+ "modified": "2026-07-15 16:07:20.516627",
  "modified_by": "Administrator",
  "module": "Next PMS",
  "name": "Project Status Update Template",
@@ -68,6 +69,19 @@
    "read": 1,
    "report": 1,
    "role": "Projects Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
    "select": 1,
    "share": 1,
    "write": 1

--- a/next_pms/tests/timesheet/api/test_project_status_update.py
+++ b/next_pms/tests/timesheet/api/test_project_status_update.py
@@ -6,6 +6,7 @@ from next_pms.timesheet.api.project_status_update import (
     add_comment_to_project_status_update,
     create_project_status_update,
     delete_comment_from_project_status_update,
+    delete_project_status_update,
     get_project_status_update,
     get_project_status_updates_by_project,
     update_comment_in_project_status_update,
@@ -14,6 +15,11 @@ from next_pms.timesheet.api.project_status_update import (
 
 AUTHOR_USER = "psu.author@example.com"
 OTHER_USER = "psu.other@example.com"
+# Holds no Projects role, so the endpoints' only_for gate must reject it.
+NO_ROLE_USER = "psu.norole@example.com"
+# Holds Projects User: allowed through the API, but must still be denied direct
+# (permission-checked) Frappe CRUD, since the doctype grants the role no perms.
+PROJECTS_USER = "psu.projectsuser@example.com"
 
 
 def _find_comment(comments: list[dict], name: str) -> dict | None:
@@ -44,13 +50,16 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
         cls.company = get_default_company()
         cls.project = cls._make_project()
 
-        # Projects Manager clears both the ROLES gate on the endpoints and the
-        # doctype-level permissions on Project Status Update.
-        cls.author_user = cls._make_user(AUTHOR_USER)
-        cls.other_user = cls._make_user(OTHER_USER)
+        # Projects Manager clears the ROLES gate on the endpoints. The doctype
+        # itself grants no CRUD to this role; writes succeed only because the
+        # endpoints run with ignore_permissions, so the API is the sole gate.
+        cls.author_user = cls._make_user(AUTHOR_USER, roles=("Projects Manager",))
+        cls.other_user = cls._make_user(OTHER_USER, roles=("Projects Manager",))
+        cls.no_role_user = cls._make_user(NO_ROLE_USER)
+        cls.projects_user = cls._make_user(PROJECTS_USER, roles=("Projects User",))
 
     @classmethod
-    def _make_user(cls, email):
+    def _make_user(cls, email, roles=()):
         if not frappe.db.exists("User", email):
             frappe.get_doc(
                 {
@@ -61,7 +70,8 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
                     "send_welcome_email": 0,
                 }
             ).insert(ignore_permissions=True)
-        frappe.get_doc("User", email).add_roles("Projects Manager")
+        if roles:
+            frappe.get_doc("User", email).add_roles(*roles)
         return email
 
     @classmethod
@@ -154,6 +164,19 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
         self.assertEqual(root["comment"], "<p>root comment</p>")
         self.assertIsNone(root["reply_to"])
         self.assertEqual(root["reply_count"], 0)
+
+    def test_role_user_can_write_through_api(self):
+        # The doctype grants Projects Manager no CRUD, yet a non-admin holder of
+        # the role can create and comment because the endpoints run with
+        # ignore_permissions. This is the API-only access model.
+        frappe.set_user(AUTHOR_USER)
+
+        created = self._make_update(title="Author-created Update")
+        self.assertEqual(created["owner"], AUTHOR_USER)
+
+        result = add_comment_to_project_status_update(name=created["name"], comment="<p>by author</p>")
+        self.assertEqual(len(result["comments"]), 1)
+        self.assertEqual(result["comments"][0]["user"], AUTHOR_USER)
 
     def test_add_reply_and_reply_chain_nesting(self):
         created = self._make_update()
@@ -293,3 +316,71 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
 
         with self.assertRaises(frappe.exceptions.ValidationError):
             delete_comment_from_project_status_update(name=created["name"], comment_name=root)
+
+    def test_user_without_projects_role_is_rejected_by_endpoints(self):
+        # A user holding neither Projects Manager nor Projects User must be
+        # blocked at the only_for gate on every endpoint - read and write.
+        created = self._make_update()
+        comment_name = self._add_comment(created["name"], "<p>seed</p>")
+
+        frappe.set_user(NO_ROLE_USER)
+        with self.assertRaises(frappe.PermissionError):
+            get_project_status_update(name=created["name"])
+        with self.assertRaises(frappe.PermissionError):
+            create_project_status_update(project=self.project, title="nope", description="<p>nope</p>", status="Draft")
+        with self.assertRaises(frappe.PermissionError):
+            add_comment_to_project_status_update(name=created["name"], comment="<p>nope</p>")
+        with self.assertRaises(frappe.PermissionError):
+            update_comment_in_project_status_update(
+                name=created["name"], comment="<p>nope</p>", comment_name=comment_name
+            )
+        with self.assertRaises(frappe.PermissionError):
+            delete_comment_from_project_status_update(name=created["name"], comment_name=comment_name)
+        with self.assertRaises(frappe.PermissionError):
+            delete_project_status_update(name=created["name"])
+
+    def test_author_can_delete_update(self):
+        frappe.set_user(AUTHOR_USER)
+        created = self._make_update(title="To be deleted")
+
+        delete_project_status_update(name=created["name"])
+
+        self.assertFalse(frappe.db.exists("Project Status Update", created["name"]))
+
+    def test_delete_update_by_non_author_is_forbidden(self):
+        frappe.set_user(AUTHOR_USER)
+        created = self._make_update(title="Author's update")
+
+        frappe.set_user(OTHER_USER)
+        with self.assertRaises(frappe.PermissionError):
+            delete_project_status_update(name=created["name"])
+
+        self.assertTrue(frappe.db.exists("Project Status Update", created["name"]))
+
+    def _assert_direct_crud_forbidden(self, user):
+        # Acting as `user` through the permission-checked ORM (the Desk path),
+        # every write must raise PermissionError because the doctype grants the
+        # role no create/write/delete. This is what forces all access through
+        # the API, where only_for + author-only ownership checks apply.
+        created = self._make_update()
+        frappe.set_user(user)
+
+        with self.assertRaises(frappe.PermissionError):
+            new_update = frappe.new_doc("Project Status Update")
+            new_update.project = self.project
+            new_update.title = "direct create"
+            new_update.insert()
+
+        with self.assertRaises(frappe.PermissionError):
+            doc = frappe.get_doc("Project Status Update", created["name"])
+            doc.title = "direct edit"
+            doc.save()
+
+        with self.assertRaises(frappe.PermissionError):
+            frappe.get_doc("Project Status Update", created["name"]).delete()
+
+    def test_projects_manager_cannot_edit_via_direct_crud(self):
+        self._assert_direct_crud_forbidden(AUTHOR_USER)
+
+    def test_projects_user_cannot_edit_via_direct_crud(self):
+        self._assert_direct_crud_forbidden(PROJECTS_USER)

--- a/next_pms/tests/timesheet/api/test_project_status_update.py
+++ b/next_pms/tests/timesheet/api/test_project_status_update.py
@@ -30,11 +30,12 @@ def _find_comment(comments: list[dict], name: str) -> dict | None:
 class TestProjectStatusUpdateComments(IntegrationTestCase):
     """Cover the Project Status Update CRUD + threaded comment endpoints.
 
-    Deleting a comment is a soft delete: the comment content is replaced with
-    a "deleted at <timestamp>" tombstone while the author and the thread
-    structure (child comments) are preserved. Editing a comment appends an
-    "edited at <timestamp>" marker to the content instead of replacing it,
-    and repeated edits replace the previous marker rather than stacking.
+    Deleting a comment is a soft delete: the deleted flag is set and
+    deleted_at recorded while the author and the thread structure (child
+    comments) are preserved; the serialized content is blanked so deleted text
+    never reaches the client. Editing a comment stores the new content verbatim
+    and ticks the edited flag. A deleted comment can no longer be edited or
+    deleted again.
     """
 
     @classmethod
@@ -183,29 +184,30 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
                 name=created["name"], comment="<p>orphan</p>", reply_to="does-not-exist"
             )
 
-    def test_update_comment_content_appends_edited_marker(self):
+    def test_update_comment_stores_content_verbatim_and_flags_edited(self):
         created = self._make_update()
         root = self._add_comment(created["name"], "<p>before</p>")
+
+        # A fresh comment is not flagged as edited.
+        self.assertFalse(get_project_status_update(name=created["name"])["comments"][0]["edited"])
+
         result = update_comment_in_project_status_update(
             name=created["name"], comment="<p>after</p>", comment_name=root
         )
-        edited = result["comments"][0]["comment"]
-        self.assertTrue(edited.startswith("<p>after</p>\n\nedited at "))
+        edited = result["comments"][0]
+        self.assertEqual(edited["comment"], "<p>after</p>")
+        self.assertTrue(edited["edited"])
 
-    def test_repeated_edits_do_not_stack_markers(self):
+    def test_repeated_edits_keep_content_verbatim(self):
         created = self._make_update()
         root = self._add_comment(created["name"], "<p>v1</p>")
 
-        first = update_comment_in_project_status_update(name=created["name"], comment="<p>v2</p>", comment_name=root)
-        edited_once = first["comments"][0]["comment"]
+        update_comment_in_project_status_update(name=created["name"], comment="<p>v2</p>", comment_name=root)
+        second = update_comment_in_project_status_update(name=created["name"], comment="<p>v3</p>", comment_name=root)
 
-        # Simulate the client sending back the stored content (marker included).
-        second = update_comment_in_project_status_update(name=created["name"], comment=edited_once, comment_name=root)
-        edited_twice = second["comments"][0]["comment"]
-
-        self.assertTrue(edited_twice.startswith("<p>v2</p>\n\nedited at "))
-        # Only a single trailing marker remains, not one per edit.
-        self.assertEqual(edited_twice.count("edited at "), 1)
+        edited = second["comments"][0]
+        self.assertEqual(edited["comment"], "<p>v3</p>")
+        self.assertTrue(edited["edited"])
 
     def test_update_comment_requires_comment_name(self):
         created = self._make_update()
@@ -223,9 +225,10 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
         self.assertEqual(len(result["comments"]), 1)
         deleted = result["comments"][0]
         self.assertEqual(deleted["name"], root)
-        # Content is replaced with a "[deleted at <timestamp>]" tombstone.
-        self.assertTrue(deleted["comment"].startswith("[deleted at "))
-        self.assertTrue(deleted["comment"].endswith("]"))
+        # Flagged as deleted with a timestamp; content is blanked out.
+        self.assertTrue(deleted["deleted"])
+        self.assertIsNotNone(deleted["deleted_at"])
+        self.assertEqual(deleted["comment"], "")
         # Author and identity metadata are preserved.
         self.assertEqual(deleted["user"], AUTHOR_USER)
 
@@ -241,7 +244,8 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
         details = get_project_status_update(name=created["name"])
         deleted_reply = _find_comment(details["comments"], reply)
         self.assertIsNotNone(deleted_reply)
-        self.assertTrue(deleted_reply["comment"].startswith("[deleted at "))
+        self.assertTrue(deleted_reply["deleted"])
+        self.assertEqual(deleted_reply["comment"], "")
         self.assertEqual(deleted_reply["reply_to"], root)
 
         # The child of the deleted comment survives unchanged.
@@ -271,3 +275,21 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
         frappe.set_user(OTHER_USER)
         with self.assertRaises(frappe.PermissionError):
             update_comment_in_project_status_update(name=created["name"], comment="<p>hijack</p>", comment_name=root)
+
+    def test_editing_a_deleted_comment_is_forbidden(self):
+        created = self._make_update()
+        frappe.set_user(AUTHOR_USER)
+        root = self._add_comment(created["name"], "<p>to be deleted</p>")
+        delete_comment_from_project_status_update(name=created["name"], comment_name=root)
+
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            update_comment_in_project_status_update(name=created["name"], comment="<p>resurrect</p>", comment_name=root)
+
+    def test_deleting_a_deleted_comment_is_forbidden(self):
+        created = self._make_update()
+        frappe.set_user(AUTHOR_USER)
+        root = self._add_comment(created["name"], "<p>to be deleted</p>")
+        delete_comment_from_project_status_update(name=created["name"], comment_name=root)
+
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            delete_comment_from_project_status_update(name=created["name"], comment_name=root)

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -4,7 +4,7 @@ import frappe
 from frappe import _, enqueue, only_for
 from frappe.desk.notifications import extract_mentions
 from frappe.types import DF
-from frappe.utils import cint, now, now_datetime
+from frappe.utils import cint, now_datetime
 from frappe.utils.user import get_user_fullname
 
 from next_pms.api.utils import error_logger
@@ -51,7 +51,7 @@ def create_project_status_update(
         doc.status = status
         if pinned is not None:
             doc.pinned = cint(pinned)
-        doc.insert()
+        doc.insert(ignore_permissions=True)
 
         if status == "Publish":
             should_enqueue_publish_notification = True
@@ -180,9 +180,36 @@ def update_project_status_update(
     if pinned is not None:
         doc.pinned = cint(pinned)
 
-    doc.save()
+    doc.save(ignore_permissions=True)
 
     return get_project_status_update_details(doc.name)
+
+
+@frappe.whitelist(methods=["POST"])
+@error_logger
+def delete_project_status_update(name: str) -> dict[str, Any]:
+    """
+    Delete a Project Status Update. Only its author (owner) may delete it.
+
+    Args:
+        name (str): Document name
+
+    Returns:
+        Dict[str, Any]: The name of the deleted document
+    """
+    only_for(ROLES, message=True)
+
+    if not frappe.db.exists("Project Status Update", name):
+        frappe.throw(_("Project Status Update '{name}' does not exist").format(name=name))
+
+    doc = frappe.get_doc("Project Status Update", name)
+
+    if frappe.session.user != "Administrator" and doc.owner != frappe.session.user:
+        frappe.throw(_("You do not have permission to delete this update"), frappe.PermissionError)
+
+    doc.delete(ignore_permissions=True)
+
+    return {"name": name}
 
 
 @frappe.whitelist(methods=["POST"])
@@ -215,11 +242,11 @@ def add_comment_to_project_status_update(name: str, comment: str, reply_to: str 
     comment_row.user = frappe.session.user
     comment_row.comment = comment
     comment_row.reply_to = reply_to or None
-    current_time = now()
+    current_time = now_datetime()
     comment_row.created_at = current_time
     comment_row.modified_at = current_time
 
-    doc.save()
+    doc.save(ignore_permissions=True)
 
     enqueue(
         notify_mentions,
@@ -281,7 +308,7 @@ def update_comment_in_project_status_update(
     target_row.comment = comment
     target_row.edited = 1
     target_row.modified_at = now_datetime()
-    doc.save()
+    doc.save(ignore_permissions=True)
 
     enqueue(
         notify_mentions,
@@ -340,7 +367,7 @@ def delete_comment_from_project_status_update(name: str, comment_name: str) -> d
     target_row.deleted = 1
     target_row.deleted_at = deleted_at
     target_row.modified_at = deleted_at
-    doc.save()
+    doc.save(ignore_permissions=True)
 
     return get_project_status_update_details(doc.name)
 

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any
 
 import frappe
@@ -276,11 +275,12 @@ def update_comment_in_project_status_update(
     if frappe.session.user != "Administrator" and target_row.user != frappe.session.user:
         frappe.throw(_("You do not have permission to edit this comment"), frappe.PermissionError)
 
-    edited_at = now_datetime().replace(microsecond=0)
-    # drop a previous "edited at ..." marker so repeated edits don't stack
-    base_comment = re.sub(r"\n\nedited at \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$", "", comment)
-    target_row.comment = f"{base_comment}\n\nedited at {edited_at}"
-    target_row.modified_at = edited_at
+    if target_row.deleted:
+        frappe.throw(_("This comment has been deleted and can no longer be edited"))
+
+    target_row.comment = comment
+    target_row.edited = 1
+    target_row.modified_at = now_datetime()
     doc.save()
 
     enqueue(
@@ -332,9 +332,13 @@ def delete_comment_from_project_status_update(name: str, comment_name: str) -> d
     if frappe.session.user != "Administrator" and target_row.user != frappe.session.user:
         frappe.throw(_("You do not have permission to delete this comment"), frappe.PermissionError)
 
-    # keep the author and thread structure, but blank out the content
-    deleted_at = now_datetime().replace(microsecond=0)
-    target_row.comment = f"[deleted at {deleted_at}]"
+    if target_row.deleted:
+        frappe.throw(_("This comment has already been deleted"))
+
+    # keep the author and thread structure; the row is flagged as deleted
+    deleted_at = now_datetime()
+    target_row.deleted = 1
+    target_row.deleted_at = deleted_at
     target_row.modified_at = deleted_at
     doc.save()
 
@@ -355,20 +359,27 @@ def _serialize_comment(comment, user_map: dict[str, tuple]) -> dict[str, Any]:
             "reply_to": "parent_comment_row_name",
             "created_at": "2025-05-14 10:00:00.000000",
             "modified_at": "2025-05-14 12:30:00.000000",
+            "edited": True,
+            "deleted": False,
+            "deleted_at": None,
             "owner": "jane@example.com",
             "modified_by": "jane@example.com",
         }
     """
     user_details = user_map.get(comment.user)
+    is_deleted = bool(comment.deleted)
     return {
         "name": comment.name,
         "user": comment.user,
         "user_full_name": user_details[0] if user_details else comment.user,
         "user_image": user_details[1] if user_details else None,
-        "comment": comment.comment,
+        "comment": "" if is_deleted else comment.comment,
         "reply_to": comment.reply_to,
         "created_at": comment.created_at,
         "modified_at": comment.modified_at,
+        "edited": bool(comment.edited),
+        "deleted": is_deleted,
+        "deleted_at": comment.deleted_at,
         "owner": comment.owner,
         "modified_by": comment.modified_by,
     }


### PR DESCRIPTION
## Description

comment implementation (project status update) adds backend fields instead of text edit

when a comment is deleted, delete check will be true with timestamp
when a comment is edited, edited check will be true with timestamp
once deleted, a comment cannot be edited or deleted
only the user who created the notes can delete it
permission fixes: removed unwanted perms and moved entirely to api perm check

## Relevant Technical Choices

1. backend fields added to log info 

## Testing Instructions

1. add a comment
2. edit it 
3. delete it 

## Screenshot/Screencast

backend logging 
<img width="793" height="244" alt="image" src="https://github.com/user-attachments/assets/721703b6-0532-49df-824f-a98746770e29" />

FE:

<img width="1217" height="808" alt="Screenshot 2026-07-14 at 1 25 32 PM" src="https://github.com/user-attachments/assets/ea20aaee-e088-4058-afdd-ed6aa361014d" />

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1780 #1788