### PR TITLE
Fix: overflow of non-billable dot indicator and set max width for row labels

### DIFF
--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -71,7 +71,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         >
           <SmallDown strokeWidth={1.5} size={16} />
         </span>
-        <div className="flex gap-2 items-center min-w-0">
+        <div className="flex gap-2 items-center min-w-0 max-w-75 sm:max-w-112">
           <Avatar image={avatarUrl} shape="circle" label={label} size="xs" />
           <span className="text-base font-medium truncate text-ink-gray-8">
             {label}

--- a/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
@@ -58,7 +58,7 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({
         >
           <SmallDown strokeWidth={1.5} size={16} />
         </span>
-        <div className="flex items-center min-w-0 gap-2 text-ink-gray-8">
+        <div className="flex items-center min-w-0 max-w-75 sm:max-w-112 gap-2 text-ink-gray-8">
           <span className="shrink-0">
             {renderPrefix ? (
               renderPrefix()

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -135,7 +135,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
       <div className="flex items-center flex-1 min-w-0 group">
         <div className="flex items-center min-w-0 gap-2">
           <TaskStatus status={status} />
-          <span className="min-w-0 text-base font-medium truncate">
+          <span className="min-w-0 max-w-75 sm:max-w-112 text-base font-medium truncate">
             <PreviewCard.Root>
               <PreviewCard.Trigger
                 onClick={() => onLabelClick?.(taskKey)}

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -234,7 +234,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
                     <span>{timeEntry.time}</span>
                   )}
                   {timeEntry.nonBillable ? (
-                    <span className="block absolute z-10 -bottom-0.5 left-1/2 w-1 h-1 rounded-full bg-surface-amber-3 transform -translate-x-1/2"></span>
+                    <span className="block absolute z-5 -bottom-0.5 left-1/2 w-1 h-1 rounded-full bg-surface-amber-3 transform -translate-x-1/2"></span>
                   ) : null}
                 </Button>
               )}

--- a/frontend/packages/design-system/src/components/timesheet/rows/week/weekRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/week/weekRow.tsx
@@ -79,7 +79,7 @@ export const WeekRow: React.FC<WeekRowProps> = ({
         >
           <SmallDown size={16} />
         </span>
-        <div className="flex items-center min-w-0 gap-2">
+        <div className="flex items-center min-w-0 max-w-75 sm:max-w-112 gap-2">
           <span className="text-base font-medium text-ink-gray-8 truncate">
             {label}
           </span>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
* Fixed an issue where the non-billable indicator intersected with the header row due to a `z-index` issue.
* Added a maximum width to row labels to prevent long task or project names from causing unnecessary horizontal scrolling.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
- Dot indicator fix:


https://github.com/user-attachments/assets/b740aad4-3ca6-46fb-ba07-ef8b9a46e522



- Long row label
<img width="1082" height="250" alt="image" src="https://github.com/user-attachments/assets/1f764301-88db-4770-a7af-0cfe6522f604" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1803 #1795