### PR TITLE
fix: add number formatting for project details and dashboard pages

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -282,6 +282,46 @@ export const currencyFormat = (currency: string = "INR"): Intl.NumberFormat => {
   }
 };
 
+export type NumericFormatValue = number | string | null | undefined;
+
+/**
+ * Formats a numeric value into a string representation with a maximum of two decimal places.
+ * @param value - The numeric value to format.
+ * @returns A string representation of the numeric value.
+ */
+export const formatNumber = (value: NumericFormatValue): string => {
+  if (value === null || value === undefined || value === "") {
+    return "0";
+  }
+
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return "0";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    useGrouping: false,
+    maximumFractionDigits: 2,
+  }).format(numericValue);
+};
+
+/**
+ * Formats a numeric value representing hours into a string representation with a specified suffix.
+ * @param value - The numeric value representing hours to format.
+ * @param suffix - The suffix to append to the formatted string (default is "h").
+ * @returns A string representation of the numeric value with the specified suffix.
+ */
+export const formatHours = (value: NumericFormatValue, suffix = "h"): string =>
+  `${formatNumber(value)}${suffix}`;
+
+/**
+ * Formats a numeric value representing a percentage into a string representation with a "%" suffix.
+ * @param value - The numeric value representing a percentage to format.
+ * @returns
+ */
+export const formatPercentage = (value: NumericFormatValue): string =>
+  `${formatNumber(value)}%`;
+
 export const getBgCsssForToday = (date: string) => {
   return isToday(getUTCDateTime(date)) ? "bg-slate-100 dark:bg-muted/50 " : "";
 };

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -299,10 +299,7 @@ export const formatNumber = (value: NumericFormatValue): string => {
     return "0";
   }
 
-  return new Intl.NumberFormat("en-US", {
-    useGrouping: false,
-    maximumFractionDigits: 2,
-  }).format(numericValue);
+  return `${Number(numericValue.toFixed(2))}`;
 };
 
 /**
@@ -317,7 +314,7 @@ export const formatHours = (value: NumericFormatValue, suffix = "h"): string =>
 /**
  * Formats a numeric value representing a percentage into a string representation with a "%" suffix.
  * @param value - The numeric value representing a percentage to format.
- * @returns
+ * @returns A percentage string with a maximum of two decimal places and a "%" suffix.
  */
 export const formatPercentage = (value: NumericFormatValue): string =>
   `${formatNumber(value)}%`;

--- a/frontend/packages/app/src/pages/dashboard/widget/assigned-projects/hours-burn.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/assigned-projects/hours-burn.tsx
@@ -3,6 +3,7 @@
  */
 import { ProgressBar } from "@next-pms/design-system/components";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
+import { formatHours } from "@/lib/utils";
 
 export function HoursBurnBar({ used, total }: { used: number; total: number }) {
   const usedPercent = total > 0 ? Math.min(100, (used / total) * 100) : 0;
@@ -15,10 +16,10 @@ export function HoursBurnBar({ used, total }: { used: number; total: number }) {
         indicatorClassName="bg-surface-blue-4"
       />
       <div className="absolute inset-0 flex">
-        <Tooltip text={`${used}h used`}>
+        <Tooltip text={`${formatHours(used)} used`}>
           <div style={{ width: `${usedPercent}%` }} />
         </Tooltip>
-        <Tooltip text={`${total}h total`}>
+        <Tooltip text={`${formatHours(total)} total`}>
           <div className="grow" />
         </Tooltip>
       </div>

--- a/frontend/packages/app/src/pages/dashboard/widget/assigned-projects/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/assigned-projects/index.tsx
@@ -18,12 +18,11 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
+import { formatHours } from "@/lib/utils";
 import { ASSIGNED_PROJECTS_COLUMNS } from "./constants";
 import { HoursBurnBar } from "./hours-burn";
 import { AssignedProjectsSkeleton } from "./skeleton";
 import type { AssignedProject, ProjectSummaryResponse } from "./types";
-
-const HOURS = (value: number) => `${value}h`;
 
 export default function AssignedProjects() {
   const [selectedCustomers, setSelectedCustomers] = useState<string[]>([]);
@@ -137,7 +136,7 @@ export default function AssignedProjects() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(row.remaining)}
+                    {formatHours(row.remaining)}
                   </span>
                 </ListRowItem>
                 <ListRowItem
@@ -155,7 +154,7 @@ export default function AssignedProjects() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(row.billableLastWeek)}
+                    {formatHours(row.billableLastWeek)}
                   </span>
                 </ListRowItem>
                 <ListRowItem
@@ -165,7 +164,7 @@ export default function AssignedProjects() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(row.nonBillableLastWeek)}
+                    {formatHours(row.nonBillableLastWeek)}
                   </span>
                 </ListRowItem>
               </ListRow>

--- a/frontend/packages/app/src/pages/dashboard/widget/kpi-cards/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/kpi-cards/index.tsx
@@ -7,7 +7,7 @@ import { SmallDown } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
-import { currencyFormat } from "@/lib/utils";
+import { currencyFormat, formatPercentage } from "@/lib/utils";
 import { LeadershipKPIResponse } from "./types";
 import { useLeadershipKpi } from "./useLeadershipKpi";
 
@@ -48,7 +48,7 @@ export default function LeadershipKpiCard({
         <span className="truncate text-2xl font-medium text-ink-gray-8">
           {data
             ? kpikey === "profit_margin"
-              ? `${data.current.toFixed(2)}%`
+              ? formatPercentage(data.current)
               : currencyFormat("USD").format(data.current)
             : "—"}
         </span>

--- a/frontend/packages/app/src/pages/dashboard/widget/stat-cards/statCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/stat-cards/statCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { mergeClassNames } from "@next-pms/design-system";
+import { formatNumber } from "@/lib/utils";
 
 export type StatCardData = {
   label: string;
@@ -23,7 +24,9 @@ export function StatCard({
     <>
       <span className="truncate text-base text-ink-gray-5">{label}</span>
       <div className="flex items-baseline gap-1">
-        <span className="text-2xl font-medium text-ink-gray-8">{value}</span>
+        <span className="text-2xl font-medium text-ink-gray-8">
+          {formatNumber(value)}
+        </span>
         {subLabel && (
           <span className="truncate text-base text-ink-gray-5">{subLabel}</span>
         )}

--- a/frontend/packages/app/src/pages/dashboard/widget/timesheet-summary/index.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/timesheet-summary/index.tsx
@@ -18,6 +18,7 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
+import { formatHours } from "@/lib/utils";
 import {
   LAST_WEEK_VALUE,
   PERIOD_OPTIONS,
@@ -28,8 +29,6 @@ import {
 import { TimesheetsSkeleton } from "./skeleton";
 import { StatusIcon } from "./statusIcon";
 import type { TeamTimesheetsResponse, WeeklyApprovalStatus } from "../../types";
-
-const HOURS = (value: number) => `${value}h`;
 
 function periodToDays(period: string): number {
   const today = new Date();
@@ -148,7 +147,7 @@ export default function Timesheets() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(member.billable)}
+                    {formatHours(member.billable)}
                   </span>
                 </ListRowItem>
                 <ListRowItem
@@ -158,7 +157,7 @@ export default function Timesheets() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(member.nonBillable)}
+                    {formatHours(member.nonBillable)}
                   </span>
                 </ListRowItem>
                 <ListRowItem
@@ -168,7 +167,7 @@ export default function Timesheets() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(member.expected)}
+                    {formatHours(member.expected)}
                   </span>
                 </ListRowItem>
                 <ListRowItem
@@ -178,7 +177,7 @@ export default function Timesheets() {
                   align="right"
                 >
                   <span className="truncate text-base text-ink-gray-6">
-                    {HOURS(member.delta)}
+                    {formatHours(member.delta)}
                   </span>
                 </ListRowItem>
                 <ListRowItem

--- a/frontend/packages/app/src/pages/project-details/about/components/memberHoverCard.tsx
+++ b/frontend/packages/app/src/pages/project-details/about/components/memberHoverCard.tsx
@@ -19,7 +19,7 @@ import {
 /**
  * Internal dependencies.
  */
-import { currencyFormat } from "@/lib/utils";
+import { currencyFormat, formatNumber } from "@/lib/utils";
 import { useProjectDetail } from "../../context";
 import type { AboutMember } from "../types";
 
@@ -116,8 +116,8 @@ export function MemberHoverCard({
                     <div className="flex items-center gap-2">
                       <Time className="size-4 shrink-0 text-ink-gray-5" />
                       <span className="truncate text-sm text-ink-gray-6">
-                        {Math.round(member.loggedHours)}/
-                        {Math.round(member.totalHoursPurchased)}h
+                        {formatNumber(member.loggedHours)}/
+                        {formatNumber(member.totalHoursPurchased)}h
                       </span>
                     </div>
                   )}

--- a/frontend/packages/app/src/pages/project-details/about/progressHoursSection.tsx
+++ b/frontend/packages/app/src/pages/project-details/about/progressHoursSection.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies.
  */
+import { formatNumber } from "@/lib/utils";
 import { Section } from "./section";
 import type { ProjectProgressHours } from "./types";
 
@@ -22,10 +23,10 @@ export function ProgressHoursSection({
       <div className="flex flex-col gap-2.5">
         <div className="flex items-center justify-between">
           <span className="text-base font-medium text-ink-gray-7">
-            {consumed} hours
+            {formatNumber(consumed)} hours
           </span>
           <span className="text-base font-light text-ink-gray-5">
-            {total} hours
+            {formatNumber(total)} hours
           </span>
         </div>
         <div

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/hoursUsage.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/hoursUsage.tsx
@@ -6,6 +6,7 @@ import { ProgressBar } from "@next-pms/design-system/components";
 /**
  * Internal dependencies.
  */
+import { formatHours } from "@/lib/utils";
 import { useTracking } from "../context";
 import { LegendItem } from "./legendItem";
 
@@ -32,14 +33,14 @@ export function HoursUsageCell() {
         <LegendItem
           className="bg-surface-blue-4"
           label="Hours utilised"
-          value={`${utilised} h`}
+          value={formatHours(utilised, " h")}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium text-ink-gray-6"
         />
         <LegendItem
           className="bg-surface-gray-3"
           label="Hours remaining"
-          value={`${remaining} h`}
+          value={formatHours(remaining, " h")}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium text-ink-gray-6"
         />

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import { currencyFormat } from "@/lib/utils";
+import { currencyFormat, formatPercentage } from "@/lib/utils";
 import { ContractsTable } from "./components/contractsTable";
 import { CostBurnCell } from "./components/costBurn";
 import { HoursUsageCell } from "./components/hoursUsage";
@@ -41,7 +41,7 @@ function TrackingContent() {
         />
         <KnowledgePoint
           title="Projected profit margin"
-          value={`${(tracking.projected_profit_margin ?? 0).toFixed(2)}%`}
+          value={formatPercentage(tracking.projected_profit_margin ?? 0)}
         />
       </div>
 

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/provider.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/provider.tsx
@@ -12,7 +12,7 @@ import {
 /**
  * Internal dependencies.
  */
-import { currencyFormat, parseFrappeErrorMsg } from "@/lib/utils";
+import { currencyFormat, formatNumber, parseFrappeErrorMsg } from "@/lib/utils";
 import {
   DEFAULT_TRACKING,
   TrackingContext,
@@ -218,10 +218,10 @@ export function TrackingProvider({ children }: PropsWithChildren) {
           name: c.name,
           startDate: c.start_date,
           endDate: c.end_date,
-          hoursBought: `${c.hours_purchased}`,
+          hoursBought: formatNumber(c.hours_purchased),
           hoursBoughtRaw: c.hours_purchased,
-          hoursUsed: `${c.consumed_hours}`,
-          hoursLeft: `${c.remaining_hours}`,
+          hoursUsed: formatNumber(c.consumed_hours),
+          hoursLeft: formatNumber(c.remaining_hours),
           salesOrder: c.sales_order ?? "",
           salesInvoice: c.sales_invoice ?? "",
         }))

--- a/frontend/packages/app/src/pages/projects/list/cells/percentCell.tsx
+++ b/frontend/packages/app/src/pages/projects/list/cells/percentCell.tsx
@@ -1,5 +1,11 @@
+import { formatPercentage } from "@/lib/utils";
+
 export function PercentCell({ value }: { value: number | null | undefined }) {
-  if (value === null || value === undefined || Number.isNaN(value)) {
+  if (
+    value === null ||
+    value === undefined ||
+    !Number.isFinite(Number(value))
+  ) {
     return (
       <span className="block truncate text-ink-gray-6 text-base">N/A</span>
     );
@@ -7,7 +13,7 @@ export function PercentCell({ value }: { value: number | null | undefined }) {
 
   return (
     <span className="block truncate text-ink-gray-6 text-base">
-      {`${value.toFixed(2)}%`}
+      {formatPercentage(value)}
     </span>
   );
 }


### PR DESCRIPTION
## Description

This PR adds a shared utility function for formatting hours, numbers, and percentages. It updates the Project Details and Dashboard pages to use this shared formatter, ensuring values are consistently displayed with a maximum of two decimal places.

<!-- What do we want to achieve with this PR? -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1379" height="619" alt="image" src="https://github.com/user-attachments/assets/99757d19-1ef5-42eb-903b-22dfc70ea6c3" />
<img width="1447" height="625" alt="image" src="https://github.com/user-attachments/assets/36dd59f0-3144-4a96-99dc-9c640ed64b60" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1796