### PR TITLE
Fix: Wire custom methods for employee lookup

### DIFF
--- a/frontend/packages/app/src/components/filters/FilterLinkValue.tsx
+++ b/frontend/packages/app/src/components/filters/FilterLinkValue.tsx
@@ -33,6 +33,8 @@ export const FilterLinkValue: React.FC<FilterLinkValueRenderProps> = ({
     doctype: linkConfig?.doctype ?? "",
     labelField: linkConfig?.labelField,
     valueField: linkConfig?.valueField,
+    filters: linkConfig?.filters,
+    customMethod: linkConfig?.customMethod,
     shouldFetch: Boolean(linkConfig?.doctype),
     query,
     selectedOption,

--- a/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
+++ b/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
@@ -14,6 +14,15 @@ interface UseDoctypeLinkLookupOptions {
   labelField?: string;
   /** Field on the target doctype whose value is stored as the filter value. Defaults to `name`. */
   valueField?: string;
+  /** Server-side filters applied to the lookup request. */
+  filters?: Array<Array<unknown>>;
+  /** Custom API method configuration for the lookup. */
+  customMethod?: {
+    /** Whitelisted API method. */
+    method: string;
+    /** Role names to restrict lookup results to. */
+    roles?: string[];
+  };
   /** Controls whether the lookup should fetch for the current UI state. */
   shouldFetch: boolean;
   /** Raw user search text before debounce is applied. */
@@ -29,28 +38,60 @@ export const useDoctypeLinkLookup = ({
   doctype,
   labelField = "name",
   valueField = "name",
+  filters,
+  customMethod,
   shouldFetch,
   query,
   selectedOption,
 }: UseDoctypeLinkLookupOptions) => {
+  const isDefaultMethod =
+    !customMethod?.method || customMethod.method === "frappe.client.get_list";
   const fields =
     labelField === "name" || labelField === valueField
       ? [valueField]
       : [valueField, labelField];
 
+  const params = isDefaultMethod
+    ? ({
+        query: searchQuery,
+        pageSize,
+      }: {
+        query: string;
+        pageSize: number;
+      }) => ({
+        doctype,
+        fields,
+        limit_page_length: pageSize,
+        order_by: `${labelField} asc`,
+        filters: [
+          ...(filters ?? []),
+          ...(searchQuery ? [[labelField, "like", `%${searchQuery}%`]] : []),
+        ],
+      })
+    : ({
+        query: searchQuery,
+        pageSize,
+      }: {
+        query: string;
+        pageSize: number;
+      }) => ({
+        employee_name: searchQuery || undefined,
+        page_length: pageSize,
+        start: 0,
+        filters: filters ?? undefined,
+        roles: customMethod.roles?.length ? customMethod.roles : undefined,
+      });
+
+  const getItems = isDefaultMethod
+    ? (message: DoctypeLinkItem[] | undefined) => message ?? []
+    : (data: { data?: DoctypeLinkItem[] } | undefined) => data?.data ?? [];
+
   return useRemoteLookup<DoctypeLinkItem[], DoctypeLinkItem, LookupOption>({
     shouldFetch,
     query,
-    params: ({ query: searchQuery, pageSize }) => ({
-      doctype,
-      fields,
-      limit_page_length: pageSize,
-      order_by: `${labelField} asc`,
-      filters: searchQuery
-        ? [[labelField, "like", `%${searchQuery}%`]]
-        : undefined,
-    }),
-    getItems: (message) => message ?? [],
+    method: customMethod?.method || "frappe.client.get_list",
+    params,
+    getItems: getItems as (message: unknown) => DoctypeLinkItem[],
     mapOption: (item) => ({
       label:
         labelField === "name"

--- a/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
+++ b/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
@@ -21,7 +21,7 @@ interface UseDoctypeLinkLookupOptions {
     /** Whitelisted API method. */
     method: string;
     /** Arguments passed to the custom method. */
-    args?: unknown;
+    args?: Record<string, unknown>;
   };
   /** Controls whether the lookup should fetch for the current UI state. */
   shouldFetch: boolean;
@@ -79,9 +79,7 @@ export const useDoctypeLinkLookup = ({
         page_length: pageSize,
         start: 0,
         filters: filters ?? undefined,
-        ...(customMethod.args
-          ? (customMethod.args as Record<string, unknown>)
-          : {}),
+        ...(customMethod.args ? customMethod.args : {}),
       });
 
   const getItems = isDefaultMethod

--- a/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
+++ b/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
@@ -20,8 +20,8 @@ interface UseDoctypeLinkLookupOptions {
   customMethod?: {
     /** Whitelisted API method. */
     method: string;
-    /** Role names to restrict lookup results to. */
-    roles?: string[];
+    /** Arguments passed to the custom method. */
+    args?: unknown;
   };
   /** Controls whether the lookup should fetch for the current UI state. */
   shouldFetch: boolean;
@@ -79,7 +79,9 @@ export const useDoctypeLinkLookup = ({
         page_length: pageSize,
         start: 0,
         filters: filters ?? undefined,
-        roles: customMethod.roles?.length ? customMethod.roles : undefined,
+        ...(customMethod.args
+          ? (customMethod.args as Record<string, unknown>)
+          : {}),
       });
 
   const getItems = isDefaultMethod

--- a/frontend/packages/app/src/pages/allocations/project/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/project/constants.ts
@@ -56,7 +56,7 @@ export const projectAllocationFilters: FilterField[] = [
       valueField: "user_id",
       customMethod: {
         method: "next_pms.timesheet.api.employee.get_employee_list",
-        roles: ["Projects Manager"],
+        args: { roles: ["Projects Manager"] },
       },
     },
     operators: [

--- a/frontend/packages/app/src/pages/allocations/project/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/project/constants.ts
@@ -50,7 +50,15 @@ export const projectAllocationFilters: FilterField[] = [
     name: "project_manager",
     label: "Project Manager",
     type: "link",
-    link: { doctype: "User", labelField: "full_name" },
+    link: {
+      doctype: "Employee",
+      labelField: "employee_name",
+      valueField: "user_id",
+      customMethod: {
+        method: "next_pms.timesheet.api.employee.get_employee_list",
+        roles: ["Projects Manager"],
+      },
+    },
     operators: [
       { label: "Equals", value: "=" },
       { label: "Not Equals", value: "!=" },

--- a/frontend/packages/app/src/pages/allocations/team/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/team/constants.ts
@@ -41,7 +41,7 @@ export const teamAllocationFilters: FilterField[] = [
       valueField: "employee_name",
       customMethod: {
         method: "next_pms.timesheet.api.employee.get_employee_list",
-        roles: ["Projects Manager"],
+        args: { roles: ["Projects Manager"] },
       },
     },
     operators: [

--- a/frontend/packages/app/src/pages/allocations/team/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/team/constants.ts
@@ -39,6 +39,10 @@ export const teamAllocationFilters: FilterField[] = [
       doctype: "Employee",
       labelField: "employee_name",
       valueField: "employee_name",
+      customMethod: {
+        method: "next_pms.timesheet.api.employee.get_employee_list",
+        roles: ["Projects Manager"],
+      },
     },
     operators: [
       { label: "Equals", value: "=" },

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -145,7 +145,7 @@ export function ProjectListSubHeader() {
                 valueField: "user_id",
                 customMethod: {
                   method: "next_pms.timesheet.api.employee.get_employee_list",
-                  roles: ["Projects Manager"],
+                  args: { roles: ["Projects Manager"] },
                 },
               },
               operators: [

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -139,7 +139,15 @@ export function ProjectListSubHeader() {
               name: "custom_project_manager",
               label: "Project Manager",
               type: "link",
-              link: { doctype: "User", labelField: "full_name" },
+              link: {
+                doctype: "Employee",
+                labelField: "employee_name",
+                valueField: "user_id",
+                customMethod: {
+                  method: "next_pms.timesheet.api.employee.get_employee_list",
+                  roles: ["Projects Manager"],
+                },
+              },
               operators: [
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },
@@ -208,7 +216,14 @@ export function ProjectListSubHeader() {
               name: "custom_engineering_manager",
               label: "Engineering Manager",
               type: "link",
-              link: { doctype: "User", labelField: "full_name" },
+              link: {
+                doctype: "Employee",
+                labelField: "employee_name",
+                valueField: "user_id",
+                customMethod: {
+                  method: "next_pms.timesheet.api.employee.get_employee_list",
+                },
+              },
               operators: [
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },
@@ -218,7 +233,14 @@ export function ProjectListSubHeader() {
               name: "custom_account_manager_",
               label: "Account Manager",
               type: "link",
-              link: { doctype: "User", labelField: "full_name" },
+              link: {
+                doctype: "Employee",
+                labelField: "employee_name",
+                valueField: "user_id",
+                customMethod: {
+                  method: "next_pms.timesheet.api.employee.get_employee_list",
+                },
+              },
               operators: [
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },


### PR DESCRIPTION
## Description

Adds custom method in look up with roles for employees lookup instead of all users

## Testing Instructions

- Go to Projects page
- Click on Filters.
- Select Project Manager
- Observe the list, should show only employees list with Project Manager role


## Screenshot/Screencast


https://github.com/user-attachments/assets/c77f1f3a-5068-4ae9-8c04-abc6da418588




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Depends on: https://github.com/rtCamp/frappe-ui-react/pull/308
Fixes: #1797 