### PR TITLE
Fix: wire Project Type filter as link

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/project/constants.ts
@@ -44,7 +44,12 @@ export const projectAllocationFilters: FilterField[] = [
   {
     name: "project_type",
     label: "Project Type",
-    type: "string",
+    type: "link",
+    link: { doctype: "Project Type" },
+    operators: [
+      { label: "Equals", value: "=" },
+      { label: "Not Equals", value: "!=" },
+    ],
   },
   {
     name: "project_manager",

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -166,15 +166,11 @@ export function ProjectListSubHeader() {
             {
               name: "project_type",
               label: "Project Type",
-              type: "select",
+              type: "link",
+              link: { doctype: "Project Type" },
               operators: [
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },
-              ],
-              options: [
-                { label: "Internal", value: "internal" },
-                { label: "External", value: "external" },
-                { label: "Other", value: "other" },
               ],
             },
             {


### PR DESCRIPTION
## Description

Add config for "Project Type" filter as link fieldtype to fetch options

## Testing Instructions

- Go to Allocations -> Projects page
- Select filter as "Project Type"
- Observe the suggested options, should be documents from Project Type DocType

## Screenshot/Screencast


https://github.com/user-attachments/assets/889b949b-7f26-4165-8706-f435d9248c0d




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Part of: #1818 