### PR TITLE
fix: use circle instead of path

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/taskCompletion.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/taskCompletion.tsx
@@ -3,8 +3,10 @@
  */
 import { useTracking } from "../context";
 
-const ARC_RADIUS = 75;
-const ARC_LENGTH = Math.PI * ARC_RADIUS;
+// Full circle normalized to 200 units; the rotated dash keeps only the
+// top semicircle (100 units) visible, so gauge values map 1:1 to percent.
+const CIRCLE_PATH_LENGTH = 200;
+const SEMICIRCLE = CIRCLE_PATH_LENGTH / 2;
 
 export function TaskCompletionCell() {
   const tasks = useTracking((state) => state.tracking.tasks);
@@ -28,22 +30,31 @@ export function TaskCompletionCell() {
             className="block w-full h-auto"
             aria-hidden
           >
-            <path
-              d="M 15 100 A 75 75 0 0 1 185 100"
+            <circle
+              cx={100}
+              cy={100}
+              r={85}
               fill="none"
               stroke="currentColor"
               strokeWidth={22}
               strokeLinecap="round"
+              pathLength={CIRCLE_PATH_LENGTH}
+              strokeDasharray={`${SEMICIRCLE} ${CIRCLE_PATH_LENGTH}`}
+              transform="rotate(180 100 100)"
               className="text-surface-gray-2"
             />
             {ratio > 0 && (
-              <path
-                d="M 15 100 A 75 75 0 0 1 185 100"
+              <circle
+                cx={100}
+                cy={100}
+                r={85}
                 fill="none"
                 stroke="currentColor"
                 strokeWidth={22}
                 strokeLinecap="round"
-                strokeDasharray={`${ratio * ARC_LENGTH} ${ARC_LENGTH}`}
+                pathLength={CIRCLE_PATH_LENGTH}
+                strokeDasharray={`${ratio * SEMICIRCLE} ${CIRCLE_PATH_LENGTH}`}
+                transform="rotate(180 100 100)"
                 className="text-surface-green-5"
               />
             )}


### PR DESCRIPTION
## Description

Remove paths and use circles to create half donut chart.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

<img width="565" height="197" alt="Screenshot 2026-07-13 at 8 24 20 PM" src="https://github.com/user-attachments/assets/f294fd73-fc9d-49a7-aa85-dfa0827b56f1" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1799 