### PR TITLE
fix: show project name instead of ID in project link filter

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/project/constants.ts
@@ -14,7 +14,12 @@ export const projectAllocationFilters: FilterField[] = [
   {
     name: "tag",
     label: "Tag",
-    type: "string",
+    type: "link",
+    link: { doctype: "Tag" },
+    operators: [
+      { label: "Equals", value: "=" },
+      { label: "Not Equals", value: "!=" },
+    ],
   },
   {
     name: "customer",

--- a/frontend/packages/app/src/pages/allocations/team/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/team/constants.ts
@@ -19,7 +19,12 @@ export const teamAllocationFilters: FilterField[] = [
   {
     name: "tag",
     label: "Tag",
-    type: "string",
+    type: "link",
+    link: { doctype: "Tag" },
+    operators: [
+      { label: "Equals", value: "=" },
+      { label: "Not Equals", value: "!=" },
+    ],
   },
   {
     name: "business_unit",

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -129,7 +129,7 @@ export function ProjectListSubHeader() {
               name: "name",
               label: "Project",
               type: "link",
-              link: { doctype: "Project" },
+              link: { doctype: "Project", labelField: "project_name" },
               operators: [
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },

--- a/frontend/packages/app/src/pages/timesheet/constants.ts
+++ b/frontend/packages/app/src/pages/timesheet/constants.ts
@@ -78,7 +78,7 @@ export const personalTimesheetFilters: FilterField[] = [
     name: "project",
     label: "Project",
     type: "link",
-    link: { doctype: "Project" },
+    link: { doctype: "Project", labelField: "project_name" },
     operators: [
       { label: "Equals", value: "=" },
       { label: "Not Equals", value: "!=" },
@@ -108,7 +108,7 @@ export const teamTimesheetFilters: FilterField[] = [
     name: "project",
     label: "Project",
     type: "link",
-    link: { doctype: "Project" },
+    link: { doctype: "Project", labelField: "project_name" },
     operators: [
       { label: "Equals", value: "=" },
       { label: "Not Equals", value: "!=" },
@@ -178,7 +178,7 @@ export const projectTimesheetFilters: FilterField[] = [
     name: "project",
     label: "Project",
     type: "link",
-    link: { doctype: "Project" },
+    link: { doctype: "Project", labelField: "project_name" },
     operators: [
       { label: "Equals", value: "=" },
       { label: "Not Equals", value: "!=" },


### PR DESCRIPTION
## Description

Change the label of Project filter from ID to Name, additionally adds config for "Tag" filter as link.

## Testing Instructions

- Go to Timesheet -> Projects page (or any page with "Project" filter)
- Select "Project" filter
- Observe the options to be project names instead of ID

## Screenshot/Screencast


https://github.com/user-attachments/assets/6875359d-d324-448e-ab5b-504e17099975




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes: #1811 