### PR TITLE
fix: allow user to clear repeat for field

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -712,11 +712,21 @@ function AddAllocationModal({
                       min={1}
                       disabled={variant === "edit"}
                       value={
-                        Number.isNaN(field.state.value) ? "" : field.state.value
+                        field.state.value == null ||
+                        Number.isNaN(field.state.value)
+                          ? ""
+                          : field.state.value
                       }
                       onChange={(e) => {
                         const raw = e.target.value;
-                        field.handleChange(raw === "" ? NaN : Number(raw));
+                        if (raw === "") {
+                          field.handleChange(NaN);
+                          return;
+                        }
+                        const parsed = Number(raw);
+                        if (Number.isFinite(parsed)) {
+                          field.handleChange(parsed);
+                        }
                       }}
                       inputClassName="pr-13"
                     />

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -106,7 +106,7 @@ function AddAllocationModal({
         recurrence: value.recurrence,
         fromDate: value.fromDate,
         toDate: value.toDate,
-        repeatFor: value.repeatFor ?? 0,
+        repeatFor: Number.isFinite(value.repeatFor) ? value.repeatFor : 0,
         includeWeekends: value.includeWeekends,
       });
 
@@ -283,9 +283,8 @@ function AddAllocationModal({
     form.store,
     (state) => state.values.hoursPerDay,
   );
-  const repeatFor = useSelector(
-    form.store,
-    (state) => state.values.repeatFor ?? 0,
+  const repeatFor = useSelector(form.store, (state) =>
+    Number.isFinite(state.values.repeatFor) ? state.values.repeatFor : 0,
   );
   const fromDate = useSelector(form.store, (state) => state.values.fromDate);
   const toDate = useSelector(form.store, (state) => state.values.toDate);
@@ -710,11 +709,15 @@ function AddAllocationModal({
                       type="number"
                       size="md"
                       variant="outline"
+                      min={1}
                       disabled={variant === "edit"}
-                      value={field.state.value ?? ""}
-                      onChange={(e) =>
-                        field.handleChange(Math.max(1, Number(e.target.value)))
+                      value={
+                        Number.isNaN(field.state.value) ? "" : field.state.value
                       }
+                      onChange={(e) => {
+                        const raw = e.target.value;
+                        field.handleChange(raw === "" ? NaN : Number(raw));
+                      }}
                       inputClassName="pr-13"
                     />
                     <span className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-gray-5 text-sm">

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
@@ -42,9 +42,10 @@ export const addAllocationFormSchema = z
         required_error: "Please enter hours per day.",
       })
       .positive({ message: "Must be greater than 0." }),
-    // z.number() rejects NaN outright; NaN is the "field cleared" sentinel
-    // here, so accept any number and validate it in superRefine below.
-    repeatFor: z.custom<number>((value) => typeof value === "number"),
+    // z.number() rejects NaN outright, so union in z.nan() to allow it as
+    // the "field cleared" sentinel while keeping the int/nonnegative constraint
+    // for real values; superRefine below handles the NaN/<1 recurring check.
+    repeatFor: z.union([z.number().int().nonnegative(), z.nan()]),
     isBillable: z.boolean(),
     isTentative: z.boolean(),
     note: z.string().trim(),

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
@@ -42,7 +42,9 @@ export const addAllocationFormSchema = z
         required_error: "Please enter hours per day.",
       })
       .positive({ message: "Must be greater than 0." }),
-    repeatFor: z.number().int().nonnegative(),
+    // z.number() rejects NaN outright; NaN is the "field cleared" sentinel
+    // here, so accept any number and validate it in superRefine below.
+    repeatFor: z.custom<number>((value) => typeof value === "number"),
     isBillable: z.boolean(),
     isTentative: z.boolean(),
     note: z.string().trim(),
@@ -56,7 +58,10 @@ export const addAllocationFormSchema = z
       });
     }
 
-    if (value.recurrence === "recurring" && value.repeatFor < 1) {
+    if (
+      value.recurrence === "recurring" &&
+      (Number.isNaN(value.repeatFor) || value.repeatFor < 1)
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["repeatFor"],


### PR DESCRIPTION
## Description
The "Repeat for" number input in the Add Allocation modal previously forced a value of 1 on clear (via Math.max(1, Number(...))), making it impossible for users to empty the field while typing. This uses NaN as a "field cleared" sentinel: the input renders empty when the value is NaN, and validation (via superRefine) now catches NaN/<1 for recurring allocations instead of relying on the schema type to reject it outright.

## Screenshot/Screencast
https://github.com/user-attachments/assets/14e8e9e0-1296-4ed6-ad20-9ffe52c39bce


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Fixes #1813 