### PR TITLE
Fix: add custom endpoint for Member filter

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/constants.ts
+++ b/frontend/packages/app/src/pages/timesheet/constants.ts
@@ -135,7 +135,13 @@ export const teamTimesheetFilters: FilterField[] = [
     name: "employee",
     label: "Member",
     type: "link",
-    link: { doctype: "Employee", labelField: "employee_name" },
+    link: {
+      doctype: "Employee",
+      labelField: "employee_name",
+      customMethod: {
+        method: "next_pms.timesheet.api.employee.get_employee_list",
+      },
+    },
     operators: [
       { label: "Equals", value: "=" },
       { label: "Not Equals", value: "!=" },
@@ -194,7 +200,13 @@ export const projectTimesheetFilters: FilterField[] = [
     name: "employee",
     label: "Member",
     type: "link",
-    link: { doctype: "Employee", labelField: "employee_name" },
+    link: {
+      doctype: "Employee",
+      labelField: "employee_name",
+      customMethod: {
+        method: "next_pms.timesheet.api.employee.get_employee_list",
+      },
+    },
     operators: [
       { label: "Equals", value: "=" },
       { label: "Not Equals", value: "!=" },


### PR DESCRIPTION
## Description

Added config to fetch the options for "Member" filter from custom endpoint.

## Testing Instructions

- Go to Timesheets -> Team/Projects page
- Select the "Member" filter.
- Observe the suggestions to be populated with Employees

## Screenshot/Screencast


https://github.com/user-attachments/assets/13bddf99-56bf-4f85-9e50-2ae5fe79b911





## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Discussed in: #1832 