### PR TITLE
refactor:  profit projection and separate billable/non-billable hours

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/hoursUsage.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/hoursUsage.tsx
@@ -11,10 +11,16 @@ import { useTracking } from "../context";
 import { LegendItem } from "./legendItem";
 
 export function HoursUsageCell() {
+  const billable = useTracking(
+    (state) => state.tracking.hours_utilised_billable,
+  );
+  const nonBillable = useTracking(
+    (state) => state.tracking.hours_utilised_non_billable,
+  );
   const utilised = useTracking((state) => state.tracking.hours_utilised);
   const remainingRaw = useTracking((state) => state.tracking.hours_remaining);
   const remaining = remainingRaw ?? 0;
-  const total = utilised + remaining;
+  const contracted = utilised + remaining;
 
   return (
     <div className="flex flex-1 flex-col gap-4 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
@@ -24,22 +30,38 @@ export function HoursUsageCell() {
         </span>
       </div>
       <ProgressBar
-        value={utilised}
-        maxValue={total}
+        value={billable}
+        secondaryValue={billable + nonBillable}
+        maxValue={contracted}
         size="md"
-        indicatorClassName="bg-surface-blue-4"
+        indicatorClassName="bg-surface-blue-5"
+        secondaryIndicatorClassName="bg-surface-blue-2"
       />
       <div className="flex flex-col gap-2 text-base">
         <LegendItem
-          className="bg-surface-blue-4"
-          label="Hours utilised"
+          className="bg-surface-blue-5"
+          label="Billable hours utilised"
+          value={formatHours(billable, " h")}
+          labelClassName="text-ink-gray-6"
+          valueClassName="font-medium text-ink-gray-6"
+        />
+        <LegendItem
+          className="bg-surface-blue-2"
+          label="Non-billable hours utilised"
+          value={formatHours(nonBillable, " h")}
+          labelClassName="text-ink-gray-6"
+          valueClassName="font-medium text-ink-gray-6"
+        />
+        <LegendItem
+          className="bg-surface-gray-5"
+          label="Total hours utilised"
           value={formatHours(utilised, " h")}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium text-ink-gray-6"
         />
         <LegendItem
           className="bg-surface-gray-3"
-          label="Hours remaining"
+          label="Total hours remaining"
           value={formatHours(remaining, " h")}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium text-ink-gray-6"

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/context.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/context.ts
@@ -48,6 +48,8 @@ export const DEFAULT_TRACKING: Tracking = {
   forecasted_cost_to_completion: 0,
   expected_total_cost: 0,
   hours_utilised: 0,
+  hours_utilised_billable: 0,
+  hours_utilised_non_billable: 0,
   hours_remaining: null,
   tasks: { total: 0, open: 0, completed: 0 },
   invoice_burn: {

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
@@ -36,7 +36,7 @@ function TrackingContent() {
           )}
         />
         <KnowledgePoint
-          title="Project profit"
+          title="Projected profit"
           value={currencyFormat(currency).format(tracking.project_profit ?? 0)}
         />
         <KnowledgePoint

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/types.ts
@@ -83,6 +83,8 @@ export type TrackingMessage = {
   forecasted_cost_to_completion: number;
   expected_total_cost: number;
   hours_utilised: number;
+  hours_utilised_billable: number;
+  hours_utilised_non_billable: number;
   hours_remaining: number | null;
   tasks: TrackingTasks;
   invoice_burn: TrackingInvoiceBurn;

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -727,7 +727,7 @@ def _get_hours_split(project: str) -> tuple[float, float]:
             Coalesce(Sum(TimesheetDetail.hours), 0).as_("total"),
         )
         .where(TimesheetDetail.project == project)
-        .where((TimesheetDetail.docstatus == 1) | (TimesheetDetail.docstatus == 0))
+        .where(TimesheetDetail.docstatus.isin([0, 1]))
         .groupby(TimesheetDetail.is_billable)
         .run(as_dict=True)
     )
@@ -764,7 +764,7 @@ def get_project_tracking(project: str):
         currency : str
             Project currency code.
         hours_utilised : float
-            Total hours logged via Timesheets.
+            Total hours logged via Timesheets (billable plus non-billable).
         hours_utilised_billable : float
             Billable hours logged via Timesheets.
         hours_utilised_non_billable : float
@@ -821,7 +821,6 @@ def get_project_tracking(project: str):
             "custom_billing_type",
             "total_costing_amount",
             "total_sales_amount",
-            "actual_time",
             "custom_currency",
             "custom_target_cost",
             "custom_total_hours_purchased",
@@ -851,6 +850,7 @@ def get_project_tracking(project: str):
     projected_profit_margin = (projected_profit / total_project_value * 100) if total_project_value else 0
 
     hours_utilised_billable, hours_utilised_non_billable = _get_hours_split(project)
+    hours_utilised = hours_utilised_billable + hours_utilised_non_billable
     total_contracted_hours = flt(p.custom_total_hours_purchased) if has_hours_pool else flt(p.custom_target_hours)
 
     contracts = None
@@ -934,10 +934,10 @@ def get_project_tracking(project: str):
         "actual_cost_incurred": actual_cost_incurred,
         "forecasted_cost_to_completion": forecasted_cost_to_completion,
         "expected_total_cost": flt(p.custom_target_cost),
-        "hours_utilised": flt(p.actual_time),
+        "hours_utilised": hours_utilised,
         "hours_utilised_billable": hours_utilised_billable,
         "hours_utilised_non_billable": hours_utilised_non_billable,
-        "hours_remaining": total_contracted_hours - flt(p.actual_time),
+        "hours_remaining": total_contracted_hours - hours_utilised,
         "tasks": task_counts,
         "invoice_burn": {
             **(invoice_burn or {}),

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -717,6 +717,32 @@ def _get_task_counts(project_name: str) -> dict:
     }
 
 
+def _get_hours_split(project: str) -> tuple[float, float]:
+    """Billable and non-billable hours logged against the project via Timesheets."""
+    TimesheetDetail = frappe.qb.DocType("Timesheet Detail")
+    rows = (
+        frappe.qb.from_(TimesheetDetail)
+        .select(
+            TimesheetDetail.is_billable,
+            Coalesce(Sum(TimesheetDetail.hours), 0).as_("total"),
+        )
+        .where(TimesheetDetail.project == project)
+        .where((TimesheetDetail.docstatus == 1) | (TimesheetDetail.docstatus == 0))
+        .groupby(TimesheetDetail.is_billable)
+        .run(as_dict=True)
+    )
+
+    billable = 0
+    non_billable = 0
+    for row in rows:
+        if cint(row.is_billable):
+            billable += flt(row.total)
+        else:
+            non_billable += flt(row.total)
+
+    return billable, non_billable
+
+
 @whitelist(methods=["GET"])
 @error_logger
 def get_project_tracking(project: str):
@@ -739,9 +765,13 @@ def get_project_tracking(project: str):
             Project currency code.
         hours_utilised : float
             Total hours logged via Timesheets.
+        hours_utilised_billable : float
+            Billable hours logged via Timesheets.
+        hours_utilised_non_billable : float
+            Non-billable hours logged via Timesheets.
         hours_remaining : float
-            Remaining hours from Project Budget pool, or target hours minus
-            utilised hours when there is no hours pool (may be negative).
+            Contracted hours (total hours purchased for hours-pool projects,
+            target hours otherwise) minus utilised hours (may be negative).
         tasks : dict
             total, open, completed task counts.
         invoice_burn : dict
@@ -793,10 +823,8 @@ def get_project_tracking(project: str):
             "total_sales_amount",
             "actual_time",
             "custom_currency",
-            "custom_estimated_profit",
-            "custom_percentage_estimated_profit",
             "custom_target_cost",
-            "custom_total_hours_remaining",
+            "custom_total_hours_purchased",
             "custom_target_hours",
             "actual_start_date",
             "custom_default_hourly_billing_rate",
@@ -817,6 +845,13 @@ def get_project_tracking(project: str):
     actual_cost_incurred = flt(p.total_costing_amount)
     total_forecasted_cost = get_cost_forecasted(project)
     forecasted_cost_to_completion = max(0, total_forecasted_cost)
+
+    total_project_value = flt(p.total_sales_amount)
+    projected_profit = total_project_value - (actual_cost_incurred + forecasted_cost_to_completion)
+    projected_profit_margin = (projected_profit / total_project_value * 100) if total_project_value else 0
+
+    hours_utilised_billable, hours_utilised_non_billable = _get_hours_split(project)
+    total_contracted_hours = flt(p.custom_total_hours_purchased) if has_hours_pool else flt(p.custom_target_hours)
 
     contracts = None
     if has_hours_pool:
@@ -893,18 +928,16 @@ def get_project_tracking(project: str):
         "company": p.company,
         "billing_type": billing_type,
         "currency": p.custom_currency,
-        "total_project_value": flt(p.total_sales_amount) if is_billable else None,
-        "project_profit": flt(p.custom_estimated_profit) if is_billable else None,
-        "projected_profit_margin": flt(p.custom_percentage_estimated_profit) if is_billable else None,
+        "total_project_value": total_project_value if is_billable else None,
+        "project_profit": projected_profit if is_billable else None,
+        "projected_profit_margin": projected_profit_margin if is_billable else None,
         "actual_cost_incurred": actual_cost_incurred,
         "forecasted_cost_to_completion": forecasted_cost_to_completion,
         "expected_total_cost": flt(p.custom_target_cost),
         "hours_utilised": flt(p.actual_time),
-        "hours_remaining": (
-            flt(p.custom_total_hours_remaining)
-            if has_hours_pool
-            else flt(p.get("custom_target_hours")) - flt(p.actual_time)
-        ),
+        "hours_utilised_billable": hours_utilised_billable,
+        "hours_utilised_non_billable": hours_utilised_non_billable,
+        "hours_remaining": total_contracted_hours - flt(p.actual_time),
         "tasks": task_counts,
         "invoice_burn": {
             **(invoice_burn or {}),

--- a/next_pms/tests/next_projects/api/test_project_hours_fallback.py
+++ b/next_pms/tests/next_projects/api/test_project_hours_fallback.py
@@ -1,6 +1,7 @@
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, nowdate
 
 from next_pms.next_projects.api.project import get_project_sidebar, get_project_tracking
 
@@ -12,13 +13,17 @@ class TestProjectHoursFallback(IntegrationTestCase):
         cls.company = get_default_company()
         cls.projects = {}
 
+        employee = frappe.db.get_value("Employee", {"status": "Active"}, "name")
+        activity_type = frappe.db.get_value("Activity Type", {}, "name")
+
         fixtures = {
-            "Fixed Cost": (100, 40, 200, 60),
-            "Retainer": (80, 25, 150, 55),
-            "Time and Material": (999, 888, 120, 30),
-            "Non-Billable": (999, 888, 50, 70),
+            "Fixed Cost": (100, 40, 200, 60, 6, 2),
+            "Retainer": (80, 25, 150, 55, 4, 3),
+            "Time and Material": (999, 888, 120, 30, 5, 1),
+            "Non-Billable": (999, 888, 50, 70, 0, 4),
         }
-        for billing_type, (purchased, remaining, target, actual) in fixtures.items():
+        for index, (billing_type, values) in enumerate(fixtures.items()):
+            purchased, remaining, target, actual, billable, non_billable = values
             name = (
                 frappe.get_doc(
                     {
@@ -30,6 +35,38 @@ class TestProjectHoursFallback(IntegrationTestCase):
                 .insert(ignore_permissions=True)
                 .name
             )
+            task = (
+                frappe.get_doc(
+                    {
+                        "doctype": "Task",
+                        "subject": f"HoursFallback {billing_type}",
+                        "project": name,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+            time_logs = [
+                {
+                    "activity_type": activity_type,
+                    "task": task,
+                    "hours": hours,
+                    "project": name,
+                    "is_billable": is_billable,
+                    "from_time": f"{add_days(nowdate(), -(2 * index + day))} 09:00:00",
+                    "description": f"HoursFallback {billing_type}",
+                }
+                for day, (hours, is_billable) in enumerate(((billable, 1), (non_billable, 0)), start=1)
+                if hours
+            ]
+            frappe.get_doc(
+                {
+                    "doctype": "Timesheet",
+                    "company": cls.company,
+                    "employee": employee,
+                    "time_logs": time_logs,
+                }
+            ).insert(ignore_permissions=True)
             frappe.db.set_value(
                 "Project",
                 name,
@@ -48,6 +85,8 @@ class TestProjectHoursFallback(IntegrationTestCase):
                 "remaining": remaining,
                 "target": target,
                 "actual": actual,
+                "billable": billable,
+                "non_billable": non_billable,
             }
 
         frappe.set_user("Administrator")
@@ -73,23 +112,37 @@ class TestProjectHoursFallback(IntegrationTestCase):
                 msg=billing_type,
             )
 
-    def test_tracking_uses_purchased_minus_actual_for_hours_pool(self):
+    def test_tracking_splits_utilised_hours_by_billability(self):
+        for billing_type, fixture in self.projects.items():
+            result = get_project_tracking(fixture["name"])
+            self.assertEqual(result["hours_utilised_billable"], fixture["billable"], msg=billing_type)
+            self.assertEqual(
+                result["hours_utilised_non_billable"],
+                fixture["non_billable"],
+                msg=billing_type,
+            )
+            self.assertEqual(
+                result["hours_utilised"],
+                fixture["billable"] + fixture["non_billable"],
+                msg=billing_type,
+            )
+
+    def test_tracking_uses_purchased_minus_utilised_for_hours_pool(self):
         for billing_type in ("Fixed Cost", "Retainer"):
             fixture = self.projects[billing_type]
             result = get_project_tracking(fixture["name"])
             self.assertEqual(
                 result["hours_remaining"],
-                fixture["purchased"] - fixture["actual"],
+                fixture["purchased"] - (fixture["billable"] + fixture["non_billable"]),
                 msg=billing_type,
             )
-            self.assertEqual(result["hours_utilised"], fixture["actual"], msg=billing_type)
 
-    def test_tracking_falls_back_to_target_minus_actual_without_hours_pool(self):
+    def test_tracking_falls_back_to_target_minus_utilised_without_hours_pool(self):
         for billing_type in ("Time and Material", "Non-Billable"):
             fixture = self.projects[billing_type]
             result = get_project_tracking(fixture["name"])
             self.assertEqual(
                 result["hours_remaining"],
-                fixture["target"] - fixture["actual"],
+                fixture["target"] - (fixture["billable"] + fixture["non_billable"]),
                 msg=billing_type,
             )

--- a/next_pms/tests/next_projects/api/test_project_hours_fallback.py
+++ b/next_pms/tests/next_projects/api/test_project_hours_fallback.py
@@ -73,11 +73,15 @@ class TestProjectHoursFallback(IntegrationTestCase):
                 msg=billing_type,
             )
 
-    def test_tracking_uses_remaining_hours_for_hours_pool(self):
+    def test_tracking_uses_purchased_minus_actual_for_hours_pool(self):
         for billing_type in ("Fixed Cost", "Retainer"):
             fixture = self.projects[billing_type]
             result = get_project_tracking(fixture["name"])
-            self.assertEqual(result["hours_remaining"], fixture["remaining"], msg=billing_type)
+            self.assertEqual(
+                result["hours_remaining"],
+                fixture["purchased"] - fixture["actual"],
+                msg=billing_type,
+            )
             self.assertEqual(result["hours_utilised"], fixture["actual"], msg=billing_type)
 
     def test_tracking_falls_back_to_target_minus_actual_without_hours_pool(self):


### PR DESCRIPTION
## Description

* Added `_get_hours_split` function to calculate billable and non-billable hours from timesheets and integrated these values into the `get_project_tracking` API response. 
* Updated profit calculation logic to use actual and forecasted costs, and replaced estimated profit fields with new projected profit and margin calculations. 
* Changed how contracted hours are calculated and reported, using purchased hours for hours-pool projects and target hours otherwise. 
* Updated and renamed a test to reflect the new logic for calculating remaining hours.
* Updated the `HoursUsageCell` component to display billable, non-billable, and total utilised hours separately, and adjusted the progress bar to visually differentiate between billable and non-billable hours. 
* Updated types and context to support new billable and non-billable hour fields. 
* Renamed the "Project profit" label to "Projected profit" for accuracy.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1234" height="803" alt="Screenshot 2026-07-15 at 10 49 44 AM" src="https://github.com/user-attachments/assets/abcf2022-97f7-4c33-847f-2f3ea48fad77" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1829 , #1826 