### PR TITLE
fix: show projects with allocation on top

### DIFF
--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -18,6 +18,8 @@ from next_pms.resource_management.api.utils.query import (
     get_allocation_list_for_employee_for_given_range,
     get_allocation_worked_hours_for_given_employee,
     get_allocation_worked_hours_for_given_projects,
+    get_projects_with_allocations,
+    has_active_allocation_filter,
 )
 
 
@@ -65,13 +67,15 @@ def get_resource_management_project_view_data(
             carrying the tag. Ignored for callers without write permission.
         is_billable: Filters the per-project allocation breakdown to billable
             (1) or non-billable (0) allocations. Accepts an int or a JSON
-            string. Does not change which projects are returned, only their allocation
-            data. A matching is_billable condition in filters overrides this.
+            string. Projects without a single matching allocation in the window
+            are excluded from the result (and from total_count). A matching
+            is_billable condition in filters overrides this.
             Ignored for callers without write permission.
         allocation_status: Status value(s) to match against Resource Allocation.status,
             e.g. ["Confirmed", "Tentative"]. Accepts a single value, a list, or a JSON
             string. Filters the per-project allocation breakdown to the matching statuses;
-            does not change which projects are returned. None or [] disables the filter.
+            projects without a single matching allocation in the window are excluded
+            from the result (and from total_count). None or [] disables the filter.
             Ignored for callers without write permission.
         page_length: Maximum number of projects to return in this page. Defaults to 10.
         start: Zero-based offset of the first project to return (pagination). Defaults
@@ -102,7 +106,9 @@ def get_resource_management_project_view_data(
             - data (list): one entry per project, the project fields plus
               all_week_data (per-week allocated/worked hours), all_dates_data
               (per-date allocation detail), project_allocations (the allocations
-              keyed by name), and weekly_capacity.
+              keyed by name), and weekly_capacity. When no allocation-level filter
+              (is_billable / allocation_status) is active, projects with at least
+              one allocation in the window are listed before projects with none.
             - customer (dict): customer metadata referenced by the allocations.
             - employees (dict): employee metadata keyed by employee id for the
               employees appearing in the allocations.
@@ -180,6 +186,20 @@ def _get_resource_management_project_view_data(
             project_id = json.loads(project_id)
         ids = project_id
 
+    weeks = get_dates_date(max_week, date)
+
+    allocated_projects = get_projects_with_allocations(
+        weeks[0].get("start_date"),
+        weeks[-1].get("end_date"),
+        is_billable,
+        allocation_status=allocation_status,
+    )
+    prioritized_ids = None
+    if has_active_allocation_filter(is_billable, allocation_status):
+        project_conditions.append(["name", "in", allocated_projects or []])
+    else:
+        prioritized_ids = allocated_projects
+
     projects, total_count = filter_project_list(
         project_name,
         page_length=page_length,
@@ -192,11 +212,11 @@ def _get_resource_management_project_view_data(
         ids=ids,
         extra_conditions=project_conditions,
         tag_conditions=tag_conditions,
+        prioritized_ids=prioritized_ids,
     )
 
     data = []
     customer = {}
-    weeks = get_dates_date(max_week, date)
     res = {"dates": weeks}
 
     resource_allocation_data = get_allocation_list_for_employee_for_given_range(

--- a/next_pms/resource_management/api/utils/helpers.py
+++ b/next_pms/resource_management/api/utils/helpers.py
@@ -372,8 +372,9 @@ def filter_project_list(
 ):
     """Return one page of Projects plus the total count of matches.
 
-    When prioritized_ids is given, matching projects in that list are paginated
-    before the rest (two-phase pagination); total_count is unaffected.
+    When prioritized_ids is a non-empty list, matching projects in that list are
+    paginated before the rest (two-phase pagination); total_count is unaffected.
+    An empty list behaves like None (plain single-query pagination).
     """
     from next_pms.timesheet.api import get_count
 
@@ -449,7 +450,7 @@ def filter_project_list(
 
     total_count = get_count("Project", filters=conditions)
 
-    if prioritized_ids is None:
+    if not prioritized_ids:
         projects = frappe.get_list(
             "Project",
             filters=conditions,
@@ -459,8 +460,8 @@ def filter_project_list(
         )
         return projects, total_count
 
-    prioritized_conditions = [*conditions, ["name", "in", prioritized_ids or []]]
-    remaining_conditions = [*conditions, ["name", "not in", prioritized_ids or []]]
+    prioritized_conditions = [*conditions, ["name", "in", prioritized_ids]]
+    remaining_conditions = [*conditions, ["name", "not in", prioritized_ids]]
     prioritized_count = get_count("Project", filters=prioritized_conditions)
 
     projects = []

--- a/next_pms/resource_management/api/utils/helpers.py
+++ b/next_pms/resource_management/api/utils/helpers.py
@@ -368,7 +368,13 @@ def filter_project_list(
     ids=None,
     extra_conditions=None,
     tag_conditions=None,
+    prioritized_ids=None,
 ):
+    """Return one page of Projects plus the total count of matches.
+
+    When prioritized_ids is given, matching projects in that list are paginated
+    before the rest (two-phase pagination); total_count is unaffected.
+    """
     from next_pms.timesheet.api import get_count
 
     start = int(start)
@@ -441,15 +447,41 @@ def filter_project_list(
         name_op = "in" if operator in ("=", "like") else "not in"
         conditions.append(["name", name_op, tagged_projects or []])
 
-    projects = frappe.get_list(
-        "Project",
-        filters=conditions,
-        fields=fields,
-        offset=start,
-        limit=page_length,
-    )
-
     total_count = get_count("Project", filters=conditions)
+
+    if prioritized_ids is None:
+        projects = frappe.get_list(
+            "Project",
+            filters=conditions,
+            fields=fields,
+            offset=start,
+            limit=page_length,
+        )
+        return projects, total_count
+
+    prioritized_conditions = [*conditions, ["name", "in", prioritized_ids or []]]
+    remaining_conditions = [*conditions, ["name", "not in", prioritized_ids or []]]
+    prioritized_count = get_count("Project", filters=prioritized_conditions)
+
+    projects = []
+    if start < prioritized_count:
+        projects = frappe.get_list(
+            "Project",
+            filters=prioritized_conditions,
+            fields=fields,
+            offset=start,
+            limit=page_length,
+        )
+
+    remaining_page_length = page_length - len(projects)
+    if remaining_page_length > 0:
+        projects += frappe.get_list(
+            "Project",
+            filters=remaining_conditions,
+            fields=fields,
+            offset=max(0, start - prioritized_count),
+            limit=remaining_page_length,
+        )
 
     return projects, total_count
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -81,6 +81,53 @@ def get_allocation_list_for_employee_for_given_range(
     return query.run(as_dict=True)
 
 
+def get_projects_with_allocations(
+    start_date: str | datetime.date,
+    end_date: str | datetime.date,
+    is_billable: list | int | None = None,
+    allocation_status: list | None = None,
+) -> list[str]:
+    """Return the distinct projects having at least one Resource Allocation in the window.
+
+    Mirrors the predicates of get_allocation_list_for_employee_for_given_range (window
+    overlap, is_billable, status) without the project restriction, so the two queries
+    can never disagree on which allocations "match".
+
+    Args:
+        start_date (str | datetime.date): Range start.
+        end_date (str | datetime.date): Range end.
+        is_billable (list | int | None): Billable filter, same conventions as
+            get_allocation_list_for_employee_for_given_range. Defaults to None.
+        allocation_status (list | None): Status values to match. ``None`` or ``[]``
+            skips the filter. Defaults to None.
+
+    Returns:
+        list[str]: Distinct project names with a matching allocation in the window.
+    """
+    ResourceAllocation = frappe.qb.DocType("Resource Allocation")
+
+    query = (
+        frappe.qb.from_(ResourceAllocation)
+        .select(ResourceAllocation.project)
+        .distinct()
+        .where(ResourceAllocation.allocation_start_date <= end_date)
+        .where(ResourceAllocation.allocation_end_date >= start_date)
+    )
+
+    billable_values = _normalize_is_billable_filter(is_billable)
+    if billable_values:
+        query = query.where(ResourceAllocation.is_billable.isin(billable_values))
+    if allocation_status:
+        query = query.where(ResourceAllocation.status.isin(allocation_status))
+
+    return query.run(pluck=True)
+
+
+def has_active_allocation_filter(is_billable: list | int | None, allocation_status: list | None) -> bool:
+    """Whether the caller requested an allocation-level filter (billable or status)."""
+    return bool(allocation_status) or bool(_normalize_is_billable_filter(is_billable))
+
+
 def _normalize_is_billable_filter(is_billable: list | int | None) -> list[int]:
     """Normalise the ``is_billable`` argument into a clean list of integers.
 

--- a/next_pms/tests/resource_management/api/test_project_view.py
+++ b/next_pms/tests/resource_management/api/test_project_view.py
@@ -263,8 +263,8 @@ class TestProjectViewProjectListFilters(_ProjectViewBase):
 class TestProjectViewAllocationFilters(_ProjectViewBase):
     """The per-project allocation breakdown — allocation query branches.
 
-    These filters change which allocations appear (project_allocations), not which
-    projects are returned.
+    These filters change which allocations appear (project_allocations) and drop
+    projects left without a single matching allocation in the window.
     """
 
     @classmethod
@@ -324,10 +324,100 @@ class TestProjectViewAllocationFilters(_ProjectViewBase):
         tentative = self._allocation_names(allocation_status=json.dumps(["Tentative"]))
         self.assertEqual(tentative, {self.a_nonbillable})
 
-    def test_allocation_filters_do_not_drop_the_project(self):
-        # Even a status that matches nothing in-window leaves the project in the payload.
+    def test_allocation_filters_drop_projects_without_matching_allocations(self):
+        # No in-window allocation is both non-billable and Confirmed, so the project
+        # is excluded from the payload instead of rendering as an empty row.
         result = self._call(
             project_id=json.dumps([self.project]), is_billable="0", allocation_status=json.dumps(["Confirmed"])
         )
-        self.assertIn(self.project, self._project_ids(result))
-        self.assertEqual(self._entry(result, self.project)["project_allocations"], {})
+        self.assertEqual(result["data"], [])
+        self.assertEqual(result["total_count"], 0)
+        self.assertFalse(result["has_more"])
+
+
+class TestProjectViewAllocationProjectFiltering(_ProjectViewBase):
+    """Which projects the allocation-level filters keep, and how unfiltered rows order.
+
+    With allocation_status / is_billable active only projects owning a matching
+    in-window allocation survive; without them, allocated projects paginate before
+    projects that have no allocation in the window.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(WRITE_USER, projects_user=True)
+        cls.customer = cls._make_customer("PV Partition Customer")
+        cls.employee = cls._make_employee("PV Partition Employee")
+
+        cls.p_confirmed = cls._make_project("PV Zeta Portal", cls.customer)
+        cls.p_tentative = cls._make_project("PV Eta Portal", cls.customer)
+        cls.p_empty = cls._make_project("PV Theta Portal", cls.customer)
+
+        cls._make_allocation(
+            cls.employee, cls.p_confirmed, "2026-06-16", "2026-06-17", is_billable=1, status="Confirmed"
+        )
+        cls._make_allocation(
+            cls.employee, cls.p_tentative, "2026-06-18", "2026-06-19", is_billable=0, status="Tentative"
+        )
+        # p_empty only has an out-of-window allocation, so the window guard must
+        # treat it as having no allocations.
+        cls._make_allocation(cls.employee, cls.p_empty, "2026-07-06", "2026-07-08", is_billable=1, status="Confirmed")
+
+        frappe.clear_cache()
+
+    def _scoped_call(self, **kwargs):
+        return self._call(customer=self.customer, **kwargs)
+
+    def test_status_filter_keeps_only_projects_with_matching_allocations(self):
+        result = self._scoped_call(allocation_status=json.dumps(["Confirmed"]))
+        self.assertEqual(self._project_ids(result), {self.p_confirmed})
+        self.assertEqual(result["total_count"], 1)
+        self.assertTrue(self._entry(result, self.p_confirmed)["project_allocations"])
+
+    def test_billable_filter_keeps_only_projects_with_matching_allocations(self):
+        billable = self._scoped_call(is_billable="1")
+        self.assertEqual(self._project_ids(billable), {self.p_confirmed})
+        self.assertEqual(billable["total_count"], 1)
+
+        non_billable = self._scoped_call(is_billable="0")
+        self.assertEqual(self._project_ids(non_billable), {self.p_tentative})
+        self.assertEqual(non_billable["total_count"], 1)
+
+    def test_no_matching_projects_returns_empty_page(self):
+        result = self._scoped_call(is_billable="1", allocation_status=json.dumps(["Tentative"]))
+        self.assertEqual(result["data"], [])
+        self.assertEqual(result["total_count"], 0)
+        self.assertFalse(result["has_more"])
+
+    def test_unfiltered_lists_allocated_projects_before_empty_ones(self):
+        result = self._scoped_call()
+        ordered = [entry["name"] for entry in result["data"]]
+        self.assertEqual(set(ordered), {self.p_confirmed, self.p_tentative, self.p_empty})
+        self.assertEqual(result["total_count"], 3)
+        self.assertEqual(ordered[-1], self.p_empty)
+
+    def test_unfiltered_pagination_across_partitions(self):
+        pages = [self._scoped_call(page_length=1, start=start) for start in range(3)]
+
+        ordered = [entry["name"] for page in pages for entry in page["data"]]
+        self.assertEqual(len(ordered), 3)
+        self.assertEqual(set(ordered), {self.p_confirmed, self.p_tentative, self.p_empty})
+        self.assertEqual(ordered[-1], self.p_empty)
+
+        for page in pages:
+            self.assertEqual(page["total_count"], 3)
+        self.assertTrue(pages[0]["has_more"])
+        self.assertTrue(pages[1]["has_more"])
+        self.assertFalse(pages[2]["has_more"])
+
+    def test_unfiltered_boundary_page_spans_both_partitions(self):
+        # start=1, page_length=2 straddles the allocated/empty boundary: one allocated
+        # project plus p_empty, without duplicates or gaps.
+        result = self._scoped_call(page_length=2, start=1)
+        ordered = [entry["name"] for entry in result["data"]]
+        self.assertEqual(len(ordered), 2)
+        self.assertEqual(ordered[-1], self.p_empty)
+        self.assertIn(ordered[0], {self.p_confirmed, self.p_tentative})
+        self.assertFalse(result["has_more"])

--- a/next_pms/tests/resource_management/api/test_project_view.py
+++ b/next_pms/tests/resource_management/api/test_project_view.py
@@ -421,3 +421,12 @@ class TestProjectViewAllocationProjectFiltering(_ProjectViewBase):
         self.assertEqual(ordered[-1], self.p_empty)
         self.assertIn(ordered[0], {self.p_confirmed, self.p_tentative})
         self.assertFalse(result["has_more"])
+
+    def test_empty_prioritized_ids_falls_back_to_plain_pagination(self):
+        from next_pms.resource_management.api.utils.helpers import filter_project_list
+
+        frappe.set_user("Administrator")
+        plain, plain_count = filter_project_list(customer=self.customer)
+        empty, empty_count = filter_project_list(customer=self.customer, prioritized_ids=[])
+        self.assertEqual([p.name for p in empty], [p.name for p in plain])
+        self.assertEqual(empty_count, plain_count)


### PR DESCRIPTION
## Description

* Updated the project view API so that when `is_billable` or `allocation_status` filters are active, only projects with at least one matching allocation in the window are returned; projects without matches are excluded from both the result and the total count. 
* When no allocation-level filters are active, projects with allocations in the window are listed first, followed by projects with none, affecting both ordering and pagination. 
* Added `get_projects_with_allocations` and `has_active_allocation_filter` helper functions to efficiently determine which projects have allocations matching the current filters and to check if allocation-level filters are active. 
* Enhanced the `filter_project_list` function to accept a `prioritized_ids` argument, implementing two-phase pagination: prioritized (allocated) projects are paginated before the rest, without affecting the total count. 
* Updated and expanded tests to verify that allocation-level filters exclude projects without matching allocations and to check the new ordering and pagination logic when filters are not used. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast


https://github.com/user-attachments/assets/35153d87-f7a1-4e88-8541-1cff98c846ed




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1742 