### PR TITLE
Fix: Editing a single day in a recurring allocation series impacts all future weeks

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleSummaryTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleSummaryTable.tsx
@@ -7,13 +7,11 @@ import { formatRange, getRangeHours, toDisplayHours } from "../utils";
 
 interface ScheduleSummaryTableProps {
   rows: PreviewRow[];
-  repeatWeeks?: number;
   variant?: "date" | "day";
 }
 
 function ScheduleSummaryTable({
   rows,
-  repeatWeeks,
   variant = "date",
 }: ScheduleSummaryTableProps) {
   return (
@@ -26,7 +24,7 @@ function ScheduleSummaryTable({
           </tr>
         </thead>
         <tbody>
-          {rows.map((row, index) => (
+          {rows.map((row) => (
             <tr
               key={`${row.startDate}_${row.endDate}`}
               className={cn(
@@ -37,9 +35,6 @@ function ScheduleSummaryTable({
             >
               <td className="w-1/2 truncate border-r border-outline-gray-2 px-2 py-2.25 text-base text-ink-gray-6">
                 {formatRange(row.startDate, row.endDate, variant)}
-                {repeatWeeks && index === rows.length - 1 ? (
-                  <span className="text-ink-gray-5">{` (+${repeatWeeks} week${repeatWeeks === 1 ? "" : "s"})`}</span>
-                ) : null}
               </td>
               <td className="w-1/2 px-2 py-2.25 text-base">
                 <span className="text-ink-gray-6">

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleSummaryTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleSummaryTable.tsx
@@ -8,11 +8,13 @@ import { formatRange, getRangeHours, toDisplayHours } from "../utils";
 interface ScheduleSummaryTableProps {
   rows: PreviewRow[];
   repeatWeeks?: number;
+  variant?: "date" | "day";
 }
 
 function ScheduleSummaryTable({
   rows,
   repeatWeeks,
+  variant = "date",
 }: ScheduleSummaryTableProps) {
   return (
     <div className="overflow-hidden rounded border border-outline-gray-2">
@@ -34,7 +36,7 @@ function ScheduleSummaryTable({
               )}
             >
               <td className="w-1/2 truncate border-r border-outline-gray-2 px-2 py-2.25 text-base text-ink-gray-6">
-                {formatRange(row.startDate, row.endDate)}
+                {formatRange(row.startDate, row.endDate, variant)}
                 {repeatWeeks && index === rows.length - 1 ? (
                   <span className="text-ink-gray-5">{` (+${repeatWeeks} week${repeatWeeks === 1 ? "" : "s"})`}</span>
                 ) : null}

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -274,7 +274,7 @@ function EditScheduleModal({
   const validateScheduleChange = useCallback(
     () =>
       scheduleDraft.hasSelection && !hasScheduleChange
-        ? "Change hours to save."
+        ? "Update hours first."
         : undefined,
     [hasScheduleChange, scheduleDraft.hasSelection],
   );
@@ -378,45 +378,38 @@ function EditScheduleModal({
             }}
           >
             {(field) => (
-              <ScheduleHoursPerDayField
-                value={scheduleDraft.hoursPerDay}
-                disabled={!scheduleDraft.hasSelection}
-                onChange={(value) => {
-                  form.setFieldValue("schedule.input.mode", "hoursPerDay");
-                  field.handleChange(value);
-                }}
-                error={
-                  schedule.input.mode === "hoursPerDay"
-                    ? getErrorMessage(field.state.meta.errors[0])
-                    : undefined
-                }
-              />
-            )}
-          </form.Field>
-          <form.Field
-            name="schedule.input.value"
-            validators={{
-              onDynamic: validateScheduleChange,
-            }}
-          >
-            {(field) => (
-              <ScheduleTotalHoursField
-                value={
-                  scheduleDraft.hasSelection
-                    ? toDisplayHours(scheduleDraft.totalHours)
-                    : ""
-                }
-                disabled={!scheduleDraft.hasSelection}
-                onChange={(value) => {
-                  form.setFieldValue("schedule.input.mode", "totalHours");
-                  field.handleChange(value);
-                }}
-                error={
-                  schedule.input.mode === "totalHours"
-                    ? getErrorMessage(field.state.meta.errors[0])
-                    : undefined
-                }
-              />
+              <>
+                <ScheduleHoursPerDayField
+                  value={scheduleDraft.hoursPerDay}
+                  disabled={!scheduleDraft.hasSelection}
+                  onChange={(value) => {
+                    form.setFieldValue("schedule.input.mode", "hoursPerDay");
+                    field.handleChange(value);
+                  }}
+                  error={
+                    schedule.input.mode === "hoursPerDay"
+                      ? getErrorMessage(field.state.meta.errors[0])
+                      : undefined
+                  }
+                />
+                <ScheduleTotalHoursField
+                  value={
+                    scheduleDraft.hasSelection
+                      ? toDisplayHours(scheduleDraft.totalHours)
+                      : ""
+                  }
+                  disabled={!scheduleDraft.hasSelection}
+                  onChange={(value) => {
+                    form.setFieldValue("schedule.input.mode", "totalHours");
+                    field.handleChange(value);
+                  }}
+                  error={
+                    schedule.input.mode === "totalHours"
+                      ? getErrorMessage(field.state.meta.errors[0])
+                      : undefined
+                  }
+                />
+              </>
             )}
           </form.Field>
         </div>

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -50,7 +50,7 @@ function EditScheduleModal({
   const [selectionAnchor, setSelectionAnchor] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [applyMode, setApplyMode] =
-    useState<EditScheduleApplyMode>("this_and_future");
+    useState<EditScheduleApplyMode>("only_this");
 
   const safeValues = useMemo(
     () =>
@@ -281,14 +281,14 @@ function EditScheduleModal({
 
     form.reset(formDefaultValues);
     setSelectionAnchor(null);
-    setApplyMode("this_and_future");
+    setApplyMode("only_this");
   }, [form, formDefaultValues, open]);
 
   const closeModal = useCallback(() => {
     onOpenChange(false);
     form.reset(formDefaultValues);
     setSelectionAnchor(null);
-    setApplyMode("this_and_future");
+    setApplyMode("only_this");
   }, [form, formDefaultValues, onOpenChange]);
 
   return (
@@ -438,6 +438,7 @@ function EditScheduleModal({
           <ScheduleSummaryTable
             rows={scheduleDraft.previewRows}
             repeatWeeks={summaryRepeatWeeks}
+            variant={applyMode === "this_and_future" ? "day" : "date"}
           />
         </div>
       </div>

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -118,13 +118,6 @@ function EditScheduleModal({
     return `Repeats for ${seriesInfo.remainingWeeks} week${seriesInfo.remainingWeeks === 1 ? "" : "s"} till ${format(parseISO(seriesInfo.seriesEndDate), "MMM d")}`;
   }, [applyMode, isRecurringAllocation, seriesInfo]);
 
-  const summaryRepeatWeeks =
-    isRecurringAllocation &&
-    applyMode !== "only_this" &&
-    seriesInfo?.remainingWeeks
-      ? Math.max(0, seriesInfo.remainingWeeks - 1)
-      : 0;
-
   const days = useMemo(
     () => buildDays(fullRange.startDate, fullRange.endDate),
     [fullRange.endDate, fullRange.startDate],
@@ -459,7 +452,6 @@ function EditScheduleModal({
           </label>
           <ScheduleSummaryTable
             rows={scheduleDraft.previewRows}
-            repeatWeeks={summaryRepeatWeeks}
             variant={applyMode === "this_and_future" ? "day" : "date"}
           />
         </div>

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -3,7 +3,7 @@
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Dialog, Select, useToasts } from "@rtcamp/frappe-ui-react";
-import { useForm, useStore } from "@tanstack/react-form";
+import { revalidateLogic, useForm, useStore } from "@tanstack/react-form";
 import { format, parseISO } from "date-fns";
 import {
   FrappeError,
@@ -159,6 +159,10 @@ function EditScheduleModal({
 
   const form = useForm({
     defaultValues: formDefaultValues,
+    validationLogic: revalidateLogic({
+      mode: "submit",
+      modeAfterSubmission: "change",
+    }),
     validators: {
       onChange: editScheduleFormSchema,
       onSubmit: editScheduleFormSchema,
@@ -274,6 +278,14 @@ function EditScheduleModal({
     schedulePayload.allocationHoursPerDay !==
       allocationContext?.allocationHoursPerDay;
 
+  const validateScheduleChange = useCallback(
+    () =>
+      scheduleDraft.hasSelection && !hasScheduleChange
+        ? "Change hours to save."
+        : undefined,
+    [hasScheduleChange, scheduleDraft.hasSelection],
+  );
+
   useEffect(() => {
     if (!open) {
       return;
@@ -310,7 +322,7 @@ function EditScheduleModal({
         size: "sm",
       }}
       actions={
-        <div className="flex w-full items-center justify-end gap-2">
+        <div className="flex items-center justify-end w-full gap-2">
           <Button variant="ghost" label="Cancel" onClick={closeModal} />
           <form.Subscribe selector={(state) => state.isSubmitting}>
             {(isSubmitting) => (
@@ -319,7 +331,7 @@ function EditScheduleModal({
                 label="Save changes"
                 onClick={() => form.handleSubmit()}
                 loading={submitting}
-                disabled={!hasScheduleChange || isSubmitting || submitting}
+                disabled={isSubmitting || submitting}
               />
             )}
           </form.Subscribe>
@@ -366,7 +378,12 @@ function EditScheduleModal({
         </form.Field>
 
         <div className="flex w-full items-start gap-2 pb-1.5">
-          <form.Field name="schedule.input.value">
+          <form.Field
+            name="schedule.input.value"
+            validators={{
+              onDynamic: validateScheduleChange,
+            }}
+          >
             {(field) => (
               <ScheduleHoursPerDayField
                 value={scheduleDraft.hoursPerDay}
@@ -383,7 +400,12 @@ function EditScheduleModal({
               />
             )}
           </form.Field>
-          <form.Field name="schedule.input.value">
+          <form.Field
+            name="schedule.input.value"
+            validators={{
+              onDynamic: validateScheduleChange,
+            }}
+          >
             {(field) => (
               <ScheduleTotalHoursField
                 value={

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
@@ -100,10 +100,19 @@ export const getHoursPerDayFromTotalHours = (
 export const formatRange = (
   startDate: string,
   endDate?: string | null,
+  variant: "date" | "day" = "date",
 ): string => {
-  if (!endDate) return format(parseISO(startDate), "MMM d");
+  const safe = normalizeRange(startDate, endDate ?? startDate);
 
-  const safe = normalizeRange(startDate, endDate);
+  if (variant === "day") {
+    const start = format(parseISO(safe.startDate), "EEE");
+
+    if (safe.startDate === safe.endDate) {
+      return start;
+    }
+
+    return `${start} - ${format(parseISO(safe.endDate), "EEE")}`;
+  }
 
   if (safe.startDate === safe.endDate) {
     return format(parseISO(safe.startDate), "MMM d");

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
@@ -189,11 +189,14 @@ export const buildPreviewRows = ({
       selection !== undefined &&
       dateKey >= selection.startDate &&
       dateKey <= selection.endDate;
-    const hoursPerDay = inSelection
-      ? selection.hoursPerDay
-      : dayOverride?.cancelled === 1
+    const currentHoursPerDay =
+      dayOverride?.cancelled === 1
         ? 0
         : (dayOverride?.hours ?? defaultHoursPerDay);
+    const hoursPerDay = inSelection
+      ? selection.hoursPerDay
+      : currentHoursPerDay;
+    const isModified = inSelection && hoursPerDay !== currentHoursPerDay;
 
     if (
       currentRow &&
@@ -201,8 +204,7 @@ export const buildPreviewRows = ({
       currentRow.isSelected === inSelection
     ) {
       currentRow.endDate = dateKey;
-      currentRow.isModified =
-        currentRow.isSelected && currentRow.hoursPerDay !== defaultHoursPerDay;
+      currentRow.isModified = currentRow.isModified || isModified;
       continue;
     }
 
@@ -211,7 +213,7 @@ export const buildPreviewRows = ({
       endDate: dateKey,
       hoursPerDay,
       isSelected: inSelection,
-      isModified: inSelection && hoursPerDay !== defaultHoursPerDay,
+      isModified,
     };
     rows.push(currentRow);
   }


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
* Changes the default "Apply edits to" option from "This Allocation" to "This Allocation" instead of "This and Future", reducing the risk of users accidentally applying changes to future allocations.
* Updates the Schedule Summary for recurring allocations. When "This and Future" is selected, the summary displays day names (e.g., "Mon", "Tue") instead of specific dates to make it clear that the changes apply to future occurrences.
* Removed the "(+X weeks)" label from the Schedule Summary row, as it is not clear what it represents and could mislead users.

Other:
* The "Save Changes" button is no longer disabled when no schedule changes have been made. Instead, clicking it provides clear validation feedback:
  * If no date range is selected, the user is prompted to select a range.
  * If a range is selected but no changes have been made, the user is prompted to modify the selected range before saving.
  
This change improves the user experience by making it clear why the action cannot be completed, instead of leaving the button disabled without explanation.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->



https://github.com/user-attachments/assets/0bab2253-3c19-4e74-aedc-10dbbf5f45b0


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1815