### PR TITLE
Fix: Team Timesheet View Does Not Show Employees Who Haven't Submitted Timesheets

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -88,6 +88,7 @@ export const TeamTimesheetRow = ({
                 workingHour={member.workingHour}
                 workingFrequency={member.workingFrequency}
                 status={member.status}
+                hideAction={member.status === "Not Submitted"}
                 className="pl-7.5"
                 collapsed={true}
                 disabled={member.status === "Approved"}

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -166,14 +166,6 @@ export function useTeamTimesheetData({
         Object.values(payload.data ?? {})
           .filter((emp) => emp.name)
           .forEach((emp) => {
-            // Eliminate "Not Submitted" weeks at the source so all downstream
-            // logic can assume every timesheet entry is worth displaying.
-            const submittedTimesheets = Object.fromEntries(
-              Object.entries(emp.timesheet_details ?? {}).filter(
-                ([, week]) => week.status !== "Not Submitted",
-              ),
-            );
-
             if (!employeeMap[emp.name]) {
               employeeMap[emp.name] = {
                 member: {
@@ -183,7 +175,7 @@ export function useTeamTimesheetData({
                 },
                 working_hour: emp.working_hour,
                 working_frequency: emp.working_frequency,
-                timesheetDetails: submittedTimesheets,
+                timesheetDetails: emp.timesheet_details ?? {},
                 leaves: emp.leaves ?? [],
                 holidays: emp.holidays ?? [],
               };
@@ -201,7 +193,7 @@ export function useTeamTimesheetData({
                 ...existing,
                 timesheetDetails: {
                   ...existing.timesheetDetails,
-                  ...submittedTimesheets,
+                  ...(emp.timesheet_details ?? {}),
                 },
                 leaves: [
                   ...existing.leaves,
@@ -223,8 +215,8 @@ export function useTeamTimesheetData({
       const weekMap = new Map<string, WeekGroup>();
 
       // Seed week skeletons from the API-declared date ranges so that weeks
-      // are always present in the output even when every employee's timesheet
-      // for that week has status "Not Submitted" (and was filtered above).
+      // are always present in the output even when no employee has any
+      // timesheet data for that week.
       pages.forEach((payload) => {
         (payload.dates ?? []).forEach((weekEntry) => {
           if (!weekMap.has(weekEntry.start_date)) {

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -39,6 +39,8 @@ export interface MemberRowProps {
   totalHoursTheme?: TotalHoursTheme;
   /** Additional class names for the member row container. */
   className?: string;
+  /** When true, hides the trailing status action button. */
+  hideAction?: boolean;
 }
 
 export const MemberRow: React.FC<MemberRowProps> = ({
@@ -52,6 +54,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
   totalHours = "",
   totalHoursTheme,
   className,
+  hideAction = false,
 }) => {
   const isStatusNone = status === "none";
 
@@ -62,7 +65,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         className,
       )}
     >
-      <div className="flex flex-1 gap-2 items-center min-w-0 align-middle">
+      <div className="flex items-center flex-1 min-w-0 gap-2 align-middle">
         <span
           className={cn(
             "w-4 transition-transform shrink-0",
@@ -71,7 +74,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         >
           <SmallDown strokeWidth={1.5} size={16} />
         </span>
-        <div className="flex gap-2 items-center min-w-0 max-w-75 sm:max-w-112">
+        <div className="flex items-center min-w-0 gap-2 max-w-75 sm:max-w-112">
           <Avatar image={avatarUrl} shape="circle" label={label} size="xs" />
           <span className="text-base font-medium truncate text-ink-gray-8">
             {label}
@@ -151,8 +154,8 @@ export const MemberRow: React.FC<MemberRowProps> = ({
         </span>
       </div>
 
-      <div className="flex justify-end items-center w-12 h-7 whitespace-nowrap shrink-0">
-        {!isStatusNone && memberStatusIcon[status]?.icon ? (
+      <div className="flex items-center justify-end w-12 h-7 whitespace-nowrap shrink-0">
+        {!hideAction && !isStatusNone && memberStatusIcon[status]?.icon ? (
           <Button
             onClick={(e) => {
               e.stopPropagation();


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR removes the filtering of not-submitted timesheets, allowing them to be displayed on the frontend even if the user has not entered any time entries.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1856" height="983" alt="Screenshot 2026-07-15 at 2 32 13 PM" src="https://github.com/user-attachments/assets/765ec76d-4a98-4c17-b5b4-3bf01be889d9" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1805