### PR TITLE
Fix: Link filters showing different labels instead of the human readable selected ones

### DIFF
--- a/frontend/packages/app/src/components/filters/FilterLinkValue.tsx
+++ b/frontend/packages/app/src/components/filters/FilterLinkValue.tsx
@@ -18,6 +18,7 @@ import { useDoctypeLinkLookup } from "@/hooks/useDoctypeLinkLookup";
 export const FilterLinkValue: React.FC<FilterLinkValueRenderProps> = ({
   field,
   value,
+  displayLabel,
   onChange,
   disabled,
 }) => {
@@ -25,8 +26,8 @@ export const FilterLinkValue: React.FC<FilterLinkValueRenderProps> = ({
   const [query, setQuery] = useState("");
 
   const selectedOption = useMemo(
-    () => (value ? { label: value, value } : null),
-    [value],
+    () => (value ? { label: displayLabel ?? value, value } : null),
+    [value, displayLabel],
   );
 
   const { options, isLoading } = useDoctypeLinkLookup({
@@ -50,7 +51,11 @@ export const FilterLinkValue: React.FC<FilterLinkValueRenderProps> = ({
       openOnFocus
       disabled={disabled}
       placeholder="Value"
-      onChange={(val) => onChange(val)}
+      onChange={(val, option) => {
+        const label =
+          option && typeof option !== "string" ? option.label : undefined;
+        onChange(val, label);
+      }}
       className="w-50"
     />
   );

--- a/frontend/packages/app/src/components/filters/FilterLinkValue.tsx
+++ b/frontend/packages/app/src/components/filters/FilterLinkValue.tsx
@@ -57,6 +57,7 @@ export const FilterLinkValue: React.FC<FilterLinkValueRenderProps> = ({
         onChange(val, label);
       }}
       className="w-50"
+      popupClassName="w-fit max-w-[300px]"
     />
   );
 };


### PR DESCRIPTION
## Description

Fixes link field values showing raw IDs or other fields (e.g. "TASK-00001") instead of human-readable label names selected in link config after filter popover close/reopen.

## Relevant Technical Choices

- When a link field value is selected, the human-readable label is captured from the Combobox option and stored alongside the stored value in the filter state. On popover reopen/page reload/URL copy-paste, the stored label is used for display instead of falling back to the raw ID.
- Couldn't replicate earlier on local env due to less data being added. The bug only appears when the selected document is not in the first page of results, production had enough data to trigger it.
- Added a minor cosmetic change: Combobox popup width is now independent of the input width, allowing to view dropdown in more width and less truncation. Suggested in: https://github.com/rtCamp/next-pms/pull/1823#issuecomment-4960531067

## Testing Instructions

- Go to any page in Next PMS with link filters
- Select the link filter and search or select any option that is not on the first page of the dropdown
- Observe the label remains the same after selecting it, reopening the filter popover, reloading the page and copying the URL and opening it in different tab.  

## Screenshot/Screencast

- Updated Behaviour

https://github.com/user-attachments/assets/604eea37-81d0-4813-9109-1ac6a628bbdb

- Previous Behvaiour


https://github.com/user-attachments/assets/d6a42f92-5d00-4b50-b41b-c6b9ace65e79

If any option apart from the first page suggested ones (the ones immediately in the dropdown sugestions) were selected, the label would fall back to the filter field instead of the labelField we selected in the link config



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1832 
Depends on: https://github.com/rtCamp/frappe-ui-react/pull/311