### PR TITLE
Fix: Unable to modify date for an already existing time entry  

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -200,10 +200,13 @@ export const InlineTimeEntry = ({
   }, [baseEngaged]);
   const isEngaged = baseEngaged || stayEngaged;
 
-  // Freeze the tasks when a mutation is in progress to avoid flickering of the list when the data is being updated.
-  if (!isMutating) {
-    frozenTasksRef.current = tasks;
-  }
+  // Snapshot the list while this popover's own mutation is in flight, so the realtime
+  // data (which arrives before the response of the mutation) can't cause flicker of the list.
+  useEffect(() => {
+    if (!isMutating) {
+      frozenTasksRef.current = tasks;
+    }
+  }, [isMutating, tasks]);
   const displayTasks = isMutating ? frozenTasksRef.current : tasks;
   const hasNoTimeEntries = displayTasks.length === 0;
 

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -94,6 +94,7 @@ export const InlineTimeEntry = ({
     date: string;
   } | null>(null);
   const pendingProceedAfterSaveRef = useRef<(() => void) | null>(null);
+  const frozenTasksRef = useRef(tasks);
 
   const { call: saveTime, loading: isSaving } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
@@ -114,7 +115,6 @@ export const InlineTimeEntry = ({
       ? hoursLeft + selectedEntry.hours
       : hoursLeft;
   const defaultDuration = hoursLeft >= 0.5 ? 0.5 : 0;
-  const hasNoTimeEntries = (tasks.length ?? 0) === 0;
   const isDraftAvailableInEdit =
     entryFormMode === ENTRY_FORM_MODE.EDIT && addDraft !== null;
 
@@ -159,7 +159,7 @@ export const InlineTimeEntry = ({
           });
           toast.success("Time Entry submitted successfully");
         }
-        if (hasNoTimeEntries && entryFormMode === ENTRY_FORM_MODE.DEFAULT) {
+        if (tasks.length === 0 && entryFormMode === ENTRY_FORM_MODE.DEFAULT) {
           onSubmitSuccess?.();
         }
         pendingProceedAfterSaveRef.current?.();
@@ -199,6 +199,13 @@ export const InlineTimeEntry = ({
     }
   }, [baseEngaged]);
   const isEngaged = baseEngaged || stayEngaged;
+
+  // Freeze the tasks when a mutation is in progress to avoid flickering of the list when the data is being updated.
+  if (!isMutating) {
+    frozenTasksRef.current = tasks;
+  }
+  const displayTasks = isMutating ? frozenTasksRef.current : tasks;
+  const hasNoTimeEntries = displayTasks.length === 0;
 
   const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
   hasUnsavedChangesRef.current = hasUnsavedChanges;
@@ -352,7 +359,7 @@ export const InlineTimeEntry = ({
 
   return (
     <div className="animate-fade-in min-w-68 w-fit max-w-[min(720px,90vw)] max-h-[min(500px,90dvh)] overflow-auto scrollbar-thin shadow bg-surface-modal rounded-lg flex flex-col gap-2 p-2">
-      {tasks.map((entry: TaskDataItemProps, index: number) => {
+      {displayTasks.map((entry: TaskDataItemProps, index: number) => {
         const isEditingThisEntry =
           entryFormMode === ENTRY_FORM_MODE.EDIT &&
           selectedEntry?.name === entry.name;
@@ -368,7 +375,9 @@ export const InlineTimeEntry = ({
               <Accordion.Item
                 value={entry.name}
                 className={cn("border-outline-gray-modals", {
-                  "pb-2 border-b": !(disabled && tasks.length - 1 === index),
+                  "pb-2 border-b": !(
+                    disabled && displayTasks.length - 1 === index
+                  ),
                 })}
               >
                 {!isEditingThisEntry ? (

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -88,9 +88,11 @@ export const InlineTimeEntry = ({
   } = useResizeEngagement();
   const [collapsedEntryNames, setCollapsedEntryNames] = useState<string[]>([]);
   const hasInitializedInteractiveModeRef = useRef(false);
-  const editBaselineRef = useRef<{ duration: number; comment: string } | null>(
-    null,
-  );
+  const editBaselineRef = useRef<{
+    duration: number;
+    comment: string;
+    date: string;
+  } | null>(null);
   const pendingProceedAfterSaveRef = useRef<(() => void) | null>(null);
 
   const { call: saveTime } = useFrappePostCall(
@@ -173,14 +175,16 @@ export const InlineTimeEntry = ({
     },
   });
 
-  const { duration: liveDuration, comment: liveComment } = useStore(
-    form.store,
-    (state) => state.values,
-  );
+  const {
+    duration: liveDuration,
+    comment: liveComment,
+    date: liveDate,
+  } = useStore(form.store, (state) => state.values);
   const hasUnsavedChanges =
     entryFormMode === ENTRY_FORM_MODE.EDIT && editBaselineRef.current
       ? liveDuration !== editBaselineRef.current.duration ||
-        liveComment !== editBaselineRef.current.comment
+        liveComment !== editBaselineRef.current.comment ||
+        liveDate !== editBaselineRef.current.date
       : liveDuration !== defaultValues.duration ||
         liveComment !== defaultValues.comment;
   const isEngaged =
@@ -267,14 +271,16 @@ export const InlineTimeEntry = ({
       editBaselineRef.current = {
         duration: entry.hours,
         comment: entry.description ?? "",
+        date,
       };
       setCollapsedEntryNames((prev) =>
         prev.filter((name) => name !== entry.name),
       );
       form.setFieldValue("duration", entry.hours);
       form.setFieldValue("comment", entry.description ?? "");
+      form.setFieldValue("date", date);
     },
-    [entryFormMode, form, defaultValues, tasks],
+    [entryFormMode, form, defaultValues, date, tasks],
   );
 
   const handleToggleAddMode = useCallback(() => {

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -70,7 +70,6 @@ export const InlineTimeEntry = ({
   disabled,
 }: InlineTimeEntryProps) => {
   const toast = useToasts();
-  const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [entryFormMode, setEntryFormMode] = useState<EntryFormMode>(
     ENTRY_FORM_MODE.DEFAULT,
@@ -95,15 +94,18 @@ export const InlineTimeEntry = ({
   } | null>(null);
   const pendingProceedAfterSaveRef = useRef<(() => void) | null>(null);
 
-  const { call: saveTime } = useFrappePostCall(
+  const { call: saveTime, loading: isSaving } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
   );
-  const { call: updateTimesheet } = useFrappePostCall(
+  const { call: updateTimesheet, loading: isUpdating } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.bulk_update_timesheet_detail",
   );
-  const { call: deleteTimesheet } = useFrappePostCall(
+  const { call: deleteTimesheet, loading: isDeleting } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.delete",
   );
+
+  const isSavingEntry = isSaving || isUpdating;
+  const isMutating = isSavingEntry || isDeleting;
 
   const hoursLeft = (dailyWorkingHours ?? 0) - (totalUsedHoursInDay ?? 0);
   const effectiveHoursLeft =
@@ -128,7 +130,6 @@ export const InlineTimeEntry = ({
   const form = useInlineTimeEntryForm({
     defaultValues,
     onSubmit: async ({ value }) => {
-      setSubmitting(true);
       setSubmitError(null);
 
       try {
@@ -165,7 +166,6 @@ export const InlineTimeEntry = ({
         setSubmitError(parseFrappeErrorMsg(err as FrappeError));
       } finally {
         pendingProceedAfterSaveRef.current = null;
-        setSubmitting(false);
         form.reset();
         editBaselineRef.current = null;
         setSelectedEntry(null);
@@ -230,7 +230,6 @@ export const InlineTimeEntry = ({
 
   const handleDelete = useCallback(async () => {
     if (!selectedEntry) return;
-    setSubmitting(true);
     try {
       await deleteTimesheet({
         parent: selectedEntry.parent,
@@ -241,7 +240,6 @@ export const InlineTimeEntry = ({
       const error = parseFrappeErrorMsg(err as FrappeError);
       toast.error(error);
     } finally {
-      setSubmitting(false);
       form.reset();
       editBaselineRef.current = null;
       setSelectedEntry(null);
@@ -441,7 +439,8 @@ export const InlineTimeEntry = ({
                         durationLabel="Edit time"
                         maxDurationInHours={dailyWorkingHours}
                         editBaseline={editBaselineRef.current}
-                        submitting={submitting}
+                        isSaving={isSavingEntry}
+                        isMutating={isMutating}
                         submitError={submitError}
                         onSave={() => handleSubmit()}
                         onCommentKeyDown={handleSubmit}
@@ -453,7 +452,8 @@ export const InlineTimeEntry = ({
                           size="sm"
                           iconLeft={() => <Delete size={16} />}
                           onClick={handleDelete}
-                          disabled={submitting}
+                          loading={isDeleting}
+                          disabled={isSavingEntry}
                         >
                           Delete entry
                         </Button>
@@ -490,7 +490,8 @@ export const InlineTimeEntry = ({
               hoursLeft={effectiveHoursLeft}
               durationLabel={hasNoTimeEntries ? false : "Add time"}
               maxDurationInHours={dailyWorkingHours}
-              submitting={submitting}
+              isSaving={isSavingEntry}
+              isMutating={isMutating}
               submitError={submitError}
               onSave={() => handleSubmit()}
               onCommentKeyDown={handleSubmit}
@@ -500,7 +501,10 @@ export const InlineTimeEntry = ({
           {!hasNoTimeEntries && entryFormMode !== ENTRY_FORM_MODE.ADD ? (
             <div className="flex justify-between w-full gap-2">
               <Button
-                className="text-ink-gray-7"
+                className={cn(
+                  "text-ink-gray-7",
+                  isMutating && "text-ink-gray-4",
+                )}
                 variant="ghost"
                 size="sm"
                 iconLeft={() =>
@@ -511,7 +515,7 @@ export const InlineTimeEntry = ({
                   )
                 }
                 onClick={handleToggleAddMode}
-                disabled={submitting}
+                disabled={isMutating}
               >
                 {isDraftAvailableInEdit ? "Draft" : "Add time"}
               </Button>

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -86,6 +86,7 @@ export const InlineTimeEntry = ({
     onResizePointerDown: handleCommentPointerDown,
   } = useResizeEngagement();
   const [collapsedEntryNames, setCollapsedEntryNames] = useState<string[]>([]);
+  const [stayEngaged, setStayEngaged] = useState(false);
   const hasInitializedInteractiveModeRef = useRef(false);
   const editBaselineRef = useRef<{
     duration: number;
@@ -187,10 +188,17 @@ export const InlineTimeEntry = ({
         liveDate !== editBaselineRef.current.date
       : liveDuration !== defaultValues.duration ||
         liveComment !== defaultValues.comment;
-  const isEngaged =
+  const baseEngaged =
     entryFormMode !== ENTRY_FORM_MODE.DEFAULT ||
     hasUnsavedChanges ||
     commentResizeActive;
+
+  useEffect(() => {
+    if (baseEngaged) {
+      setStayEngaged(true);
+    }
+  }, [baseEngaged]);
+  const isEngaged = baseEngaged || stayEngaged;
 
   const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
   hasUnsavedChangesRef.current = hasUnsavedChanges;
@@ -205,6 +213,7 @@ export const InlineTimeEntry = ({
     editBaselineRef.current = null;
     setSelectedEntry(null);
     setAddDraft(null);
+    setStayEngaged(false);
     setEntryFormMode(ENTRY_FORM_MODE.DEFAULT);
   }, [form]);
 
@@ -236,6 +245,10 @@ export const InlineTimeEntry = ({
         name: selectedEntry.name,
       });
       toast.success("Time Entry deleted successfully");
+      // Deleting the last remaining entry leaves nothing to show, so close.
+      if (tasks.length <= 1) {
+        onSubmitSuccess?.();
+      }
     } catch (err) {
       const error = parseFrappeErrorMsg(err as FrappeError);
       toast.error(error);
@@ -246,7 +259,7 @@ export const InlineTimeEntry = ({
       setAddDraft(null);
       setEntryFormMode(ENTRY_FORM_MODE.DEFAULT);
     }
-  }, [selectedEntry, deleteTimesheet, toast, form]);
+  }, [selectedEntry, deleteTimesheet, toast, form, tasks, onSubmitSuccess]);
 
   const handleEditEntry = useCallback(
     (entry: TaskDataItemProps) => {

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
@@ -86,7 +86,9 @@ export const TimeEntryForm = ({
                   clearable={false}
                   placement="bottom-start"
                   disabled={isMutating}
-                  formatter={(date) => format(parseISO(date), "MMM d, yyyy")}
+                  formatter={(date) =>
+                    date ? format(parseISO(date), "MMM d, yyyy") : ""
+                  }
                   value={field.state.value}
                   onChange={(val) =>
                     field.handleChange(

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
@@ -4,11 +4,14 @@
 import { mergeClassNames as cn } from "@next-pms/design-system";
 import {
   Button,
+  DatePicker,
   ErrorMessage,
   TextEditor,
   DurationInput,
+  TextInput,
 } from "@rtcamp/frappe-ui-react";
-import { AddSm } from "@rtcamp/frappe-ui-react/icons";
+import { AddSm, Calendar } from "@rtcamp/frappe-ui-react/icons";
+import { format, parseISO } from "date-fns";
 
 /**
  * Internal dependencies
@@ -65,6 +68,48 @@ export const TimeEntryForm = ({
           );
         }}
       />
+      {mode === ENTRY_FORM_MODE.EDIT ? (
+        <form.Field
+          name="date"
+          children={(field) => {
+            return (
+              <div className="flex flex-col w-full gap-1.5">
+                <label className="block text-xs text-ink-gray-5">
+                  Edit date
+                </label>
+                <DatePicker
+                  label="Date"
+                  variant="outline"
+                  clearable={false}
+                  placement="bottom-start"
+                  formatter={(date) => format(parseISO(date), "MMM d, yyyy")}
+                  value={field.state.value}
+                  onChange={(val) =>
+                    field.handleChange(
+                      typeof val === "string" ? val : (val[0] ?? ""),
+                    )
+                  }
+                >
+                  {({ displayValue }) => (
+                    <TextInput
+                      className="h-8 text-base text-ink-gray-7"
+                      type="text"
+                      placeholder="Select date"
+                      value={displayValue}
+                      readOnly
+                      suffix={() => <Calendar className="size-4" />}
+                      variant="outline"
+                    />
+                  )}
+                </DatePicker>
+                {!field.state.meta.isValid && (
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                )}
+              </div>
+            );
+          }}
+        />
+      ) : null}
       <form.Field
         name="comment"
         children={(field) => {
@@ -104,12 +149,14 @@ export const TimeEntryForm = ({
       {submitError ? <ErrorMessage message={submitError} /> : null}
       <form.Subscribe
         selector={(state) => ({
+          date: state.values.date,
           duration: state.values.duration,
           comment: state.values.comment,
           durationIsDefault: state.fieldMeta.duration?.isDefaultValue ?? true,
           commentIsDefault: state.fieldMeta.comment?.isDefaultValue ?? true,
         })}
         children={({
+          date,
           duration,
           comment,
           durationIsDefault,
@@ -119,7 +166,8 @@ export const TimeEntryForm = ({
           const isEditUnchanged =
             editBaseline !== null &&
             duration === editBaseline.duration &&
-            comment === editBaseline.comment;
+            comment === editBaseline.comment &&
+            date === editBaseline.date;
           const isSaveDisabled =
             submitting ||
             (mode === ENTRY_FORM_MODE.ADD ? isAddUnchanged : isEditUnchanged);

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/timeEntryForm.tsx
@@ -27,7 +27,8 @@ import { TimeEntryFormProps } from "./types";
  * @param hoursLeft The number of hours left that can be logged for the day.
  * @param durationVariant The variant style to apply to the duration input field.
  * @param maxDurationInHours The maximum number of hours that can be entered in the duration field.
- * @param submitting A boolean indicating whether the form is currently being submitted, used to disable inputs during submission.
+ * @param isSaving Whether this form's own save/update request is in flight; drives the Save button's loading state.
+ * @param isMutating Whether any mutation (save, update or delete) is in flight; disables every input and the Save button.
  * @param editBaseline An optional object containing the original duration and comment values when in edit mode.
  * @param onCommentKeyDown A callback function to handle key down events in the comment textarea.
  */
@@ -37,7 +38,8 @@ export const TimeEntryForm = ({
   hoursLeft,
   durationLabel,
   maxDurationInHours,
-  submitting,
+  isSaving,
+  isMutating,
   submitError = null,
   editBaseline = null,
   onSave,
@@ -60,6 +62,7 @@ export const TimeEntryForm = ({
                 value={field.state.value}
                 onChange={(val) => field.handleChange(val)}
                 maxDuration={maxDurationInHours}
+                disabled={isMutating}
               />
               {!field.state.meta.isValid && (
                 <ErrorMessage message={field.state.meta.errors[0]?.message} />
@@ -82,6 +85,7 @@ export const TimeEntryForm = ({
                   variant="outline"
                   clearable={false}
                   placement="bottom-start"
+                  disabled={isMutating}
                   formatter={(date) => format(parseISO(date), "MMM d, yyyy")}
                   value={field.state.value}
                   onChange={(val) =>
@@ -90,13 +94,14 @@ export const TimeEntryForm = ({
                     )
                   }
                 >
-                  {({ displayValue }) => (
+                  {({ displayValue, disabled }) => (
                     <TextInput
                       className="h-8 text-base text-ink-gray-7"
                       type="text"
                       placeholder="Select date"
                       value={displayValue}
                       readOnly
+                      disabled={disabled}
                       suffix={() => <Calendar className="size-4" />}
                       variant="outline"
                     />
@@ -121,7 +126,7 @@ export const TimeEntryForm = ({
                 onPointerDownCapture={onCommentPointerDown}
               >
                 <TextEditor
-                  editable={!submitting}
+                  editable={!isMutating}
                   content={field.state.value}
                   onChange={(value) => field.handleChange(value)}
                   fixedMenu={false}
@@ -169,17 +174,21 @@ export const TimeEntryForm = ({
             comment === editBaseline.comment &&
             date === editBaseline.date;
           const isSaveDisabled =
-            submitting ||
+            isMutating ||
             (mode === ENTRY_FORM_MODE.ADD ? isAddUnchanged : isEditUnchanged);
 
           return (
             <div className="flex justify-between w-full gap-2">
               <Button
-                className="text-ink-gray-7"
+                className={cn(
+                  "text-ink-gray-7",
+                  (isSaving || isSaveDisabled) && "text-ink-gray-4",
+                )}
                 variant="subtle"
                 size="sm"
                 iconLeft={() => <AddSm size={16} />}
                 onClick={onSave}
+                loading={isSaving}
                 disabled={isSaveDisabled}
               >
                 Save entry

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
@@ -32,7 +32,7 @@ export type TimeEntryFormProps = {
   maxDurationInHours: number;
   submitting: boolean;
   submitError?: string | null;
-  editBaseline?: { duration: number; comment: string } | null;
+  editBaseline?: { duration: number; comment: string; date: string } | null;
   onSave: () => void;
   onCommentKeyDown: (e: KeyboardEvent<Element>) => void;
   onCommentPointerDown?: (e: PointerEvent<HTMLElement>) => void;

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/types.ts
@@ -30,7 +30,8 @@ export type TimeEntryFormProps = {
   hoursLeft: number;
   durationLabel: string | false;
   maxDurationInHours: number;
-  submitting: boolean;
+  isSaving: boolean;
+  isMutating: boolean;
   submitError?: string | null;
   editBaseline?: { duration: number; comment: string; date: string } | null;
   onSave: () => void;


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds a date field to the inline edit time entry modal, allowing users to change the date of an existing time entry. This functionality was supported in NextPMS 1.0, so this is a frontend-only change.

Other: 
- Improved the loading state for inline time entry actions. Previously, there was no loading indication while saving or deleting a time entry, which could make it appear that nothing was happening.
- Fixed the accidental closer of popover after edit or delete of one of the time entry.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/37081c21-b47b-4837-92f7-96e99ccaf556



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1836