### PR TITLE
fix: disable Edit Schedule button on project-employee mismatch

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -677,7 +677,8 @@ function AddAllocationModal({
                       <Button
                         variant="ghost"
                         label="Edit Schedule"
-                        className="p-0 bg-transparent h-fit text-ink-gray-5 hover:bg-transparent focus:bg-transparent active:bg-transparent"
+                        className="p-0 bg-transparent h-fit text-ink-gray-5 hover:bg-transparent focus:bg-transparent active:bg-transparent disabled:cursor-not-allowed!"
+                        disabled={isProjectEmployeeMismatch}
                         onClick={onEditScheduleClick}
                       />
                     ) : null}


### PR DESCRIPTION
## Description
Disables the "Edit Schedule" button in the add/edit allocation modal when isProjectEmployeeMismatch is true, with a cursor-not-allowed hover state so it's clear the action is unavailable.

## Screenshot/Screencast
<img width="848" height="727" alt="image" src="https://github.com/user-attachments/assets/322febe1-db51-4f99-bb87-8956ba1962d0" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1822