### PR TITLE
fix: display real remaining hours in duration field in add time modal

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -25,9 +25,9 @@ import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 /**
  * Internal Dependencies
  */
+import { FALLBACK_DAILY_WORKING_HOURS } from "@/lib/constant";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUnsavedChangesSource } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
-import { FALLBACK_DAILY_WORKING_HOURS } from "@/pages/timesheet/constants";
 import { TaskDataItemProps } from "@/types/timesheet";
 import { useInlineTimeEntryForm } from "./form";
 import { TimeEntryForm } from "./timeEntryForm";

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -27,6 +27,7 @@ import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
  */
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUnsavedChangesSource } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
+import { FALLBACK_DAILY_WORKING_HOURS } from "@/pages/timesheet/constants";
 import { TaskDataItemProps } from "@/types/timesheet";
 import { useInlineTimeEntryForm } from "./form";
 import { TimeEntryForm } from "./timeEntryForm";
@@ -61,7 +62,7 @@ export const InlineTimeEntry = ({
   date,
   taskKey,
   employee,
-  dailyWorkingHours = 8,
+  dailyWorkingHours = FALLBACK_DAILY_WORKING_HOURS,
   totalUsedHoursInDay,
   onSubmitSuccess,
   onEngagedChange,

--- a/frontend/packages/app/src/lib/constant.ts
+++ b/frontend/packages/app/src/lib/constant.ts
@@ -37,5 +37,8 @@ export const CustomTime = [
 
 export const NUMBER_OF_WEEKS_TO_FETCH = 4;
 
+/** Default daily working hours used when an employee's configured hours are unavailable. */
+export const FALLBACK_DAILY_WORKING_HOURS = 8;
+
 /** Operators that carry no value. */
 export const NO_VALUE_OPERATORS: string[] = ["is_empty", "is_not_empty"];

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/constants.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/constants.ts
@@ -1,7 +1,5 @@
 import { getTodayDate } from "@next-pms/design-system/date";
 
-export const FALLBACK_DAILY_WORKING_HOURS = 8;
-
 export const allocationRecurrenceLabels = {
   "one-time": "One time",
   recurring: "Recurring",

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -18,11 +18,7 @@ import {
 import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
-import {
-  FrappeError,
-  useFrappeGetCall,
-  useFrappePostCall,
-} from "frappe-react-sdk";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
@@ -37,7 +33,7 @@ import { useUser } from "@/providers/user";
 import CalendarEvents from "./calendarEvents";
 import { addTimeFormSchema, type addTimeFormValues } from "./schema";
 import type { AddTimeProps, SelectedCalendarEvent } from "./type";
-import { FALLBACK_DAILY_WORKING_HOURS } from "../../constants";
+import { useRemainingHours } from "../../hooks/useRemainingHours";
 
 const COMMENT_EDITOR_STARTERKIT_OPTIONS: NonNullable<
   TextEditorProps["starterkitOptions"]
@@ -168,12 +164,15 @@ const AddTime = ({
       }
     : null;
 
-  const { data: remainingHours, isValidating: isRemainingHoursLoading } =
-    useFrappeGetCall(
-      "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
-      { employee: employeeId, date: selectedDate },
-      open && employeeId && selectedDate ? undefined : null,
-    );
+  const {
+    maxDuration,
+    hoursLeft,
+    isLoading: isRemainingHoursLoading,
+  } = useRemainingHours({
+    employee: employeeId,
+    date: selectedDate,
+    enabled: open,
+  });
 
   useEffect(() => {
     if (!open) {
@@ -408,14 +407,8 @@ const AddTime = ({
                     label="Duration"
                     size="md"
                     snap="smooth"
-                    maxDuration={
-                      remainingHours?.message?.working_hour ??
-                      FALLBACK_DAILY_WORKING_HOURS
-                    }
-                    hoursLeft={
-                      remainingHours?.message?.remaining_hours ??
-                      FALLBACK_DAILY_WORKING_HOURS
-                    }
+                    maxDuration={maxDuration}
+                    hoursLeft={hoursLeft}
                     loading={isRemainingHoursLoading}
                     disabled={isRemainingHoursLoading}
                     value={field.state.value}

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -18,7 +18,11 @@ import {
 import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
-import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
+import {
+  FrappeError,
+  useFrappeGetCall,
+  useFrappePostCall,
+} from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
@@ -33,6 +37,7 @@ import { useUser } from "@/providers/user";
 import CalendarEvents from "./calendarEvents";
 import { addTimeFormSchema, type addTimeFormValues } from "./schema";
 import type { AddTimeProps, SelectedCalendarEvent } from "./type";
+import { FALLBACK_DAILY_WORKING_HOURS } from "../../constants";
 
 const COMMENT_EDITOR_STARTERKIT_OPTIONS: NonNullable<
   TextEditorProps["starterkitOptions"]
@@ -162,6 +167,13 @@ const AddTime = ({
         status: selectedTaskStatus,
       }
     : null;
+
+  const { data: remainingHours, isValidating: isRemainingHoursLoading } =
+    useFrappeGetCall(
+      "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
+      { employee: employeeId, date: selectedDate },
+      open && employeeId && selectedDate ? undefined : null,
+    );
 
   useEffect(() => {
     if (!open) {
@@ -391,11 +403,21 @@ const AddTime = ({
             name="duration"
             children={(field) => {
               return (
-                <div className="flex-1 flex flex-col gap-2 w-full">
+                <div className="flex flex-col flex-1 w-full gap-2">
                   <DurationInput
                     label="Duration"
                     size="md"
                     snap="smooth"
+                    maxDuration={
+                      remainingHours?.message?.working_hour ??
+                      FALLBACK_DAILY_WORKING_HOURS
+                    }
+                    hoursLeft={
+                      remainingHours?.message?.remaining_hours ??
+                      FALLBACK_DAILY_WORKING_HOURS
+                    }
+                    loading={isRemainingHoursLoading}
+                    disabled={isRemainingHoursLoading}
                     value={field.state.value}
                     onChange={(val) => field.handleChange(val)}
                   />

--- a/frontend/packages/app/src/pages/timesheet/constants.ts
+++ b/frontend/packages/app/src/pages/timesheet/constants.ts
@@ -3,8 +3,6 @@
  */
 import { FilterField } from "@rtcamp/frappe-ui-react";
 
-export const FALLBACK_DAILY_WORKING_HOURS = 8;
-
 const projectOptions = [
   { label: "Atlas UI Stabilization", value: "atlas-ui" },
   { label: "Backend Refactor", value: "backend" },

--- a/frontend/packages/app/src/pages/timesheet/constants.ts
+++ b/frontend/packages/app/src/pages/timesheet/constants.ts
@@ -1,4 +1,9 @@
+/**
+ * External dependencies.
+ */
 import { FilterField } from "@rtcamp/frappe-ui-react";
+
+export const FALLBACK_DAILY_WORKING_HOURS = 8;
 
 const projectOptions = [
   { label: "Atlas UI Stabilization", value: "atlas-ui" },

--- a/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
@@ -1,0 +1,48 @@
+/**
+ * External Dependencies.
+ */
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+/**
+ * Internal Dependencies.
+ */
+import { FALLBACK_DAILY_WORKING_HOURS } from "../constants";
+
+type RemainingHoursResponse = {
+  message: {
+    working_hour: number;
+    remaining_hours: number;
+  };
+};
+
+interface UseRemainingHoursArgs {
+  /** Employee the time entry is being logged for. */
+  employee?: string;
+  /** Date the time entry is being logged on. */
+  date?: string;
+  /** Only fetch remaining hours if this is true. */
+  enabled: boolean;
+}
+
+/**
+ * A hook to fetch the remaining hours for an employee on a given date.
+ */
+export const useRemainingHours = ({
+  employee,
+  date,
+  enabled,
+}: UseRemainingHoursArgs) => {
+  const shouldFetch = enabled && Boolean(employee) && Boolean(date);
+
+  const { data, isValidating } = useFrappeGetCall<RemainingHoursResponse>(
+    "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
+    { employee, date },
+    shouldFetch ? undefined : null,
+  );
+
+  return {
+    maxDuration: data?.message?.working_hour ?? FALLBACK_DAILY_WORKING_HOURS,
+    hoursLeft: data?.message?.remaining_hours ?? FALLBACK_DAILY_WORKING_HOURS,
+    isLoading: shouldFetch && isValidating,
+  };
+};

--- a/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
@@ -6,7 +6,7 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 /**
  * Internal Dependencies.
  */
-import { FALLBACK_DAILY_WORKING_HOURS } from "../constants";
+import { FALLBACK_DAILY_WORKING_HOURS } from "@/lib/constant";
 
 type RemainingHoursResponse = {
   message: {

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -16,11 +16,7 @@ import {
 import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
-import {
-  FrappeError,
-  useFrappeGetCall,
-  useFrappePostCall,
-} from "frappe-react-sdk";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
@@ -34,7 +30,7 @@ import { useTaskLookup, type TaskLookupOption } from "@/hooks/useTaskLookup";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { addTimeFormSchema, type addTimeFormValues } from "./schema";
 import type { AddTeamTimeProps } from "./type";
-import { FALLBACK_DAILY_WORKING_HOURS } from "../../constants";
+import { useRemainingHours } from "../../hooks/useRemainingHours";
 
 const AddEmployeeTime = ({
   initialDate,
@@ -158,12 +154,15 @@ const AddEmployeeTime = ({
       }
     : null;
 
-  const { data: remainingHours, isLoading: isRemainingHoursLoading } =
-    useFrappeGetCall(
-      "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
-      { employee: selectedEmployeeId, date: selectedDate },
-      open && selectedEmployeeId && selectedDate ? undefined : null,
-    );
+  const {
+    maxDuration,
+    hoursLeft,
+    isLoading: isRemainingHoursLoading,
+  } = useRemainingHours({
+    employee: selectedEmployeeId,
+    date: selectedDate,
+    enabled: open,
+  });
 
   useEffect(() => {
     if (!open) {
@@ -421,14 +420,8 @@ const AddEmployeeTime = ({
                     label="Duration"
                     size="md"
                     snap="smooth"
-                    maxDuration={
-                      remainingHours?.message?.working_hour ??
-                      FALLBACK_DAILY_WORKING_HOURS
-                    }
-                    hoursLeft={
-                      remainingHours?.message?.remaining_hours ??
-                      FALLBACK_DAILY_WORKING_HOURS
-                    }
+                    maxDuration={maxDuration}
+                    hoursLeft={hoursLeft}
                     loading={isRemainingHoursLoading}
                     disabled={isRemainingHoursLoading}
                     value={field.state.value}

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -16,7 +16,11 @@ import {
 import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
-import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
+import {
+  FrappeError,
+  useFrappeGetCall,
+  useFrappePostCall,
+} from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
@@ -30,6 +34,7 @@ import { useTaskLookup, type TaskLookupOption } from "@/hooks/useTaskLookup";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { addTimeFormSchema, type addTimeFormValues } from "./schema";
 import type { AddTeamTimeProps } from "./type";
+import { FALLBACK_DAILY_WORKING_HOURS } from "../../constants";
 
 const AddEmployeeTime = ({
   initialDate,
@@ -126,6 +131,11 @@ const AddEmployeeTime = ({
     form.store,
     (state) => state.values.taskStatus,
   );
+  const selectedDate = useSelector(form.store, (state) => state.values.date);
+  const selectedEmployeeId = useSelector(
+    form.store,
+    (state) => state.values.employeeId,
+  );
   const selectedProjectOption: ProjectLookupOption | null = selectedProject
     ? {
         label: selectedProjectLabel || selectedProject,
@@ -147,6 +157,13 @@ const AddEmployeeTime = ({
         status: selectedTaskStatus,
       }
     : null;
+
+  const { data: remainingHours, isLoading: isRemainingHoursLoading } =
+    useFrappeGetCall(
+      "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
+      { employee: selectedEmployeeId, date: selectedDate },
+      open && selectedEmployeeId && selectedDate ? undefined : null,
+    );
 
   useEffect(() => {
     if (!open) {
@@ -399,11 +416,21 @@ const AddEmployeeTime = ({
             name="duration"
             children={(field) => {
               return (
-                <div className="flex-1 flex flex-col gap-2 w-full">
+                <div className="flex flex-col flex-1 w-full gap-2">
                   <DurationInput
                     label="Duration"
                     size="md"
                     snap="smooth"
+                    maxDuration={
+                      remainingHours?.message?.working_hour ??
+                      FALLBACK_DAILY_WORKING_HOURS
+                    }
+                    hoursLeft={
+                      remainingHours?.message?.remaining_hours ??
+                      FALLBACK_DAILY_WORKING_HOURS
+                    }
+                    loading={isRemainingHoursLoading}
+                    disabled={isRemainingHoursLoading}
                     value={field.state.value}
                     onChange={(val) => field.handleChange(val)}
                   />

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -24,6 +24,7 @@ const ApprovalPopup = () => {
     avatarUrl,
     dateRange,
     totalHours,
+    dailyWorkingHours,
     isReadOnly,
     groupedByDay,
     checkedDays,
@@ -100,6 +101,7 @@ const ApprovalPopup = () => {
                     key={entry.timesheetId}
                     entry={entry}
                     readOnly={isReadOnly}
+                    maxDuration={dailyWorkingHours}
                     onSave={handleTimesheetUpdate}
                   />
                 ))}

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -22,6 +22,7 @@ import type { TimesheetEntry } from "./types";
 interface EntryRowProps {
   entry: TimesheetEntry;
   readOnly?: boolean;
+  maxDuration?: number;
   onSave: (
     timesheetId: string,
     taskId: string,
@@ -32,7 +33,12 @@ interface EntryRowProps {
   ) => void;
 }
 
-const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
+const EntryRow = ({
+  entry,
+  readOnly = false,
+  maxDuration,
+  onSave,
+}: EntryRowProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const [description, setDescription] = useState(entry.description);
   const [hours, setHours] = useState(entry.hours);
@@ -98,6 +104,8 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
               <DurationInput
                 snap="smooth"
                 variant="outline"
+                maxDuration={maxDuration}
+                allowOverflow
                 value={hours}
                 onChange={setHours}
               />

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/provider.tsx
@@ -35,6 +35,7 @@ export interface WeeklyApprovalContextValue {
   avatarUrl: string;
   dateRange: string;
   totalHours: number;
+  dailyWorkingHours: number;
   isReadOnly: boolean;
   rejectionError: string | null;
   groupedByDay: GroupedDay[];
@@ -112,6 +113,7 @@ export const WeeklyApprovalProvider = ({
     [timesheetData.entries],
   );
   const totalHours = timesheetData.totalHours;
+  const dailyWorkingHours = timesheetData.dailyWorkingHours;
   const isReadOnly =
     timesheetData.status === "Approved" ||
     timesheetData.status === "Processing Timesheet";
@@ -277,6 +279,7 @@ export const WeeklyApprovalProvider = ({
       avatarUrl,
       dateRange,
       totalHours,
+      dailyWorkingHours,
       isReadOnly,
       rejectionError,
       groupedByDay,
@@ -297,6 +300,7 @@ export const WeeklyApprovalProvider = ({
       avatarUrl,
       dateRange,
       totalHours,
+      dailyWorkingHours,
       isReadOnly,
       rejectionError,
       groupedByDay,

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -81,7 +81,13 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
   const weeklyData = response?.message?.data;
 
   if (!weeklyData) {
-    return { dateRange: "", totalHours: 0, status: "", entries };
+    return {
+      dateRange: "",
+      totalHours: 0,
+      status: "",
+      entries,
+      dailyWorkingHours: 0,
+    };
   }
 
   const thisWeek = Object.values(weeklyData)[0];
@@ -145,6 +151,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
     totalHours: Object.values(weeklyData)[0].total_hours + displayedLeaveHours,
     status: thisWeek.status,
     entries,
+    dailyWorkingHours,
   };
 };
 /**

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -11,6 +11,7 @@ import {
  * Internal Dependencies
  */
 
+import { FALLBACK_DAILY_WORKING_HOURS } from "@/lib/constant";
 import { calculateLeaveHours, expectatedHours } from "@/lib/utils";
 import type { LeaveProps } from "@/types/timesheet";
 import type { TimesheetEntry, TimesheetApiResponse, GroupedDay } from "./types";
@@ -86,7 +87,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
       totalHours: 0,
       status: "",
       entries,
-      dailyWorkingHours: 0,
+      dailyWorkingHours: FALLBACK_DAILY_WORKING_HOURS,
     };
   }
 
@@ -97,7 +98,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
   const holidays = response?.message?.holidays ?? [];
   const displayedLeaveHoursByDate = new Map<string, number>();
   const dailyWorkingHours = expectatedHours(
-    response?.message?.working_hour ?? 0,
+    response?.message?.working_hour ?? FALLBACK_DAILY_WORKING_HOURS,
     response?.message?.working_frequency ?? "Per Day",
   );
 

--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -661,7 +661,7 @@ def get_timesheet_state(employee: str, start_date: str, end_date: str):
 @frappe.whitelist(methods=["GET"])
 @validate_current_employee(ptype="write")
 def get_remaining_hour_for_employee(employee: str, date: str):
-    """Return the working hours for the given employee on the given date."""
+    """Return the daily working-hour norm and the remaining available hours for the given employee on the given date."""
     from .employee import get_employee_working_hours
 
     working_hours = get_employee_working_hours(employee)
@@ -694,7 +694,10 @@ def get_remaining_hour_for_employee(employee: str, date: str):
                 total_hours += working_hours.get("working_hour") / 2
             else:
                 total_hours += working_hours.get("working_hour")
-    return working_hours.get("working_hour") - total_hours
+    return {
+        "working_hour": working_hours.get("working_hour"),
+        "remaining_hours": working_hours.get("working_hour") - total_hours,
+    }
 
 
 @frappe.whitelist(methods=["GET"])


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR replaces the hardcoded remaining hours shown in the `DurationInput` field used by the Add Time modals. It now uses the actual remaining hours and working hours of the selected employee, ensuring the displayed values are accurate.

Also fixes the Weekly Approval modal to use the employee's working hours in the `DurationInput` component.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Updated the existing `get_remaining_hours_for_employee` API to return both the employee's working hours and remaining hours. This allows the `DurationInput` component to display employee-specific values on the slider.
er 

## Testing Instructions 

- Personal Timesheet

1. Go to **Timesheet → Personal**.
2. Select a date and add a 3-hour time entry, then save it.
3. Click **Add Time** again for the same date.
4. Verify that the **Duration** field shows the employee's actual remaining hours for that day instead of a fixed **8h**. A loading state should be displayed briefly while the remaining hours are being fetched.
5. Change the **Date** to another day with no time entries.
6. Verify that the **Duration** field resets to the full remaining hours for that day.

- Team Timesheet

1. Go to **Timesheet → Team** and click **Add Time**.
2. Select an employee whose daily working hours are not 8 hours (for example, 6 hours).
3. Verify that the **Duration** field uses the selected employee's actual remaining working hours for the chosen date. Existing time entries and approved leave should already be taken into account.
4. Select a different employee.
5. Verify that the remaining hours update based on the newly selected employee.

- Project Timesheet

1. Go to **Timesheet → Project** and click **Add Time**.
2. Select an employee.
3. Verify that the **Duration** field displays the selected employee's actual remaining working hours for the chosen date.

- Leave or Holiday

1. Add a time entry on a date where the employee has leave or a half-day leave.
2. Verify that the remaining hours already account for the leave.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
https://github.com/user-attachments/assets/90337529-7da9-4c5b-ae0a-2260ef670593

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1812