### PR TITLE
fix: parse or_filters JSON string in get_projects

### DIFF
--- a/next_pms/timesheet/api/project.py
+++ b/next_pms/timesheet/api/project.py
@@ -37,6 +37,8 @@ def get_projects(
         fields = json.loads(fields)
     if isinstance(filters, str):
         filters = json.loads(filters)
+    if isinstance(or_filters, str):
+        or_filters = json.loads(or_filters)
 
     if not fields:
         fields = list(meta.default_fields)  # Copy to avoid mutating class attribute


### PR DESCRIPTION
## Description
Add if `isinstance(or_filters, str): or_filters = json.loads(or_filters)`, mirroring the existing filters handling.

## Additional Information:
- `get_projects` json-decodes fields and filters when passed as querystring strings, but was missing the same handling for `or_filters`.
- Frappe's query engine (`frappe.database.query.Engine.apply_filters`) treats an un-parsed string as a literal FilterValue and collapses it into {"name": <raw string>}, so any request passing or_filters as a JSON string silently matched nothing.

## Screenshot/Screencast
Previously we were getting 0 results after applying or_filters. Now we get correct results.
<img width="3306" height="1002" alt="image" src="https://github.com/user-attachments/assets/9f28d7ce-7c45-459b-a3fc-46c5ddc376d1" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1864 