### PR TITLE
fix: change costing amount to billable for budget burn

### DIFF
--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -130,7 +130,7 @@ def get_computed_sort_value(
         # Mirrors the frontend cost-burn cell: cost_accrued / total_budget * 100
         if total_budget <= 0:
             return 0
-        return (flt(project.get("total_costing_amount")) / total_budget) * 100
+        return (flt(project.get("total_billable_amount")) / total_budget) * 100
     if sort_field == "total_budget":
         return total_budget
     if sort_field == "profit_margin":
@@ -194,7 +194,8 @@ def enrich_project_with_calculated_fields(
 
     # Basic calculated values
     total_budget = get_total_budget(project)
-    cost_accrued = flt(project.get("total_costing_amount"))
+    cost_accrued = flt(project.get("total_billable_amount"))
+    cost_incurred = flt(project.get("total_costing_amount"))
     cost_forecasted = (
         cost_forecasted_map.get(project_name, 0)
         if cost_forecasted_map is not None
@@ -223,7 +224,7 @@ def enrich_project_with_calculated_fields(
             "total_budget": total_budget,
         },
         "total_budget": total_budget,
-        "profit_margin": get_profit_margin(total_budget, cost_accrued, cost_forecasted),
+        "profit_margin": get_profit_margin(total_budget, cost_incurred, cost_forecasted),
         # Dates
         "start_date": project.get("expected_start_date"),
         "next_milestone": project.get("custom_next_milestone"),
@@ -979,7 +980,7 @@ def get_project_sidebar(project: str):
     has_hours_pool = billing_type in ("Fixed Cost", "Retainer")
 
     total_budget = get_total_budget(project_doc)
-    cost_accrued = flt(project_doc.total_costing_amount)
+    cost_accrued = flt(project_doc.total_billable_amount)
     cost_forecasted = get_cost_forecasted(project)
     target_cost = flt(project_doc.custom_target_cost)
 

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -40,6 +40,23 @@ def get_total_budget(project: dict) -> float:
     return flt(project.get("estimated_costing"))
 
 
+def get_budget_burn_accrued(project: dict) -> float:
+    """
+    Amount burnt against the budget, as shown by the Budget Burn bar.
+
+    Paired with get_total_budget: for billable projects the budget is revenue
+    (total_sales_amount), so what burns it is billed work (total_billable_amount).
+    For non-billable there is no billing, so cost (total_costing_amount) burns the
+    estimated_costing budget.
+
+    Distinct from cost incurred, which is always total_costing_amount.
+    """
+    billing_type = project.get("custom_billing_type")
+    if billing_type and billing_type != "Non-Billable":
+        return flt(project.get("total_billable_amount"))
+    return flt(project.get("total_costing_amount"))
+
+
 def get_cost_forecasted(project_name: str) -> float:
     """Sum of total_cost from ongoing/future Resource Allocations for the project.
 
@@ -127,10 +144,10 @@ def get_computed_sort_value(
     if sort_field == "burn_rate_per_week":
         return get_burn_rate_per_week(project)
     if sort_field == "cost_burn_percent":
-        # Mirrors the frontend cost-burn cell: cost_accrued / total_budget * 100
+        # Mirrors the frontend cost-burn cell: cost_burn.cost_accrued / total_budget * 100
         if total_budget <= 0:
             return 0
-        return (flt(project.get("total_billable_amount")) / total_budget) * 100
+        return (get_budget_burn_accrued(project) / total_budget) * 100
     if sort_field == "total_budget":
         return total_budget
     if sort_field == "profit_margin":
@@ -194,8 +211,8 @@ def enrich_project_with_calculated_fields(
 
     # Basic calculated values
     total_budget = get_total_budget(project)
-    cost_accrued = flt(project.get("total_billable_amount"))
-    cost_incurred = flt(project.get("total_costing_amount"))
+    cost_accrued = flt(project.get("total_costing_amount"))
+    budget_burn_accrued = get_budget_burn_accrued(project)
     cost_forecasted = (
         cost_forecasted_map.get(project_name, 0)
         if cost_forecasted_map is not None
@@ -218,13 +235,13 @@ def enrich_project_with_calculated_fields(
         # Calculated financial fields
         "burn_rate_per_week": get_burn_rate_per_week(project),
         "cost_burn": {
-            "cost_accrued": cost_accrued,
+            "cost_accrued": budget_burn_accrued,
             "cost_forecasted": cost_forecasted,
             "target_cost": target_cost,
             "total_budget": total_budget,
         },
         "total_budget": total_budget,
-        "profit_margin": get_profit_margin(total_budget, cost_incurred, cost_forecasted),
+        "profit_margin": get_profit_margin(total_budget, cost_accrued, cost_forecasted),
         # Dates
         "start_date": project.get("expected_start_date"),
         "next_milestone": project.get("custom_next_milestone"),
@@ -980,7 +997,7 @@ def get_project_sidebar(project: str):
     has_hours_pool = billing_type in ("Fixed Cost", "Retainer")
 
     total_budget = get_total_budget(project_doc)
-    cost_accrued = flt(project_doc.total_billable_amount)
+    cost_accrued = get_budget_burn_accrued(project_doc)
     cost_forecasted = get_cost_forecasted(project)
     target_cost = flt(project_doc.custom_target_cost)
 

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -3,10 +3,11 @@ from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, today
 
-from next_pms.next_projects.api.project import get_projects_view
+from next_pms.next_projects.api.project import get_project_sidebar, get_projects_view
 
 # Unique marker so `search` scopes every call to this suite's fixtures only.
 FIXTURE_PREFIX = "CompSort"
+BURN_FIXTURE_PREFIX = "BurnAccrued"
 
 
 class TestGetProjectsViewComputedSort(IntegrationTestCase):
@@ -137,3 +138,97 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         result = self.call("cost_burn_percent desc", view="kanban")
         self.assertEqual(result["total_count"], 4)
         self.assertIn("columns", result)
+
+
+class TestBudgetBurnAccrued(IntegrationTestCase):
+    """The Budget Burn bar (project sidebar + projects list) burns the budget with
+    billable amounts on billable projects and with costing amounts on non-billable
+    ones, while cost-incurred metrics stay on costing amounts throughout.
+
+    Both fixtures set costing != billable so every assertion discriminates between
+    the two sources.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        # name -> (billing_type, sales, estimated, costing, billable)
+        # Derived values (cost_forecasted = 0, no allocations):
+        #   BILL:    budget 10000 (sales),     burn 7000 (billable), margin 70 (costing)
+        #   NONBILL: budget  5000 (estimated), burn 2000 (costing),  margin 60 (costing)
+        fixture_rows = {
+            "BILL": ("Fixed Cost", 10000, 0, 3000, 7000),
+            "NONBILL": ("Non-Billable", 0, 5000, 2000, 6000),
+        }
+        cls.projects = {}
+        for suffix, (billing_type, sales, estimated, costing, billable) in fixture_rows.items():
+            name = (
+                frappe.get_doc(
+                    {
+                        "doctype": "Project",
+                        "project_name": f"{BURN_FIXTURE_PREFIX} {suffix}",
+                        "company": cls.company,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+            frappe.db.set_value(
+                "Project",
+                name,
+                {
+                    "custom_billing_type": billing_type,
+                    "total_sales_amount": sales,
+                    "estimated_costing": estimated,
+                    "total_costing_amount": costing,
+                    "total_billable_amount": billable,
+                },
+                update_modified=False,
+            )
+            cls.projects[suffix] = name
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    def list_view(self, order_by=None):
+        return get_projects_view(
+            view="list",
+            search=BURN_FIXTURE_PREFIX,
+            start=0,
+            limit=20,
+            **({"order_by": order_by} if order_by else {}),
+        )
+
+    def list_row(self, suffix):
+        return next(row for row in self.list_view()["data"] if row["name"] == self.projects[suffix])
+
+    def test_list_burn_uses_billable_amount_when_billable(self):
+        cost_burn = self.list_row("BILL")["cost_burn"]
+        self.assertEqual(cost_burn["cost_accrued"], 7000)
+        self.assertEqual(cost_burn["total_budget"], 10000)
+
+    def test_list_burn_uses_costing_amount_when_non_billable(self):
+        cost_burn = self.list_row("NONBILL")["cost_burn"]
+        self.assertEqual(cost_burn["cost_accrued"], 2000)
+        self.assertEqual(cost_burn["total_budget"], 5000)
+
+    def test_sidebar_burn_matches_list_burn(self):
+        for suffix, expected in (("BILL", 7000), ("NONBILL", 2000)):
+            burn = get_project_sidebar(self.projects[suffix])["burn"]
+            self.assertEqual(burn["cost_accrued"], expected, msg=suffix)
+            self.assertEqual(burn["cost_accrued"], self.list_row(suffix)["cost_burn"]["cost_accrued"], msg=suffix)
+
+    def test_profit_margin_stays_on_costing_amount(self):
+        # Guards the cost_accrued / budget_burn_accrued split: billable amounts must
+        # not leak into the margin. BILL would read 30 instead of 70 if they did.
+        self.assertEqual(self.list_row("BILL")["profit_margin"], 70)
+        self.assertEqual(self.list_row("NONBILL")["profit_margin"], 60)
+
+    def test_cost_burn_percent_sort_ranks_by_burn_source(self):
+        # BILL burns 70% (7000/10000), NONBILL 40% (2000/5000). Sorting the whole
+        # list on costing amounts would put BILL at 30% and invert the order.
+        by_name = {name: suffix for suffix, name in self.projects.items()}
+        result = self.list_view(order_by="cost_burn_percent desc")
+        self.assertEqual([by_name[row["name"]] for row in result["data"]], ["BILL", "NONBILL"])

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -27,7 +27,7 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         # name -> (billing_type, sales, estimated, costing, rate, billable, start_days_ago)
         # Derived values (cost_forecasted = 0, no allocations):
         #   total_budget:      A 1000, B 2000, C 3000, D 0
-        #   cost_burn_percent: A 50,   B 25,   C 200,  D 0 (budget<=0 guard)
+        #   cost_burn_percent: A 70,   B 0,    C 93.3, D 0 (budget<=0 guard)
         #   profit_margin:     A 50,   B 75,   C -100, D 0 (budget<=0 guard)
         #   burn_rate/week:    A 700,  B None, C 1400, D None
         fixture_rows = {
@@ -92,8 +92,14 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         return [by_name[row["name"]] for row in result["data"]]
 
     def test_cost_burn_percent_sort(self):
-        self.assertEqual(self.fixture_order(self.call("cost_burn_percent desc")), ["C", "A", "B", "D"])
-        self.assertEqual(self.fixture_order(self.call("cost_burn_percent asc")), ["D", "B", "A", "C"])
+        # B and D both burn 0% (B has no billable amount, D is caught by the budget<=0
+        # guard), so only the ranked head is order-stable.
+        desc = self.fixture_order(self.call("cost_burn_percent desc"))
+        asc = self.fixture_order(self.call("cost_burn_percent asc"))
+        self.assertEqual(desc[:2], ["C", "A"])
+        self.assertEqual(asc[2:], ["A", "C"])
+        self.assertEqual(set(desc[2:]), {"B", "D"})
+        self.assertEqual(set(asc[:2]), {"B", "D"})
 
     def test_total_budget_sort(self):
         self.assertEqual(self.fixture_order(self.call("total_budget desc")), ["C", "B", "A", "D"])
@@ -122,10 +128,8 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         self.assertEqual(page_one["total_count"], 4)
         self.assertTrue(page_one["has_more"])
         self.assertFalse(page_two["has_more"])
-        self.assertEqual(
-            self.fixture_order(page_one) + self.fixture_order(page_two),
-            ["C", "A", "B", "D"],
-        )
+        self.assertEqual(self.fixture_order(page_one), ["C", "A"])
+        self.assertEqual(set(self.fixture_order(page_two)), {"B", "D"})
 
     def test_stored_field_sort_unchanged(self):
         result = self.call("project_name asc")

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -27,7 +27,8 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         # name -> (billing_type, sales, estimated, costing, rate, billable, start_days_ago)
         # Derived values (cost_forecasted = 0, no allocations):
         #   total_budget:      A 1000, B 2000, C 3000, D 0
-        #   cost_burn_percent: A 70,   B 0,    C 93.3, D 0 (budget<=0 guard)
+        #   cost_burn_percent: A 70,   B 25,   C 93.3, D 0 (budget<=0 guard)
+        #     (billable/budget when billable; costing/budget for non-billable B and D)
         #   profit_margin:     A 50,   B 75,   C -100, D 0 (budget<=0 guard)
         #   burn_rate/week:    A 700,  B None, C 1400, D None
         fixture_rows = {
@@ -92,14 +93,8 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         return [by_name[row["name"]] for row in result["data"]]
 
     def test_cost_burn_percent_sort(self):
-        # B and D both burn 0% (B has no billable amount, D is caught by the budget<=0
-        # guard), so only the ranked head is order-stable.
-        desc = self.fixture_order(self.call("cost_burn_percent desc"))
-        asc = self.fixture_order(self.call("cost_burn_percent asc"))
-        self.assertEqual(desc[:2], ["C", "A"])
-        self.assertEqual(asc[2:], ["A", "C"])
-        self.assertEqual(set(desc[2:]), {"B", "D"})
-        self.assertEqual(set(asc[:2]), {"B", "D"})
+        self.assertEqual(self.fixture_order(self.call("cost_burn_percent desc")), ["C", "A", "B", "D"])
+        self.assertEqual(self.fixture_order(self.call("cost_burn_percent asc")), ["D", "B", "A", "C"])
 
     def test_total_budget_sort(self):
         self.assertEqual(self.fixture_order(self.call("total_budget desc")), ["C", "B", "A", "D"])
@@ -128,8 +123,10 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         self.assertEqual(page_one["total_count"], 4)
         self.assertTrue(page_one["has_more"])
         self.assertFalse(page_two["has_more"])
-        self.assertEqual(self.fixture_order(page_one), ["C", "A"])
-        self.assertEqual(set(self.fixture_order(page_two)), {"B", "D"})
+        self.assertEqual(
+            self.fixture_order(page_one) + self.fixture_order(page_two),
+            ["C", "A", "B", "D"],
+        )
 
     def test_stored_field_sort_unchanged(self):
         result = self.call("project_name asc")


### PR DESCRIPTION
## Description

* Added the `get_budget_burn_accrued` function to determine the correct amount to burn against the budget: for billable projects, it uses `total_billable_amount`; for non-billable projects, it uses `total_costing_amount`.
* Updated all uses of "cost accrued" in the project API (`enrich_project_with_calculated_fields`, `get_project_sidebar`, and sorting by `cost_burn_percent`) to use the new `get_budget_burn_accrued` logic, ensuring consistent and correct budget burn calculations throughout the UI and API. 

* Added a new test class `TestBudgetBurnAccrued` with fixtures and test cases to verify that the budget burn uses billable amounts for billable projects and costing for non-billable, and that profit margin calculations remain correct. These tests also ensure that sorting by cost burn percent reflects the correct burn source.
* Updated test fixture comments and expected values to reflect the new budget burn logic, clarifying the distinction between billable and non-billable projects.
* Imported the new API function into the test suite.

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1867 