### PR TITLE
feat: add timesheet status and rejection message for manager popup

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -32,6 +32,21 @@ const ApprovalPopup = () => {
     handleApproveSubmit,
     handleReject,
   } = useWeeklyApproval();
+
+  const allEntries = groupedByDay.flatMap((dayGroup) => dayGroup.entries);
+  const rejectedEntriesCount = allEntries.filter(
+    (entry) => entry.approvalStatus === "Rejected",
+  ).length;
+  const hasRejectedEntries = rejectedEntriesCount > 0;
+  const isFullyRejected =
+    hasRejectedEntries && rejectedEntriesCount === allEntries.length;
+
+  const summaryText = hasRejectedEntries
+    ? isFullyRejected
+      ? "This timesheet is rejected."
+      : "This timesheet is partially rejected."
+    : null;
+
   return (
     <Dialog.Popup className="fixed right-0 top-0 max-w-120 w-full h-[calc(100vh-20px)] m-2.5 z-101 bg-surface-modal rounded-xl shadow-xl flex flex-col">
       {/* Header */}
@@ -52,6 +67,9 @@ const ApprovalPopup = () => {
           </Dialog.Close>
         </div>
       </div>
+      {summaryText ? (
+        <p className="p-4 text-sm text-ink-red-4">{summaryText}</p>
+      ) : null}
       {/* Content */}
       <div className="flex-1 overflow-y-auto scrollbar">
         <Accordion.Root

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -3,9 +3,10 @@
  */
 import { useState, useCallback } from "react";
 import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
-import { TaskStatus } from "@next-pms/design-system/components";
+import { ApprovalStatus, TaskStatus } from "@next-pms/design-system/components";
 import { stripTags } from "@next-pms/design-system/utils";
 import {
+  Alert,
   Button,
   ErrorMessage,
   StaticTextEditor,
@@ -88,9 +89,12 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
         <TaskStatus status={entry.status} />
         <div className="flex-1 min-w-0">
           <div className="space-y-1">
-            <p className="text-base font-medium text-ink-gray-7 truncate">
-              {entry.taskName}
-            </p>
+            <div className="flex gap-1.5">
+              <p className="text-base font-medium text-ink-gray-7 truncate">
+                {entry.taskName}
+              </p>
+              <ApprovalStatus status={entry.approvalStatus} />
+            </div>
             <p className="text-xs text-ink-gray-5 truncate">
               {entry.projectName}
             </p>
@@ -145,9 +149,12 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
       <TaskStatus status={entry.status} />
       <div className="flex-1 min-w-0">
         <div className="space-y-1">
-          <p className="text-base font-medium text-ink-gray-7 truncate">
-            {entry.taskName}
-          </p>
+          <div className="flex gap-1.5">
+            <p className="text-base font-medium text-ink-gray-7 truncate">
+              {entry.taskName}
+            </p>
+            <ApprovalStatus status={entry.approvalStatus} />
+          </div>
           <p className="text-xs text-ink-gray-5 truncate">
             {entry.projectName}
           </p>
@@ -155,6 +162,17 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
             editorClass="prose-sm text-ink-gray-7 mt-3"
             content={entry.description}
           />
+          {entry.rejectionReason ? (
+            <Alert
+              title="Rejection reason"
+              variant="outline"
+              theme="red"
+              dismissable={false}
+              renderIcon={false}
+              renderDescription={entry.rejectionReason}
+              className="[&_h3]:text-xs [&_h3]:font-bold [&_h3]:text-ink-red-4 [&_p]:text-xs [&_p]:text-ink-red-3 p-2"
+            />
+          ) : null}
         </div>
       </div>
       <span className="relative size-fit text-base text-ink-gray-6 rounded-sm outline outline-offset-6 outline-outline-gray-modals">

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
@@ -1,4 +1,7 @@
-import { TaskStatusType } from "@next-pms/design-system/components";
+import {
+  TaskStatusType,
+  type ApprovalStatusLabelType,
+} from "@next-pms/design-system/components";
 import type { WorkingFrequency } from "@/types";
 import type { HolidayProp, LeaveProps } from "@/types/timesheet";
 
@@ -35,6 +38,8 @@ export interface TimesheetEntry {
   docstatus: number;
   leaveHours: number;
   leaveLabel?: string;
+  approvalStatus: ApprovalStatusLabelType;
+  rejectionReason?: string;
 }
 
 export interface TaskDataEntry {
@@ -49,6 +54,8 @@ export interface TaskDataEntry {
   hours: number;
   parent: string;
   docstatus: number;
+  custom_approval_status: ApprovalStatusLabelType;
+  custom_rejection_reason?: string | null;
 }
 
 export interface Task {

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -130,6 +130,8 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
           leaveHours,
           leaveLabel:
             leaveHours > 0 ? getLeaveLabelForDate(leaves, date) : undefined,
+          approvalStatus: entry.custom_approval_status!,
+          rejectionReason: entry.custom_rejection_reason || undefined,
         });
       });
     }

--- a/frontend/packages/design-system/src/components/approval-status/approvalStatus.tsx
+++ b/frontend/packages/design-system/src/components/approval-status/approvalStatus.tsx
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies.
+ */
+import { approvalStatusIcon, approvalStatusIconVariants } from "./constants";
+import type { ApprovalStatusLabelType } from "./types";
+import { mergeClassNames as cn } from "../../utils";
+
+export type { ApprovalStatusLabelType } from "./types";
+
+interface ApprovalStatusProps {
+  status: ApprovalStatusLabelType;
+  className?: string;
+}
+
+const ApprovalStatus = ({ status, className }: ApprovalStatusProps) => {
+  const StatusIcon = approvalStatusIcon[status];
+
+  return (
+    <span className={cn("w-4 shrink-0", className)}>
+      <StatusIcon
+        strokeWidth={1.5}
+        size={16}
+        className={approvalStatusIconVariants({ status })}
+      />
+    </span>
+  );
+};
+
+export default ApprovalStatus;

--- a/frontend/packages/design-system/src/components/approval-status/constants.ts
+++ b/frontend/packages/design-system/src/components/approval-status/constants.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies.
+ */
+import { Success, CloseCircle, Hourglass } from "@rtcamp/frappe-ui-react/icons";
+import { cva } from "class-variance-authority";
+
+/**
+ * Internal dependencies.
+ */
+import type { ApprovalStatusLabelType } from "./types";
+
+export const approvalStatusIcon: Record<
+  ApprovalStatusLabelType,
+  React.ComponentType<{
+    size?: number;
+    strokeWidth?: number;
+    className?: string;
+  }>
+> = {
+  Approved: Success,
+  Rejected: CloseCircle,
+  "Approval Pending": Hourglass,
+  "Processing Timesheet": Hourglass,
+  "Not Submitted": Hourglass,
+  "Partially Approved": Success,
+  "Partially Rejected": CloseCircle,
+  None: Hourglass,
+};
+
+export const approvalStatusIconVariants = cva("", {
+  variants: {
+    status: {
+      Approved: "text-ink-green-4",
+      Rejected: "text-ink-red-4",
+      "Approval Pending": "text-ink-amber-4",
+      "Processing Timesheet": "text-ink-amber-4",
+      "Not Submitted": "text-ink-amber-4",
+      "Partially Approved": "text-ink-green-4",
+      "Partially Rejected": "text-ink-red-4",
+      None: "text-ink-amber-4",
+    },
+  },
+});

--- a/frontend/packages/design-system/src/components/approval-status/constants.ts
+++ b/frontend/packages/design-system/src/components/approval-status/constants.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies.
  */
-import { Success, CloseCircle, Hourglass } from "@rtcamp/frappe-ui-react/icons";
+import {
+  Success,
+  CloseCircle,
+  Hourglass,
+  Overdue,
+} from "@rtcamp/frappe-ui-react/icons";
 import { cva } from "class-variance-authority";
 
 /**
@@ -21,7 +26,7 @@ export const approvalStatusIcon: Record<
   Rejected: CloseCircle,
   "Approval Pending": Hourglass,
   "Processing Timesheet": Hourglass,
-  "Not Submitted": Hourglass,
+  "Not Submitted": Overdue,
   "Partially Approved": Success,
   "Partially Rejected": CloseCircle,
   None: Hourglass,
@@ -34,7 +39,7 @@ export const approvalStatusIconVariants = cva("", {
       Rejected: "text-ink-red-4",
       "Approval Pending": "text-ink-amber-4",
       "Processing Timesheet": "text-ink-amber-4",
-      "Not Submitted": "text-ink-amber-4",
+      "Not Submitted": "text-ink-gray-4",
       "Partially Approved": "text-ink-green-4",
       "Partially Rejected": "text-ink-red-4",
       None: "text-ink-amber-4",

--- a/frontend/packages/design-system/src/components/approval-status/index.ts
+++ b/frontend/packages/design-system/src/components/approval-status/index.ts
@@ -1,0 +1,3 @@
+export { default as ApprovalStatus } from "./approvalStatus";
+export { approvalStatusIcon, approvalStatusIconVariants } from "./constants";
+export type { ApprovalStatusLabelType } from "./types";

--- a/frontend/packages/design-system/src/components/approval-status/types.ts
+++ b/frontend/packages/design-system/src/components/approval-status/types.ts
@@ -1,0 +1,9 @@
+export type ApprovalStatusLabelType =
+  | "Approved"
+  | "Rejected"
+  | "Approval Pending"
+  | "Processing Timesheet"
+  | "Not Submitted"
+  | "Partially Approved"
+  | "Partially Rejected"
+  | "None";

--- a/frontend/packages/design-system/src/components/index.ts
+++ b/frontend/packages/design-system/src/components/index.ts
@@ -12,6 +12,12 @@ export {
   type TaskStatusType,
 } from "./task-status";
 export {
+  ApprovalStatus,
+  approvalStatusIcon,
+  approvalStatusIconVariants,
+  type ApprovalStatusLabelType,
+} from "./approval-status";
+export {
   default as TaskProgress,
   type TaskProgressProps,
 } from "./task-progress";


### PR DESCRIPTION
## Description

Adds approval status icons and rejection messages for the Project Manager weekly approval popup.

## Relevant Technical Choices

- Added a new `approval-status` component for approval icons.
- Added the `Alert` component from frappe-ui-react for rejected entry messages.

## Testing Instructions

- Go to the team timesheet page.
- Open any weekly timesheet view.
- Verify the different approval status icons and rejection messages (if any).

## Screenshot/Screencast

<img width="496" height="929" alt="image" src="https://github.com/user-attachments/assets/2fa76e55-b8ae-4745-8db1-a1ff00134750" />


<img width="492" height="925" alt="image" src="https://github.com/user-attachments/assets/0363521c-6d41-4ad8-860b-c51413209ef5" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially Fixes #1751 