### PR TITLE
feat: composite filter and sorting for task

### DIFF
--- a/next_pms/tests/timesheet/api/test_task_list.py
+++ b/next_pms/tests/timesheet/api/test_task_list.py
@@ -159,6 +159,41 @@ class TestGetTaskListFiltersAndSorting(IntegrationTestCase):
             ["Charlie billing sync", "Bravo push service", "Alpha login page", "Delta reporting"],
         )
 
+    def test_order_by_default_field(self):
+        # `modified` is a Frappe default column, not a Task DocField, but must still be sortable.
+        # Stamp distinct modified values so order is deterministic (avoids same-second ties).
+        stamps = {
+            "Alpha login page": "2024-01-01 10:00:00",
+            "Bravo push service": "2024-01-03 10:00:00",
+            "Charlie billing sync": "2024-01-02 10:00:00",
+            "Delta reporting": "2024-01-04 10:00:00",
+        }
+        for subject, modified in stamps.items():
+            frappe.db.set_value("Task", self.task_names[subject], "modified", modified, update_modified=False)
+
+        result = get_task_list(projects=[self.project], order_by="modified desc")
+        self.assertEqual(
+            self._subjects(result),
+            ["Delta reporting", "Bravo push service", "Charlie billing sync", "Alpha login page"],
+        )
+
+    def test_filter_on_default_field(self):
+        stamps = {
+            "Alpha login page": "1999-06-01 00:00:00",
+            "Bravo push service": "2024-01-03 10:00:00",
+            "Charlie billing sync": "2024-01-02 10:00:00",
+            "Delta reporting": "2024-01-04 10:00:00",
+        }
+        for subject, modified in stamps.items():
+            frappe.db.set_value("Task", self.task_names[subject], "modified", modified, update_modified=False)
+
+        result = get_task_list(projects=[self.project], filters=[["modified", ">", "2000-01-01"]])
+        self.assertEqual(result["total_count"], 3)
+        self.assertEqual(
+            set(self._subjects(result)),
+            {"Bravo push service", "Charlie billing sync", "Delta reporting"},
+        )
+
     def test_order_by_unknown_field_raises(self):
         with self.assertRaises(frappe.ValidationError):
             get_task_list(projects=[self.project], order_by="not_a_real_field asc")

--- a/next_pms/tests/timesheet/api/test_task_list.py
+++ b/next_pms/tests/timesheet/api/test_task_list.py
@@ -1,0 +1,176 @@
+import json
+
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.timesheet.api.task import get_task_list
+
+CUSTOMER_NAME = "Task List Test Customer"
+PROJECT_NAME = "Task List Test Project"
+
+# (subject, priority, status, expected_time)
+TASKS = [
+    ("Alpha login page", "Low", "Working", 5),
+    ("Bravo push service", "High", "Working", 10),
+    ("Charlie billing sync", "High", "Pending Review", 2),
+    ("Delta reporting", "Medium", "Overdue", 8),
+]
+
+
+class TestGetTaskListFiltersAndSorting(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.customer = cls._make_customer(CUSTOMER_NAME)
+        cls.project = cls._make_project(PROJECT_NAME, cls.customer)
+        cls.task_names = {
+            subject: cls._make_task(subject, priority, status, expected_time)
+            for subject, priority, status, expected_time in TASKS
+        }
+
+    @classmethod
+    def _make_customer(cls, customer_name):
+        existing = frappe.db.get_value("Customer", {"customer_name": customer_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": customer_name,
+                    "customer_type": "Company",
+                    "default_currency": frappe.get_cached_value("Company", cls.company, "default_currency"),
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project(cls, project_name, customer):
+        if frappe.db.exists("Project", {"project_name": project_name}):
+            return frappe.db.get_value("Project", {"project_name": project_name}, "name")
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": project_name,
+                    "company": cls.company,
+                    "customer": customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_task(cls, subject, priority, status, expected_time):
+        existing = frappe.db.get_value("Task", {"subject": subject, "project": cls.project})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Task",
+                    "subject": subject,
+                    "project": cls.project,
+                    "priority": priority,
+                    "status": status,
+                    "expected_time": expected_time,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def _subjects(self, result):
+        return [row["subject"] for row in result["task"]]
+
+    def test_filter_single_field(self):
+        result = get_task_list(projects=[self.project], filters=[["priority", "=", "High"]])
+        self.assertEqual(set(self._subjects(result)), {"Bravo push service", "Charlie billing sync"})
+        self.assertEqual(result["total_count"], 2)
+
+    def test_filter_multiple_fields_are_anded(self):
+        result = get_task_list(
+            projects=[self.project],
+            filters=[["priority", "=", "High"], ["status", "=", "Working"]],
+        )
+        self.assertEqual(self._subjects(result), ["Bravo push service"])
+        self.assertEqual(result["total_count"], 1)
+
+    def test_filter_in_operator(self):
+        result = get_task_list(projects=[self.project], filters=[["status", "in", ["Working", "Overdue"]]])
+        self.assertEqual(
+            set(self._subjects(result)),
+            {"Alpha login page", "Bravo push service", "Delta reporting"},
+        )
+        self.assertEqual(result["total_count"], 3)
+
+    def test_filter_comparison_operator(self):
+        result = get_task_list(projects=[self.project], filters=[["expected_time", ">", 5]])
+        self.assertEqual(set(self._subjects(result)), {"Bravo push service", "Delta reporting"})
+
+    def test_filter_dict_form_raises(self):
+        with self.assertRaises(frappe.exceptions.FrappeTypeError):
+            get_task_list(projects=[self.project], filters={"priority": "Medium"})
+
+    def test_filter_accepts_json_string(self):
+        result = get_task_list(projects=[self.project], filters=json.dumps([["status", "=", "Pending Review"]]))
+        self.assertEqual(self._subjects(result), ["Charlie billing sync"])
+
+    def test_filter_unknown_field_raises(self):
+        with self.assertRaises(frappe.ValidationError):
+            get_task_list(projects=[self.project], filters=[["not_a_real_field", "=", "x"]])
+
+    def test_filter_unknown_operator_raises(self):
+        with self.assertRaises(frappe.ValidationError):
+            get_task_list(projects=[self.project], filters=[["priority", "matches", "High"]])
+
+    def test_order_by_ascending(self):
+        result = get_task_list(projects=[self.project], order_by="subject asc")
+        self.assertEqual(
+            self._subjects(result),
+            ["Alpha login page", "Bravo push service", "Charlie billing sync", "Delta reporting"],
+        )
+
+    def test_order_by_descending(self):
+        result = get_task_list(projects=[self.project], order_by="subject desc")
+        self.assertEqual(
+            self._subjects(result),
+            ["Delta reporting", "Charlie billing sync", "Bravo push service", "Alpha login page"],
+        )
+
+    def test_order_by_numeric_field(self):
+        result = get_task_list(projects=[self.project], order_by="expected_time asc")
+        self.assertEqual(
+            self._subjects(result),
+            ["Charlie billing sync", "Alpha login page", "Delta reporting", "Bravo push service"],
+        )
+
+    def test_order_by_multiple_fields(self):
+        # priority asc groups alphabetically (High, Low, Medium); subject desc breaks ties.
+        result = get_task_list(projects=[self.project], order_by="priority asc, subject desc")
+        self.assertEqual(
+            self._subjects(result),
+            ["Charlie billing sync", "Bravo push service", "Alpha login page", "Delta reporting"],
+        )
+
+    def test_order_by_unknown_field_raises(self):
+        with self.assertRaises(frappe.ValidationError):
+            get_task_list(projects=[self.project], order_by="not_a_real_field asc")
+
+    def test_order_by_invalid_direction_raises(self):
+        with self.assertRaises(frappe.ValidationError):
+            get_task_list(projects=[self.project], order_by="subject sideways")
+
+    def test_filters_and_order_by_combined(self):
+        result = get_task_list(
+            projects=[self.project],
+            filters=[["priority", "=", "High"]],
+            order_by="subject asc",
+        )
+        self.assertEqual(self._subjects(result), ["Bravo push service", "Charlie billing sync"])

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -61,7 +61,7 @@ def parse_task_filters(raw_filters: list | str | None) -> list:
             frappe.throw(frappe._("Unsupported filter operator '{0}'.").format(operator))
         if field != "name" and not meta.has_field(field):
             frappe.throw(frappe._("Filtering on field '{0}' of Task is not supported.").format(field))
-        parsed.append([field, operator, value])
+        parsed.append([field, operator.lower().strip(), value])
     return parsed
 
 

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -8,6 +8,91 @@ from pypika import Criterion, Order
 
 from . import get_count
 from .project import get_project_filter_for_contractor
+from .timesheet import _apply_qb_condition
+
+TASK_FILTER_OPERATORS = {
+    "=",
+    "!=",
+    "like",
+    "not like",
+    "in",
+    "not in",
+    ">=",
+    "<=",
+    ">",
+    "<",
+    "between",
+    "is",
+}
+
+
+def parse_task_filters(raw_filters: list | str | None) -> list:
+    """Parse [field, operator, value] filters into validated triples for Task.
+
+    Args:
+        raw_filters: A list of [field, operator, value] entries, or a JSON string encoding one.
+            Every field must exist on the Task doctype, so all Task fields are supported without
+            allowing arbitrary column access.
+
+    Returns:
+        A list of validated [field, operator, value] triples.
+    """
+    import json
+
+    if not raw_filters:
+        return []
+
+    if isinstance(raw_filters, str):
+        try:
+            raw_filters = json.loads(raw_filters)
+        except (ValueError, TypeError):
+            frappe.throw(frappe._("Invalid filters format. Expected a JSON array of [field, operator, value] entries."))
+
+    if not isinstance(raw_filters, list):
+        frappe.throw(frappe._("Filters must be a list of [field, operator, value] entries."))
+
+    meta = frappe.get_meta("Task")
+    parsed = []
+    for condition in raw_filters:
+        if not isinstance(condition, (list, tuple)) or len(condition) != 3:
+            frappe.throw(frappe._("Each filter must be a list of [field, operator, value]."))
+        field, operator, value = condition
+        if not isinstance(operator, str) or operator.lower().strip() not in TASK_FILTER_OPERATORS:
+            frappe.throw(frappe._("Unsupported filter operator '{0}'.").format(operator))
+        if field != "name" and not meta.has_field(field):
+            frappe.throw(frappe._("Filtering on field '{0}' of Task is not supported.").format(field))
+        parsed.append([field, operator, value])
+    return parsed
+
+
+def parse_task_order_by(order_by: str | None) -> list:
+    """Parse a Frappe-style order_by string into validated sort pairs for Task.
+
+    Args:
+        order_by: A sort string such as "field asc, other desc". Every field must exist on the
+            Task doctype.
+
+    Returns:
+        A list of (field, Order) pairs to apply to the query in order.
+    """
+    if not order_by:
+        return []
+
+    meta = frappe.get_meta("Task")
+    parsed = []
+    for clause in str(order_by).split(","):
+        clause = clause.strip()
+        if not clause:
+            continue
+        tokens = clause.split()
+        field = tokens[0]
+        direction = tokens[1].lower() if len(tokens) > 1 else "asc"
+        if len(tokens) > 2 or direction not in ("asc", "desc"):
+            frappe.throw(frappe._("Invalid order_by clause '{0}'.").format(clause))
+        if field != "name" and not meta.has_field(field):
+            frappe.throw(frappe._("Sorting on field '{0}' of Task is not supported.").format(field))
+        parsed.append((field, Order.asc if direction == "asc" else Order.desc))
+    return parsed
 
 
 @frappe.whitelist(methods=["GET"])
@@ -19,8 +104,27 @@ def get_task_list(
     status: list | str = None,
     fields: list | str = None,
     filter_recent: bool = False,
+    filters: list | str | None = None,
+    order_by: str | None = None,
 ):
-    """Get the list of tasks. If no filters are provided, it fetches all tasks for projects the user has access to. Users can filter by projects, status, and search text, and can also limit results to tasks they have worked on recently by setting filter_recent to True."""
+    """Get the list of tasks for projects the user has access to, with optional filters and sorting.
+
+    Args:
+        search: Text matched against task name, subject, and github issue link.
+        page_length: Number of tasks to return.
+        start: Pagination offset.
+        projects: Restrict results to these project names.
+        status: Restrict results to these task statuses.
+        fields: Extra Task fields to include in each result row.
+        filter_recent: Order tasks the user logged time against in the last week first.
+        filters: Composite conditions on any Task field, combined with AND. A list of
+            [field, operator, value] entries, or a JSON string encoding one.
+        order_by: Frappe-style sort string such as "priority desc, modified asc". When provided it
+            replaces the default recent/liked/open ordering.
+
+    Returns:
+        A dict with the task list, the total matching count, and whether more results exist.
+    """
     import json
 
     frappe.has_permission(doctype="Project", throw=True)
@@ -31,6 +135,9 @@ def get_task_list(
         status = json.loads(status)
     if fields and isinstance(fields, str):
         fields = json.loads(fields)
+
+    parsed_filters = parse_task_filters(filters)
+    parsed_order_by = parse_task_order_by(order_by)
 
     field_list = [
         "name",
@@ -111,40 +218,48 @@ def get_task_list(
         tasks = tasks.where(doctype.status.isin(status))
         filter.update({"status": ["in", status]})
 
+    for field, operator, value in parsed_filters:
+        tasks = _apply_qb_condition(tasks, doctype, field, operator, value)
+
     if page_length:
-        tasks = tasks.limit(page_length)
+        tasks = tasks.limit(int(page_length))
+    tasks = tasks.offset(int(start or 0))
 
-    order_conditions = []
-
-    # If filter_recent is True, we will order the tasks based on the recent worked tasks First.
-    # This will help in showing the tasks that the user has worked on recently at the top.
-    if filter_recent:
-        recent_worked_tasks = get_recent_log_tasks()
+    if parsed_order_by:
+        # An explicit caller sort replaces the default recent/liked/open heuristic ordering.
+        for field, order in parsed_order_by:
+            tasks = tasks.orderby(getattr(doctype, field), order=order)
+    else:
         order_conditions = []
-        if recent_worked_tasks:
-            order_conditions.append(Case().when(doctype.name.isin(recent_worked_tasks), 1).else_(0))
 
-    order_conditions.append(
-        Case()
-        .when(
-            fn.Function("INSTR", doctype._liked_by, f'"{frappe.session.user}"') > 0,
-            1,
+        # If filter_recent is True, we will order the tasks based on the recent worked tasks First.
+        # This will help in showing the tasks that the user has worked on recently at the top.
+        if filter_recent:
+            recent_worked_tasks = get_recent_log_tasks()
+            if recent_worked_tasks:
+                order_conditions.append(Case().when(doctype.name.isin(recent_worked_tasks), 1).else_(0))
+
+        order_conditions.append(
+            Case()
+            .when(
+                fn.Function("INSTR", doctype._liked_by, f'"{frappe.session.user}"') > 0,
+                1,
+            )
+            .else_(0)
         )
-        .else_(0)
-    )
-    # Since we can not hide closed tasks, as user might need to add time against it,
-    # We can deprioritize the closed tasks.
-    order_conditions.append(Case().when(doctype.status.isin(["Open", "Working"]), 1).else_(0))
+        # Since we can not hide closed tasks, as user might need to add time against it,
+        # We can deprioritize the closed tasks.
+        order_conditions.append(Case().when(doctype.status.isin(["Open", "Working"]), 1).else_(0))
 
-    tasks = tasks.offset(start).orderby(
-        *order_conditions,
-        order=Order.desc,
-    )
+        tasks = tasks.orderby(*order_conditions, order=Order.desc)
+
     tasks = tasks.run(as_dict=True)
 
+    count_filters = [[field, condition[0], condition[1]] for field, condition in filter.items()]
+    count_filters.extend(parsed_filters)
     count = get_count(
         doctype="Task",
-        filters=filter,
+        filters=count_filters,
         or_filters=search_filter,
         ignore_permissions=True,
     )

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -6,24 +6,11 @@ from frappe.query_builder import functions as fn
 from frappe.utils import add_days, getdate, now_datetime
 from pypika import Criterion, Order
 
+from next_pms.timesheet.utils.constant import TASK_FILTER_OPERATORS, TASK_META_FIELDS
+
 from . import get_count
 from .project import get_project_filter_for_contractor
 from .timesheet import _apply_qb_condition
-
-TASK_FILTER_OPERATORS = {
-    "=",
-    "!=",
-    "like",
-    "not like",
-    "in",
-    "not in",
-    ">=",
-    "<=",
-    ">",
-    "<",
-    "between",
-    "is",
-}
 
 
 def parse_task_filters(raw_filters: list | str | None) -> list:
@@ -31,8 +18,8 @@ def parse_task_filters(raw_filters: list | str | None) -> list:
 
     Args:
         raw_filters: A list of [field, operator, value] entries, or a JSON string encoding one.
-            Every field must exist on the Task doctype, so all Task fields are supported without
-            allowing arbitrary column access.
+            Every field must be a Task field or a Frappe default column (e.g. modified, creation),
+            so all real Task columns are supported without allowing arbitrary column access.
 
     Returns:
         A list of validated [field, operator, value] triples.
@@ -59,7 +46,7 @@ def parse_task_filters(raw_filters: list | str | None) -> list:
         field, operator, value = condition
         if not isinstance(operator, str) or operator.lower().strip() not in TASK_FILTER_OPERATORS:
             frappe.throw(frappe._("Unsupported filter operator '{0}'.").format(operator))
-        if field != "name" and not meta.has_field(field):
+        if field not in TASK_META_FIELDS and not meta.has_field(field):
             frappe.throw(frappe._("Filtering on field '{0}' of Task is not supported.").format(field))
         parsed.append([field, operator.lower().strip(), value])
     return parsed
@@ -69,8 +56,8 @@ def parse_task_order_by(order_by: str | None) -> list:
     """Parse a Frappe-style order_by string into validated sort pairs for Task.
 
     Args:
-        order_by: A sort string such as "field asc, other desc". Every field must exist on the
-            Task doctype.
+        order_by: A sort string such as "field asc, other desc". Every field must be a Task field
+            or a Frappe default column (e.g. modified, creation).
 
     Returns:
         A list of (field, Order) pairs to apply to the query in order.
@@ -89,7 +76,7 @@ def parse_task_order_by(order_by: str | None) -> list:
         direction = tokens[1].lower() if len(tokens) > 1 else "asc"
         if len(tokens) > 2 or direction not in ("asc", "desc"):
             frappe.throw(frappe._("Invalid order_by clause '{0}'.").format(clause))
-        if field != "name" and not meta.has_field(field):
+        if field not in TASK_META_FIELDS and not meta.has_field(field):
             frappe.throw(frappe._("Sorting on field '{0}' of Task is not supported.").format(field))
         parsed.append((field, Order.asc if direction == "asc" else Order.desc))
     return parsed

--- a/next_pms/timesheet/utils/constant.py
+++ b/next_pms/timesheet/utils/constant.py
@@ -1,7 +1,28 @@
+from frappe.model import DEFAULT_FIELDS
+
 # Cache Keys
 
 EMP_WOKING_DETAILS = "emp_working_details"
 EMP_TIMESHEET = "emp_timesheet"
+
+TASK_FILTER_OPERATORS = {
+    "=",
+    "!=",
+    "like",
+    "not like",
+    "in",
+    "not in",
+    ">=",
+    "<=",
+    ">",
+    "<",
+    "between",
+    "is",
+}
+
+# Frappe's default columns minus the virtual "doctype", which has no physical column on the table.
+# These sit alongside the doctype's own fields as valid targets for filtering and sorting.
+TASK_META_FIELDS = DEFAULT_FIELDS - {"doctype"}
 
 ALLOWED_FILTER_FIELDS = {
     "Timesheet": {


### PR DESCRIPTION
## Description

composite filter and sorting for task page backend 

## Relevant Technical Choices

1. added the filter and sorting functionality

## Testing Instructions

```
next_pms feat/composite-filter-task* ≡
 ❯ SID="bc6d9607e1711b5fc60b4f83040fd42c3635ed69325e26496769a0ee"
BASE="http://erp16.localhost/api/method/next_pms.timesheet.api.task.get_task_list"
curl -s -G "$BASE" -H "Cookie: sid=$SID" \
  --data-urlencode 'filters=[["name","in",["SEED-TASK-0000004","SEED-TASK-0000008","SEED-TASK-0000009"]],["status","=","Overdue"]]' \
  --data-urlencode 'fields=["task_weight","priority"]' \
  --data-urlencode 'page_length=50' | jq
{
  "message": {
    "task": [
      {
        "task_weight": 3.0,
        "status": "Overdue",
        "actual_time": 0.0,
        "subject": "Stakeholder demo and feedback session",
        "description": null,
        "priority": "High",
        "name": "SEED-TASK-0000004",
        "expected_time": 12.0,
        "_liked_by": null,
        "project": "PROJ-0002",
        "project_name": "SEED Mobile Banking App",
        "custom_is_billable": 0,
        "exp_end_date": "2026-04-16 00:00:00"
      },
      {
        "task_weight": 8.0,
        "status": "Overdue",
        "actual_time": 0.0,
        "subject": "Code review and quality assurance",
        "description": null,
        "priority": "High",
        "name": "SEED-TASK-0000008",
        "expected_time": 12.0,
        "_liked_by": null,
        "project": "PROJ-0003",
        "project_name": "SEED CRM Integration Project",
        "custom_is_billable": 0,
        "exp_end_date": "2026-04-29 00:00:00"
      }
    ],
    "total_count": 2,
    "has_more": false
  }
}

next_pms feat/composite-filter-task* ≡
 ❯
```

```
next_pms feat/composite-filter-task* ≡
 ❯ curl -s -G "$BASE" -H "Cookie: sid=$SID" \
  --data-urlencode 'filters=[["priority","=","High"],["task_weight",">=",4]]' \
  --data-urlencode 'order_by=task_weight desc' \
  --data-urlencode 'fields=["task_weight","priority"]' \
  --data-urlencode 'page_length=50' | jq
{
  "message": {
    "task": [
      {
        "task_weight": 8.0,
        "status": "Overdue",
        "actual_time": 0.0,
        "subject": "Code review and quality assurance",
        "description": null,
        "priority": "High",
        "name": "SEED-TASK-0000008",
        "expected_time": 12.0,
        "_liked_by": null,
        "project": "PROJ-0003",
        "project_name": "SEED CRM Integration Project",
        "custom_is_billable": 0,
        "exp_end_date": "2026-04-29 00:00:00"
      },
      {
        "task_weight": 7.0,
        "status": "Completed",
                                                                               "actual_time": 0.0,                                                                                  "subject": "Documentation and handover",                                                             "description": null,                                                                                 "priority": "High",                                                                                  "name": "SEED-TASK-0000339",                                                                         "expected_time": 20.0,                                                                               "_liked_by": null,                                                                                   "project": "SEED-PROJ-0000125",                                                                      "project_name": "DevOps Setup SEED-PROJ-0000125",                                                    "custom_is_billable": 0,                                                                             "exp_end_date": "2026-04-30 00:00:00"                                                              },                                                                                                   {                                                                                                      "task_weight": 6.0,                                                                                  "status": "Overdue",                                                                                 "actual_time": 0.0,                                                                                  "subject": "Post-launch monitoring and support",                                                     "description": null,
        "priority": "High",
        "name": "SEED-TASK-0000061",
        "expected_time": 6.0,
        "_liked_by": null,
        "project": "SEED-PROJ-0000015",
        "project_name": "Compliance SEED-PROJ-0000015",        "custom_is_billable": 0,
        "exp_end_date": "2026-04-15 00:00:00"
      },
      {
        "task_weight": 5.0,
        "status": "Working",
        "actual_time": 3.5,
        "subject": "Technical design and architecture review",
        "description": null,
        "priority": "High",
        "name": "SEED-TASK-0000002",
        "expected_time": 8.0,
        "_liked_by": null,
        "project": "PROJ-0001",
        "project_name": "SEED E-Commerce Platform Rebuild",
        "custom_is_billable": 0,
        "exp_end_date": "2050-12-31 00:00:00"
      },
      {
        "task_weight": 4.0,
        "status": "Overdue",
        "actual_time": 0.0,
        "subject": "Build refund and dispute handling flow",
        "description": null,
        "priority": "High",
        "name": "SEED-TASK-0000409",
        "expected_time": 20.0,
        "_liked_by": null,
        "project": "SEED-PROJ-0000152",
        "project_name": "Payment Gateway SEED-PROJ-0000152",
        "custom_is_billable": 0,
        "exp_end_date": "2026-04-22 00:00:00"
      }
    ],
    "total_count": 5,
    "has_more": false
  }
}

next_pms feat/composite-filter-task* ≡
 ❯
 ```

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1859 