### PR TITLE
feat: add timesheet status and rejection message for timesheet table for employees

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -11,8 +11,10 @@ import {
 } from "react";
 import { Accordion } from "@base-ui/react/accordion";
 import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
+import { ApprovalStatus } from "@next-pms/design-system/components";
 import { stripTags } from "@next-pms/design-system/utils";
 import {
+  Alert,
   Badge,
   Button,
   StaticTextEditor,
@@ -363,6 +365,7 @@ export const InlineTimeEntry = ({
   return (
     <div className="animate-fade-in min-w-68 w-fit max-w-[min(720px,90vw)] max-h-[min(500px,90dvh)] overflow-auto scrollbar-thin shadow bg-surface-modal rounded-lg flex flex-col gap-2 p-2">
       {displayTasks.map((entry: TaskDataItemProps, index: number) => {
+        const isEntryApproved = entry.custom_approval_status === "Approved";
         const isEditingThisEntry =
           entryFormMode === ENTRY_FORM_MODE.EDIT &&
           selectedEntry?.name === entry.name;
@@ -415,9 +418,15 @@ export const InlineTimeEntry = ({
                             size="md"
                             className="gap-0 lining-nums tabular-nums text-ink-gray-8"
                           >
-                            {entry.hours
-                              ? floatToTime(entry.hours, 2)
-                              : "00:00"}
+                            <span>
+                              {entry.hours
+                                ? floatToTime(entry.hours, 2)
+                                : "00:00"}
+                            </span>
+                            <ApprovalStatus
+                              status={entry.custom_approval_status || "None"}
+                              className="w-3 m-1"
+                            />
                           </Badge>
                         </div>
                         {!isExpanded ? (
@@ -431,7 +440,7 @@ export const InlineTimeEntry = ({
                               : null}
                           </span>
                         ) : null}
-                        {!disabled ? (
+                        {!disabled && !isEntryApproved ? (
                           <Button
                             className={cn(
                               "w-5 h-5 absolute right-0 top-0 opacity-0 pointer-events-none",
@@ -496,6 +505,18 @@ export const InlineTimeEntry = ({
                             "contain-[inline-size] wrap-anywhere **:max-w-full **:wrap-anywhere",
                           )}
                         />
+                        {entry.custom_approval_status === "Rejected" &&
+                        entry.custom_rejection_reason ? (
+                          <Alert
+                            title="Rejection reason"
+                            variant="outline"
+                            theme="red"
+                            dismissable={false}
+                            renderIcon={false}
+                            renderDescription={entry.custom_rejection_reason}
+                            className="mt-2 [&_h3]:text-xs [&_h3]:font-bold [&_h3]:text-ink-red-4 [&_p]:text-xs [&_p]:text-ink-red-3 p-2"
+                          />
+                        ) : null}
                       </div>
                     )}
                   </div>

--- a/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/inline-time-entry/index.tsx
@@ -423,10 +423,12 @@ export const InlineTimeEntry = ({
                                 ? floatToTime(entry.hours, 2)
                                 : "00:00"}
                             </span>
-                            <ApprovalStatus
-                              status={entry.custom_approval_status || "None"}
-                              className="w-3 m-1"
-                            />
+                            {entry.custom_approval_status && (
+                              <ApprovalStatus
+                                status={entry.custom_approval_status}
+                                className="w-3 m-1"
+                              />
+                            )}
                           </Badge>
                         </div>
                         {!isExpanded ? (

--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -22,6 +22,13 @@ import type { TaskDataItemProps } from "@/types/timesheet";
 import type { TaskRowProps } from "./types";
 import { InlineTimeEntry } from "../inline-time-entry";
 
+const statusPriority: Record<string, number> = {
+  Rejected: 5,
+  "Approval Pending": 4,
+  "Processing Timesheet": 3,
+  Approved: 2,
+};
+
 /**
  * @description This is the task row component for the timesheet table.
  * It is responsible for rendering the task row of the timesheet table.
@@ -67,19 +74,47 @@ export const TaskRow = ({
     const tasksForDates: TaskDataItemProps[][] = [];
     for (const date of dates) {
       const currentTotal = calculateTotalHours(tasks, date);
-      // Check if the time entry for the day is approved or not.
+      // Build per-day status metadata from approval status.
       const tasksForDate = tasks[taskKey].data.filter((entry) =>
         entry.from_time.includes(date),
       );
-      const isApproved = tasksForDate.some((entry) => entry.docstatus === 1);
-      totalTimeEntries.push({
+      let dayStatus: string | undefined;
+      let highestPriority = 0;
+      let rejectionReason: string | null = null;
+      const isDayFullyApproved =
+        tasksForDate.length > 0 &&
+        tasksForDate.every(
+          (entry) => entry.custom_approval_status === "Approved",
+        );
+
+      for (const entry of tasksForDate) {
+        const approvalStatus = entry.custom_approval_status;
+        if (!approvalStatus) {
+          continue;
+        }
+
+        const priority = statusPriority[approvalStatus] ?? 1;
+        if (priority > highestPriority) {
+          highestPriority = priority;
+          dayStatus = approvalStatus;
+        }
+
+        if (!rejectionReason && approvalStatus === "Rejected") {
+          rejectionReason = entry.custom_rejection_reason ?? null;
+        }
+      }
+
+      const timeEntry: TaskRowTimeEntry = {
         time: currentTotal === 0 ? "" : floatToTime(currentTotal, 2),
         nonBillable:
           currentTotal === 0 || (taskKey && tasks[taskKey]?.is_billable)
             ? false
             : true,
-        disabled: disabled || isApproved || false,
-      });
+        disabled: disabled || isDayFullyApproved || false,
+        status: dayStatus,
+        rejectionReason,
+      };
+      totalTimeEntries.push(timeEntry);
       tasksForDates.push(tasksForDate);
       total += currentTotal;
     }

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/entryRow.tsx
@@ -93,7 +93,9 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
               <p className="text-base font-medium text-ink-gray-7 truncate">
                 {entry.taskName}
               </p>
-              <ApprovalStatus status={entry.approvalStatus} />
+              {entry.approvalStatus && (
+                <ApprovalStatus status={entry.approvalStatus} />
+              )}
             </div>
             <p className="text-xs text-ink-gray-5 truncate">
               {entry.projectName}
@@ -153,7 +155,9 @@ const EntryRow = ({ entry, readOnly = false, onSave }: EntryRowProps) => {
             <p className="text-base font-medium text-ink-gray-7 truncate">
               {entry.taskName}
             </p>
-            <ApprovalStatus status={entry.approvalStatus} />
+            {entry.approvalStatus && (
+              <ApprovalStatus status={entry.approvalStatus} />
+            )}
           </div>
           <p className="text-xs text-ink-gray-5 truncate">
             {entry.projectName}

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
@@ -38,7 +38,7 @@ export interface TimesheetEntry {
   docstatus: number;
   leaveHours: number;
   leaveLabel?: string;
-  approvalStatus: ApprovalStatusLabelType;
+  approvalStatus?: ApprovalStatusLabelType;
   rejectionReason?: string;
 }
 
@@ -54,7 +54,7 @@ export interface TaskDataEntry {
   hours: number;
   parent: string;
   docstatus: number;
-  custom_approval_status: ApprovalStatusLabelType;
+  custom_approval_status?: ApprovalStatusLabelType | null;
   custom_rejection_reason?: string | null;
 }
 

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -130,7 +130,7 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
           leaveHours,
           leaveLabel:
             leaveHours > 0 ? getLeaveLabelForDate(leaves, date) : undefined,
-          approvalStatus: entry.custom_approval_status!,
+          approvalStatus: entry.custom_approval_status || undefined,
           rejectionReason: entry.custom_rejection_reason || undefined,
         });
       });

--- a/frontend/packages/app/src/types/timesheet.ts
+++ b/frontend/packages/app/src/types/timesheet.ts
@@ -37,6 +37,8 @@ export interface TaskDataItemProps {
   subject?: string;
   project?: string;
   project_name?: string | null;
+  custom_approval_status?: ApprovalStatusLabelType | null;
+  custom_rejection_reason?: string | null;
 }
 
 export interface LeaveProps {

--- a/frontend/packages/design-system/src/components/approval-status/constants.ts
+++ b/frontend/packages/design-system/src/components/approval-status/constants.ts
@@ -29,7 +29,6 @@ export const approvalStatusIcon: Record<
   "Not Submitted": Overdue,
   "Partially Approved": Success,
   "Partially Rejected": CloseCircle,
-  None: Hourglass,
 };
 
 export const approvalStatusIconVariants = cva("", {
@@ -42,7 +41,6 @@ export const approvalStatusIconVariants = cva("", {
       "Not Submitted": "text-ink-gray-4",
       "Partially Approved": "text-ink-green-4",
       "Partially Rejected": "text-ink-red-4",
-      None: "text-ink-amber-4",
     },
   },
 });

--- a/frontend/packages/design-system/src/components/approval-status/types.ts
+++ b/frontend/packages/design-system/src/components/approval-status/types.ts
@@ -5,5 +5,4 @@ export type ApprovalStatusLabelType =
   | "Processing Timesheet"
   | "Not Submitted"
   | "Partially Approved"
-  | "Partially Rejected"
-  | "None";
+  | "Partially Rejected";

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/constants.ts
@@ -2,6 +2,8 @@ export type TaskRowTimeEntry = {
   time: string;
   nonBillable?: boolean;
   disabled?: boolean;
+  status?: string;
+  rejectionReason?: string | null;
 };
 
 export type TaskData = {

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -25,10 +25,6 @@ const timeEntryStatusClassNames: Record<string, string> = {
   "Partially Rejected": "!text-ink-red-4",
 };
 
-const getTimeEntryStatusClassName = (status?: string) => {
-  return status ? timeEntryStatusClassNames[status] : undefined;
-};
-
 export interface TaskRowProps {
   /** Label for the task row. */
   label: string;
@@ -190,12 +186,9 @@ export const TaskRow: React.FC<TaskRowProps> = ({
         const canOpenInlineTimeEntry = !(
           timeEntry.disabled && timeEntry.time === ""
         );
-        const timeEntryTextClassName = cn(
-          getTimeEntryStatusClassName(timeEntry.status),
-          {
-            "text-ink-gray-4": timeEntry.time === "",
-          },
-        );
+        const timeEntryTextClassName = timeEntry.status
+          ? timeEntryStatusClassNames[timeEntry.status]
+          : undefined;
 
         return (
           <div

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -16,6 +16,19 @@ import { AddMd, Star, SolidStar } from "@rtcamp/frappe-ui-react/icons";
 import { type TaskRowTimeEntry } from "./constants";
 import { mergeClassNames as cn } from "../../../../utils";
 
+const timeEntryStatusClassNames: Record<string, string> = {
+  Approved: "!text-ink-green-4",
+  Rejected: "!text-ink-red-4",
+  "Approval Pending": "!text-ink-amber-4",
+  "Processing Timesheet": "!text-ink-amber-4",
+  "Partially Approved": "!text-ink-green-4",
+  "Partially Rejected": "!text-ink-red-4",
+};
+
+const getTimeEntryStatusClassName = (status?: string) => {
+  return status ? timeEntryStatusClassNames[status] : undefined;
+};
+
 export interface TaskRowProps {
   /** Label for the task row. */
   label: string;
@@ -177,6 +190,12 @@ export const TaskRow: React.FC<TaskRowProps> = ({
         const canOpenInlineTimeEntry = !(
           timeEntry.disabled && timeEntry.time === ""
         );
+        const timeEntryTextClassName = cn(
+          getTimeEntryStatusClassName(timeEntry.status),
+          {
+            "text-ink-gray-4": timeEntry.time === "",
+          },
+        );
 
         return (
           <div
@@ -194,9 +213,10 @@ export const TaskRow: React.FC<TaskRowProps> = ({
                   {...props}
                   variant="ghost"
                   className={cn(
-                    "w-14.25 relative group flex justify-center items-center text-ink-gray-6 lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
+                    "w-14.25 relative group flex justify-center items-center lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                     "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
                     "aria-disabled:cursor-default! aria-disabled:text-ink-gray-5 aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent aria-disabled:active:bg-transparent",
+                    timeEntryTextClassName,
                   )}
                   aria-disabled={timeEntry.disabled}
                   onClick={(event) => {


### PR DESCRIPTION
## Description

Adds approval/rejection visibility improvements across timesheet row views by showing status-driven colors, approval icons in entry badges, and rejection reason messaging in inline entry popovers.

## Relevant Technical Choices

- Added rejection reason rendering using the same red outline Alert style pattern used in manager popup work.
- Added Color status for Approved/Pending/Rejected entries
- Added status icon in each entry badge
- Avoided the separate Hover/click status to maintain uniformity in hovering behaviour between Approved/Rejected entries and partially/fully rejected entries


## Testing Instructions

- Go to the timesheet views
- Open a week containing mixed approval states.
- Verify time values are color-coded:
Rejected: red
Approval Pending : amber
Approved: green
- Hover/open inline entries and verify each entry badge shows the approval icon.
- For rejected entries, verify rejection reason appears in the popover as a red outline alert.

## Screenshot/Screencast

<img width="1683" height="929" alt="image" src="https://github.com/user-attachments/assets/19260eb3-8dfc-4b67-9325-f3bdf8d83845" />

<img width="1681" height="928" alt="image" src="https://github.com/user-attachments/assets/1c11fa01-02df-42ff-8906-dafbf8d03710" />

<img width="1680" height="727" alt="image" src="https://github.com/user-attachments/assets/0aa7f1e4-f046-4fa6-b17e-1254aea8c497" />

<img width="1667" height="562" alt="image" src="https://github.com/user-attachments/assets/dd889bdb-c128-491a-a29b-458b721df5e5" />


https://github.com/user-attachments/assets/64897a9d-0701-4213-a2a1-5c67a388f28b



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Depends on: https://github.com/rtCamp/next-pms/pull/1879

Fixes #1752 