### PR TITLE
fix: rename project tracking labels for consistency

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/costBurn.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/costBurn.tsx
@@ -60,7 +60,7 @@ export function CostBurnCell() {
         />
         <LegendItem
           className="bg-surface-gray-3"
-          label="Expected total cost"
+          label="Target Cost"
           value={currencyFormat(currency).format(total)}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium"

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/invoiceBurn.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/invoiceBurn.tsx
@@ -60,7 +60,7 @@ export function InvoiceBurnCell() {
         />
         <LegendItem
           className="bg-surface-gray-3"
-          label="Total project amount"
+          label="Total Project Value"
           value={currencyFormat(currency).format(totalAmount ?? 0)}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium"


### PR DESCRIPTION
## Description

Rename project tracking labels "Expected Total Cost" to "Target Cost" and "Total Project Amount" to "Total Project Value".

## Testing Instructions

- Go to projects page
- Open any project
- Go to tracking tab
- Observe the "Total Project Value" and "Target Cost" labels.

## Screenshot/Screencast

<img width="1239" height="173" alt="image" src="https://github.com/user-attachments/assets/984796a5-61ff-44a4-91ce-64129a41629b" />


https://github.com/user-attachments/assets/76818a08-dadb-415c-b9bd-f37aef868f48




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1880 