### PR TITLE
feat: add task page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -125,7 +125,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2949,7 +2948,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3484,7 +3482,6 @@
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3504,7 +3501,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3515,7 +3511,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3561,7 +3556,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -3787,7 +3781,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4128,7 +4121,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4480,7 +4472,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4956,7 +4947,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6797,6 +6787,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7532,7 +7523,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7593,7 +7583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -7688,7 +7677,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7712,7 +7700,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7747,7 +7734,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7843,7 +7829,6 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
       "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.3",
         "react-router": "6.30.4"
@@ -7897,8 +7882,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8096,8 +8080,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -8549,8 +8532,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
       "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -8734,7 +8716,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8913,7 +8894,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9349,7 +9329,6 @@
     "packages/design-system/node_modules/quill-delta": {
       "version": "5.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-diff": "^1.3.0",
         "lodash.clonedeep": "^4.5.0",
@@ -9430,6 +9409,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/frontend/packages/app/src/components/task-log/components/title.tsx
+++ b/frontend/packages/app/src/components/task-log/components/title.tsx
@@ -29,7 +29,7 @@ const Title: React.FC<TitleProps> = ({
           className="text-lg text-ink-gray-8 font-semibold flex items-end gap-1"
         >
           {taskName}
-          <ArrowUpRight className="size-4 shrink-0 text-ink-gray-5" />
+          <ArrowUpRight className="size-4 shrink-0 text-ink-gray-8" />
         </a>
       ) : (
         <div className="text-lg text-ink-gray-8 font-semibold">{taskName}</div>

--- a/frontend/packages/app/src/components/task-log/components/title.tsx
+++ b/frontend/packages/app/src/components/task-log/components/title.tsx
@@ -3,18 +3,37 @@
  */
 import { TaskStatus, TaskStatusType } from "@next-pms/design-system/components";
 import { mergeClassNames as cn } from "@next-pms/design-system/utils";
+import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
 
 type TitleProps = {
   taskName: string;
   status: TaskStatusType;
   className?: string;
+  ghLink?: string;
 };
 
-const Title: React.FC<TitleProps> = ({ taskName, status, className }) => {
+const Title: React.FC<TitleProps> = ({
+  taskName,
+  status,
+  className,
+  ghLink,
+}) => {
   return (
     <div className={cn("flex items-center gap-x-2 gap-y-1.5 pr-2", className)}>
       <TaskStatus status={status} />
-      <div className="text-lg text-ink-gray-8 font-semibold">{taskName}</div>
+      {ghLink ? (
+        <a
+          href={ghLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-lg text-ink-gray-8 font-semibold flex items-end gap-1"
+        >
+          {taskName}
+          <ArrowUpRight className="size-4 shrink-0 text-ink-gray-5" />
+        </a>
+      ) : (
+        <div className="text-lg text-ink-gray-8 font-semibold">{taskName}</div>
+      )}
     </div>
   );
 };

--- a/frontend/packages/app/src/components/task-log/personalTaskLog.tsx
+++ b/frontend/packages/app/src/components/task-log/personalTaskLog.tsx
@@ -89,6 +89,7 @@ const PersonalTaskLog: React.FC<PersonalTaskLogProps> = ({
             <Title
               taskName={taskDetails.label}
               status={taskStatusMap[taskDetails.status]}
+              ghLink={taskDetails.ghLink}
             />
           );
         },

--- a/frontend/packages/app/src/components/task-log/teamTaskLog.tsx
+++ b/frontend/packages/app/src/components/task-log/teamTaskLog.tsx
@@ -84,6 +84,7 @@ const TeamTaskLog: React.FC<TeamTaskLogProps> = ({
             <Title
               taskName={taskDetails.label}
               status={taskStatusMap[taskDetails.status]}
+              ghLink={taskDetails.ghLink}
             />
           );
         },

--- a/frontend/packages/app/src/components/task-log/useTaskLog.ts
+++ b/frontend/packages/app/src/components/task-log/useTaskLog.ts
@@ -20,6 +20,7 @@ type UseTaskLogReturn = {
     status: string;
     dueDate?: string;
     workedBy: TaskWorker[];
+    ghLink?: string;
   };
   taskLogs: TaskLog[];
 };
@@ -48,6 +49,7 @@ const useTaskLog = ({
     exp_end_date: dueDate,
     status = "Open",
     worked_by: workedByRaw,
+    gh_link: ghLink,
   } = data?.message || {};
 
   let workedBy: TaskWorker[] = (workedByRaw || []).map(
@@ -123,6 +125,7 @@ const useTaskLog = ({
       status,
       dueDate,
       workedBy,
+      ghLink,
     },
     taskLogs: taskLogs,
   };

--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -134,7 +134,7 @@ export const TaskRow = ({
         ),
       );
     }
-  }, [likeError, toast]);
+  }, [likeError]);
 
   return (
     <BaseTaskRow

--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -113,7 +113,7 @@ export const TaskRow = ({
 
   const handleStar = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    void toggleLike();
+    toggleLike();
   };
 
   const onLabelClick = useCallback(

--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { floatToTime } from "@next-pms/design-system";
 import {
   TaskRow as BaseTaskRow,
   type TaskRowTimeEntry,
   taskStatusMap,
 } from "@next-pms/design-system/components";
+import { useToggleLike } from "@next-pms/hooks";
 import { useToasts } from "@rtcamp/frappe-ui-react";
-import { useFrappePostCall } from "frappe-react-sdk";
 
 /**
  * Internal dependencies
@@ -48,18 +48,25 @@ export const TaskRow = ({
   setSelectedTask,
   ...rest
 }: TaskRowProps) => {
-  const [taskLiked, setTaskLiked] = useState(false);
   const likedTaskData = usePersonalTimesheet(
     ({ state }) => state.likedTaskData,
   );
   const refetchLikedTasks = usePersonalTimesheet(
     ({ actions }) => actions.refetchLikedTasks,
   );
-  const { call: toggleLikeCall } = useFrappePostCall(
-    "frappe.desk.like.toggle_like",
-  );
   const toast = useToasts();
   const requestGuarded = useGuardedAction();
+
+  const {
+    liked: taskLiked,
+    error: likeError,
+    toggle: toggleLike,
+  } = useToggleLike({
+    doctype: "Task",
+    name: taskKey,
+    liked: likedTaskData?.some((obj) => obj.name === taskKey) || false,
+    onToggled: refetchLikedTasks,
+  });
 
   const taskData = useMemo(() => {
     let total = 0;
@@ -104,27 +111,9 @@ export const TaskRow = ({
     [rest.label, tasks, status],
   );
 
-  const handleStar = async (
-    e: React.MouseEvent<HTMLButtonElement>,
-    taskKey: string,
-  ): Promise<void> => {
+  const handleStar = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    const data = {
-      name: taskKey,
-      add: taskLiked ? "No" : "Yes",
-      doctype: "Task",
-    };
-    setTaskLiked((prev) => !prev);
-    try {
-      await toggleLikeCall(data);
-      // Refetch liked tasks to update the context
-      refetchLikedTasks();
-    } catch (err) {
-      const error = parseFrappeErrorMsg(
-        err as Parameters<typeof parseFrappeErrorMsg>[0],
-      );
-      toast.error(error);
-    }
+    void toggleLike();
   };
 
   const onLabelClick = useCallback(
@@ -138,8 +127,14 @@ export const TaskRow = ({
   );
 
   useEffect(() => {
-    setTaskLiked(likedTaskData?.some((obj) => obj.name === taskKey) || false);
-  }, [likedTaskData, taskKey]);
+    if (likeError) {
+      toast.error(
+        parseFrappeErrorMsg(
+          likeError as Parameters<typeof parseFrappeErrorMsg>[0],
+        ),
+      );
+    }
+  }, [likeError, toast]);
 
   return (
     <BaseTaskRow

--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -172,15 +172,7 @@ const Sidebar = () => {
     render: <LinkWithPreload to={ROUTES.task} />,
   };
 
-  const taskItems: SidebarSectionType["items"] = [];
-
-  if (
-    roles.includes("Projects Manager") ||
-    roles.includes("Projects User") ||
-    roles.includes("Timesheet Manager")
-  ) {
-    taskItems.push(tasks);
-  }
+  const taskItems: SidebarSectionType["items"] = [tasks];
 
   const notificationsOption = {
     label: "Notifications",
@@ -235,6 +227,10 @@ const Sidebar = () => {
       label: "Allocations - project",
       action: () => navigate(ROUTES["allocations-project"]),
     },
+    {
+      label: "Tasks",
+      action: () => navigate(ROUTES["task"]),
+    },
   ];
 
   if (roles.includes("System Manager")) {
@@ -252,10 +248,6 @@ const Sidebar = () => {
     searchItems.push({
       label: "Projects",
       action: () => navigate(ROUTES["project"]),
-    });
-    searchItems.push({
-      label: "Tasks",
-      action: () => navigate(ROUTES["task"]),
     });
   }
 

--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -20,15 +20,9 @@ import {
   Folder,
   Grid,
   LogOut,
+  Summary,
 } from "@rtcamp/frappe-ui-react/icons";
-import {
-  ArrowLeftRight,
-  Briefcase,
-  BarChart2,
-  ListTodo,
-  Moon,
-  Sun,
-} from "lucide-react";
+import { ArrowLeftRight, Briefcase, BarChart2, Moon, Sun } from "lucide-react";
 /**
  * Internal dependencies.
  */
@@ -166,7 +160,7 @@ const Sidebar = () => {
 
   const tasks = {
     label: "Tasks",
-    icon: ListTodo,
+    icon: Summary,
     to: ROUTES.task,
     isActive: pathname === ROUTES.task,
     render: <LinkWithPreload to={ROUTES.task} />,

--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -21,7 +21,14 @@ import {
   Grid,
   LogOut,
 } from "@rtcamp/frappe-ui-react/icons";
-import { ArrowLeftRight, Briefcase, BarChart2, Moon, Sun } from "lucide-react";
+import {
+  ArrowLeftRight,
+  Briefcase,
+  BarChart2,
+  ListTodo,
+  Moon,
+  Sun,
+} from "lucide-react";
 /**
  * Internal dependencies.
  */
@@ -157,6 +164,24 @@ const Sidebar = () => {
     projectItems.push(projects);
   }
 
+  const tasks = {
+    label: "Tasks",
+    icon: ListTodo,
+    to: ROUTES.task,
+    isActive: pathname === ROUTES.task,
+    render: <LinkWithPreload to={ROUTES.task} />,
+  };
+
+  const taskItems: SidebarSectionType["items"] = [];
+
+  if (
+    roles.includes("Projects Manager") ||
+    roles.includes("Projects User") ||
+    roles.includes("Timesheet Manager")
+  ) {
+    taskItems.push(tasks);
+  }
+
   const notificationsOption = {
     label: "Notifications",
     icon: Notifications,
@@ -227,6 +252,10 @@ const Sidebar = () => {
     searchItems.push({
       label: "Projects",
       action: () => navigate(ROUTES["project"]),
+    });
+    searchItems.push({
+      label: "Tasks",
+      action: () => navigate(ROUTES["task"]),
     });
   }
 
@@ -304,6 +333,7 @@ const Sidebar = () => {
               ...(timesheetItems.length === 1 ? timesheetItems : []),
               ...notificationItems,
               ...projectItems,
+              ...taskItems,
               ...(dashboardItems.length === 1 ? dashboardItems : []),
             ],
           },

--- a/frontend/packages/app/src/lib/constant.ts
+++ b/frontend/packages/app/src/lib/constant.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
   "dashboard-manager": "/dashboard/manager",
   project: "/projects",
   "project-kanban": "/projects/kanban",
+  task: "/tasks",
   "timesheet-personal": "/timesheet",
   "timesheet-team": "/timesheet/team",
   "timesheet-project": "/timesheet/project",

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -620,6 +620,25 @@ export const buildFrappeFilters = (compositeFilters: FilterCondition[]) => {
 };
 
 /**
+ * Builds native Frappe filters from composite filters on a single doctype
+ * (no `fieldCategory` prefix) — e.g. `[["priority", "=", "Urgent"]]`.
+ *
+ * @param compositeFilters Array of FilterCondition objects.
+ * @returns Array of Frappe filters in the format [[field, operator, value]].
+ */
+export const buildFilterConditions = (compositeFilters: FilterCondition[]) => {
+  return compositeFilters
+    .filter(isCompleteFilterCondition)
+    .map((filter) => [
+      filter.field,
+      filter.operator,
+      isNoValueOperator(filter.operator)
+        ? null
+        : normalizeLikeFilterValue(filter.operator, filter.value),
+    ]);
+};
+
+/**
  * Builds composite filters by extracting relevant information from the given
  * array of FilterCondition objects, including start date, maximum week range,
  * and native Frappe filters.

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -553,14 +553,19 @@ export const isNoValueOperator = (operator: string): boolean =>
   NO_VALUE_OPERATORS.includes(operator);
 
 /**
- * Parses a URL search param holding a JSON-encoded array of FilterCondition
- * objects, returning an empty array if the param is missing or malformed.
+ * Parses a URL search param holding a JSON-encoded array, returning an
+ * empty array if the param is missing, malformed, or decodes to a
+ * non-array value. Pass `decode` (e.g. `decodeURI`) when the param was
+ * encoded before being written to the URL.
  */
-export const parseAdvancedFilters = (raw: string | null): FilterCondition[] => {
+export const parseJSONArrayParam = <T>(
+  raw: string | null,
+  decode: (value: string) => string = (value) => value,
+): T[] => {
   if (!raw) return [];
   try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as FilterCondition[]) : [];
+    const parsed = JSON.parse(decode(raw));
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
   } catch {
     return [];
   }

--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -553,6 +553,20 @@ export const isNoValueOperator = (operator: string): boolean =>
   NO_VALUE_OPERATORS.includes(operator);
 
 /**
+ * Parses a URL search param holding a JSON-encoded array of FilterCondition
+ * objects, returning an empty array if the param is missing or malformed.
+ */
+export const parseAdvancedFilters = (raw: string | null): FilterCondition[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as FilterCondition[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+/**
  * Returns true when a FilterCondition is fully specified and ready to be sent
  * to the API — i.e. it has a field, an operator, and either a non-empty value
  * or an operator that requires no value.

--- a/frontend/packages/app/src/pages/projects/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/subHeader.tsx
@@ -45,8 +45,12 @@ export function ProjectListSubHeader() {
   const debouncedSearch = useDebounce(searchInput, 400);
 
   useEffect(() => {
-    if (debouncedSearch !== search) setSearch(debouncedSearch);
-  }, [debouncedSearch, search, setSearch]);
+    if (debouncedSearch !== searchInput || debouncedSearch === search) {
+      return;
+    }
+
+    setSearch(debouncedSearch);
+  }, [debouncedSearch, searchInput, search, setSearch]);
 
   useEffect(() => {
     setSearchInput(search);

--- a/frontend/packages/app/src/pages/projects/hooks/useProjectFilters.ts
+++ b/frontend/packages/app/src/pages/projects/hooks/useProjectFilters.ts
@@ -9,7 +9,7 @@ import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
-import { parseAdvancedFilters } from "@/lib/utils";
+import { parseJSONArrayParam } from "@/lib/utils";
 import type {
   Phase,
   ProjectListFilters,
@@ -38,7 +38,9 @@ export function useProjectFilters() {
       ) as unknown as RagStatus[],
       phase: (searchParams.get("phase") ?? "") as Phase | "",
       status: (searchParams.get("status") ?? "") as ProjectStatus | "",
-      advanced: parseAdvancedFilters(searchParams.get("advanced")),
+      advanced: parseJSONArrayParam<FilterCondition>(
+        searchParams.get("advanced"),
+      ),
     }),
     [searchParams],
   );

--- a/frontend/packages/app/src/pages/projects/hooks/useProjectFilters.ts
+++ b/frontend/packages/app/src/pages/projects/hooks/useProjectFilters.ts
@@ -9,6 +9,7 @@ import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
+import { parseAdvancedFilters } from "@/lib/utils";
 import type {
   Phase,
   ProjectListFilters,
@@ -26,16 +27,6 @@ const FILTER_PARAM_KEYS = [
   "sortOrder",
 ] as const;
 
-const parseAdvanced = (raw: string | null): FilterCondition[] => {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as FilterCondition[]) : [];
-  } catch {
-    return [];
-  }
-};
-
 export function useProjectFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -47,7 +38,7 @@ export function useProjectFilters() {
       ) as unknown as RagStatus[],
       phase: (searchParams.get("phase") ?? "") as Phase | "",
       status: (searchParams.get("status") ?? "") as ProjectStatus | "",
-      advanced: parseAdvanced(searchParams.get("advanced")),
+      advanced: parseAdvancedFilters(searchParams.get("advanced")),
     }),
     [searchParams],
   );

--- a/frontend/packages/app/src/pages/tasks/components/header.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/header.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies.
+ */
+import { Breadcrumbs, Button } from "@rtcamp/frappe-ui-react";
+import { AddSm } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { Header } from "@/layout/header";
+
+function TasksHeader() {
+  return (
+    <Header>
+      <Breadcrumbs items={[{ id: "tasks", label: "Tasks" }]} />
+      <Button
+        variant="solid"
+        label="Add task"
+        iconLeft={() => <AddSm />}
+        onClick={() => {}}
+      />
+    </Header>
+  );
+}
+
+export default TasksHeader;

--- a/frontend/packages/app/src/pages/tasks/components/header.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/header.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies.
  */
-import { Breadcrumbs, Button } from "@rtcamp/frappe-ui-react";
-import { AddSm } from "@rtcamp/frappe-ui-react/icons";
+import { Breadcrumbs } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
@@ -13,12 +12,6 @@ function TasksHeader() {
   return (
     <Header>
       <Breadcrumbs items={[{ id: "tasks", label: "Tasks" }]} />
-      <Button
-        variant="solid"
-        label="Add task"
-        iconLeft={() => <AddSm />}
-        onClick={() => {}}
-      />
     </Header>
   );
 }

--- a/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
@@ -25,7 +25,7 @@ import { useTaskFilters } from "../useTaskFilters";
 
 export function TaskListSubHeader() {
   const {
-    filters: { search, project, status, advanced },
+    filters: { search, project, projectLabel, status, advanced },
     sort,
     setSearch,
     setProject,
@@ -56,8 +56,8 @@ export function TaskListSubHeader() {
 
   const [projectQuery, setProjectQuery] = useState("");
   const selectedProjectOption = useMemo(
-    () => (project ? { label: project, value: project } : null),
-    [project],
+    () => (project ? { label: projectLabel || project, value: project } : null),
+    [project, projectLabel],
   );
   const { options: projectLookupOptions, isLoading: isProjectLoading } =
     useDoctypeLinkLookup({
@@ -93,7 +93,11 @@ export function TaskListSubHeader() {
             onSearchChange={setProjectQuery}
             openOnFocus
             placeholder="Project"
-            onChange={(val) => setProject(val ?? "")}
+            onChange={(val, option) => {
+              const label =
+                option && typeof option !== "string" ? option.label : undefined;
+              setProject(val ?? "", label);
+            }}
             className="w-full"
           />
         </div>
@@ -153,7 +157,7 @@ export function TaskListSubHeader() {
           onClearAll={() => {
             setSearchInput("");
             setSearch("");
-            setProject("");
+            setProject("", "");
             setStatus([]);
           }}
         />

--- a/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
@@ -32,6 +32,7 @@ export function TaskListSubHeader() {
     setStatus,
     setAdvanced,
     setSort,
+    resetFilters,
   } = useTaskFilters();
 
   const externalFilterCount =
@@ -156,9 +157,7 @@ export function TaskListSubHeader() {
           externalFilterCount={externalFilterCount}
           onClearAll={() => {
             setSearchInput("");
-            setSearch("");
-            setProject("", "");
-            setStatus([]);
+            resetFilters();
           }}
         />
       </div>

--- a/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
@@ -1,0 +1,176 @@
+/**
+ * External dependencies.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { SortSelector } from "@next-pms/design-system/components";
+import {
+  Combobox,
+  Filter,
+  MultiSelect,
+  TextInput,
+} from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import { FilterLinkValue } from "@/components/filters/FilterLinkValue";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useDoctypeLinkLookup } from "@/hooks/useDoctypeLinkLookup";
+import {
+  TASK_PRIORITY_OPTIONS,
+  TASK_SORTABLE_FIELDS,
+  TASK_STATUS_OPTIONS,
+} from "../constants";
+import type { TaskStatus } from "../types";
+import { useTaskFilters } from "../useTaskFilters";
+
+export function TaskListSubHeader() {
+  const {
+    filters: { search, project, status, advanced },
+    sort,
+    setSearch,
+    setProject,
+    setStatus,
+    setAdvanced,
+    setSort,
+  } = useTaskFilters();
+
+  const externalFilterCount =
+    (search !== "" ? 1 : 0) +
+    (project !== "" ? 1 : 0) +
+    (status.length > 0 ? 1 : 0);
+
+  const [searchInput, setSearchInput] = useState(search);
+  const debouncedSearch = useDebounce(searchInput, 400);
+
+  useEffect(() => {
+    if (debouncedSearch !== searchInput || debouncedSearch === search) {
+      return;
+    }
+
+    setSearch(debouncedSearch);
+  }, [debouncedSearch, searchInput, search, setSearch]);
+
+  useEffect(() => {
+    setSearchInput(search);
+  }, [search]);
+
+  const [projectQuery, setProjectQuery] = useState("");
+  const selectedProjectOption = useMemo(
+    () => (project ? { label: project, value: project } : null),
+    [project],
+  );
+  const { options: projectOptions, isLoading: isProjectLoading } =
+    useDoctypeLinkLookup({
+      doctype: "Project",
+      labelField: "project_name",
+      shouldFetch: true,
+      query: projectQuery,
+      selectedOption: selectedProjectOption,
+    });
+
+  return (
+    <div className="flex flex-wrap gap-2 justify-between px-5 py-3.5">
+      <div className="flex gap-2">
+        <div className="w-44 shrink-0">
+          <TextInput
+            className="w-full text-ink-gray-7"
+            size="sm"
+            placeholder="Search task"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+        </div>
+        <div className="w-44 shrink-0">
+          <Combobox
+            options={projectOptions}
+            value={project}
+            loading={isProjectLoading}
+            searchValue={projectQuery}
+            onSearchChange={setProjectQuery}
+            openOnFocus
+            placeholder="Project"
+            onChange={(val) => setProject(val ?? "")}
+            className="w-full"
+          />
+        </div>
+        <div className="w-44 shrink-0">
+          <MultiSelect
+            placeholder="Status"
+            options={TASK_STATUS_OPTIONS}
+            value={status}
+            onChange={(v) => setStatus(v as TaskStatus[])}
+          />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <SortSelector
+          sort={sort.field ? sort : null}
+          onSortChange={setSort}
+          fields={TASK_SORTABLE_FIELDS.map(({ field, label }) => ({
+            field,
+            label,
+          }))}
+        />
+        <Filter
+          align="end"
+          value={advanced}
+          onChange={setAdvanced}
+          renderLinkValue={(props) => <FilterLinkValue {...props} />}
+          fields={[
+            {
+              name: "priority",
+              label: "Priority",
+              type: "select",
+              options: TASK_PRIORITY_OPTIONS,
+              operators: [
+                { label: "Equals", value: "=" },
+                { label: "Not Equals", value: "!=" },
+              ],
+            },
+            {
+              name: "type",
+              label: "Task Type",
+              type: "link",
+              link: { doctype: "Task Type" },
+              operators: [
+                { label: "Equals", value: "=" },
+                { label: "Not Equals", value: "!=" },
+              ],
+            },
+            {
+              name: "department",
+              label: "Department",
+              type: "link",
+              link: { doctype: "Department" },
+              operators: [
+                { label: "Equals", value: "=" },
+                { label: "Not Equals", value: "!=" },
+              ],
+            },
+            {
+              name: "custom_is_billable",
+              label: "Is Billable",
+              type: "select",
+              options: [
+                { label: "Yes", value: "1" },
+                { label: "No", value: "0" },
+              ],
+              operators: [
+                { label: "Equals", value: "=" },
+                { label: "Not Equals", value: "!=" },
+              ],
+            },
+          ]}
+          externalFilterCount={externalFilterCount}
+          onClearAll={() => {
+            setSearchInput("");
+            setSearch("");
+            setProject("");
+            setStatus([]);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/subHeader.tsx
@@ -13,7 +13,6 @@ import {
 /**
  * Internal dependencies.
  */
-import { FilterLinkValue } from "@/components/filters/FilterLinkValue";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useDoctypeLinkLookup } from "@/hooks/useDoctypeLinkLookup";
 import {
@@ -60,7 +59,7 @@ export function TaskListSubHeader() {
     () => (project ? { label: project, value: project } : null),
     [project],
   );
-  const { options: projectOptions, isLoading: isProjectLoading } =
+  const { options: projectLookupOptions, isLoading: isProjectLoading } =
     useDoctypeLinkLookup({
       doctype: "Project",
       labelField: "project_name",
@@ -68,6 +67,10 @@ export function TaskListSubHeader() {
       query: projectQuery,
       selectedOption: selectedProjectOption,
     });
+  const projectOptions = useMemo(
+    () => [{ label: "All", value: "" }, ...projectLookupOptions],
+    [projectLookupOptions],
+  );
 
   return (
     <div className="flex flex-wrap gap-2 justify-between px-5 py-3.5">
@@ -116,33 +119,12 @@ export function TaskListSubHeader() {
           align="end"
           value={advanced}
           onChange={setAdvanced}
-          renderLinkValue={(props) => <FilterLinkValue {...props} />}
           fields={[
             {
               name: "priority",
               label: "Priority",
               type: "select",
               options: TASK_PRIORITY_OPTIONS,
-              operators: [
-                { label: "Equals", value: "=" },
-                { label: "Not Equals", value: "!=" },
-              ],
-            },
-            {
-              name: "type",
-              label: "Task Type",
-              type: "link",
-              link: { doctype: "Task Type" },
-              operators: [
-                { label: "Equals", value: "=" },
-                { label: "Not Equals", value: "!=" },
-              ],
-            },
-            {
-              name: "department",
-              label: "Department",
-              type: "link",
-              link: { doctype: "Department" },
               operators: [
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },
@@ -160,6 +142,11 @@ export function TaskListSubHeader() {
                 { label: "Equals", value: "=" },
                 { label: "Not Equals", value: "!=" },
               ],
+            },
+            {
+              name: "exp_end_date",
+              label: "Due date",
+              type: "daterange",
             },
           ]}
           externalFilterCount={externalFilterCount}

--- a/frontend/packages/app/src/pages/tasks/constants.ts
+++ b/frontend/packages/app/src/pages/tasks/constants.ts
@@ -1,0 +1,36 @@
+export const TASK_LIST_PAGE_SIZE = 20;
+
+export const TASK_STATUSES = [
+  "Open",
+  "Working",
+  "Pending Review",
+  "Overdue",
+  "Completed",
+  "Cancelled",
+] as const;
+
+export const TASK_STATUS_OPTIONS = TASK_STATUSES.map((status) => ({
+  label: status,
+  value: status,
+}));
+
+export const TASK_PRIORITIES = ["Low", "Medium", "High", "Urgent"] as const;
+
+export const TASK_PRIORITY_OPTIONS = TASK_PRIORITIES.map((priority) => ({
+  label: priority,
+  value: priority,
+}));
+
+/**
+ * Sortable fields, kept in sync with TASK_LIST_COLUMNS (every column except
+ * "like"). `column` is the ListView column key; `field` is the backend Task
+ * field to sort by — they differ only for "project_name", since the Task
+ * doctype has no such field (only the "project" link field is native).
+ */
+export const TASK_SORTABLE_FIELDS = [
+  { column: "subject", field: "subject", label: "Subject" },
+  { column: "project_name", field: "project", label: "Project" },
+  { column: "status", field: "status", label: "Status" },
+  { column: "priority", field: "priority", label: "Priority" },
+  { column: "exp_end_date", field: "exp_end_date", label: "Due date" },
+] as const;

--- a/frontend/packages/app/src/pages/tasks/constants.ts
+++ b/frontend/packages/app/src/pages/tasks/constants.ts
@@ -21,16 +21,11 @@ export const TASK_PRIORITY_OPTIONS = TASK_PRIORITIES.map((priority) => ({
   value: priority,
 }));
 
-/**
- * Sortable fields, kept in sync with TASK_LIST_COLUMNS (every column except
- * "like"). `column` is the ListView column key; `field` is the backend Task
- * field to sort by — they differ only for "project_name", since the Task
- * doctype has no such field (only the "project" link field is native).
- */
 export const TASK_SORTABLE_FIELDS = [
   { column: "subject", field: "subject", label: "Subject" },
   { column: "project_name", field: "project", label: "Project" },
   { column: "status", field: "status", label: "Status" },
   { column: "priority", field: "priority", label: "Priority" },
   { column: "exp_end_date", field: "exp_end_date", label: "Due date" },
+  { column: "modified", field: "modified", label: "Last updated" },
 ] as const;

--- a/frontend/packages/app/src/pages/tasks/list/cells/addTimeCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/addTimeCell.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies.
+ */
+import { Tooltip } from "@rtcamp/frappe-ui-react";
+import { Clock } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import type { OpenAddTimeDialogOptions } from "@/pages/timesheet/outletContext";
+import type { TaskListItem } from "../types";
+
+export function AddTimeCell({
+  row,
+  onAddTime,
+}: {
+  row: TaskListItem;
+  onAddTime?: (prefill: OpenAddTimeDialogOptions) => void;
+}) {
+  const handleAddTime = () => {
+    onAddTime?.({
+      project: row.project,
+      projectLabel: row.project_name ?? row.project,
+      task: row.name,
+      taskLabel: row.subject,
+    });
+  };
+
+  return (
+    <Tooltip text="Add time">
+      {/* A native <button> can't be used here: ListRow already wraps every
+      cell in a <button>, and nested buttons are invalid HTML / trigger a
+      React DOM-nesting warning. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleAddTime();
+        }}
+        onKeyDown={(e) => {
+          if (
+            e.target === e.currentTarget &&
+            (e.key === "Enter" || e.key === " ")
+          ) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleAddTime();
+          }
+        }}
+        aria-label="Add time"
+        className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
+      >
+        <Clock className="text-ink-gray-6" size={16} />
+      </div>
+    </Tooltip>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/addTimeCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/addTimeCell.tsx
@@ -51,7 +51,7 @@ export function AddTimeCell({
         aria-label="Add time"
         className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
       >
-        <Clock className="text-ink-gray-6" size={16} />
+        <Clock className="text-ink-gray-4 size-4" />
       </div>
     </Tooltip>
   );

--- a/frontend/packages/app/src/pages/tasks/list/cells/dateCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/dateCell.tsx
@@ -9,8 +9,6 @@ import { format, parseISO } from "date-fns";
  */
 import { TextCell } from "./textCell";
 
-// `exp_end_date` is a Datetime field, so it needs `parseISO` (not the
-// date-only `formatProjectDate` used for the Projects list' Date fields).
 export function DateCell({ isoDate }: { isoDate: string | null }) {
   if (!isoDate) {
     return <TextCell text="N/A" />;

--- a/frontend/packages/app/src/pages/tasks/list/cells/dateCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/dateCell.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies.
+ */
+import { CalendarDeadline } from "@rtcamp/frappe-ui-react/icons";
+import { format, parseISO } from "date-fns";
+
+/**
+ * Internal dependencies.
+ */
+import { TextCell } from "./textCell";
+
+// `exp_end_date` is a Datetime field, so it needs `parseISO` (not the
+// date-only `formatProjectDate` used for the Projects list' Date fields).
+export function DateCell({ isoDate }: { isoDate: string | null }) {
+  if (!isoDate) {
+    return <TextCell text="N/A" />;
+  }
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5 text-ink-gray-6 text-base">
+      <CalendarDeadline className="size-4 shrink-0 text-ink-gray-6" />
+      <span className="truncate">
+        {format(parseISO(isoDate), "MMM d, yyyy")}
+      </span>
+    </span>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies.
+ */
+import { DateCell } from "./dateCell";
+import { LikeCell } from "./likeCell";
+import { PriorityCell } from "./priorityCell";
+import { StatusCell } from "./statusCell";
+import { SubjectCell } from "./subjectCell";
+import { TextCell } from "./textCell";
+import type { ListViewColumn } from "../../types";
+import type { TaskListItem } from "../types";
+
+export function TaskListCell({
+  row,
+  column,
+  onOpenTask,
+}: {
+  row: TaskListItem;
+  column: ListViewColumn;
+  onOpenTask?: (taskName: string) => void;
+}) {
+  switch (column.key) {
+    case "subject":
+      return (
+        <SubjectCell
+          name={row.name}
+          subject={row.subject}
+          onOpenTask={onOpenTask}
+        />
+      );
+    case "project_name":
+      return <TextCell text={row.project_name} />;
+    case "status":
+      return <StatusCell status={row.status} />;
+    case "priority":
+      return <PriorityCell priority={row.priority} />;
+    case "exp_end_date":
+      return <DateCell isoDate={row.exp_end_date} />;
+    case "like":
+      return <LikeCell name={row.name} likedBy={row._liked_by} />;
+    default:
+      return null;
+  }
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
@@ -1,11 +1,14 @@
 /**
  * Internal dependencies.
  */
+import type { OpenAddTimeDialogOptions } from "@/pages/timesheet/outletContext";
+import { AddTimeCell } from "./addTimeCell";
 import { DateCell } from "./dateCell";
 import { LikeCell } from "./likeCell";
 import { PriorityCell } from "./priorityCell";
 import { StatusCell } from "./statusCell";
 import { SubjectCell } from "./subjectCell";
+import { TaskRowActions } from "./taskRowActions";
 import { TextCell } from "./textCell";
 import type { ListViewColumn } from "../../types";
 import type { TaskListItem } from "../types";
@@ -14,10 +17,14 @@ export function TaskListCell({
   row,
   column,
   onOpenTask,
+  onAddTime,
+  onDeleteTask,
 }: {
   row: TaskListItem;
   column: ListViewColumn;
   onOpenTask?: (taskName: string) => void;
+  onAddTime?: (prefill: OpenAddTimeDialogOptions) => void;
+  onDeleteTask?: (name: string) => void;
 }) {
   switch (column.key) {
     case "subject":
@@ -36,8 +43,12 @@ export function TaskListCell({
       return <PriorityCell priority={row.priority} />;
     case "exp_end_date":
       return <DateCell isoDate={row.exp_end_date} />;
+    case "add_time":
+      return <AddTimeCell row={row} onAddTime={onAddTime} />;
     case "like":
       return <LikeCell name={row.name} likedBy={row._liked_by} />;
+    case "actions":
+      return <TaskRowActions name={row.name} onDelete={onDeleteTask} />;
     default:
       return null;
   }

--- a/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
@@ -3,7 +3,7 @@
  */
 import { useEffect } from "react";
 import { useToggleLike } from "@next-pms/hooks";
-import { useToasts } from "@rtcamp/frappe-ui-react";
+import { Tooltip, useToasts } from "@rtcamp/frappe-ui-react";
 import { Star, SolidStar } from "@rtcamp/frappe-ui-react/icons";
 
 /**
@@ -11,14 +11,17 @@ import { Star, SolidStar } from "@rtcamp/frappe-ui-react/icons";
  */
 import { isLiked, parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
+import { useTaskList } from "../context";
 
 export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
   const currentUser = useUser(({ state }) => state.currentUser);
+  const refresh = useTaskList((c) => c.actions.refresh);
   const toast = useToasts();
   const { liked, isToggling, error, toggle } = useToggleLike({
     doctype: "Task",
     name,
     liked: isLiked(likedBy, currentUser ?? ""),
+    onToggled: refresh,
   });
 
   useEffect(() => {
@@ -33,36 +36,38 @@ export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
   const handleToggle = () => void toggle();
 
   return (
-    // A native <button> can't be used here: ListRow already wraps every cell
-    // in a <button>, and nested buttons are invalid HTML / trigger a React
-    // DOM-nesting warning.
-    <div
-      role="button"
-      tabIndex={isToggling ? -1 : 0}
-      aria-disabled={isToggling}
-      onClick={(e) => {
-        e.stopPropagation();
-        if (!isToggling) handleToggle();
-      }}
-      onKeyDown={(e) => {
-        if (
-          !isToggling &&
-          e.target === e.currentTarget &&
-          (e.key === "Enter" || e.key === " ")
-        ) {
-          e.preventDefault();
+    <Tooltip text={liked ? "Unstar task" : "Star task"}>
+      {/* A native <button> can't be used here: ListRow already wraps every
+      cell in a <button>, and nested buttons are invalid HTML / trigger a
+      React DOM-nesting warning. */}
+      <div
+        role="button"
+        tabIndex={isToggling ? -1 : 0}
+        aria-disabled={isToggling}
+        onClick={(e) => {
           e.stopPropagation();
-          handleToggle();
-        }
-      }}
-      aria-label={liked ? "Unstar task" : "Star task"}
-      className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
-    >
-      {liked ? (
-        <SolidStar className="text-ink-amber-2" size={16} />
-      ) : (
-        <Star className="text-ink-gray-4" size={16} />
-      )}
-    </div>
+          if (!isToggling) handleToggle();
+        }}
+        onKeyDown={(e) => {
+          if (
+            !isToggling &&
+            e.target === e.currentTarget &&
+            (e.key === "Enter" || e.key === " ")
+          ) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleToggle();
+          }
+        }}
+        aria-label={liked ? "Unstar task" : "Star task"}
+        className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
+      >
+        {liked ? (
+          <SolidStar className="text-ink-amber-2" size={16} />
+        ) : (
+          <Star className="text-ink-gray-4" size={16} />
+        )}
+      </div>
+    </Tooltip>
   );
 }

--- a/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies.
+ */
+import { useEffect } from "react";
+import { useToggleLike } from "@next-pms/hooks";
+import { useToasts } from "@rtcamp/frappe-ui-react";
+import { Star, SolidStar } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { isLiked, parseFrappeErrorMsg } from "@/lib/utils";
+import { useUser } from "@/providers/user";
+
+export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
+  const currentUser = useUser(({ state }) => state.currentUser);
+  const toast = useToasts();
+  const { liked, isToggling, error, toggle } = useToggleLike({
+    doctype: "Task",
+    name,
+    liked: isLiked(likedBy, currentUser ?? ""),
+  });
+
+  useEffect(() => {
+    if (error) {
+      toast.error(
+        parseFrappeErrorMsg(error as Parameters<typeof parseFrappeErrorMsg>[0]),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error]);
+
+  const handleToggle = () => void toggle();
+
+  return (
+    // A native <button> can't be used here: ListRow already wraps every cell
+    // in a <button>, and nested buttons are invalid HTML / trigger a React
+    // DOM-nesting warning.
+    <div
+      role="button"
+      tabIndex={isToggling ? -1 : 0}
+      aria-disabled={isToggling}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!isToggling) handleToggle();
+      }}
+      onKeyDown={(e) => {
+        if (
+          !isToggling &&
+          e.target === e.currentTarget &&
+          (e.key === "Enter" || e.key === " ")
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          handleToggle();
+        }
+      }}
+      aria-label={liked ? "Unstar task" : "Star task"}
+      className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
+    >
+      {liked ? (
+        <SolidStar className="text-ink-amber-2" size={16} />
+      ) : (
+        <Star className="text-ink-gray-4" size={16} />
+      )}
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
@@ -33,8 +33,6 @@ export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [error]);
 
-  const handleToggle = () => void toggle();
-
   return (
     <Tooltip text={liked ? "Unstar task" : "Star task"}>
       {/* A native <button> can't be used here: ListRow already wraps every
@@ -46,7 +44,7 @@ export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
         aria-disabled={isToggling}
         onClick={(e) => {
           e.stopPropagation();
-          if (!isToggling) handleToggle();
+          if (!isToggling) toggle();
         }}
         onKeyDown={(e) => {
           if (
@@ -56,7 +54,7 @@ export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
           ) {
             e.preventDefault();
             e.stopPropagation();
-            handleToggle();
+            toggle();
           }
         }}
         aria-label={liked ? "Unstar task" : "Star task"}

--- a/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/likeCell.tsx
@@ -63,9 +63,9 @@ export function LikeCell({ name, likedBy }: { name: string; likedBy: string }) {
         className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
       >
         {liked ? (
-          <SolidStar className="text-ink-amber-2" size={16} />
+          <SolidStar className="text-ink-amber-2 size-4" />
         ) : (
-          <Star className="text-ink-gray-4" size={16} />
+          <Star className="text-ink-gray-4 size-4" />
         )}
       </div>
     </Tooltip>

--- a/frontend/packages/app/src/pages/tasks/list/cells/priorityCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/priorityCell.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies.
+ */
+import { SolidDotLg } from "@rtcamp/frappe-ui-react/icons";
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Internal dependencies.
+ */
+import { pickAllowed } from "@/lib/utils";
+import { TextCell } from "./textCell";
+import { TASK_PRIORITIES } from "../../constants";
+import type { TaskPriority } from "../../types";
+
+const priorityDotVariants = cva("size-4 shrink-0", {
+  variants: {
+    priority: {
+      Low: "text-ink-gray-4",
+      Medium: "text-ink-blue-3",
+      High: "text-ink-amber-3",
+      Urgent: "text-ink-red-3",
+    } satisfies Record<TaskPriority, string>,
+  },
+});
+
+export type PriorityDotProps = VariantProps<typeof priorityDotVariants>;
+
+export function PriorityCell({ priority }: { priority?: string }) {
+  const value = pickAllowed<TaskPriority>(priority, TASK_PRIORITIES);
+
+  if (!value) {
+    return <TextCell text="N/A" />;
+  }
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-ink-gray-6 text-base">
+      <SolidDotLg className={priorityDotVariants({ priority: value })} />
+      <span className="truncate">{value}</span>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/priorityCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/priorityCell.tsx
@@ -1,10 +1,4 @@
 /**
- * External dependencies.
- */
-import { SolidDotLg } from "@rtcamp/frappe-ui-react/icons";
-import { cva, type VariantProps } from "class-variance-authority";
-
-/**
  * Internal dependencies.
  */
 import { pickAllowed } from "@/lib/utils";
@@ -12,29 +6,11 @@ import { TextCell } from "./textCell";
 import { TASK_PRIORITIES } from "../../constants";
 import type { TaskPriority } from "../../types";
 
-const priorityDotVariants = cva("size-4 shrink-0", {
-  variants: {
-    priority: {
-      Low: "text-ink-gray-4",
-      Medium: "text-ink-blue-3",
-      High: "text-ink-amber-3",
-      Urgent: "text-ink-red-3",
-    } satisfies Record<TaskPriority, string>,
-  },
-});
-
-export type PriorityDotProps = VariantProps<typeof priorityDotVariants>;
-
 export function PriorityCell({ priority }: { priority?: string }) {
   const value = pickAllowed<TaskPriority>(priority, TASK_PRIORITIES);
 
   if (!value) {
     return <TextCell text="N/A" />;
   }
-  return (
-    <div className="flex min-w-0 items-center gap-2 text-ink-gray-6 text-base">
-      <SolidDotLg className={priorityDotVariants({ priority: value })} />
-      <span className="truncate">{value}</span>
-    </div>
-  );
+  return <TextCell text={value} />;
 }

--- a/frontend/packages/app/src/pages/tasks/list/cells/statusCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/statusCell.tsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies.
+ */
+import { TaskStatus, taskStatusMap } from "@next-pms/design-system/components";
+
+export function StatusCell({ status }: { status: string }) {
+  const statusKey = taskStatusMap[status] ?? "open";
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-ink-gray-6 text-base">
+      <TaskStatus status={statusKey} />
+      <span className="truncate">{status}</span>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/subjectCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/subjectCell.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies.
+ */
+import { mergeClassNames } from "@next-pms/design-system";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
+
+export function SubjectCell({
+  name,
+  subject,
+  onOpenTask,
+}: {
+  name: string;
+  subject: string;
+  onOpenTask?: (taskName: string) => void;
+}) {
+  const handleOpen = () => onOpenTask?.(name);
+
+  return (
+    <Tooltip text={subject}>
+      {/* A native <button> can't be used here: ListRow already wraps every
+          cell in a <button>, and nested buttons are invalid HTML / trigger
+          a React DOM-nesting warning. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleOpen();
+        }}
+        onKeyDown={(e) => {
+          if (
+            e.target === e.currentTarget &&
+            (e.key === "Enter" || e.key === " ")
+          ) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleOpen();
+          }
+        }}
+        className={mergeClassNames(
+          "inline-flex items-center justify-start w-full h-7 px-0 rounded text-base font-medium text-left cursor-pointer",
+          "text-ink-gray-8 bg-transparent hover:bg-surface-gray-3 active:bg-surface-gray-4",
+          "focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 transition-colors",
+        )}
+      >
+        <span className="ml-2 truncate">{subject}</span>
+      </div>
+    </Tooltip>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
@@ -37,7 +37,7 @@ export function TaskRowActions({
         aria-label="Task actions"
         className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
       >
-        <DotHorizontal className="text-ink-gray-6" size={16} />
+        <DotHorizontal className="text-ink-gray-6 size-4" />
       </div>
     </Dropdown>
   );

--- a/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
@@ -16,10 +16,6 @@ export function TaskRowActions({
       placement="center"
       options={[
         {
-          key: "edit",
-          label: "Edit",
-        },
-        {
           key: "delete",
           label: "Delete",
           theme: "red",

--- a/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies.
+ */
+import { Dropdown } from "@rtcamp/frappe-ui-react";
+import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
+
+export function TaskRowActions({
+  name,
+  onDelete,
+}: {
+  name: string;
+  onDelete?: (name: string) => void;
+}) {
+  return (
+    <Dropdown
+      placement="center"
+      options={[
+        {
+          key: "edit",
+          label: "Edit",
+        },
+        {
+          key: "delete",
+          label: "Delete",
+          theme: "red",
+          onClick: () => onDelete?.(name),
+        },
+      ]}
+    >
+      {/* A native <button> can't be used here: ListRow already wraps every
+      cell in a <button>, and nested buttons are invalid HTML / trigger a
+      React DOM-nesting warning. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={(e) => e.stopPropagation()}
+        aria-label="Task actions"
+        className="inline-flex w-4 h-4 shrink-0 cursor-pointer items-center justify-center focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 rounded"
+      >
+        <DotHorizontal className="text-ink-gray-6" size={16} />
+      </div>
+    </Dropdown>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/textCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/textCell.tsx
@@ -1,0 +1,7 @@
+export function TextCell({ text }: { text?: number | string | null }) {
+  return (
+    <span className="block truncate text-ink-gray-6 text-base">
+      {text || "N/A"}
+    </span>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/cells/textCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/textCell.tsx
@@ -1,7 +1,7 @@
 export function TextCell({ text }: { text?: number | string | null }) {
   return (
     <span className="block truncate text-ink-gray-6 text-base">
-      {text || "N/A"}
+      {text === null || text === undefined || text === "" ? "N/A" : text}
     </span>
   );
 }

--- a/frontend/packages/app/src/pages/tasks/list/columns.ts
+++ b/frontend/packages/app/src/pages/tasks/list/columns.ts
@@ -1,0 +1,8 @@
+export const TASK_LIST_COLUMNS = [
+  { key: "subject", label: "Subject", width: "280px" },
+  { key: "project_name", label: "Project", width: "200px" },
+  { key: "status", label: "Status", width: "160px" },
+  { key: "priority", label: "Priority", width: "120px" },
+  { key: "exp_end_date", label: "Due date", width: "140px" },
+  { key: "like", label: "", width: "48px" },
+];

--- a/frontend/packages/app/src/pages/tasks/list/columns.ts
+++ b/frontend/packages/app/src/pages/tasks/list/columns.ts
@@ -4,5 +4,7 @@ export const TASK_LIST_COLUMNS = [
   { key: "status", label: "Status", width: "160px" },
   { key: "priority", label: "Priority", width: "120px" },
   { key: "exp_end_date", label: "Due date", width: "140px" },
+  { key: "add_time", label: "", width: "48px" },
   { key: "like", label: "", width: "48px" },
+  { key: "actions", label: "", width: "48px" },
 ];

--- a/frontend/packages/app/src/pages/tasks/list/context.ts
+++ b/frontend/packages/app/src/pages/tasks/list/context.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies.
+ */
+import { createContext, useContextSelector } from "use-context-selector";
+
+/**
+ * Internal dependencies.
+ */
+import type { TaskListItem } from "./types";
+
+export interface TaskListContextProps {
+  state: {
+    data: TaskListItem[];
+    hasMore: boolean;
+    isLoading: boolean;
+    error: unknown;
+  };
+  actions: {
+    loadMore: () => void;
+  };
+}
+
+const noop = () => {};
+
+export const TaskListContext = createContext<TaskListContextProps>({
+  state: {
+    data: [],
+    hasMore: false,
+    isLoading: false,
+    error: null,
+  },
+  actions: {
+    loadMore: noop,
+  },
+});
+
+export const useTaskList = <T>(selector: (state: TaskListContextProps) => T) =>
+  useContextSelector(TaskListContext, selector);

--- a/frontend/packages/app/src/pages/tasks/list/context.ts
+++ b/frontend/packages/app/src/pages/tasks/list/context.ts
@@ -18,10 +18,12 @@ export interface TaskListContextProps {
   actions: {
     loadMore: () => void;
     refresh: () => void;
+    deleteTask: (name: string) => Promise<void>;
   };
 }
 
 const noop = () => {};
+const noopAsync = async () => {};
 
 export const TaskListContext = createContext<TaskListContextProps>({
   state: {
@@ -33,6 +35,7 @@ export const TaskListContext = createContext<TaskListContextProps>({
   actions: {
     loadMore: noop,
     refresh: noop,
+    deleteTask: noopAsync,
   },
 });
 

--- a/frontend/packages/app/src/pages/tasks/list/context.ts
+++ b/frontend/packages/app/src/pages/tasks/list/context.ts
@@ -17,6 +17,7 @@ export interface TaskListContextProps {
   };
   actions: {
     loadMore: () => void;
+    refresh: () => void;
   };
 }
 
@@ -31,6 +32,7 @@ export const TaskListContext = createContext<TaskListContextProps>({
   },
   actions: {
     loadMore: noop,
+    refresh: noop,
   },
 });
 

--- a/frontend/packages/app/src/pages/tasks/list/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies.
+ */
+import { TaskListProvider } from "./provider";
+import TaskListView from "./view";
+import TasksHeader from "../components/header";
+import { TaskListSubHeader } from "../components/subHeader";
+
+function TaskListPage() {
+  return (
+    <TaskListProvider>
+      <TasksHeader />
+      <TaskListSubHeader />
+      <TaskListView />
+    </TaskListProvider>
+  );
+}
+
+export default TaskListPage;

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -53,7 +53,7 @@ export function TaskListProvider({ children }: PropsWithChildren) {
     [querySignature],
   );
 
-  const { data, error, isLoading, isValidating, size, setSize } =
+  const { data, error, isLoading, isValidating, size, setSize, mutate } =
     usePagination<ResponseTaskList>(
       "next_pms.timesheet.api.task.get_task_list",
       getKey,
@@ -88,6 +88,10 @@ export function TaskListProvider({ children }: PropsWithChildren) {
     void setSize((s) => s + 1);
   }, [isLoading, isNextPageLoading, hasMore, setSize]);
 
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+
   const value: TaskListContextProps = useMemo(
     () => ({
       state: {
@@ -98,9 +102,10 @@ export function TaskListProvider({ children }: PropsWithChildren) {
       },
       actions: {
         loadMore,
+        refresh,
       },
     }),
-    [tasks, hasMore, isLoading, error, loadMore],
+    [tasks, hasMore, isLoading, error, loadMore, refresh],
   );
 
   return (

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -3,17 +3,21 @@
  */
 import { useCallback, useMemo, type PropsWithChildren } from "react";
 import { type PaginationKey, usePagination } from "@next-pms/hooks";
+import { useToasts } from "@rtcamp/frappe-ui-react";
+import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
-import { buildFilterConditions } from "@/lib/utils";
+import { buildFilterConditions, parseFrappeErrorMsg } from "@/lib/utils";
 import { TASK_LIST_PAGE_SIZE } from "../constants";
 import { TaskListContext, type TaskListContextProps } from "./context";
 import type { ResponseTaskList } from "./types";
 import { useTaskFilters } from "../useTaskFilters";
 
 export function TaskListProvider({ children }: PropsWithChildren) {
+  const toast = useToasts();
+  const { deleteDoc } = useFrappeDeleteDoc();
   const { filters, sort } = useTaskFilters();
   const frappeFilters = useMemo(
     () => buildFilterConditions(filters.advanced),
@@ -92,6 +96,19 @@ export function TaskListProvider({ children }: PropsWithChildren) {
     mutate();
   }, [mutate]);
 
+  const deleteTask = useCallback(
+    async (name: string) => {
+      try {
+        await deleteDoc("Task", name);
+        refresh();
+        toast.success("Task deleted");
+      } catch (err) {
+        toast.error(parseFrappeErrorMsg(err as FrappeError));
+      }
+    },
+    [deleteDoc, refresh],
+  );
+
   const value: TaskListContextProps = useMemo(
     () => ({
       state: {
@@ -103,9 +120,10 @@ export function TaskListProvider({ children }: PropsWithChildren) {
       actions: {
         loadMore,
         refresh,
+        deleteTask,
       },
     }),
-    [tasks, hasMore, isLoading, error, loadMore, refresh],
+    [tasks, hasMore, isLoading, error, loadMore, refresh, deleteTask],
   );
 
   return (

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -1,0 +1,111 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useMemo, type PropsWithChildren } from "react";
+import { type PaginationKey, usePagination } from "@next-pms/hooks";
+
+/**
+ * Internal dependencies.
+ */
+import { buildFilterConditions } from "@/lib/utils";
+import { TASK_LIST_PAGE_SIZE } from "../constants";
+import { TaskListContext, type TaskListContextProps } from "./context";
+import type { ResponseTaskList } from "./types";
+import { useTaskFilters } from "../useTaskFilters";
+
+export function TaskListProvider({ children }: PropsWithChildren) {
+  const { filters, sort } = useTaskFilters();
+  const frappeFilters = useMemo(
+    () => buildFilterConditions(filters.advanced),
+    [filters.advanced],
+  );
+
+  const querySignature = useMemo(
+    () =>
+      JSON.stringify({
+        search: filters.search,
+        project: filters.project,
+        status: filters.status,
+        frappeFilters,
+        order_by: sort.field ? `${sort.field} ${sort.order}` : undefined,
+        page_length: TASK_LIST_PAGE_SIZE,
+      }),
+    [
+      filters.search,
+      filters.project,
+      filters.status,
+      frappeFilters,
+      sort.field,
+      sort.order,
+    ],
+  );
+
+  const getKey = useCallback(
+    (
+      pageIndex: number,
+      previousPageData: ResponseTaskList | null,
+    ): PaginationKey | null => {
+      if (previousPageData?.message && !previousPageData.message.has_more) {
+        return null;
+      }
+      return [querySignature, pageIndex] as const;
+    },
+    [querySignature],
+  );
+
+  const { data, error, isLoading, isValidating, size, setSize } =
+    usePagination<ResponseTaskList>(
+      "next_pms.timesheet.api.task.get_task_list",
+      getKey,
+      {
+        search: filters.search,
+        projects: filters.project ? [filters.project] : undefined,
+        status: filters.status.length ? filters.status : undefined,
+        filters: frappeFilters,
+        order_by: sort.field ? `${sort.field} ${sort.order}` : undefined,
+        page_length: TASK_LIST_PAGE_SIZE,
+      },
+      {
+        revalidateOnFocus: false,
+        revalidateAll: false,
+        revalidateFirstPage: false,
+        keepPreviousData: false,
+      },
+    );
+
+  const tasks = useMemo(
+    () => (data ?? []).flatMap((page) => page.message?.task ?? []),
+    [data],
+  );
+
+  const lastPage = data?.at(-1);
+  const hasMore = lastPage ? Boolean(lastPage.message?.has_more) : true;
+  const isNextPageLoading =
+    !isLoading && isValidating && typeof data?.[size - 1] === "undefined";
+
+  const loadMore = useCallback(() => {
+    if (isLoading || isNextPageLoading || !hasMore) return;
+    void setSize((s) => s + 1);
+  }, [isLoading, isNextPageLoading, hasMore, setSize]);
+
+  const value: TaskListContextProps = useMemo(
+    () => ({
+      state: {
+        data: tasks,
+        hasMore,
+        isLoading,
+        error,
+      },
+      actions: {
+        loadMore,
+      },
+    }),
+    [tasks, hasMore, isLoading, error, loadMore],
+  );
+
+  return (
+    <TaskListContext.Provider value={value}>
+      {children}
+    </TaskListContext.Provider>
+  );
+}

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -85,11 +85,11 @@ export function TaskListProvider({ children }: PropsWithChildren) {
 
   const loadMore = useCallback(() => {
     if (isLoading || isNextPageLoading || !hasMore) return;
-    void setSize((s) => s + 1);
+    setSize((s) => s + 1);
   }, [isLoading, isNextPageLoading, hasMore, setSize]);
 
   const refresh = useCallback(() => {
-    void mutate();
+    mutate();
   }, [mutate]);
 
   const value: TaskListContextProps = useMemo(

--- a/frontend/packages/app/src/pages/tasks/list/types.ts
+++ b/frontend/packages/app/src/pages/tasks/list/types.ts
@@ -1,0 +1,21 @@
+export type TaskListItem = {
+  name: string;
+  subject: string;
+  project: string;
+  project_name: string | null;
+  status: string;
+  priority: string;
+  exp_end_date: string | null;
+  actual_time: number;
+  expected_time: number;
+  custom_is_billable?: boolean;
+  _liked_by: string;
+};
+
+export type ResponseTaskList = {
+  message: {
+    task: TaskListItem[];
+    total_count: number;
+    has_more: boolean;
+  };
+};

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -1,21 +1,28 @@
 /**
  * External dependencies.
  */
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { getTodayDate } from "@next-pms/design-system";
+import { DeleteActionDialog } from "@next-pms/design-system/components";
 import {
   ListHeader,
   ListHeaderItem,
   ListRow,
   ListRows,
   ListView,
+  useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { ArrowDown, ArrowUp } from "@rtcamp/frappe-ui-react/icons";
+import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
 import { InfiniteScroll } from "@/components/infiniteScroll";
 import PersonalTaskLog from "@/components/task-log/personalTaskLog";
+import { parseFrappeErrorMsg } from "@/lib/utils";
+import AddTime from "@/pages/timesheet/components/add-time";
+import type { OpenAddTimeDialogOptions } from "@/pages/timesheet/outletContext";
 import { TaskListCell } from "./cells";
 import { TASK_LIST_COLUMNS } from "./columns";
 import { useTaskList } from "./context";
@@ -31,8 +38,33 @@ function TaskList() {
   const isLoading = useTaskList((c) => c.state.isLoading);
   const hasMore = useTaskList((c) => c.state.hasMore);
   const loadMore = useTaskList((c) => c.actions.loadMore);
+  const refresh = useTaskList((c) => c.actions.refresh);
   const { sort, setSort } = useTaskFilters();
   const [openTask, setOpenTask] = useState<string | null>(null);
+  const [addTimePrefill, setAddTimePrefill] =
+    useState<OpenAddTimeDialogOptions>({ date: getTodayDate() });
+  const [isAddTimeOpen, setIsAddTimeOpen] = useState(false);
+  const [deleteTaskName, setDeleteTaskName] = useState<string | null>(null);
+  const { deleteDoc } = useFrappeDeleteDoc();
+  const toast = useToasts();
+
+  const handleAddTime = useCallback((prefill: OpenAddTimeDialogOptions) => {
+    setAddTimePrefill({ date: getTodayDate(), ...prefill });
+    setIsAddTimeOpen(true);
+  }, []);
+
+  const handleDeleteTask = useCallback(
+    async (name: string) => {
+      try {
+        await deleteDoc("Task", name);
+        refresh();
+        toast.success("Task deleted");
+      } catch (err) {
+        toast.error(parseFrappeErrorMsg(err as FrappeError));
+      }
+    },
+    [deleteDoc, refresh, toast],
+  );
 
   const handleHeaderClick = (sortField: string) => {
     if (sort.field === sortField) {
@@ -107,6 +139,8 @@ function TaskList() {
                       row={row}
                       column={column}
                       onOpenTask={setOpenTask}
+                      onAddTime={handleAddTime}
+                      onDeleteTask={setDeleteTaskName}
                     />
                   ))}
                 </ListRow>
@@ -120,6 +154,23 @@ function TaskList() {
           task={openTask}
           open={Boolean(openTask)}
           onOpenChange={(open) => !open && setOpenTask(null)}
+        />
+      )}
+      <AddTime
+        initialDate={addTimePrefill.date || getTodayDate()}
+        open={isAddTimeOpen}
+        onOpenChange={setIsAddTimeOpen}
+        project={addTimePrefill.project}
+        projectLabel={addTimePrefill.projectLabel}
+        task={addTimePrefill.task}
+        taskLabel={addTimePrefill.taskLabel}
+      />
+      {deleteTaskName && (
+        <DeleteActionDialog
+          title="Delete task"
+          description="Are you sure you want to delete this task? This action cannot be undone."
+          onClose={() => setDeleteTaskName(null)}
+          onConfirm={() => handleDeleteTask(deleteTaskName)}
         />
       )}
     </>

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -10,10 +10,8 @@ import {
   ListRow,
   ListRows,
   ListView,
-  useToasts,
 } from "@rtcamp/frappe-ui-react";
 import { ArrowDown, ArrowUp } from "@rtcamp/frappe-ui-react/icons";
-import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
@@ -21,7 +19,6 @@ import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
 import { InfiniteScroll } from "@/components/infiniteScroll";
 import PersonalTaskLog from "@/components/task-log/personalTaskLog";
 import TeamTaskLog from "@/components/task-log/teamTaskLog";
-import { parseFrappeErrorMsg } from "@/lib/utils";
 import AddTime from "@/pages/timesheet/components/add-time";
 import type { OpenAddTimeDialogOptions } from "@/pages/timesheet/outletContext";
 import { useUser } from "@/providers/user";
@@ -40,7 +37,7 @@ function TaskList() {
   const isLoading = useTaskList((c) => c.state.isLoading);
   const hasMore = useTaskList((c) => c.state.hasMore);
   const loadMore = useTaskList((c) => c.actions.loadMore);
-  const refresh = useTaskList((c) => c.actions.refresh);
+  const deleteTask = useTaskList((c) => c.actions.deleteTask);
   const { sort, setSort } = useTaskFilters();
   const roles = useUser(({ state }) => state.roles);
   const showTeamTaskLog =
@@ -50,26 +47,11 @@ function TaskList() {
     useState<OpenAddTimeDialogOptions>({ date: getTodayDate() });
   const [isAddTimeOpen, setIsAddTimeOpen] = useState(false);
   const [deleteTaskName, setDeleteTaskName] = useState<string | null>(null);
-  const { deleteDoc } = useFrappeDeleteDoc();
-  const toast = useToasts();
 
   const handleAddTime = useCallback((prefill: OpenAddTimeDialogOptions) => {
     setAddTimePrefill({ date: getTodayDate(), ...prefill });
     setIsAddTimeOpen(true);
   }, []);
-
-  const handleDeleteTask = useCallback(
-    async (name: string) => {
-      try {
-        await deleteDoc("Task", name);
-        refresh();
-        toast.success("Task deleted");
-      } catch (err) {
-        toast.error(parseFrappeErrorMsg(err as FrappeError));
-      }
-    },
-    [deleteDoc, refresh, toast],
-  );
 
   const handleHeaderClick = (sortField: string) => {
     if (sort.field === sortField) {
@@ -185,7 +167,7 @@ function TaskList() {
           title="Delete task"
           description="Are you sure you want to delete this task? This action cannot be undone."
           onClose={() => setDeleteTaskName(null)}
-          onConfirm={() => handleDeleteTask(deleteTaskName)}
+          onConfirm={() => deleteTask(deleteTaskName)}
         />
       )}
     </>

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -20,9 +20,11 @@ import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
  */
 import { InfiniteScroll } from "@/components/infiniteScroll";
 import PersonalTaskLog from "@/components/task-log/personalTaskLog";
+import TeamTaskLog from "@/components/task-log/teamTaskLog";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import AddTime from "@/pages/timesheet/components/add-time";
 import type { OpenAddTimeDialogOptions } from "@/pages/timesheet/outletContext";
+import { useUser } from "@/providers/user";
 import { TaskListCell } from "./cells";
 import { TASK_LIST_COLUMNS } from "./columns";
 import { useTaskList } from "./context";
@@ -40,6 +42,9 @@ function TaskList() {
   const loadMore = useTaskList((c) => c.actions.loadMore);
   const refresh = useTaskList((c) => c.actions.refresh);
   const { sort, setSort } = useTaskFilters();
+  const roles = useUser(({ state }) => state.roles);
+  const showTeamTaskLog =
+    roles.includes("Projects Manager") || roles.includes("Timesheet Manager");
   const [openTask, setOpenTask] = useState<string | null>(null);
   const [addTimePrefill, setAddTimePrefill] =
     useState<OpenAddTimeDialogOptions>({ date: getTodayDate() });
@@ -149,13 +154,20 @@ function TaskList() {
           )}
         </ListRows>
       </ListView>
-      {openTask && (
-        <PersonalTaskLog
-          task={openTask}
-          open={Boolean(openTask)}
-          onOpenChange={(open) => !open && setOpenTask(null)}
-        />
-      )}
+      {openTask &&
+        (showTeamTaskLog ? (
+          <TeamTaskLog
+            task={openTask}
+            open={Boolean(openTask)}
+            onOpenChange={(open) => !open && setOpenTask(null)}
+          />
+        ) : (
+          <PersonalTaskLog
+            task={openTask}
+            open={Boolean(openTask)}
+            onOpenChange={(open) => !open && setOpenTask(null)}
+          />
+        ))}
       <AddTime
         initialDate={addTimePrefill.date || getTodayDate()}
         open={isAddTimeOpen}

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { useCallback, useState } from "react";
-import { getTodayDate } from "@next-pms/design-system";
+import { getTodayDate, mergeClassNames as cn } from "@next-pms/design-system";
 import { DeleteActionDialog } from "@next-pms/design-system/components";
 import {
   ListHeader,
@@ -106,7 +106,10 @@ function TaskList() {
             return (
               <ListHeaderItem key={column.key} item={column}>
                 <div
-                  className={`flex h-7 items-center gap-1 py-1.5${sortField ? " cursor-pointer select-none" : ""}`}
+                  className={cn(
+                    "flex h-7 items-center gap-1 py-1.5",
+                    sortField && "cursor-pointer select-none",
+                  )}
                   onClick={
                     sortField ? () => handleHeaderClick(sortField) : undefined
                   }

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -1,0 +1,129 @@
+/**
+ * External dependencies.
+ */
+import { useState } from "react";
+import {
+  ListHeader,
+  ListHeaderItem,
+  ListRow,
+  ListRows,
+  ListView,
+} from "@rtcamp/frappe-ui-react";
+import { ArrowDown, ArrowUp } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { InfiniteScroll } from "@/components/infiniteScroll";
+import PersonalTaskLog from "@/components/task-log/personalTaskLog";
+import { TaskListCell } from "./cells";
+import { TASK_LIST_COLUMNS } from "./columns";
+import { useTaskList } from "./context";
+import { TASK_LIST_PAGE_SIZE, TASK_SORTABLE_FIELDS } from "../constants";
+import { useTaskFilters } from "../useTaskFilters";
+
+const SORT_FIELD_BY_COLUMN = new Map(
+  TASK_SORTABLE_FIELDS.map((f) => [f.column as string, f.field as string]),
+);
+
+function TaskList() {
+  const data = useTaskList((c) => c.state.data);
+  const isLoading = useTaskList((c) => c.state.isLoading);
+  const hasMore = useTaskList((c) => c.state.hasMore);
+  const loadMore = useTaskList((c) => c.actions.loadMore);
+  const { sort, setSort } = useTaskFilters();
+  const [openTask, setOpenTask] = useState<string | null>(null);
+
+  const handleHeaderClick = (sortField: string) => {
+    if (sort.field === sortField) {
+      setSort({
+        field: sortField,
+        order: sort.order === "asc" ? "desc" : "asc",
+      });
+    } else {
+      setSort({ field: sortField, order: "desc" });
+    }
+  };
+
+  return (
+    <>
+      <ListView
+        className="px-5 py-0 scrollbar-thin"
+        columns={TASK_LIST_COLUMNS}
+        rows={data}
+        rowKey="name"
+        options={{
+          options: {
+            selectable: false,
+            showTooltip: true,
+            resizeColumn: false,
+          },
+          slots: {
+            cell: TaskListCell,
+          },
+        }}
+      >
+        <ListHeader className="mb-0 rounded-none bg-transparent border-b border-outline-gray-1 p-2 gap-2">
+          {TASK_LIST_COLUMNS.map((column) => {
+            const sortField = SORT_FIELD_BY_COLUMN.get(column.key);
+            return (
+              <ListHeaderItem key={column.key} item={column}>
+                <div
+                  className={`flex h-7 items-center gap-1 py-1.5${sortField ? " cursor-pointer select-none" : ""}`}
+                  onClick={
+                    sortField ? () => handleHeaderClick(sortField) : undefined
+                  }
+                >
+                  <span className="truncate">{column.label}</span>
+                  {sortField &&
+                    sort.field === sortField &&
+                    (sort.order === "asc" ? (
+                      <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
+                    ) : (
+                      <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
+                    ))}
+                </div>
+              </ListHeaderItem>
+            );
+          })}
+        </ListHeader>
+        <ListRows>
+          {data.length === 0 ? (
+            <p className="py-6 text-center text-base text-ink-gray-5">
+              No tasks found.
+            </p>
+          ) : (
+            <InfiniteScroll
+              isLoading={isLoading}
+              hasMore={hasMore}
+              verticalLodMore={loadMore}
+              count={TASK_LIST_PAGE_SIZE}
+            >
+              {data.map((row) => (
+                <ListRow key={row.name} row={row}>
+                  {TASK_LIST_COLUMNS.map((column) => (
+                    <TaskListCell
+                      key={column.key}
+                      row={row}
+                      column={column}
+                      onOpenTask={setOpenTask}
+                    />
+                  ))}
+                </ListRow>
+              ))}
+            </InfiniteScroll>
+          )}
+        </ListRows>
+      </ListView>
+      {openTask && (
+        <PersonalTaskLog
+          task={openTask}
+          open={Boolean(openTask)}
+          onOpenChange={(open) => !open && setOpenTask(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export default TaskList;

--- a/frontend/packages/app/src/pages/tasks/types.ts
+++ b/frontend/packages/app/src/pages/tasks/types.ts
@@ -1,0 +1,16 @@
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+
+import { TASK_PRIORITIES, TASK_STATUSES } from "./constants";
+
+export type ListViewColumn = { key: string; label: string; width?: string };
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+
+export interface TaskListFilters {
+  search: string;
+  project: string;
+  status: TaskStatus[];
+  advanced: FilterCondition[];
+}

--- a/frontend/packages/app/src/pages/tasks/types.ts
+++ b/frontend/packages/app/src/pages/tasks/types.ts
@@ -11,6 +11,7 @@ export type TaskPriority = (typeof TASK_PRIORITIES)[number];
 export interface TaskListFilters {
   search: string;
   project: string;
+  projectLabel: string;
   status: TaskStatus[];
   advanced: FilterCondition[];
 }

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -9,7 +9,7 @@ import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
-import { parseAdvancedFilters } from "@/lib/utils";
+import { parseJSONArrayParam } from "@/lib/utils";
 import type { TaskListFilters, TaskStatus } from "./types";
 
 const FILTER_PARAM_KEYS = [
@@ -30,10 +30,13 @@ export function useTaskFilters() {
       search: searchParams.get("search") ?? "",
       project: searchParams.get("project") ?? "",
       projectLabel: searchParams.get("projectLabel") ?? "",
-      status: JSON.parse(
-        decodeURI(searchParams.get("status") || "[]"),
-      ) as unknown as TaskStatus[],
-      advanced: parseAdvancedFilters(searchParams.get("advanced")),
+      status: parseJSONArrayParam<TaskStatus>(
+        searchParams.get("status"),
+        decodeURI,
+      ),
+      advanced: parseJSONArrayParam<FilterCondition>(
+        searchParams.get("advanced"),
+      ),
     }),
     [searchParams],
   );

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -14,6 +14,7 @@ import type { TaskListFilters, TaskStatus } from "./types";
 const FILTER_PARAM_KEYS = [
   "search",
   "project",
+  "projectLabel",
   "status",
   "advanced",
   "sortField",
@@ -37,6 +38,7 @@ export function useTaskFilters() {
     () => ({
       search: searchParams.get("search") ?? "",
       project: searchParams.get("project") ?? "",
+      projectLabel: searchParams.get("projectLabel") ?? "",
       status: JSON.parse(
         decodeURI(searchParams.get("status") || "[]"),
       ) as unknown as TaskStatus[],
@@ -71,8 +73,19 @@ export function useTaskFilters() {
     [setParam],
   );
   const setProject = useCallback(
-    (v: string) => setParam("project", v),
-    [setParam],
+    (v: string, label?: string) => {
+      setSearchParams(
+        (prev) => {
+          if (v) prev.set("project", v);
+          else prev.delete("project");
+          if (label) prev.set("projectLabel", label);
+          else prev.delete("projectLabel");
+          return prev;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
   const setStatus = useCallback(
     (v: TaskStatus[]) =>

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -47,8 +47,8 @@ export function useTaskFilters() {
 
   const sort: SortState = useMemo(
     () => ({
-      field: searchParams.get("sortField") ?? "subject",
-      order: (searchParams.get("sortOrder") ?? "asc") as SortOrder,
+      field: searchParams.get("sortField") ?? "modified",
+      order: (searchParams.get("sortOrder") ?? "desc") as SortOrder,
     }),
     [searchParams],
   );

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -53,9 +53,10 @@ export function useTaskFilters() {
     (key: string, value: string) =>
       setSearchParams(
         (prev) => {
-          if (value) prev.set(key, value);
-          else prev.delete(key);
-          return prev;
+          const next = new URLSearchParams(prev);
+          if (value) next.set(key, value);
+          else next.delete(key);
+          return next;
         },
         { replace: true },
       ),
@@ -70,11 +71,12 @@ export function useTaskFilters() {
     (v: string, label?: string) => {
       setSearchParams(
         (prev) => {
-          if (v) prev.set("project", v);
-          else prev.delete("project");
-          if (label) prev.set("projectLabel", label);
-          else prev.delete("projectLabel");
-          return prev;
+          const next = new URLSearchParams(prev);
+          if (v) next.set("project", v);
+          else next.delete("project");
+          if (label) next.set("projectLabel", label);
+          else next.delete("projectLabel");
+          return next;
         },
         { replace: true },
       );
@@ -93,28 +95,30 @@ export function useTaskFilters() {
   );
   const setSort = useCallback(
     (v: SortState | null) => {
-      if (!v) {
-        setSearchParams(
-          (prev) => {
-            prev.delete("sortField");
-            prev.delete("sortOrder");
-            return prev;
-          },
-          { replace: true },
-        );
-      } else {
-        setParam("sortField", v.field);
-        setParam("sortOrder", v.order);
-      }
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (!v) {
+            next.delete("sortField");
+            next.delete("sortOrder");
+          } else {
+            next.set("sortField", v.field);
+            next.set("sortOrder", v.order);
+          }
+          return next;
+        },
+        { replace: true },
+      );
     },
-    [setParam],
+    [setSearchParams],
   );
   const resetFilters = useCallback(
     () =>
       setSearchParams(
         (prev) => {
-          for (const key of FILTER_PARAM_KEYS) prev.delete(key);
-          return prev;
+          const next = new URLSearchParams(prev);
+          for (const key of FILTER_PARAM_KEYS) next.delete(key);
+          return next;
         },
         { replace: true },
       ),

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -18,8 +18,6 @@ const FILTER_PARAM_KEYS = [
   "projectLabel",
   "status",
   "advanced",
-  "sortField",
-  "sortOrder",
 ] as const;
 
 export function useTaskFilters() {

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -9,6 +9,7 @@ import type { FilterCondition } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
+import { parseAdvancedFilters } from "@/lib/utils";
 import type { TaskListFilters, TaskStatus } from "./types";
 
 const FILTER_PARAM_KEYS = [
@@ -21,16 +22,6 @@ const FILTER_PARAM_KEYS = [
   "sortOrder",
 ] as const;
 
-const parseAdvanced = (raw: string | null): FilterCondition[] => {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as FilterCondition[]) : [];
-  } catch {
-    return [];
-  }
-};
-
 export function useTaskFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -42,7 +33,7 @@ export function useTaskFilters() {
       status: JSON.parse(
         decodeURI(searchParams.get("status") || "[]"),
       ) as unknown as TaskStatus[],
-      advanced: parseAdvanced(searchParams.get("advanced")),
+      advanced: parseAdvancedFilters(searchParams.get("advanced")),
     }),
     [searchParams],
   );

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -1,0 +1,127 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { SortOrder, SortState } from "@next-pms/design-system/components";
+import type { FilterCondition } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import type { TaskListFilters, TaskStatus } from "./types";
+
+const FILTER_PARAM_KEYS = [
+  "search",
+  "project",
+  "status",
+  "advanced",
+  "sortField",
+  "sortOrder",
+] as const;
+
+const parseAdvanced = (raw: string | null): FilterCondition[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as FilterCondition[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+export function useTaskFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters: TaskListFilters = useMemo(
+    () => ({
+      search: searchParams.get("search") ?? "",
+      project: searchParams.get("project") ?? "",
+      status: JSON.parse(
+        decodeURI(searchParams.get("status") || "[]"),
+      ) as unknown as TaskStatus[],
+      advanced: parseAdvanced(searchParams.get("advanced")),
+    }),
+    [searchParams],
+  );
+
+  const sort: SortState = useMemo(
+    () => ({
+      field: searchParams.get("sortField") ?? "",
+      order: (searchParams.get("sortOrder") ?? "desc") as SortOrder,
+    }),
+    [searchParams],
+  );
+
+  const setParam = useCallback(
+    (key: string, value: string) =>
+      setSearchParams(
+        (prev) => {
+          if (value) prev.set(key, value);
+          else prev.delete(key);
+          return prev;
+        },
+        { replace: true },
+      ),
+    [setSearchParams],
+  );
+
+  const setSearch = useCallback(
+    (v: string) => setParam("search", v),
+    [setParam],
+  );
+  const setProject = useCallback(
+    (v: string) => setParam("project", v),
+    [setParam],
+  );
+  const setStatus = useCallback(
+    (v: TaskStatus[]) =>
+      setParam("status", v.length ? encodeURI(JSON.stringify(v)) : ""),
+    [setParam],
+  );
+  const setAdvanced = useCallback(
+    (v: FilterCondition[]) =>
+      setParam("advanced", v.length ? JSON.stringify(v) : ""),
+    [setParam],
+  );
+  const setSort = useCallback(
+    (v: SortState | null) => {
+      if (!v) {
+        setSearchParams(
+          (prev) => {
+            prev.delete("sortField");
+            prev.delete("sortOrder");
+            return prev;
+          },
+          { replace: true },
+        );
+      } else {
+        setParam("sortField", v.field);
+        setParam("sortOrder", v.order);
+      }
+    },
+    [setParam],
+  );
+  const resetFilters = useCallback(
+    () =>
+      setSearchParams(
+        (prev) => {
+          for (const key of FILTER_PARAM_KEYS) prev.delete(key);
+          return prev;
+        },
+        { replace: true },
+      ),
+    [setSearchParams],
+  );
+
+  return {
+    filters,
+    sort,
+    setSearch,
+    setProject,
+    setStatus,
+    setAdvanced,
+    setSort,
+    resetFilters,
+  };
+}

--- a/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
+++ b/frontend/packages/app/src/pages/tasks/useTaskFilters.ts
@@ -47,8 +47,8 @@ export function useTaskFilters() {
 
   const sort: SortState = useMemo(
     () => ({
-      field: searchParams.get("sortField") ?? "",
-      order: (searchParams.get("sortOrder") ?? "desc") as SortOrder,
+      field: searchParams.get("sortField") ?? "subject",
+      order: (searchParams.get("sortOrder") ?? "asc") as SortOrder,
     }),
     [searchParams],
   );

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -61,7 +61,7 @@ export const routeConfig: Record<
   },
   task: {
     Component: ReactLazyPreload(() => import("@/pages/tasks/list")),
-    allowedRoles: ["Projects Manager", "Timesheet Manager", "Projects User"],
+    allowedRoles: [],
   },
   "timesheet-personal": {
     Component: ReactLazyPreload(() => import("@/pages/timesheet/personal")),
@@ -155,15 +155,7 @@ export function Router() {
               element={<ProjectKanban />}
             />
           </Route>
-          <Route
-            element={
-              <RoleProtectedRoute
-                allowedRoles={routeConfig["task"].allowedRoles}
-              />
-            }
-          >
-            <Route path={ROUTES.task} element={<TaskList />} />
-          </Route>
+          <Route path={ROUTES.task} element={<TaskList />} />
           <Route
             path={`${ROUTES.project}/:projectId`}
             element={<ProjectDetail />}

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -59,6 +59,10 @@ export const routeConfig: Record<
     Component: ReactLazyPreload(() => import("@/pages/projects/kanban")),
     allowedRoles: ["Projects Manager", "Timesheet Manager", "Projects User"],
   },
+  task: {
+    Component: ReactLazyPreload(() => import("@/pages/tasks/list")),
+    allowedRoles: ["Projects Manager", "Timesheet Manager", "Projects User"],
+  },
   "timesheet-personal": {
     Component: ReactLazyPreload(() => import("@/pages/timesheet/personal")),
     allowedRoles: [],
@@ -90,6 +94,7 @@ export function Router() {
   const ManagerDashboard = routeConfig["dashboard-manager"].Component;
   const ProjectList = routeConfig.project.Component;
   const ProjectKanban = routeConfig["project-kanban"].Component;
+  const TaskList = routeConfig.task.Component;
   const TimesheetPersonal = routeConfig["timesheet-personal"].Component;
   const TimesheetTeam = routeConfig["timesheet-team"].Component;
   const TimesheetProject = routeConfig["timesheet-project"].Component;
@@ -149,6 +154,15 @@ export function Router() {
               path={ROUTES["project-kanban"]}
               element={<ProjectKanban />}
             />
+          </Route>
+          <Route
+            element={
+              <RoleProtectedRoute
+                allowedRoles={routeConfig["task"].allowedRoles}
+              />
+            }
+          >
+            <Route path={ROUTES.task} element={<TaskList />} />
           </Route>
           <Route
             path={`${ROUTES.project}/:projectId`}

--- a/frontend/packages/hooks/src/index.ts
+++ b/frontend/packages/hooks/src/index.ts
@@ -9,3 +9,4 @@ export { useQueryParam } from "./useQueryParam";
 export { useFrappeVersionUpdate } from "./useFrappeVersionUpdate";
 export { useProjectPhase } from "./useProjectPhase";
 export { useSavedState } from "./useSavedState";
+export { useToggleLike } from "./useToggleLike";

--- a/frontend/packages/hooks/src/useToggleLike.ts
+++ b/frontend/packages/hooks/src/useToggleLike.ts
@@ -13,11 +13,6 @@ interface UseToggleLikeOptions {
   onToggled?: (liked: boolean) => void;
 }
 
-/**
- * Wraps Frappe core's `frappe.desk.like.toggle_like` with optimistic update
- * and rollback-on-error, so callers don't have to re-implement the
- * like/unlike dance for every doctype that needs a star toggle.
- */
 export const useToggleLike = ({
   doctype,
   name,

--- a/frontend/packages/hooks/src/useToggleLike.ts
+++ b/frontend/packages/hooks/src/useToggleLike.ts
@@ -1,0 +1,53 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useFrappePostCall } from "frappe-react-sdk";
+
+interface UseToggleLikeOptions {
+  doctype: string;
+  name: string;
+  /** Current liked state from the server (e.g. derived from `_liked_by`). */
+  liked: boolean;
+  /** Called after a successful toggle, e.g. to resync a separate liked-items list. */
+  onToggled?: (liked: boolean) => void;
+}
+
+/**
+ * Wraps Frappe core's `frappe.desk.like.toggle_like` with optimistic update
+ * and rollback-on-error, so callers don't have to re-implement the
+ * like/unlike dance for every doctype that needs a star toggle.
+ */
+export const useToggleLike = ({
+  doctype,
+  name,
+  liked,
+  onToggled,
+}: UseToggleLikeOptions) => {
+  const [isLiked, setIsLiked] = useState(liked);
+  const [isToggling, setIsToggling] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const { call } = useFrappePostCall("frappe.desk.like.toggle_like");
+
+  useEffect(() => {
+    setIsLiked(liked);
+  }, [liked]);
+
+  const toggle = useCallback(async () => {
+    const next = !isLiked;
+    setIsLiked(next);
+    setIsToggling(true);
+    setError(null);
+    try {
+      await call({ doctype, name, add: next ? "Yes" : "No" });
+      onToggled?.(next);
+    } catch (err) {
+      setIsLiked(!next);
+      setError(err);
+    } finally {
+      setIsToggling(false);
+    }
+  }, [isLiked, doctype, name, call, onToggled]);
+
+  return { liked: isLiked, isToggling, error, toggle };
+};


### PR DESCRIPTION
## Description

### Task page
- added new task page with simple and composite filters.
- added sorting feature with default to last updated
- clicking a task row opens - personal task log for employee and team task log for PMs
- added like support and refactored old code into a separate reusable hook
- added clock/add time button support for each row
- added kebab menu with delete and edit. delete works, edit will be added in another pr.
NOTE: Most of the code is copy/past of project list page.

### Task log component
- updated task log title to support github link

### Project page
- bug fix: clear all was not clearing the simple filters. this is now fixed.

## Screenshot/Screencast
https://github.com/user-attachments/assets/1c3b7f4c-3899-4377-aba0-4038ccbd2c9f

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1859 #1861