### PR TITLE
feat: add tooltip for Total Project Value label

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/invoiceBurn.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/invoiceBurn.tsx
@@ -61,6 +61,7 @@ export function InvoiceBurnCell() {
         <LegendItem
           className="bg-surface-gray-3"
           label="Total Project Value"
+          labelTooltipText="Total Sales Order Value"
           value={currencyFormat(currency).format(totalAmount ?? 0)}
           labelClassName="text-ink-gray-6"
           valueClassName="font-medium"

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/legendItem.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/legendItem.tsx
@@ -1,11 +1,13 @@
 /**
  * Internal dependencies.
  */
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { mergeClassNames as cn } from "@/lib/utils";
 
 type LegendItemProps = {
   className: string;
   label: string;
+  labelTooltipText?: string;
   value: string;
   labelClassName?: string;
   valueClassName?: string;
@@ -14,15 +16,24 @@ type LegendItemProps = {
 export function LegendItem({
   className,
   label,
+  labelTooltipText,
   value,
   labelClassName,
   valueClassName,
 }: LegendItemProps) {
+  const labelContent = (
+    <span className={cn("truncate", labelClassName)}>{label}</span>
+  );
+
   return (
     <div className="flex items-center gap-2">
       <span className={cn("size-2 shrink-0 rounded-full", className)} />
-      <span className={cn("min-w-0 flex-1 truncate", labelClassName)}>
-        {label}
+      <span className="min-w-0 flex-1">
+        {labelTooltipText ? (
+          <Tooltip text={labelTooltipText}>{labelContent}</Tooltip>
+        ) : (
+          labelContent
+        )}
       </span>
       <span className={cn(valueClassName)}>{value}</span>
     </div>


### PR DESCRIPTION
## Description

Add tooltip text for "Total Project Value" label in the Invoice Burn Section

## Relevant Technical Choices

- Added an optional prop support in the LegendItem component for tooltip text to be displayed on hover.

## Testing Instructions

- Go to projects page
- Open any project
- Go to tracking tab
- Hover on the "Total Project Value" label in the Invoice Burn section
- Observe a tooltip with text "Total Sales Order Value" should appear.

## Screenshot/Screencast

<img width="641" height="202" alt="image" src="https://github.com/user-attachments/assets/a3c48462-83c1-4c85-a0ec-1188accfa56f" />


https://github.com/user-attachments/assets/60d91112-b40a-4b8e-8473-472089c5e5d7




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Partially Fixes #1880 