### PR TITLE
fix: allocation page keyboard navigation issues

### DIFF
--- a/frontend/packages/app/src/components/infiniteScroll.tsx
+++ b/frontend/packages/app/src/components/infiniteScroll.tsx
@@ -84,15 +84,13 @@ const InfiniteScroll = ({
     <ScrollArea.Root className={cn("relative h-full w-full", className)}>
       <ScrollArea.Viewport
         ref={handleViewportRef}
-        className={cn(
-          "h-full w-full rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
-          {
-            "w-[calc(100%-var(--spacing)*1.5)]":
-              showScrollbar && scrollbarVariant === "classic",
-            "h-[calc(100%-var(--spacing)*1.5)]":
-              showScrollbar && scrollbarVariant === "classic",
-          },
-        )}
+        tabIndex={-1}
+        className={cn("h-full w-full", {
+          "w-[calc(100%-var(--spacing)*1.5)]":
+            showScrollbar && scrollbarVariant === "classic",
+          "h-[calc(100%-var(--spacing)*1.5)]":
+            showScrollbar && scrollbarVariant === "classic",
+        })}
       >
         <ScrollArea.Content className="min-h-full">
           {content}

--- a/frontend/packages/app/src/components/infiniteScroll.tsx
+++ b/frontend/packages/app/src/components/infiniteScroll.tsx
@@ -84,12 +84,15 @@ const InfiniteScroll = ({
     <ScrollArea.Root className={cn("relative h-full w-full", className)}>
       <ScrollArea.Viewport
         ref={handleViewportRef}
-        className={cn("h-full w-full", {
-          "w-[calc(100%-var(--spacing)*1.5)]":
-            showScrollbar && scrollbarVariant === "classic",
-          "h-[calc(100%-var(--spacing)*1.5)]":
-            showScrollbar && scrollbarVariant === "classic",
-        })}
+        className={cn(
+          "h-full w-full rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
+          {
+            "w-[calc(100%-var(--spacing)*1.5)]":
+              showScrollbar && scrollbarVariant === "classic",
+            "h-[calc(100%-var(--spacing)*1.5)]":
+              showScrollbar && scrollbarVariant === "classic",
+          },
+        )}
       >
         <ScrollArea.Content className="min-h-full">
           {content}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationBar.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { PreviewCard } from "@base-ui/react/preview-card";
+import { Popover } from "@base-ui/react/popover";
 import { Button } from "@rtcamp/frappe-ui-react";
 
 /**
@@ -291,13 +291,15 @@ export function GanttAllocationBar({
   }, [handleClick, handleResetPreview]);
 
   return (
-    <PreviewCard.Root
+    <Popover.Root
       open={isModified ? false : previewOpen}
       onOpenChange={setPreviewOpen}
     >
-      <PreviewCard.Trigger
+      <Popover.Trigger
+        openOnHover
         delay={400}
         closeDelay={150}
+        nativeButton={false}
         render={
           <GanttBar
             ref={allocationBarRef}
@@ -315,13 +317,12 @@ export function GanttAllocationBar({
             }
             left={previewGeometry.left}
             width={previewGeometry.width}
-            className={cn("outline-none", isModified && "z-20")}
+            className={cn(isModified && "z-20")}
             billable={allocation.billable}
             showOutline={isModified}
             renderFloatingLabel={isModified ? renderFloatingLabel : undefined}
             resizable={canResize}
             snapUnitPx={columnWidth}
-            tabIndex={0}
             minLeft={bounds.minLeft}
             maxRight={bounds.maxRight}
             onKeyDown={handleKeyDown}
@@ -329,18 +330,18 @@ export function GanttAllocationBar({
           />
         }
       />
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
-          <PreviewCard.Popup className="z-50 outline-none">
+      <Popover.Portal>
+        <Popover.Positioner side="bottom" align="start" sideOffset={4}>
+          <Popover.Popup className="z-50 outline-none">
             <GanttAllocationPopover
               entries={[entry]}
               variant={variant}
               hasRoleAccess={hasRoleAccess}
             />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/allocationPopover.tsx
@@ -148,7 +148,7 @@ function AllocationItem({
                 <button
                   type="button"
                   onClick={() => entry.onEdit?.()}
-                  className="transition-colors text-ink-gray-6 hover:text-ink-gray-7"
+                  className="rounded-sm transition-colors text-ink-gray-6 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
                   aria-label="Edit allocation"
                 >
                   <EditAlt className="size-4 text-ink-gray-6" />
@@ -158,7 +158,7 @@ function AllocationItem({
                 <button
                   type="button"
                   onClick={() => entry.onDelete?.()}
-                  className="transition-colors text-ink-gray-6 hover:text-ink-gray-7"
+                  className="rounded-sm transition-colors text-ink-gray-6 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
                   aria-label="Delete allocation"
                 >
                   <DeleteAlt className="size-4 text-ink-gray-6" />

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/draftBar.tsx
@@ -239,7 +239,7 @@ export function DraftBar({
         renderFloatingLabel={renderFloatingLabel}
         left={previewGeometry.left}
         width={previewGeometry.width}
-        className="outline-none z-20"
+        className="z-20"
         minLeft={bounds.minLeft}
         maxRight={bounds.maxRight}
         resizable={Boolean(onOpenAllocation)}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -26,7 +26,7 @@ export interface GanttBarRenderState {
 }
 
 const ganttBarVariants = cva(
-  "group pointer-events-auto absolute shrink-0 flex items-center gap-1.5 rounded-[9px] mx-0.5 px-2.5 py-2 whitespace-nowrap",
+  "group pointer-events-auto absolute shrink-0 flex items-center gap-1.5 rounded-[9px] mx-0.5 px-2.5 py-2 whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
   {
     variants: {
       variant: {

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { PreviewCard } from "@base-ui/react/preview-card";
+import { Popover } from "@base-ui/react/popover";
 import { differenceInCalendarDays } from "date-fns";
 
 /**
@@ -98,10 +98,13 @@ export function GanttMemberSummaryBar({
     : undefined;
 
   return (
-    <PreviewCard.Root>
-      <PreviewCard.Trigger
+    <Popover.Root>
+      <Popover.Trigger
+        openOnHover
         delay={400}
         closeDelay={150}
+        nativeButton={false}
+        aria-label="Allocation summary"
         render={
           <GanttBar
             variant={capacityStatus.variant}
@@ -113,19 +116,19 @@ export function GanttMemberSummaryBar({
           />
         }
       />
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
-          <PreviewCard.Popup className="z-50 outline-none">
+      <Popover.Portal>
+        <Popover.Positioner side="bottom" align="start" sideOffset={4}>
+          <Popover.Popup className="z-50 outline-none">
             <GanttAllocationPopover
               entries={entries}
               variant={variant}
               onAdd={handleAdd}
               hasRoleAccess={hasRoleAccess}
             />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectSummaryBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/projectSummaryBar.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import { PreviewCard } from "@base-ui/react/preview-card";
+import { Popover } from "@base-ui/react/popover";
 import { useGanttStore } from "../ganttStore";
 import type { ProjectGroup, ProjectSummaryBar } from "../ganttStore";
 import { formatHours } from "../utils";
@@ -73,10 +73,13 @@ export function GanttProjectSummaryBar({
     : undefined;
 
   return (
-    <PreviewCard.Root>
-      <PreviewCard.Trigger
+    <Popover.Root>
+      <Popover.Trigger
+        openOnHover
         delay={400}
         closeDelay={150}
+        nativeButton={false}
+        aria-label="Allocation summary"
         render={
           <GanttBar
             variant="projectSummary"
@@ -87,19 +90,19 @@ export function GanttProjectSummaryBar({
           />
         }
       />
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner side="bottom" align="start" sideOffset={4}>
-          <PreviewCard.Popup className="z-50 outline-none">
+      <Popover.Portal>
+        <Popover.Positioner side="bottom" align="start" sideOffset={4}>
+          <Popover.Popup className="z-50 outline-none">
             <GanttAllocationPopover
               entries={entries}
               variant={variant}
               onAdd={handleAdd}
               hasRoleAccess={hasRoleAccess}
             />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
@@ -66,7 +66,7 @@ function GanttMemberHoverCard({
             target="_blank"
             rel="noreferrer"
             aria-label="Open employee"
-            className="ml-2 shrink-0 text-ink-gray-8 hover:text-ink-gray-8"
+            className="ml-2 shrink-0 rounded-sm text-ink-gray-8 hover:text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
             onClick={(e) => e.stopPropagation()}
           >
             <ArrowUpRight className="size-4 text-ink-gray-8 shrink-0" />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberHoverCard.tsx
@@ -33,7 +33,7 @@ function GanttMemberHoverCard({
       : undefined;
 
   return (
-    <div className="flex flex-col gap-3 p-3 w-60 rounded-xl shadow-2xl bg-surface-modal">
+    <div className="flex flex-col gap-3 p-3 w-60 rounded-xl shadow-2xl bg-surface-modal animate-fade-in">
       {/* Header */}
       <div
         className={cn("flex items-start", {

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -81,19 +81,20 @@ export function GanttMemberItem({
           className="relative overflow-hidden transition-[height] duration-200 ease-in-out"
           style={{ height: contentHeight }}
         >
-          {/* Mouse only trigger */}
+          {/* Mouse-only trigger */}
           <Popover.Trigger
             id={`${triggerId}-cell`}
             openOnHover
             delay={300}
             closeDelay={150}
             tabIndex={-1}
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => {
               if (canExpand) handleToggle?.();
             }}
             render={<button type="button" />}
             className={cn(
-              "absolute inset-0 z-10",
+              "absolute inset-0 z-10 focus:outline-none",
               canExpand ? "cursor-pointer" : "cursor-default",
             )}
           />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -23,6 +23,7 @@ export interface GanttMemberItemProps {
   showChevron?: boolean;
   onToggle?: () => void;
   className?: string;
+  buttonClassName?: string;
   style?: CSSProperties;
   contentHeight?: number;
 }
@@ -35,6 +36,7 @@ export function GanttMemberItem({
   showChevron = true,
   onToggle,
   className,
+  buttonClassName,
   style,
   contentHeight = CELL_HEIGHT,
 }: GanttMemberItemProps) {
@@ -68,7 +70,7 @@ export function GanttMemberItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-3 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
+              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               className,
             )}
             style={{
@@ -89,10 +91,11 @@ export function GanttMemberItem({
             disabled={!canExpand}
             onClick={() => handleToggle?.()}
             className={cn(
-              "flex h-full w-full shrink-0 items-center overflow-hidden",
+              "flex pl-3 pr-3 h-full w-full shrink-0 items-center overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
               {
                 "cursor-default!": !canExpand,
               },
+              buttonClassName,
             )}
             aria-expanded={canExpand ? isExpanded : undefined}
           >

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberItem.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies.
  */
-import type { CSSProperties } from "react";
-import { PreviewCard } from "@base-ui/react/preview-card";
+import { useId, type CSSProperties } from "react";
+import { Popover } from "@base-ui/react/popover";
 import { Avatar, Badge } from "@rtcamp/frappe-ui-react";
 import { RightChevron } from "@rtcamp/frappe-ui-react/icons";
 
@@ -49,6 +49,7 @@ export function GanttMemberItem({
       hasRoleAccess: s.hasRoleAccess,
     }));
 
+  const triggerId = useId();
   const hasMemberIndex = memberInd !== undefined;
   const storeMember = hasMemberIndex ? members[memberInd] : undefined;
   const member = memberProp ?? storeMember;
@@ -63,53 +64,67 @@ export function GanttMemberItem({
     onToggle ?? (hasMemberIndex ? () => toggleRow(memberInd) : undefined);
 
   return (
-    <PreviewCard.Root>
-      <PreviewCard.Trigger
-        delay={300}
-        closeDelay={150}
-        render={
-          <th
-            className={cn(
-              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
-              className,
-            )}
-            style={{
-              width: headerWidth,
-              minWidth: headerWidth,
-              maxWidth: headerWidth,
-              ...style,
-            }}
-          />
-        }
-      >
+    <th
+      className={cn(
+        "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] hover:bg-surface-gray-1",
+        className,
+      )}
+      style={{
+        width: headerWidth,
+        minWidth: headerWidth,
+        maxWidth: headerWidth,
+        ...style,
+      }}
+    >
+      <Popover.Root>
         <div
-          className="overflow-hidden transition-[height] duration-200 ease-in-out"
+          className="relative overflow-hidden transition-[height] duration-200 ease-in-out"
           style={{ height: contentHeight }}
         >
-          <button
-            type="button"
-            disabled={!canExpand}
-            onClick={() => handleToggle?.()}
+          {/* Mouse only trigger */}
+          <Popover.Trigger
+            id={`${triggerId}-cell`}
+            openOnHover
+            delay={300}
+            closeDelay={150}
+            tabIndex={-1}
+            onClick={() => {
+              if (canExpand) handleToggle?.();
+            }}
+            render={<button type="button" />}
             className={cn(
-              "flex pl-3 pr-3 h-full w-full shrink-0 items-center overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
-              {
-                "cursor-default!": !canExpand,
-              },
+              "absolute inset-0 z-10",
+              canExpand ? "cursor-pointer" : "cursor-default",
+            )}
+          />
+          <div
+            className={cn(
+              "flex pl-3 pr-3 h-full w-full shrink-0 items-center overflow-hidden",
               buttonClassName,
             )}
-            aria-expanded={canExpand ? isExpanded : undefined}
           >
             <div className="flex flex-col gap-1 w-full min-w-0">
               <div className="flex gap-1 justify-between items-center w-full">
-                <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
+                <div className="flex flex-1 items-center w-full min-w-0">
                   {showChevron ? (
-                    <RightChevron
+                    <button
+                      type="button"
+                      disabled={!canExpand}
+                      onClick={() => handleToggle?.()}
+                      aria-expanded={canExpand ? isExpanded : undefined}
+                      aria-label={isExpanded ? "Collapse" : "Expand"}
                       className={cn(
-                        "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-8",
+                        "mr-1 shrink-0 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
                         { "opacity-0 pointer-events-none": !canExpand },
-                        { "rotate-90": isExpanded },
                       )}
-                    />
+                    >
+                      <RightChevron
+                        className={cn(
+                          "size-4 transition-transform duration-150 text-ink-gray-8",
+                          { "rotate-90": isExpanded },
+                        )}
+                      />
+                    </button>
                   ) : null}
                   <Avatar
                     size="xs"
@@ -117,13 +132,18 @@ export function GanttMemberItem({
                     image={member.image}
                     label={member.name}
                   />
-                  <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
+                  <Popover.Trigger
+                    id={`${triggerId}-name`}
+                    nativeButton={false}
+                    aria-label={`View ${member.name} details`}
+                    render={<span />}
+                    className="ml-2 rounded-sm text-base font-medium text-left truncate text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+                  >
                     {member.name}
-                  </span>
+                  </Popover.Trigger>
                 </div>
                 {member.badge && (
                   <Badge
-                    className=""
                     label={member.badge}
                     size="sm"
                     variant="subtle"
@@ -144,24 +164,24 @@ export function GanttMemberItem({
                 )}
               </div>
             </div>
-          </button>
+          </div>
         </div>
-      </PreviewCard.Trigger>
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner
-          side="right"
-          align="center"
-          alignOffset={20}
-          sideOffset={-42}
-        >
-          <PreviewCard.Popup className="outline-none">
-            <GanttMemberHoverCard
-              member={member}
-              canOpenEmployee={hasRoleAccess}
-            />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+        <Popover.Portal>
+          <Popover.Positioner
+            side="right"
+            align="center"
+            alignOffset={20}
+            sideOffset={-42}
+          >
+            <Popover.Popup initialFocus={false} className="z-50 outline-none">
+              <GanttMemberHoverCard
+                member={member}
+                canOpenEmployee={hasRoleAccess}
+              />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </th>
   );
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -64,7 +64,7 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
         isExpanded={false}
         canExpand={false}
         showChevron={false}
-        className="pl-8 pr-3"
+        buttonClassName="pl-8 pr-3"
         contentHeight={animatedRowHeight}
         style={{
           height: animatedRowHeight,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -134,7 +134,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
           onTransitionEnd={childRowsPresence.onTransitionEnd}
         >
           <th
-            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
+            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,
@@ -157,7 +157,7 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
                   })
                 }
                 tabIndex={childRowsVisible ? undefined : -1}
-                className="flex h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8"
+                className="flex pl-8 pr-3 h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3"
               >
                 <AddMd className="size-4 shrink-0" />
                 <span className="truncate">Add project</span>

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
@@ -60,7 +60,7 @@ function GanttProjectHoverCard({
             target="_blank"
             rel="noreferrer"
             aria-label="Open project"
-            className="shrink-0 text-ink-gray-6 hover:text-ink-gray-8"
+            className="shrink-0 rounded-sm text-ink-gray-6 hover:text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
             onClick={(event) => event.stopPropagation()}
           >
             <ArrowUpRight className="size-4 text-ink-gray-8 shrink-0" />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
@@ -42,7 +42,7 @@ function GanttProjectHoverCard({
       : undefined;
 
   return (
-    <div className="flex flex-col gap-3 p-3 w-72 rounded-xl shadow-2xl bg-surface-modal">
+    <div className="flex flex-col gap-3 p-3 w-72 rounded-xl shadow-2xl bg-surface-modal animate-fade-in">
       <div
         className={cn("flex items-start gap-3", {
           "justify-between": projectHref,

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies.
  */
-import type { CSSProperties } from "react";
-import { PreviewCard } from "@base-ui/react/preview-card";
+import { useId, type CSSProperties } from "react";
+import { Popover } from "@base-ui/react/popover";
 import { Badge } from "@rtcamp/frappe-ui-react";
 import { Folder, RightChevron } from "@rtcamp/frappe-ui-react/icons";
 
@@ -45,56 +45,83 @@ export function GanttProjectItem({
   style,
   contentHeight = CELL_HEIGHT,
 }: GanttProjectItemProps) {
+  const triggerId = useId();
   const subtext = [dateRange, client].filter(Boolean).join(" · ");
 
   return (
-    <PreviewCard.Root open={showHoverCard ? undefined : false}>
-      <PreviewCard.Trigger
-        delay={300}
-        closeDelay={150}
-        render={
-          <th
-            className={cn(
-              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
-              className,
-            )}
-            style={style}
-          />
-        }
-      >
+    <th
+      className={cn(
+        "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] hover:bg-surface-gray-1",
+        className,
+      )}
+      style={style}
+    >
+      <Popover.Root open={showHoverCard ? undefined : false}>
         <div
-          className="overflow-hidden transition-[height] duration-200 ease-in-out"
+          className="relative overflow-hidden transition-[height] duration-200 ease-in-out"
           style={{ height: contentHeight }}
         >
-          <button
-            type="button"
-            disabled={!canExpand}
-            onClick={() => onToggle?.()}
+          {/* Mouse only trigger */}
+          <Popover.Trigger
+            id={`${triggerId}-cell`}
+            openOnHover
+            delay={300}
+            closeDelay={150}
+            tabIndex={-1}
+            onClick={() => {
+              if (canExpand) onToggle?.();
+            }}
+            render={<button type="button" />}
             className={cn(
-              "flex pr-3 h-full w-full shrink-0 items-center overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
-              {
-                "cursor-default!": !canExpand,
-              },
+              "absolute inset-0 z-10",
+              canExpand ? "cursor-pointer" : "cursor-default",
+            )}
+          />
+          <div
+            className={cn(
+              "flex pr-3 h-full w-full shrink-0 items-center overflow-hidden",
               showChevron ? "pl-3" : "pl-8",
             )}
-            aria-expanded={canExpand ? isExpanded : undefined}
           >
             <div className="flex flex-col gap-1 w-full min-w-0">
               <div className="flex gap-1 justify-between items-center w-full">
-                <div className="flex overflow-hidden flex-1 items-center w-full min-w-0">
+                <div className="flex flex-1 items-center w-full min-w-0">
                   {showChevron ? (
-                    <RightChevron
+                    <button
+                      type="button"
+                      disabled={!canExpand}
+                      onClick={() => onToggle?.()}
+                      aria-expanded={canExpand ? isExpanded : undefined}
+                      aria-label={isExpanded ? "Collapse" : "Expand"}
                       className={cn(
-                        "size-4 mr-1 transition-transform duration-150 shrink-0 text-ink-gray-8",
+                        "mr-1 shrink-0 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
                         { "opacity-0 pointer-events-none": !canExpand },
-                        { "rotate-90": isExpanded },
                       )}
-                    />
+                    >
+                      <RightChevron
+                        className={cn(
+                          "size-4 transition-transform duration-150 text-ink-gray-8",
+                          { "rotate-90": isExpanded },
+                        )}
+                      />
+                    </button>
                   ) : null}
                   <Folder className="size-4 shrink-0" />
-                  <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
-                    {name}
-                  </span>
+                  {showHoverCard ? (
+                    <Popover.Trigger
+                      id={`${triggerId}-name`}
+                      nativeButton={false}
+                      aria-label={`View ${name} details`}
+                      render={<span />}
+                      className="ml-2 rounded-sm text-base font-medium text-left truncate text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+                    >
+                      {name}
+                    </Popover.Trigger>
+                  ) : (
+                    <span className="ml-2 text-base font-medium truncate text-ink-gray-8">
+                      {name}
+                    </span>
+                  )}
                 </div>
                 {badge && (
                   <Badge
@@ -118,32 +145,32 @@ export function GanttProjectItem({
                 )}
               </div>
             </div>
-          </button>
+          </div>
         </div>
-      </PreviewCard.Trigger>
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner
-          side="right"
-          align="center"
-          alignOffset={20}
-          sideOffset={-42}
-        >
-          <PreviewCard.Popup className="outline-none">
-            <GanttProjectHoverCard
-              project={{
-                id,
-                name,
-                client,
-                dateRange,
-                projectDateRange,
-                projectManager,
-                weeklyCapacity,
-              }}
-              canOpenProject={hasRoleAccess}
-            />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+        <Popover.Portal>
+          <Popover.Positioner
+            side="right"
+            align="center"
+            alignOffset={20}
+            sideOffset={-42}
+          >
+            <Popover.Popup initialFocus={false} className="z-50 outline-none">
+              <GanttProjectHoverCard
+                project={{
+                  id,
+                  name,
+                  client,
+                  dateRange,
+                  projectDateRange,
+                  projectManager,
+                  weeklyCapacity,
+                }}
+                canOpenProject={hasRoleAccess}
+              />
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </th>
   );
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -55,8 +55,7 @@ export function GanttProjectItem({
         render={
           <th
             className={cn(
-              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
-              showChevron ? "pl-3" : "pl-8",
+              "sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1",
               className,
             )}
             style={style}
@@ -72,10 +71,11 @@ export function GanttProjectItem({
             disabled={!canExpand}
             onClick={() => onToggle?.()}
             className={cn(
-              "flex h-full w-full shrink-0 items-center overflow-hidden",
+              "flex pr-3 h-full w-full shrink-0 items-center overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
               {
                 "cursor-default!": !canExpand,
               },
+              showChevron ? "pl-3" : "pl-8",
             )}
             aria-expanded={canExpand ? isExpanded : undefined}
           >

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -61,19 +61,20 @@ export function GanttProjectItem({
           className="relative overflow-hidden transition-[height] duration-200 ease-in-out"
           style={{ height: contentHeight }}
         >
-          {/* Mouse only trigger */}
+          {/* Mouse-only trigger */}
           <Popover.Trigger
             id={`${triggerId}-cell`}
             openOnHover
             delay={300}
             closeDelay={150}
             tabIndex={-1}
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => {
               if (canExpand) onToggle?.();
             }}
             render={<button type="button" />}
             className={cn(
-              "absolute inset-0 z-10",
+              "absolute inset-0 z-10 focus:outline-none",
               canExpand ? "cursor-pointer" : "cursor-default",
             )}
           />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectRows.tsx
@@ -155,7 +155,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
           onTransitionEnd={childRowsPresence.onTransitionEnd}
         >
           <th
-            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 pl-8 pr-3 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
+            className="sticky left-0 z-25 bg-surface-white border-b border-r border-outline-gray-1 font-normal text-left align-middle transition-[height,background-color] cursor-pointer hover:bg-surface-gray-1"
             style={{
               width: headerWidth,
               minWidth: headerWidth,
@@ -179,7 +179,7 @@ export const GanttProjectRows: React.FC<GanttProjectRowsProps> = ({
                   })
                 }
                 tabIndex={childRowsVisible ? undefined : -1}
-                className="flex h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8"
+                className="flex pl-8 pr-3 h-full w-full items-center gap-2 overflow-hidden text-base font-medium text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3"
               >
                 <AddMd className="size-4 shrink-0" />
                 <span className="truncate">Add member</span>


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes missing keyboard navigation and focus highlighting on the Allocation pages.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Replaced the preview card with a popover in both the Allocation Bar and Summary Bar. This allows the preview content to receive keyboard focus, improving keyboard accessibility.
- To make the member and project details hover cards keyboard accessible, separate interaction patterns were introduced for mouse and keyboard users.
  - For mouse users, an overlay button covers the entire table cell, allowing the row to be expanded or collapsed by clicking anywhere in the cell while also showing the hover card when the cell is hovered.
  - The overlay button is hidden from keyboard navigation. Keyboard users expand or collapse rows by focusing the chevron icon and pressing Enter or Space.
  - Pressing Tab again moves focus to the member or project name, which acts as the keyboard trigger for the details popover. The popover receives focus when opened, allowing users to continue tabbing to the link within it.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
1. Navigate to either the **Team Allocation** or **Project Allocation** page.
2. Use the keyboard to navigate to the allocation table.
3. Verify that each member row receives visible focus.
4. Press **Enter** or **Space** to expand or collapse the focused row.
5. Press **Tab** to move focus to the Summary Bar.
6. Press **Enter** or **Space** on the Summary Bar.
7. Verify that the popover opens and receives focus, allowing the allocation to be edited or deleted.
8. Expand a row and continue pressing **Tab** to move focus to the individual Allocation Bars.
9. Press **Enter** or **Space** on an Allocation Bar.
10. Verify that its popover opens and allows the allocation to be edited or deleted.

Hover Cards:

1. Navigate to either the Team Allocation or Project Allocation page.
2. Use the keyboard to navigate to the allocation table.
3. Verify that the chevron icon receives focus.
4. Press Enter to expand or collapse the row.
5. Press Tab to move focus to the member or project name.
6. Press Enter to open the hover card.
7. Verify that the hover card opens and receives keyboard focus.
8. Press Tab and verify that focus moves to the link inside the hover card.

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->



https://github.com/user-attachments/assets/caa71b7a-f90a-4c0b-8ccc-873b0caae3df





## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1698