### PR TITLE
fix(resource_allocation): patch to fill cost for all upcoming and ongoing allocation

### DIFF
--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -31,3 +31,4 @@ next_pms.next_projects.patches.setup_project_target_hours_field
 next_pms.timesheet.patches.add_project_report_permissions
 next_pms.timesheet.patches.setup_timesheet_rejection_reason_field
 next_pms.next_pms.patches.backfill_notification_title
+next_pms.resource_management.patches.update_active_allocation_currency_and_cost

--- a/next_pms/resource_management/patches/update_active_allocation_currency_and_cost.py
+++ b/next_pms/resource_management/patches/update_active_allocation_currency_and_cost.py
@@ -11,9 +11,10 @@ def execute():
     Unlike populate_resource_allocation_cost, this writes `currency` itself instead of
     skipping rows where it is blank — a blank currency is what left those rows at 0.
     """
+    as_of_date = today()
     allocations = frappe.get_all(
         "Resource Allocation",
-        filters={"allocation_end_date": [">=", today()]},
+        filters={"allocation_end_date": [">=", as_of_date]},
         fields=["name", "employee", "project", "currency", "total_allocated_hours"],
     )
     if not allocations:
@@ -32,7 +33,7 @@ def execute():
 
         key = (allocation.employee, currency)
         if key not in hourly_rates:
-            hourly_rates[key] = get_hourly_cost_rate(allocation.employee, currency)
+            hourly_rates[key] = get_hourly_cost_rate(allocation.employee, currency, as_of_date)
         hourly_cost_rate = hourly_rates[key]
 
         values = {"currency": currency}
@@ -66,8 +67,8 @@ def get_project_currency(projects: set) -> dict:
     )
 
 
-def get_hourly_cost_rate(employee: str, currency: str) -> float | None:
-    """Hourly cost of the employee in `currency`, or None when it cannot be derived."""
+def get_hourly_cost_rate(employee: str, currency: str, date: str) -> float | None:
+    """Hourly cost of the employee in `currency` as of `date`, or None when it cannot be derived."""
     from next_pms.utils.employee import get_employee_salary
 
     ctc, salary_currency = frappe.get_cached_value("Employee", employee, ["ctc", "salary_currency"])
@@ -78,7 +79,7 @@ def get_hourly_cost_rate(employee: str, currency: str) -> float | None:
         salary_info = get_employee_salary(
             employee=employee,
             to_currency=currency,
-            date=today(),
+            date=date,
             throw=False,
             ctc=ctc,
             salary_currency=salary_currency,
@@ -90,4 +91,4 @@ def get_hourly_cost_rate(employee: str, currency: str) -> float | None:
         )
         return None
 
-    return flt(salary_info.get("hourly_salary", 0)) if salary_info else 0
+    return flt(salary_info["hourly_salary"]) if salary_info else None

--- a/next_pms/resource_management/patches/update_active_allocation_currency_and_cost.py
+++ b/next_pms/resource_management/patches/update_active_allocation_currency_and_cost.py
@@ -1,0 +1,93 @@
+import frappe
+from frappe.utils import flt, today
+
+
+def execute():
+    """Re-sync currency and cost for Resource Allocations that have not ended yet.
+
+    Currency is pulled from the linked project, then hourly_cost_rate is re-derived
+    from the employee's CTC in that currency and multiplied by total_allocated_hours.
+
+    Unlike populate_resource_allocation_cost, this writes `currency` itself instead of
+    skipping rows where it is blank — a blank currency is what left those rows at 0.
+    """
+    allocations = frappe.get_all(
+        "Resource Allocation",
+        filters={"allocation_end_date": [">=", today()]},
+        fields=["name", "employee", "project", "currency", "total_allocated_hours"],
+    )
+    if not allocations:
+        return
+
+    project_currency = get_project_currency({allocation.project for allocation in allocations if allocation.project})
+    default_currency = frappe.defaults.get_global_default("currency")
+    hourly_rates = {}
+    updated = no_currency = no_rate = 0
+
+    for allocation in allocations:
+        currency = project_currency.get(allocation.project) or allocation.currency or default_currency
+        if not currency:
+            no_currency += 1
+            continue
+
+        key = (allocation.employee, currency)
+        if key not in hourly_rates:
+            hourly_rates[key] = get_hourly_cost_rate(allocation.employee, currency)
+        hourly_cost_rate = hourly_rates[key]
+
+        values = {"currency": currency}
+        if hourly_cost_rate is None:
+            no_rate += 1
+        else:
+            values["hourly_cost_rate"] = hourly_cost_rate
+            values["total_cost"] = hourly_cost_rate * flt(allocation.total_allocated_hours)
+
+        frappe.db.set_value("Resource Allocation", allocation.name, values, update_modified=False)
+        updated += 1
+
+    frappe.db.commit()
+    print(
+        f"Resource Allocation: {updated} of {len(allocations)} updated, "
+        f"{no_rate} without a derivable cost rate, {no_currency} without a currency"
+    )
+
+
+def get_project_currency(projects: set) -> dict:
+    if not projects:
+        return {}
+
+    return dict(
+        frappe.get_all(
+            "Project",
+            filters={"name": ["in", list(projects)]},
+            fields=["name", "custom_currency"],
+            as_list=True,
+        )
+    )
+
+
+def get_hourly_cost_rate(employee: str, currency: str) -> float | None:
+    """Hourly cost of the employee in `currency`, or None when it cannot be derived."""
+    from next_pms.utils.employee import get_employee_salary
+
+    ctc, salary_currency = frappe.get_cached_value("Employee", employee, ["ctc", "salary_currency"])
+    if not ctc or not salary_currency:
+        return None
+
+    try:
+        salary_info = get_employee_salary(
+            employee=employee,
+            to_currency=currency,
+            date=today(),
+            throw=False,
+            ctc=ctc,
+            salary_currency=salary_currency,
+        )
+    except Exception as e:
+        frappe.log_error(
+            message=f"Failed to derive hourly cost for {employee} in {currency}: {e!s}",
+            title="Resource Allocation Cost Patch",
+        )
+        return None
+
+    return flt(salary_info.get("hourly_salary", 0)) if salary_info else 0


### PR DESCRIPTION
## Description

* Added a new patch script `update_active_allocation_currency_and_cost.py` to the `next_pms.resource_management.patches` directory. This script updates the `currency`, `hourly_cost_rate`, and `total_cost` fields for all `Resource Allocation` records that have not yet ended, ensuring their values are synchronized with the linked project's currency and the employee's cost-to-company (CTC) in that currency.
* Unlike previous scripts, this patch writes the `currency` field even when it was previously blank, addressing cases where allocations were left with zero cost due to missing currency.
* The script efficiently batches retrieval of project currencies and caches employee hourly rates to minimize database queries. It also logs a summary of updated records and any allocations skipped due to missing data or errors.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1877 