### PR TITLE
feat: display leaves based on sandwich condition

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -362,7 +362,7 @@ export const getTimesheetHours = (
         if (isHalfDayLeave) {
           totalHours += dailyWorkingHours / 2;
           timeOffHours += dailyWorkingHours / 2;
-        } else if (holiday?.weekly_off && !data.is_lwp) {
+        } else if (holiday?.weekly_off && !data.includes_holidays) {
           continue;
         } else {
           totalHours += dailyWorkingHours;
@@ -536,8 +536,8 @@ export const calculateLeaveHours = (
 
   return leaves.reduce((total, leave) => {
     if (date >= leave.from_date && date <= leave.to_date) {
-      if (!leave.is_lwp && holiday?.weekly_off) {
-        return 0;
+      if (!leave.includes_holidays && holiday?.weekly_off) {
+        return total;
       } else if (leave.half_day && leave.half_day_date === date) {
         return total + daily_working_hours / 2;
       } else {

--- a/frontend/packages/app/src/types/timesheet.ts
+++ b/frontend/packages/app/src/types/timesheet.ts
@@ -48,6 +48,7 @@ export interface LeaveProps {
   half_day_date: string;
   leave_type: string;
   is_lwp: boolean;
+  includes_holidays: boolean;
   custom_first_halfsecond_half?: string | null;
 }
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -2,6 +2,7 @@ import datetime
 
 import frappe
 from frappe.query_builder.functions import Sum
+from frappe.utils import cint, date_diff, flt, getdate
 from frappe.utils.caching import redis_cache
 
 
@@ -209,12 +210,36 @@ def get_allocation_worked_hours_for_given_projects(project: str, start_date: str
     return total_hours.get("time") or 0.0
 
 
+def leave_includes_holidays(leave: dict) -> bool:
+    """Return whether a leave's stored day count covers the holidays inside its range.
+
+    Leave Application.total_leave_days is recomputed server-side on every save by
+    get_number_of_leave_days, which honours Leave Type.include_holiday and any
+    site-level override of that policy (rtCamp, for instance, monkey-patches it so that
+    unpaid leave spanning fewer than five working days drops holidays while longer runs
+    keep them). Comparing the stored count against the raw calendar span therefore tells
+    us what was actually counted, without restating any of those rules here.
+    """
+    span = date_diff(leave["to_date"], leave["from_date"]) + 1
+
+    if cint(leave.get("half_day")):
+        half_day_date = leave.get("half_day_date")
+        if getdate(leave["from_date"]) == getdate(leave["to_date"]):
+            span = 0.5
+        elif half_day_date and getdate(leave["from_date"]) <= getdate(half_day_date) <= getdate(leave["to_date"]):
+            span -= 0.5
+
+    return flt(leave.get("total_leave_days")) >= flt(span)
+
+
 @redis_cache
 def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
     """Return Leave Application records that overlap a date range for one or more employees.
 
     Fetches approved or open leave applications whose ``from_date``/``to_date`` window
-    overlaps ``[start_date, end_date]``. Joins ``Leave Type`` to include ``is_lwp`` (is leave without pay).
+    overlaps ``[start_date, end_date]``. Joins ``Leave Type`` to include ``is_lwp`` (is leave without pay),
+    and derives ``includes_holidays`` (see :func:`leave_includes_holidays`) so callers can render a leave
+    across its whole range or skip the holidays inside it without re-deriving leave policy.
 
     Pass a single employee ID for one person, or a ``tuple`` of IDs to batch-fetch
     leaves for multiple employees in one query.
@@ -249,6 +274,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
                 "leave_type": "Casual Leave",
                 "custom_first_halfsecond_half": None,
                 "is_lwp": 0,
+                "includes_holidays": True,
             },
         ]
 
@@ -269,6 +295,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
                 "leave_type": "Casual Leave",
                 "custom_first_halfsecond_half": None,
                 "is_lwp": 0,
+                "includes_holidays": True,
             },
             {
                 "employee": "HR-EMP-00002",
@@ -281,6 +308,7 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
                 "leave_type": "Sick Leave",
                 "custom_first_halfsecond_half": "First Half",
                 "is_lwp": 0,
+                "includes_holidays": True,
             },
         ]
         ```
@@ -329,9 +357,10 @@ def get_employee_leaves(employee: str | tuple, start_date: str, end_date: str):
 
     results = query.run(as_dict=True)
 
-    if not has_first_half_column:
-        for row in results:
+    for row in results:
+        if not has_first_half_column:
             row["custom_first_halfsecond_half"] = None
+        row["includes_holidays"] = leave_includes_holidays(row)
 
     return results
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -229,7 +229,9 @@ def leave_includes_holidays(leave: dict) -> bool:
         elif half_day_date and getdate(leave["from_date"]) <= getdate(half_day_date) <= getdate(leave["to_date"]):
             span -= 0.5
 
-    return flt(leave.get("total_leave_days")) >= flt(span)
+    # total_leave_days is persisted at 2-decimal precision; round the span to match so the
+    # comparison never trips on sub-precision float noise (e.g. a stored 6.999999 vs a span of 7).
+    return flt(leave.get("total_leave_days"), 2) >= flt(span, 2)
 
 
 @redis_cache

--- a/next_pms/tests/resource_management/api/test_leave_includes_holidays.py
+++ b/next_pms/tests/resource_management/api/test_leave_includes_holidays.py
@@ -8,7 +8,7 @@ from next_pms.resource_management.api.utils.query import (
     leave_includes_holidays,
 )
 from next_pms.tests.utils import make_employee, make_holiday_list
-from next_pms.timesheet.api.team import get_compact_view_data
+from next_pms.timesheet.api.team import _get_team_timesheet_data
 from next_pms.timesheet.api.utils import get_holidays
 
 # Aug 2026: Mon 10 … Fri 14, Sat 15 + Sun 16 weekly off, Mon 17 … Wed 19.
@@ -24,6 +24,7 @@ SEP_TUE_NEXT = "2026-09-15"
 
 HOLIDAY_LIST = "Leave Weekend Test Holiday List"
 EMPLOYEE_USER = "leave-weekend-test@example.com"
+MANAGER_USER = "leave-weekend-test-manager@example.com"
 
 INCLUDES_HOLIDAYS_TYPE = "Leave Weekend Test Incl"
 EXCLUDES_HOLIDAYS_TYPE = "Leave Weekend Test Excl"
@@ -93,6 +94,9 @@ class TestLeaveIncludesHolidays(IntegrationTestCase):
 class TestLeaveWeekendRendering(IntegrationTestCase):
     """A leave spanning a weekend is rendered to match what the backend actually counted.
 
+    Renders through the live team-view path (`_get_team_timesheet_data`), the endpoint the
+    frontend calls. The employee reports to a manager so it surfaces under `reports_to`.
+
     Both leave types below are `is_lwp` so no Leave Allocation is needed, and both are
     configured so that stock HRMS and rtCamp's override agree on the outcome — the
     assertions hold whether or not the rtcamp app is installed.
@@ -101,6 +105,9 @@ class TestLeaveWeekendRendering(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # The framework rolls back the DefaultValue row at class teardown, but set_default also
+        # rewarms a non-transactional cache that rollback won't revert, so restore it explicitly.
+        cls._prev_first_day_of_the_week = frappe.db.get_default("first_day_of_the_week")
         frappe.db.set_default("first_day_of_the_week", "Monday")
 
         weekends = []
@@ -119,10 +126,12 @@ class TestLeaveWeekendRendering(IntegrationTestCase):
         holiday_list = make_holiday_list(
             HOLIDAY_LIST, from_date="2026-01-01", to_date="2026-12-31", holiday_dates=weekends
         )
+        cls.manager = make_employee(MANAGER_USER, company=get_default_company(), leave_approver="Administrator")
         cls.employee = make_employee(
             EMPLOYEE_USER,
             company=get_default_company(),
             leave_approver="Administrator",
+            reports_to=cls.manager,
         )
         # Employee.holiday_list is ignored; HRMS resolves via Holiday List Assignment.
         if not frappe.db.exists(
@@ -153,6 +162,11 @@ class TestLeaveWeekendRendering(IntegrationTestCase):
         # A previous aborted run can leave applications behind and trip the overlap check.
         for leave in frappe.get_all("Leave Application", filters={"employee": cls.employee}, pluck="name"):
             frappe.delete_doc("Leave Application", leave, force=1, ignore_permissions=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.db.set_default("first_day_of_the_week", cls._prev_first_day_of_the_week)
+        super().tearDownClass()
 
     def tearDown(self):
         get_employee_leaves.clear_cache()
@@ -189,9 +203,7 @@ class TestLeaveWeekendRendering(IntegrationTestCase):
         ).insert()
 
     def _weekend_hours(self, week_of):
-        payload = get_compact_view_data(
-            date=week_of, max_week=1, employee_ids=[self.employee], by_pass_access_check=True
-        )
+        payload = _get_team_timesheet_data(date=week_of, max_week=1, reports_to=self.manager, by_pass_access_check=True)
         row = payload["data"][self.employee]
         days = {str(day["date"]): day for day in row["data"]}
         return row["working_hour"], days

--- a/next_pms/tests/resource_management/api/test_leave_includes_holidays.py
+++ b/next_pms/tests/resource_management/api/test_leave_includes_holidays.py
@@ -1,0 +1,199 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, getdate
+
+from next_pms.resource_management.api.utils.query import (
+    get_employee_leaves,
+    leave_includes_holidays,
+)
+from next_pms.tests.utils import make_employee, make_holiday_list
+from next_pms.timesheet.api.team import get_compact_view_data
+
+# Aug 2026: Mon 10 … Fri 14, Sat 15 + Sun 16 weekly off, Mon 17 … Wed 19.
+MON, FRI = "2026-08-10", "2026-08-14"
+SAT, SUN = "2026-08-15", "2026-08-16"
+TUE_NEXT, WED_NEXT = "2026-08-18", "2026-08-19"
+THU = "2026-08-13"
+
+# Sep 2026, one weekend per test so the two Leave Applications never overlap.
+SEP_THU, SEP_FRI = "2026-09-10", "2026-09-11"
+SEP_SAT, SEP_SUN = "2026-09-12", "2026-09-13"
+SEP_TUE_NEXT = "2026-09-15"
+
+HOLIDAY_LIST = "Leave Weekend Test Holiday List"
+EMPLOYEE_USER = "leave-weekend-test@example.com"
+
+INCLUDES_HOLIDAYS_TYPE = "Leave Weekend Test Incl"
+EXCLUDES_HOLIDAYS_TYPE = "Leave Weekend Test Excl"
+
+
+class TestLeaveIncludesHolidays(IntegrationTestCase):
+    """`leave_includes_holidays` compares the stored day count against the raw calendar span."""
+
+    def test_full_span_counted_means_holidays_included(self):
+        leave = {"from_date": getdate(THU), "to_date": getdate(WED_NEXT), "total_leave_days": 7}
+        self.assertTrue(leave_includes_holidays(leave))
+
+    def test_short_count_means_holidays_excluded(self):
+        # Fri->Mon counted as 2 days: the weekend was dropped.
+        leave = {"from_date": getdate(FRI), "to_date": getdate("2026-08-17"), "total_leave_days": 2}
+        self.assertFalse(leave_includes_holidays(leave))
+
+    def test_boundary_between_four_and_five_working_days(self):
+        """A policy that drops holidays below a threshold flips the flag on the day count alone.
+
+        rtCamp's override counts weekends only once unpaid leave reaches five working
+        days. Both sides of that boundary must be read off `total_leave_days` without
+        this helper knowing the rule exists.
+        """
+        four_working_days = {"from_date": getdate(THU), "to_date": getdate(TUE_NEXT), "total_leave_days": 4}
+        five_working_days = {"from_date": getdate(THU), "to_date": getdate(WED_NEXT), "total_leave_days": 7}
+
+        self.assertFalse(leave_includes_holidays(four_working_days))
+        self.assertTrue(leave_includes_holidays(five_working_days))
+
+    def test_half_day_on_single_day(self):
+        leave = {
+            "from_date": getdate(MON),
+            "to_date": getdate(MON),
+            "half_day": 1,
+            "half_day_date": getdate(MON),
+            "total_leave_days": 0.5,
+        }
+        self.assertTrue(leave_includes_holidays(leave))
+
+    def test_half_day_within_multi_day_range(self):
+        base = {
+            "from_date": getdate(FRI),
+            "to_date": getdate("2026-08-17"),
+            "half_day": 1,
+            "half_day_date": getdate("2026-08-17"),
+        }
+        # Raw span is 3.5 days (4 calendar days, one of them a half day).
+        self.assertTrue(leave_includes_holidays({**base, "total_leave_days": 3.5}))
+        self.assertFalse(leave_includes_holidays({**base, "total_leave_days": 1.5}))
+
+    def test_half_day_date_outside_range_does_not_shorten_span(self):
+        leave = {
+            "from_date": getdate(THU),
+            "to_date": getdate(FRI),
+            "half_day": 1,
+            "half_day_date": getdate(WED_NEXT),
+            "total_leave_days": 2,
+        }
+        self.assertTrue(leave_includes_holidays(leave))
+
+    def test_missing_total_leave_days_is_treated_as_excluding_holidays(self):
+        leave = {"from_date": getdate(THU), "to_date": getdate(FRI), "total_leave_days": None}
+        self.assertFalse(leave_includes_holidays(leave))
+
+
+class TestLeaveWeekendRendering(IntegrationTestCase):
+    """A leave spanning a weekend is rendered to match what the backend actually counted.
+
+    Both leave types below are `is_lwp` so no Leave Allocation is needed, and both are
+    configured so that stock HRMS and rtCamp's override agree on the outcome — the
+    assertions hold whether or not the rtcamp app is installed.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.db.set_default("first_day_of_the_week", "Monday")
+
+        weekends = []
+        date = getdate("2026-01-01")
+        while date <= getdate("2026-12-31"):
+            if date.weekday() >= 5:
+                weekends.append(
+                    {
+                        "holiday_date": date,
+                        "description": date.strftime("%A"),
+                        "weekly_off": 1,
+                    }
+                )
+            date = add_days(date, 1)
+
+        make_holiday_list(HOLIDAY_LIST, from_date="2026-01-01", to_date="2026-12-31", holiday_dates=weekends)
+        cls.employee = make_employee(
+            EMPLOYEE_USER,
+            company=get_default_company(),
+            holiday_list=HOLIDAY_LIST,
+            leave_approver="Administrator",
+        )
+
+        for name, include_holiday in ((INCLUDES_HOLIDAYS_TYPE, 1), (EXCLUDES_HOLIDAYS_TYPE, 0)):
+            if not frappe.db.exists("Leave Type", name):
+                frappe.get_doc(
+                    {
+                        "doctype": "Leave Type",
+                        "leave_type_name": name,
+                        "include_holiday": include_holiday,
+                        "is_lwp": 1,
+                    }
+                ).insert()
+
+        # A previous aborted run can leave applications behind and trip the overlap check.
+        for leave in frappe.get_all("Leave Application", filters={"employee": cls.employee}, pluck="name"):
+            frappe.delete_doc("Leave Application", leave, force=1, ignore_permissions=True)
+
+    def tearDown(self):
+        get_employee_leaves.clear_cache()
+        frappe.cache().delete_keys("emp_timesheet")
+
+    def _apply_leave(self, leave_type, from_date, to_date):
+        get_employee_leaves.clear_cache()
+        frappe.cache().delete_keys("emp_timesheet")
+        return frappe.get_doc(
+            {
+                "doctype": "Leave Application",
+                "employee": self.employee,
+                "leave_type": leave_type,
+                "from_date": from_date,
+                "to_date": to_date,
+                "description": "weekend rendering test",
+                "leave_approver": "Administrator",
+                "status": "Open",
+            }
+        ).insert()
+
+    def _weekend_hours(self, week_of):
+        payload = get_compact_view_data(
+            date=week_of, max_week=1, employee_ids=[self.employee], by_pass_access_check=True
+        )
+        row = payload["data"][self.employee]
+        days = {str(day["date"]): day for day in row["data"]}
+        return row["working_hour"], days
+
+    def test_leave_counting_the_weekend_renders_across_it(self):
+        leave = self._apply_leave(INCLUDES_HOLIDAYS_TYPE, THU, WED_NEXT)
+
+        row = next(r for r in get_employee_leaves(self.employee, THU, WED_NEXT) if r["name"] == leave.name)
+        self.assertTrue(row["includes_holidays"])
+
+        working_hour, days = self._weekend_hours(THU)
+        self.assertEqual(days[SAT]["hour"], working_hour)
+        self.assertTrue(days[SAT]["is_leave"])
+        self.assertEqual(days[SUN]["hour"], working_hour)
+        self.assertTrue(days[SUN]["is_leave"])
+
+        # Working days inside the range are unaffected.
+        self.assertEqual(days[FRI]["hour"], working_hour)
+        self.assertTrue(days[FRI]["is_leave"])
+
+    def test_leave_dropping_the_weekend_skips_it(self):
+        leave = self._apply_leave(EXCLUDES_HOLIDAYS_TYPE, SEP_THU, SEP_TUE_NEXT)
+
+        row = next(r for r in get_employee_leaves(self.employee, SEP_THU, SEP_TUE_NEXT) if r["name"] == leave.name)
+        self.assertFalse(row["includes_holidays"])
+
+        working_hour, days = self._weekend_hours(SEP_THU)
+        self.assertEqual(days[SEP_SAT]["hour"], 0)
+        self.assertFalse(days[SEP_SAT]["is_leave"])
+        self.assertEqual(days[SEP_SUN]["hour"], 0)
+        self.assertFalse(days[SEP_SUN]["is_leave"])
+
+        # Working days inside the range are unaffected.
+        self.assertEqual(days[SEP_FRI]["hour"], working_hour)
+        self.assertTrue(days[SEP_FRI]["is_leave"])

--- a/next_pms/tests/resource_management/api/test_leave_includes_holidays.py
+++ b/next_pms/tests/resource_management/api/test_leave_includes_holidays.py
@@ -9,6 +9,7 @@ from next_pms.resource_management.api.utils.query import (
 )
 from next_pms.tests.utils import make_employee, make_holiday_list
 from next_pms.timesheet.api.team import get_compact_view_data
+from next_pms.timesheet.api.utils import get_holidays
 
 # Aug 2026: Mon 10 … Fri 14, Sat 15 + Sun 16 weekly off, Mon 17 … Wed 19.
 MON, FRI = "2026-08-10", "2026-08-14"
@@ -115,13 +116,28 @@ class TestLeaveWeekendRendering(IntegrationTestCase):
                 )
             date = add_days(date, 1)
 
-        make_holiday_list(HOLIDAY_LIST, from_date="2026-01-01", to_date="2026-12-31", holiday_dates=weekends)
+        holiday_list = make_holiday_list(
+            HOLIDAY_LIST, from_date="2026-01-01", to_date="2026-12-31", holiday_dates=weekends
+        )
         cls.employee = make_employee(
             EMPLOYEE_USER,
             company=get_default_company(),
-            holiday_list=HOLIDAY_LIST,
             leave_approver="Administrator",
         )
+        # Employee.holiday_list is ignored; HRMS resolves via Holiday List Assignment.
+        if not frappe.db.exists(
+            "Holiday List Assignment",
+            {"assigned_to": cls.employee, "from_date": "2026-01-01", "docstatus": 1},
+        ):
+            frappe.get_doc(
+                {
+                    "doctype": "Holiday List Assignment",
+                    "applicable_for": "Employee",
+                    "assigned_to": cls.employee,
+                    "holiday_list": holiday_list.name,
+                    "from_date": "2026-01-01",
+                }
+            ).insert(ignore_permissions=True).submit()
 
         for name, include_holiday in ((INCLUDES_HOLIDAYS_TYPE, 1), (EXCLUDES_HOLIDAYS_TYPE, 0)):
             if not frappe.db.exists("Leave Type", name):
@@ -140,7 +156,21 @@ class TestLeaveWeekendRendering(IntegrationTestCase):
 
     def tearDown(self):
         get_employee_leaves.clear_cache()
+        get_holidays.clear_cache()
         frappe.cache().delete_keys("emp_timesheet")
+
+    def test_weekends_resolve_as_holidays_for_the_employee(self):
+        """Guards the fixture itself.
+
+        HRMS resolves an employee's holiday list through Holiday List Assignment, so a
+        missing assignment yields no holidays at all — and then every weekend assertion
+        below passes for the wrong reason instead of failing.
+        """
+        holidays = {str(h.holiday_date): h for h in get_holidays(self.employee, SEP_THU, SEP_TUE_NEXT)}
+
+        for weekend_day in (SEP_SAT, SEP_SUN):
+            self.assertIn(weekend_day, holidays)
+            self.assertTrue(holidays[weekend_day].weekly_off)
 
     def _apply_leave(self, leave_type, from_date, to_date):
         get_employee_leaves.clear_cache()

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -142,21 +142,25 @@ def get_compact_view_data(
                 hour = 0
                 on_leave = False
 
-                for leave in leaves:
-                    if leave["from_date"] <= date <= leave["to_date"]:
-                        if leave.get("half_day") and leave.get("half_day_date") == date:
-                            hour += daily_working_hours / 2
-                        else:
-                            hour += daily_working_hours
-                        on_leave = True
+                holiday = next((h for h in holidays if h.holiday_date == date), None)
 
-                for holiday in holidays:
-                    if date == holiday.holiday_date:
-                        if not holiday.weekly_off:
-                            hour = daily_working_hours
-                        else:
-                            hour = 0
+                for leave in leaves:
+                    if not leave["from_date"] <= date <= leave["to_date"]:
+                        continue
+                    if holiday and holiday.weekly_off and not leave.get("includes_holidays"):
+                        continue
+                    if leave.get("half_day") and leave.get("half_day_date") == date:
+                        hour += daily_working_hours / 2
+                    else:
+                        hour += daily_working_hours
+                    on_leave = True
+
+                if holiday:
+                    if not holiday.weekly_off:
+                        hour = daily_working_hours
                         on_leave = False
+                    elif not on_leave:
+                        hour = 0
                 total_hours = 0
                 notes = ""
                 for ts in employee_timesheets:
@@ -267,21 +271,25 @@ def _get_team_timesheet_data(
                 hour = 0
                 on_leave = False
 
-                for leave in leaves:
-                    if leave["from_date"] <= current_date <= leave["to_date"]:
-                        if leave.get("half_day") and leave.get("half_day_date") == current_date:
-                            hour += daily_working_hours / 2
-                        else:
-                            hour += daily_working_hours
-                        on_leave = True
-
                 holiday = holidays_by_date.get(current_date)
+
+                for leave in leaves:
+                    if not leave["from_date"] <= current_date <= leave["to_date"]:
+                        continue
+                    if holiday and holiday.weekly_off and not leave.get("includes_holidays"):
+                        continue
+                    if leave.get("half_day") and leave.get("half_day_date") == current_date:
+                        hour += daily_working_hours / 2
+                    else:
+                        hour += daily_working_hours
+                    on_leave = True
+
                 if holiday:
                     if not holiday.weekly_off:
                         hour = daily_working_hours
-                    else:
+                        on_leave = False
+                    elif not on_leave:
                         hour = 0
-                    on_leave = False
 
                 hour += hours_by_date.get(current_date, 0)
                 local_data["data"].append(


### PR DESCRIPTION
## Description

- Added `leave_includes_holidays` function in `query.py` to determine if a leave's day count covers holidays, based on the stored leave duration versus the calendar span, including half-day logic.
- The `get_employee_leaves` API now attaches the `includes_holidays` flag to each leave record, both in the real query and in test data.
- Updated timesheet and leave calculation utilities (`getTimesheetHours`, `calculateLeaveHours` in `utils.ts`) to use the new `includes_holidays` flag instead of `is_lwp` for deciding whether to count holidays inside leave periods. 
- Added the `includes_holidays` property to the `LeaveProps` TypeScript interface.
- Updated timesheet rendering logic in `team.py` to skip or include holidays in leave periods according to the new flag. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
##### Leave from 24th July to 27th July (2 days excluding weekend) 

**Before**: 
<img width="588" height="317" alt="image" src="https://github.com/user-attachments/assets/9c8dfe86-50c2-4c51-9478-3790bacd139f" />

**After**:

<img width="510" height="325" alt="image" src="https://github.com/user-attachments/assets/40b8dfa6-0e94-491a-b32e-2467e3631168" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1554 