### PR TITLE
fix: member row does not display a visible focus state during keyboard navigation

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
@@ -3,7 +3,7 @@
  */
 import { useMemo, useState } from "react";
 import { Accordion } from "@base-ui/react/accordion";
-import { floatToTime } from "@next-pms/design-system";
+import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
 import {
   ApprovalStatusMap,
   MemberRow as BaseMemberRow,
@@ -55,7 +55,13 @@ export const MemberRow = ({
         <Accordion.Trigger
           nativeButton={false}
           render={(props) => (
-            <div {...props}>
+            <div
+              {...props}
+              className={cn(
+                props.className,
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
+              )}
+            >
               <BaseMemberRow
                 {...rest}
                 avatarUrl={avatarUrl}

--- a/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
@@ -3,7 +3,7 @@
  */
 import { useMemo, useState } from "react";
 import { Accordion } from "@base-ui/react/accordion";
-import { floatToTime } from "@next-pms/design-system";
+import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
 import { ProjectRow as BaseProjectRow } from "@next-pms/design-system/components";
 
 /**
@@ -64,7 +64,13 @@ export const ProjectRow = ({
         <Accordion.Trigger
           nativeButton={false}
           render={(props) => (
-            <div {...props}>
+            <div
+              {...props}
+              className={cn(
+                props.className,
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
+              )}
+            >
               <BaseProjectRow
                 {...rest}
                 totalHours={hideTime ? "" : floatToTime(projectData.total, 2)}

--- a/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
@@ -3,7 +3,7 @@
  */
 import { useMemo, useState } from "react";
 import { Accordion } from "@base-ui/react/accordion";
-import { floatToTime } from "@next-pms/design-system";
+import { floatToTime, mergeClassNames as cn } from "@next-pms/design-system";
 import {
   WeekRow as BaseWeekRow,
   ApprovalStatusMap,
@@ -116,7 +116,13 @@ export const WeekRow = ({
         <Accordion.Trigger
           nativeButton={false}
           render={(props) => (
-            <div {...props}>
+            <div
+              {...props}
+              className={cn(
+                props.className,
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3",
+              )}
+            >
               <BaseWeekRow
                 {...rest}
                 today={today}

--- a/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
@@ -71,7 +71,7 @@ export const TotalRow: React.FC<TotalRowProps> = ({
           <button
             type="button"
             onClick={onStarClick}
-            className="flex justify-center items-center w-4 h-4 rounded transition-colors cursor-pointer hover:bg-surface-gray-2"
+            className="flex justify-center items-center w-4 h-4 rounded transition-colors cursor-pointer hover:bg-surface-gray-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
             aria-label={starTooltipText}
           >
             {starIcon}


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds the missing focus highlight styles to the timesheet rows.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Navigate to the "Personal", "Team", and "Project Timesheet" pages.
2. Use the "Tab" key to navigate through the timesheet rows.
3. Verify that a visible focus highlight appears on:
   - Week rows
   - Member rows
   - Project rows

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


https://github.com/user-attachments/assets/7433f1ce-3b97-4e83-b92b-ec25efd0dca4





## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1665