### PR TITLE
Ability to add a new Task and edit task directly from the Task List

### DIFF
--- a/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
@@ -1,0 +1,276 @@
+/**
+ * External Dependencies
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Combobox,
+  Dialog,
+  ErrorMessage,
+  Textarea,
+  TextInput,
+  useToasts,
+} from "@rtcamp/frappe-ui-react";
+import { useForm } from "@tanstack/react-form";
+import { useSelector } from "@tanstack/react-store";
+import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
+
+/**
+ * Internal Dependencies
+ */
+import {
+  useProjectLookup,
+  type ProjectLookupOption,
+} from "@/hooks/useProjectLookup";
+import { parseFrappeErrorMsg } from "@/lib/utils";
+import { addTaskFormSchema, type addTaskFormValues } from "./schema";
+import type { AddTaskProps } from "./type";
+
+const emptyValues: addTaskFormValues = {
+  subject: "",
+  project: "",
+  projectLabel: "",
+  expected_time: "",
+  description: "",
+};
+
+const AddTask = ({
+  open = false,
+  onOpenChange,
+  prefill,
+  onSuccess,
+}: AddTaskProps) => {
+  const [projectSearch, setProjectSearch] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const toast = useToasts();
+  const { call: createTask } = useFrappePostCall(
+    "next_pms.timesheet.api.task.add_task",
+  );
+
+  const initialValues = useMemo<addTaskFormValues>(
+    () => ({
+      ...emptyValues,
+      ...prefill,
+    }),
+    [prefill],
+  );
+
+  const form = useForm({
+    defaultValues: initialValues,
+    validators: {
+      onSubmit: addTaskFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setSubmitting(true);
+      setSubmitError(null);
+      try {
+        await createTask({
+          subject: value.subject.trim(),
+          project: value.project.trim(),
+          expected_time: value.expected_time.trim(),
+          description: value.description.trim(),
+        });
+
+        toast.success("Task created successfully");
+        closeModal();
+        onSuccess?.();
+      } catch (err) {
+        const error = parseFrappeErrorMsg(err as FrappeError);
+        setSubmitError(error);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset(initialValues);
+    }
+  }, [form, open, initialValues]);
+
+  const selectedProject = useSelector(
+    form.store,
+    (state) => state.values.project,
+  );
+
+  const selectedProjectLabel = useSelector(
+    form.store,
+    (state) => state.values.projectLabel,
+  );
+
+  const selectedProjectOption: ProjectLookupOption | null = selectedProject
+    ? {
+        label: selectedProjectLabel || selectedProject,
+        value: selectedProject,
+      }
+    : null;
+
+  const { options: projectOptions, isLoading: isProjectLookupLoading } =
+    useProjectLookup({
+      shouldFetch: open,
+      filters: window.frappe?.boot?.global_filters.project,
+      pageSize: 20,
+      query: projectSearch,
+      selectedOption: selectedProjectOption,
+    });
+
+  const closeModal = useCallback(() => {
+    if (submitting) {
+      return;
+    }
+    setProjectSearch("");
+    setSubmitError(null);
+    onOpenChange(false);
+    form.reset(emptyValues);
+  }, [form, onOpenChange, submitting]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        onOpenChange(true);
+        return;
+      }
+      closeModal();
+    },
+    [closeModal, onOpenChange],
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      options={{
+        title: () => <span className="text-lg font-medium">Add Task</span>,
+      }}
+      className="my-0"
+      classNames={{
+        header: "mb-5",
+        content: "pt-5 pb-2",
+        viewport: "justify-start pt-30",
+        footer: "pb-6",
+      }}
+      actions={
+        <div className="flex items-center justify-end w-full gap-2">
+          <Button variant="ghost" label="Cancel" onClick={closeModal} />
+          <Button
+            variant="solid"
+            label="Add Task"
+            onClick={() => form.handleSubmit()}
+            disabled={submitting}
+            loading={submitting}
+          />
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-12">
+          <form.Field
+            name="subject"
+            children={(field) => (
+              <div className="sm:col-span-9">
+                <label className="block text-base text-ink-gray-5 mb-1.5">
+                  Subject
+                </label>
+                <TextInput
+                  size="md"
+                  variant="outline"
+                  placeholder="Add subject"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                />
+                {!field.state.meta.isValid && (
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                )}
+              </div>
+            )}
+          />
+
+          <form.Field
+            name="expected_time"
+            children={(field) => (
+              <div className="sm:col-span-3">
+                <label className="block text-base text-ink-gray-5 mb-1.5">
+                  Expected Time
+                </label>
+                <TextInput
+                  size="md"
+                  variant="outline"
+                  placeholder="Hours"
+                  type="number"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                />
+                {!field.state.meta.isValid && (
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                )}
+              </div>
+            )}
+          />
+        </div>
+
+        <form.Field
+          name="project"
+          children={(field) => (
+            <div>
+              <label className="block text-base text-ink-gray-5 mb-1.5">
+                Project
+              </label>
+              <Combobox
+                inputClassName="bg-surface-white h-8 border-outline-gray-2 text-ink-gray-7"
+                loading={isProjectLookupLoading}
+                options={projectOptions}
+                placeholder="Select project"
+                searchValue={projectSearch}
+                onSearchChange={setProjectSearch}
+                value={field.state.value}
+                onChange={(value, option) => {
+                  const nextProject = value ?? "";
+                  const nextProjectOption =
+                    option as ProjectLookupOption | null;
+                  form.setFieldValue(
+                    "projectLabel",
+                    nextProjectOption?.label ?? nextProject,
+                  );
+                  field.handleChange(nextProject);
+                }}
+                openOnFocus
+              />
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+
+        <form.Field
+          name="description"
+          children={(field) => (
+            <div>
+              <label className="block text-base text-ink-gray-5 mb-1.5">
+                Description
+              </label>
+              <Textarea
+                rows={4}
+                placeholder="Add description"
+                value={field.state.value}
+                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  field.handleChange(event.target.value)
+                }
+              />
+              {!field.state.meta.isValid && (
+                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+              )}
+            </div>
+          )}
+        />
+
+        {submitError && <ErrorMessage message={submitError} />}
+      </div>
+    </Dialog>
+  );
+};
+
+export default AddTask;

--- a/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
@@ -1,7 +1,13 @@
 /**
  * External Dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+} from "react";
 import {
   Button,
   Combobox,
@@ -13,11 +19,8 @@ import {
 } from "@rtcamp/frappe-ui-react";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
-import {
-  FrappeError,
-  useFrappePostCall,
-  useFrappeUpdateDoc,
-} from "frappe-react-sdk";
+import { useFrappePostCall, useFrappeUpdateDoc } from "frappe-react-sdk";
+import type { FrappeError } from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
@@ -27,10 +30,14 @@ import {
   type ProjectLookupOption,
 } from "@/hooks/useProjectLookup";
 import { parseFrappeErrorMsg } from "@/lib/utils";
-import { addTaskFormSchema, type addTaskFormValues } from "./schema";
+import {
+  addTaskFormSchema,
+  editTaskFormSchema,
+  type AddTaskFormValues,
+} from "./schema";
 import type { AddTaskProps } from "./type";
 
-const emptyValues: addTaskFormValues = {
+const emptyValues: AddTaskFormValues = {
   subject: "",
   project: "",
   projectLabel: "",
@@ -56,7 +63,7 @@ const AddTask = ({
   const { updateDoc } = useFrappeUpdateDoc();
   const isEditMode = Boolean(taskName);
 
-  const initialValues = useMemo<addTaskFormValues>(
+  const initialValues = useMemo<AddTaskFormValues>(
     () => ({
       ...emptyValues,
       ...prefill,
@@ -67,7 +74,7 @@ const AddTask = ({
   const form = useForm({
     defaultValues: initialValues,
     validators: {
-      onSubmit: addTaskFormSchema,
+      onSubmit: isEditMode ? editTaskFormSchema : addTaskFormSchema,
     },
     onSubmit: async ({ value }) => {
       setSubmitting(true);
@@ -280,7 +287,7 @@ const AddTask = ({
                 rows={4}
                 placeholder="Add description"
                 value={field.state.value}
-                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                   field.handleChange(event.target.value)
                 }
               />

--- a/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
@@ -1,21 +1,16 @@
 /**
  * External Dependencies
  */
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ChangeEvent,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   Combobox,
   Dialog,
   ErrorMessage,
-  Textarea,
+  TextEditor,
   TextInput,
   useToasts,
+  type TextEditorProps,
 } from "@rtcamp/frappe-ui-react";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
@@ -36,6 +31,10 @@ import {
   type AddTaskFormValues,
 } from "./schema";
 import type { AddTaskProps } from "./type";
+
+const DESCRIPTION_EDITOR_STARTERKIT_OPTIONS: NonNullable<
+  TextEditorProps["starterkitOptions"]
+> = { trailingNode: false };
 
 const emptyValues: AddTaskFormValues = {
   subject: "",
@@ -213,7 +212,11 @@ const AddTask = ({
                   onChange={(event) => field.handleChange(event.target.value)}
                 />
                 {!field.state.meta.isValid && (
-                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                  <div className="mt-4">
+                    <ErrorMessage
+                      message={field.state.meta.errors[0]?.message}
+                    />
+                  </div>
                 )}
               </div>
             )}
@@ -235,7 +238,11 @@ const AddTask = ({
                   onChange={(event) => field.handleChange(event.target.value)}
                 />
                 {!field.state.meta.isValid && (
-                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                  <div className="mt-4">
+                    <ErrorMessage
+                      message={field.state.meta.errors[0]?.message}
+                    />
+                  </div>
                 )}
               </div>
             )}
@@ -270,7 +277,9 @@ const AddTask = ({
                 openOnFocus
               />
               {!field.state.meta.isValid && (
-                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                <div className="mt-4">
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                </div>
               )}
             </div>
           )}
@@ -283,16 +292,18 @@ const AddTask = ({
               <label className="block text-base text-ink-gray-5 mb-1.5">
                 Description
               </label>
-              <Textarea
-                rows={4}
+              <TextEditor
                 placeholder="Add description"
-                value={field.state.value}
-                onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
-                  field.handleChange(event.target.value)
-                }
+                content={field.state.value}
+                onChange={(value) => field.handleChange(value)}
+                starterkitOptions={DESCRIPTION_EDITOR_STARTERKIT_OPTIONS}
+                fixedMenu={false}
+                editorClass="px-2 h-24 prose-sm overflow-auto scrollbar-thin bg-surface-white border rounded-md border-outline-gray-2 text-ink-gray-7 text-base"
               />
               {!field.state.meta.isValid && (
-                <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                <div className="mt-4">
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                </div>
               )}
             </div>
           )}

--- a/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
@@ -13,7 +13,11 @@ import {
 } from "@rtcamp/frappe-ui-react";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
-import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
+import {
+  FrappeError,
+  useFrappePostCall,
+  useFrappeUpdateDoc,
+} from "frappe-react-sdk";
 
 /**
  * Internal Dependencies
@@ -38,6 +42,7 @@ const AddTask = ({
   open = false,
   onOpenChange,
   prefill,
+  taskName,
   onSuccess,
 }: AddTaskProps) => {
   const [projectSearch, setProjectSearch] = useState("");
@@ -48,6 +53,8 @@ const AddTask = ({
   const { call: createTask } = useFrappePostCall(
     "next_pms.timesheet.api.task.add_task",
   );
+  const { updateDoc } = useFrappeUpdateDoc();
+  const isEditMode = Boolean(taskName);
 
   const initialValues = useMemo<addTaskFormValues>(
     () => ({
@@ -66,14 +73,27 @@ const AddTask = ({
       setSubmitting(true);
       setSubmitError(null);
       try {
-        await createTask({
-          subject: value.subject.trim(),
-          project: value.project.trim(),
-          expected_time: value.expected_time.trim(),
-          description: value.description.trim(),
-        });
+        if (isEditMode && taskName) {
+          await updateDoc("Task", taskName, {
+            subject: value.subject.trim(),
+            project: value.project.trim(),
+            expected_time: value.expected_time.trim(),
+            description: value.description.trim(),
+          });
+        } else {
+          await createTask({
+            subject: value.subject.trim(),
+            project: value.project.trim(),
+            expected_time: value.expected_time.trim(),
+            description: value.description.trim(),
+          });
+        }
 
-        toast.success("Task created successfully");
+        toast.success(
+          isEditMode
+            ? "Task updated successfully"
+            : "Task created successfully",
+        );
         closeModal();
         onSuccess?.();
       } catch (err) {
@@ -143,7 +163,11 @@ const AddTask = ({
       open={open}
       onOpenChange={handleOpenChange}
       options={{
-        title: () => <span className="text-lg font-medium">Add Task</span>,
+        title: () => (
+          <span className="text-lg font-medium">
+            {isEditMode ? "Edit Task" : "Add Task"}
+          </span>
+        ),
       }}
       className="my-0"
       classNames={{
@@ -157,7 +181,7 @@ const AddTask = ({
           <Button variant="ghost" label="Cancel" onClick={closeModal} />
           <Button
             variant="solid"
-            label="Add Task"
+            label={isEditMode ? "Save" : "Add Task"}
             onClick={() => form.handleSubmit()}
             disabled={submitting}
             loading={submitting}

--- a/frontend/packages/app/src/pages/tasks/components/add-task/schema.ts
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/schema.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
 
 const expectedTimeSchema = z
-  .string({
-    required_error: "Please enter a valid number for hours.",
-  })
+  .string()
   .trim()
-  .min(1, { message: "Please enter a valid time in Hours" })
-  .refine((value) => Number.isFinite(Number(value)), {
-    message: "Invalid Time format. Please enter a valid time in Hours",
+  .refine((value) => value !== "" && Number.isFinite(Number(value)), {
+    message: "Please enter a valid time in hours.",
   });
 
 export const addTaskFormSchema = z.object({
@@ -27,4 +24,9 @@ export const addTaskFormSchema = z.object({
     .min(4, { message: "Please enter valid description." }),
 });
 
-export type addTaskFormValues = z.input<typeof addTaskFormSchema>;
+export const editTaskFormSchema = z.object({
+  ...addTaskFormSchema.shape,
+  description: z.string().trim(),
+});
+
+export type AddTaskFormValues = z.input<typeof addTaskFormSchema>;

--- a/frontend/packages/app/src/pages/tasks/components/add-task/schema.ts
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const expectedTimeSchema = z
+  .string({
+    required_error: "Please enter a valid number for hours.",
+  })
+  .trim()
+  .min(1, { message: "Please enter a valid time in Hours" })
+  .refine((value) => Number.isFinite(Number(value)), {
+    message: "Invalid Time format. Please enter a valid time in Hours",
+  });
+
+export const addTaskFormSchema = z.object({
+  subject: z
+    .string({ required_error: "Please add a subject." })
+    .trim()
+    .min(1, { message: "Please add a subject." }),
+  project: z
+    .string({ required_error: "Please select a project." })
+    .trim()
+    .min(1, { message: "Please select a project." }),
+  projectLabel: z.string().optional().default(""),
+  expected_time: expectedTimeSchema,
+  description: z
+    .string({ required_error: "Please enter description." })
+    .trim()
+    .min(4, { message: "Please enter valid description." }),
+});
+
+export type addTaskFormValues = z.input<typeof addTaskFormSchema>;

--- a/frontend/packages/app/src/pages/tasks/components/add-task/type.ts
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/type.ts
@@ -1,9 +1,9 @@
 /**
  * Internal Dependencies
  */
-import type { addTaskFormValues } from "./schema";
+import type { AddTaskFormValues } from "./schema";
 
-export type AddTaskPrefill = Partial<addTaskFormValues>;
+export type AddTaskPrefill = Partial<AddTaskFormValues>;
 
 export interface AddTaskProps {
   open: boolean;

--- a/frontend/packages/app/src/pages/tasks/components/add-task/type.ts
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/type.ts
@@ -9,5 +9,6 @@ export interface AddTaskProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   prefill?: AddTaskPrefill | null;
+  taskName?: string | null;
   onSuccess?: () => void;
 }

--- a/frontend/packages/app/src/pages/tasks/components/add-task/type.ts
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/type.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal Dependencies
+ */
+import type { addTaskFormValues } from "./schema";
+
+export type AddTaskPrefill = Partial<addTaskFormValues>;
+
+export interface AddTaskProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  prefill?: AddTaskPrefill | null;
+  onSuccess?: () => void;
+}

--- a/frontend/packages/app/src/pages/tasks/components/header.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/header.tsx
@@ -1,17 +1,28 @@
 /**
  * External dependencies.
  */
-import { Breadcrumbs } from "@rtcamp/frappe-ui-react";
+import { Breadcrumbs, Button } from "@rtcamp/frappe-ui-react";
+import { AddSm } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
  */
 import { Header } from "@/layout/header";
 
-function TasksHeader() {
+type TasksHeaderProps = {
+  openAddTask: () => void;
+};
+
+function TasksHeader({ openAddTask }: TasksHeaderProps) {
   return (
     <Header>
       <Breadcrumbs items={[{ id: "tasks", label: "Tasks" }]} />
+      <Button
+        variant="solid"
+        label="Add Task"
+        iconLeft={() => <AddSm size={16} />}
+        onClick={openAddTask}
+      />
     </Header>
   );
 }

--- a/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
@@ -18,12 +18,14 @@ export function TaskListCell({
   column,
   onOpenTask,
   onAddTime,
+  onEditTask,
   onDeleteTask,
 }: {
   row: TaskListItem;
   column: ListViewColumn;
   onOpenTask?: (taskName: string) => void;
   onAddTime?: (prefill: OpenAddTimeDialogOptions) => void;
+  onEditTask?: (task: TaskListItem) => void;
   onDeleteTask?: (name: string) => void;
 }) {
   switch (column.key) {
@@ -48,7 +50,13 @@ export function TaskListCell({
     case "like":
       return <LikeCell name={row.name} likedBy={row._liked_by} />;
     case "actions":
-      return <TaskRowActions name={row.name} onDelete={onDeleteTask} />;
+      return (
+        <TaskRowActions
+          name={row.name}
+          onEdit={() => onEditTask?.(row)}
+          onDelete={onDeleteTask}
+        />
+      );
     default:
       return null;
   }

--- a/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
@@ -6,15 +6,22 @@ import { DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
 
 export function TaskRowActions({
   name,
+  onEdit,
   onDelete,
 }: {
   name: string;
+  onEdit?: (name: string) => void;
   onDelete?: (name: string) => void;
 }) {
   return (
     <Dropdown
       placement="center"
       options={[
+        {
+          key: "edit",
+          label: "Edit",
+          onClick: () => onEdit?.(name),
+        },
         {
           key: "delete",
           label: "Delete",

--- a/frontend/packages/app/src/pages/tasks/list/context.ts
+++ b/frontend/packages/app/src/pages/tasks/list/context.ts
@@ -7,6 +7,7 @@ import { createContext, useContextSelector } from "use-context-selector";
  * Internal dependencies.
  */
 import type { TaskListItem } from "./types";
+import type { AddTaskPrefill } from "../components/add-task/type";
 
 export interface TaskListContextProps {
   state: {
@@ -14,11 +15,15 @@ export interface TaskListContextProps {
     hasMore: boolean;
     isLoading: boolean;
     error: unknown;
+    addTaskOpen: boolean;
+    addTaskPrefill: AddTaskPrefill | null;
   };
   actions: {
     loadMore: () => void;
     refresh: () => void;
     deleteTask: (name: string) => Promise<void>;
+    openAddTaskModal: (prefill?: AddTaskPrefill) => void;
+    closeAddTaskModal: () => void;
   };
 }
 
@@ -31,11 +36,15 @@ export const TaskListContext = createContext<TaskListContextProps>({
     hasMore: false,
     isLoading: false,
     error: null,
+    addTaskOpen: false,
+    addTaskPrefill: null,
   },
   actions: {
     loadMore: noop,
     refresh: noop,
     deleteTask: noopAsync,
+    openAddTaskModal: noop,
+    closeAddTaskModal: noop,
   },
 });
 

--- a/frontend/packages/app/src/pages/tasks/list/context.ts
+++ b/frontend/packages/app/src/pages/tasks/list/context.ts
@@ -17,12 +17,14 @@ export interface TaskListContextProps {
     error: unknown;
     addTaskOpen: boolean;
     addTaskPrefill: AddTaskPrefill | null;
+    editTaskName: string | null;
   };
   actions: {
     loadMore: () => void;
     refresh: () => void;
     deleteTask: (name: string) => Promise<void>;
     openAddTaskModal: (prefill?: AddTaskPrefill) => void;
+    openEditTaskModal: (task: TaskListItem) => void;
     closeAddTaskModal: () => void;
   };
 }
@@ -38,12 +40,14 @@ export const TaskListContext = createContext<TaskListContextProps>({
     error: null,
     addTaskOpen: false,
     addTaskPrefill: null,
+    editTaskName: null,
   },
   actions: {
     loadMore: noop,
     refresh: noop,
     deleteTask: noopAsync,
     openAddTaskModal: noop,
+    openEditTaskModal: noop,
     closeAddTaskModal: noop,
   },
 });

--- a/frontend/packages/app/src/pages/tasks/list/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/index.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies.
  */
+import { useTaskList } from "./context";
 import { TaskListProvider } from "./provider";
 import TaskListView from "./view";
 import TasksHeader from "../components/header";
@@ -9,10 +10,20 @@ import { TaskListSubHeader } from "../components/subHeader";
 function TaskListPage() {
   return (
     <TaskListProvider>
-      <TasksHeader />
+      <TaskListPageContent />
+    </TaskListProvider>
+  );
+}
+
+function TaskListPageContent() {
+  const openAddTask = useTaskList((c) => c.actions.openAddTaskModal);
+
+  return (
+    <>
+      <TasksHeader openAddTask={openAddTask} />
       <TaskListSubHeader />
       <TaskListView />
-    </TaskListProvider>
+    </>
   );
 }
 

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useMemo, type PropsWithChildren } from "react";
+import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
 import { type PaginationKey, usePagination } from "@next-pms/hooks";
 import { useToasts } from "@rtcamp/frappe-ui-react";
 import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
@@ -10,6 +10,8 @@ import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
  * Internal dependencies.
  */
 import { buildFilterConditions, parseFrappeErrorMsg } from "@/lib/utils";
+import AddTask from "../components/add-task";
+import type { AddTaskPrefill } from "../components/add-task/type";
 import { TASK_LIST_PAGE_SIZE } from "../constants";
 import { TaskListContext, type TaskListContextProps } from "./context";
 import type { ResponseTaskList } from "./types";
@@ -19,6 +21,18 @@ export function TaskListProvider({ children }: PropsWithChildren) {
   const toast = useToasts();
   const { deleteDoc } = useFrappeDeleteDoc();
   const { filters, sort } = useTaskFilters();
+  const [addTaskOpen, setAddTaskOpen] = useState(false);
+  const [addTaskPrefill, setAddTaskPrefill] = useState<AddTaskPrefill | null>(
+    null,
+  );
+  const openAddTaskModal = useCallback((prefill?: AddTaskPrefill) => {
+    setAddTaskPrefill(prefill ?? null);
+    setAddTaskOpen(true);
+  }, []);
+  const closeAddTaskModal = useCallback(() => {
+    setAddTaskOpen(false);
+    setAddTaskPrefill(null);
+  }, []);
   const frappeFilters = useMemo(
     () => buildFilterConditions(filters.advanced),
     [filters.advanced],
@@ -116,19 +130,49 @@ export function TaskListProvider({ children }: PropsWithChildren) {
         hasMore,
         isLoading,
         error,
+        addTaskOpen,
+        addTaskPrefill,
       },
       actions: {
         loadMore,
         refresh,
         deleteTask,
+        openAddTaskModal,
+        closeAddTaskModal,
       },
     }),
-    [tasks, hasMore, isLoading, error, loadMore, refresh, deleteTask],
+    [
+      tasks,
+      hasMore,
+      isLoading,
+      error,
+      addTaskOpen,
+      addTaskPrefill,
+      loadMore,
+      refresh,
+      deleteTask,
+      openAddTaskModal,
+      closeAddTaskModal,
+    ],
   );
 
   return (
     <TaskListContext.Provider value={value}>
       {children}
+      <AddTask
+        open={addTaskOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            setAddTaskOpen(true);
+            return;
+          }
+          closeAddTaskModal();
+        }}
+        prefill={addTaskPrefill}
+        onSuccess={() => {
+          mutate();
+        }}
+      />
     </TaskListContext.Provider>
   );
 }

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -25,13 +25,30 @@ export function TaskListProvider({ children }: PropsWithChildren) {
   const [addTaskPrefill, setAddTaskPrefill] = useState<AddTaskPrefill | null>(
     null,
   );
+  const [editTaskName, setEditTaskName] = useState<string | null>(null);
   const openAddTaskModal = useCallback((prefill?: AddTaskPrefill) => {
+    setEditTaskName(null);
     setAddTaskPrefill(prefill ?? null);
     setAddTaskOpen(true);
   }, []);
+  const openEditTaskModal = useCallback(
+    (task: TaskListContextProps["state"]["data"][number]) => {
+      setEditTaskName(task.name);
+      setAddTaskPrefill({
+        subject: task.subject,
+        project: task.project,
+        projectLabel: task.project_name ?? task.project,
+        expected_time: String(task.expected_time ?? ""),
+        description: task.description ?? "",
+      });
+      setAddTaskOpen(true);
+    },
+    [],
+  );
   const closeAddTaskModal = useCallback(() => {
     setAddTaskOpen(false);
     setAddTaskPrefill(null);
+    setEditTaskName(null);
   }, []);
   const frappeFilters = useMemo(
     () => buildFilterConditions(filters.advanced),
@@ -132,12 +149,14 @@ export function TaskListProvider({ children }: PropsWithChildren) {
         error,
         addTaskOpen,
         addTaskPrefill,
+        editTaskName,
       },
       actions: {
         loadMore,
         refresh,
         deleteTask,
         openAddTaskModal,
+        openEditTaskModal,
         closeAddTaskModal,
       },
     }),
@@ -148,10 +167,12 @@ export function TaskListProvider({ children }: PropsWithChildren) {
       error,
       addTaskOpen,
       addTaskPrefill,
+      editTaskName,
       loadMore,
       refresh,
       deleteTask,
       openAddTaskModal,
+      openEditTaskModal,
       closeAddTaskModal,
     ],
   );
@@ -169,6 +190,7 @@ export function TaskListProvider({ children }: PropsWithChildren) {
           closeAddTaskModal();
         }}
         prefill={addTaskPrefill}
+        taskName={editTaskName}
         onSuccess={() => {
           mutate();
         }}

--- a/frontend/packages/app/src/pages/tasks/list/types.ts
+++ b/frontend/packages/app/src/pages/tasks/list/types.ts
@@ -3,6 +3,7 @@ export type TaskListItem = {
   subject: string;
   project: string;
   project_name: string | null;
+  description: string | null;
   status: string;
   priority: string;
   exp_end_date: string | null;

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -38,6 +38,7 @@ function TaskList() {
   const hasMore = useTaskList((c) => c.state.hasMore);
   const loadMore = useTaskList((c) => c.actions.loadMore);
   const deleteTask = useTaskList((c) => c.actions.deleteTask);
+  const openEditTaskModal = useTaskList((c) => c.actions.openEditTaskModal);
   const { sort, setSort } = useTaskFilters();
   const roles = useUser(({ state }) => state.roles);
   const showTeamTaskLog =
@@ -130,6 +131,7 @@ function TaskList() {
                       column={column}
                       onOpenTask={setOpenTask}
                       onAddTime={handleAddTime}
+                      onEditTask={openEditTaskModal}
                       onDeleteTask={setDeleteTaskName}
                     />
                   ))}


### PR DESCRIPTION
## Description

- Adds a "+ Add Task" button in the tasks list page that allows user to add a task from PMS
- Opens up a modal which allows to add: Subject, Expected Time, Project and Description
- Adds a "Edit" button in task kebab menu to open the modal and edit the existing task.

## Relevant Technical Choices

- Using the `next_pms.timesheet.api.task.add_task` endpoint to add the task and the `useProjectLookup` hook to fetch projects list and generic `useFrappeUpdateDoc` to edit the task document.

## Testing Instructions

- Open the tasks Page.
- Click the "+ Add Task" button
- Fill the details and click save.
- Observe the task to be added successfully.
- Click "Edit" in any task's kebab menu, edit the details and click save.

## Screenshot/Screencast


https://github.com/user-attachments/assets/01891d25-6ab6-4c19-859e-fcc71cecb6a7


<img width="833" height="570" alt="image" src="https://github.com/user-attachments/assets/4dbf5367-6892-4cfe-97d8-26a6318efedd" />

<img width="753" height="561" alt="image" src="https://github.com/user-attachments/assets/8c18ba9e-ed9e-42c9-8814-a91b4bc0d1d7" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1860 