### PR TITLE
refactor: employee working hours from  HR settings and exclude elapsed days from cost forecast

### DIFF
--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -57,40 +57,187 @@ def get_budget_burn_accrued(project: dict) -> float:
     return flt(project.get("total_costing_amount"))
 
 
-def get_cost_forecasted(project_name: str) -> float:
-    """Sum of total_cost from ongoing/future Resource Allocations for the project.
+def _allocated_day_count(start: date, end: date, include_weekends: bool) -> int:
+    """Number of days an allocation charges for between start and end, both inclusive.
 
-    Past allocations are excluded: their cost is already realized in the
-    project's total_costing_amount (cost_accrued) via timesheets.
+    Weekends only count when the allocation includes them.
     """
-    ResourceAllocation = frappe.qb.DocType("Resource Allocation")
-    result = (
-        frappe.qb.from_(ResourceAllocation)
-        .select(Coalesce(Sum(ResourceAllocation.total_cost), 0).as_("total"))
-        .where(ResourceAllocation.project == project_name)
-        .where(ResourceAllocation.allocation_end_date >= today())
+    if end < start:
+        return 0
+
+    total = (end - start).days + 1
+    if include_weekends:
+        return total
+
+    full_weeks, remainder = divmod(total, 7)
+    first_weekday = start.weekday()
+    return full_weeks * 5 + sum(1 for offset in range(remainder) if (first_weekday + offset) % 7 < 5)
+
+
+def _chargeable_hours(
+    start: date,
+    end: date,
+    include_weekends: bool,
+    hours_per_day: float,
+    overrides: dict[date, float],
+) -> float:
+    """Hours an allocation charges for between start and end, both inclusive.
+
+    Every chargeable day contributes hours_per_day, and a day override replaces that
+    default for its own date. An override counts even on a day the allocation would
+    otherwise skip: a per-day entry is a deliberate instruction, so it outranks the
+    weekday rule.
+
+    Applied as deltas off the day count rather than by walking the range, so the cost
+    is proportional to the number of overrides, not to the length of the allocation.
+    """
+    if end < start:
+        return 0.0
+
+    hours = _allocated_day_count(start, end, include_weekends) * hours_per_day
+    for override_date, override_hours in overrides.items():
+        if start <= override_date <= end:
+            if include_weekends or override_date.weekday() < 5:
+                hours -= hours_per_day
+            hours += override_hours
+
+    return hours
+
+
+def _remaining_cost_ratio(
+    start: date,
+    end: date,
+    include_weekends: bool,
+    hours_per_day: float,
+    overrides: dict[date, float],
+    as_on: date,
+) -> float:
+    """Fraction of an allocation's total_cost that still lies on or after as_on.
+
+    Split by chargeable hours rather than by days, so a shortened or cancelled day
+    moves cost across the today boundary in proportion to the hours it changes.
+    """
+    if as_on <= start:
+        return 1.0
+    if as_on > end:
+        return 0.0
+
+    if not _allocated_day_count(start, end, include_weekends):
+        # No chargeable day in the range at all (a weekday allocation sitting on a
+        # weekend): the hour model cannot split it, so fall back to calendar days
+        # rather than dropping a non-zero total_cost.
+        return ((end - as_on).days + 1) / ((end - start).days + 1)
+
+    total_hours = _chargeable_hours(start, end, include_weekends, hours_per_day, overrides)
+    if total_hours <= 0:
+        # Overrides cancelled out every day: nothing is left to spend.
+        return 0.0
+
+    return _chargeable_hours(as_on, end, include_weekends, hours_per_day, overrides) / total_hours
+
+
+def _get_day_overrides(allocation_names: list[str]) -> dict[str, dict[date, float]]:
+    """Per-day override hours for the given allocations, keyed by allocation then date.
+
+    A cancelled day is read as zero hours regardless of what its hours column holds.
+    """
+    if not allocation_names:
+        return {}
+
+    ExtraEntry = frappe.qb.DocType("Resource Allocation Extra Entry")
+    rows = (
+        frappe.qb.from_(ExtraEntry)
+        .select(ExtraEntry.parent, ExtraEntry.date, ExtraEntry.hours, ExtraEntry.cancelled)
+        .where(ExtraEntry.parenttype == "Resource Allocation")
+        .where(ExtraEntry.parent.isin(allocation_names))
         .run(as_dict=True)
     )
-    return flt(result[0].total) if result else 0
+
+    overrides: dict[str, dict[date, float]] = {}
+    for row in rows:
+        overrides.setdefault(row.parent, {})[getdate(row.date)] = 0.0 if cint(row.cancelled) else flt(row.hours)
+    return overrides
+
+
+def get_cost_forecasted(project_name: str) -> float:
+    """Forecasted cost still ahead of today for the project's Resource Allocations."""
+    return get_cost_forecasted_map([project_name]).get(project_name, 0.0)
 
 
 def get_cost_forecasted_map(project_names: list[str]) -> dict[str, float]:
-    """Fetch forecasted costs (ongoing/future allocations only) for multiple projects in a single grouped query."""
+    """Forecasted costs for multiple projects, keyed by project name.
+
+    Only cost that is still ahead of today counts: elapsed allocation days are already
+    realized in the project's total_costing_amount (cost_accrued) via timesheets, so
+    counting them here would double-count them.
+
+    An allocation that has not started yet is still fully ahead whatever its internal
+    shape, so those are summed in the database and never inspected row by row. Only
+    allocations straddling today need splitting, and that set holds at most one row per
+    (employee, project) because the allocation API chunks every allocation into a single
+    week. The split runs on chargeable hours so day overrides land on the right side of
+    today, and stops at the employee's relieving date, which total_cost is already
+    clamped to. Today counts as forecast, since today's timesheet is typically not
+    submitted yet.
+    """
     if not project_names:
         return {}
+
+    as_on = getdate(today())
     ResourceAllocation = frappe.qb.DocType("Resource Allocation")
-    rows = (
+    Employee = frappe.qb.DocType("Employee")
+
+    not_started = (
         frappe.qb.from_(ResourceAllocation)
         .select(
             ResourceAllocation.project,
             Coalesce(Sum(ResourceAllocation.total_cost), 0).as_("total"),
         )
         .where(ResourceAllocation.project.isin(project_names))
-        .where(ResourceAllocation.allocation_end_date >= today())
+        .where(ResourceAllocation.allocation_start_date >= as_on)
         .groupby(ResourceAllocation.project)
         .run(as_dict=True)
     )
-    return {row.project: flt(row.total) for row in rows}
+    forecast = {row.project: flt(row.total) for row in not_started}
+
+    in_flight = (
+        frappe.qb.from_(ResourceAllocation)
+        .left_join(Employee)
+        .on(Employee.name == ResourceAllocation.employee)
+        .select(
+            ResourceAllocation.name,
+            ResourceAllocation.project,
+            ResourceAllocation.total_cost,
+            ResourceAllocation.allocation_start_date,
+            ResourceAllocation.allocation_end_date,
+            ResourceAllocation.include_weekends,
+            ResourceAllocation.hours_allocated_per_day,
+            Employee.relieving_date,
+        )
+        .where(ResourceAllocation.project.isin(project_names))
+        .where(ResourceAllocation.allocation_start_date < as_on)
+        .where(ResourceAllocation.allocation_end_date >= as_on)
+        .run(as_dict=True)
+    )
+    overrides = _get_day_overrides([row.name for row in in_flight])
+
+    for row in in_flight:
+        end = getdate(row.allocation_end_date)
+        if row.relieving_date:
+            end = min(end, getdate(row.relieving_date))
+
+        ratio = _remaining_cost_ratio(
+            getdate(row.allocation_start_date),
+            end,
+            bool(cint(row.include_weekends)),
+            flt(row.hours_allocated_per_day),
+            overrides.get(row.name, {}),
+            as_on,
+        )
+        if ratio:
+            forecast[row.project] = forecast.get(row.project, 0.0) + flt(row.total_cost) * ratio
+
+    return forecast
 
 
 def get_burn_rate_per_week(project: dict) -> float | None:

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -21,6 +21,7 @@ from next_pms.resource_management.api.utils.query import (
     get_projects_with_allocations,
     has_active_allocation_filter,
 )
+from next_pms.timesheet.api.employee import apply_working_hours_fallback
 
 
 @frappe.whitelist(methods=["GET", "POST"])
@@ -111,7 +112,8 @@ def get_resource_management_project_view_data(
               one allocation in the window are listed before projects with none.
             - customer (dict): customer metadata referenced by the allocations.
             - employees (dict): employee metadata keyed by employee id for the
-              employees appearing in the allocations.
+              employees appearing in the allocations. Blank custom_working_hours /
+              custom_work_schedule are filled from HR Settings / "Per Day" before returning.
             - total_count (int): total number of projects matching the filters,
               independent of page_length.
             - has_more (bool): whether more projects exist beyond this page.
@@ -286,6 +288,7 @@ def _get_resource_management_project_view_data(
         if emp_ids
         else {}
     )
+    apply_working_hours_fallback(employees.values())
 
     for project in projects:
         all_week_data, all_dates_data = [], {}
@@ -468,6 +471,7 @@ def _get_employees_resrouce_data_for_given_project(
             "Employee", filters={"name": ["in", list(resource_allocation_map.keys())]}, fields=emp_fields
         )
     }
+    apply_working_hours_fallback(all_employees.values())
 
     for emp_id in resource_allocation_map:
         employee_resource_allocation = resource_allocation_map.get(emp_id, [])

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -22,7 +22,7 @@ from next_pms.resource_management.api.utils.query import (
     get_employee_leaves,
 )
 from next_pms.timesheet.api import filter_employees
-from next_pms.timesheet.api.employee import get_employee_working_hours
+from next_pms.timesheet.api.employee import apply_working_hours_fallback, get_employee_working_hours
 
 
 @frappe.whitelist(methods=["GET", "POST"])
@@ -97,7 +97,8 @@ def get_resource_management_team_view_data(
                     "department": "Engineering",
                     "designation": "Software Engineer",
                     "image": "/files/photo.jpg",
-                    "custom_work_schedule": "Mon-Fri",
+                    # blanks are filled from HR Settings / "Per Day" before returning
+                    "custom_work_schedule": "Per Day",
                     "custom_working_hours": 8.0,
                     "reports_to": "HR-EMP-00002",
                     # write permission only:
@@ -395,6 +396,8 @@ def _get_resource_management_team_view_data(
         res["has_more"] = False
         res["permissions"] = permissions
         return res
+
+    apply_working_hours_fallback(employees)
 
     resource_allocation_data = get_allocation_list_for_employee_for_given_range(
         [

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -1,13 +1,48 @@
+from datetime import date
+
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
-from frappe.utils import add_days, today
+from frappe.utils import add_days, flt, today
 
-from next_pms.next_projects.api.project import get_project_sidebar, get_projects_view
+from next_pms.next_projects.api.project import (
+    _allocated_day_count,
+    _chargeable_hours,
+    _remaining_cost_ratio,
+    get_cost_forecasted,
+    get_cost_forecasted_map,
+    get_project_sidebar,
+    get_projects_view,
+)
+from next_pms.resource_management.api.allocation import upsert_day_override
 
 # Unique marker so `search` scopes every call to this suite's fixtures only.
 FIXTURE_PREFIX = "CompSort"
 BURN_FIXTURE_PREFIX = "BurnAccrued"
+FORECAST_FIXTURE_PREFIX = "CostForecast"
+ADJUSTED_FIXTURE_PREFIX = "CostAdjusted"
+
+# 2026-05-04 is a Monday, so 05-08 is Friday and 05-09/05-10 are the weekend.
+MONDAY = date(2026, 5, 4)
+TUESDAY = date(2026, 5, 5)
+WEDNESDAY = date(2026, 5, 6)
+THURSDAY = date(2026, 5, 7)
+FRIDAY = date(2026, 5, 8)
+SATURDAY = date(2026, 5, 9)
+SUNDAY = date(2026, 5, 10)
+NEXT_MONDAY = date(2026, 5, 11)
+
+NO_OVERRIDES: dict[date, float] = {}
+
+ALLOCATION_COST = 1000.0
+# suffix -> (start offset from today, end offset from today, expected share of ALLOCATION_COST)
+FORECAST_FIXTURE_ROWS = {
+    "FUTURE": (1, 5, 1.0),  # not started: whole cost is forecast
+    "PAST": (-10, -1, 0.0),  # finished: entirely in cost_accrued
+    "RUNNING": (-4, 5, 0.6),  # 10 days, today..+5 = 6 still ahead
+    "STARTS_TODAY": (0, 4, 1.0),  # boundary: nothing elapsed yet
+    "ENDS_TODAY": (-3, 0, 0.25),  # boundary: 4 days, only today ahead
+}
 
 
 class TestGetProjectsViewComputedSort(IntegrationTestCase):
@@ -232,3 +267,352 @@ class TestBudgetBurnAccrued(IntegrationTestCase):
         by_name = {name: suffix for suffix, name in self.projects.items()}
         result = self.list_view(order_by="cost_burn_percent desc")
         self.assertEqual([by_name[row["name"]] for row in result["data"]], ["BILL", "NONBILL"])
+
+
+class TestAllocationDayMath(IntegrationTestCase):
+    """The pure helpers behind cost proration: how many days an allocation charges
+    for, how many hours those days carry once day overrides are applied, and what
+    fraction of the cost is still ahead of a given day.
+
+    Dates are fixed (not relative to today) so the weekday assertions hold whichever
+    day the suite runs on. NO_OVERRIDES keeps the plain-day cases readable.
+    """
+
+    def test_calendar_days_when_weekends_included(self):
+        self.assertEqual(_allocated_day_count(MONDAY, SUNDAY, True), 7)
+        self.assertEqual(_allocated_day_count(MONDAY, MONDAY, True), 1)
+
+    def test_weekends_excluded_from_day_count(self):
+        self.assertEqual(_allocated_day_count(MONDAY, SUNDAY, False), 5)
+        self.assertEqual(_allocated_day_count(FRIDAY, NEXT_MONDAY, False), 2)
+        self.assertEqual(_allocated_day_count(SATURDAY, SUNDAY, False), 0)
+
+    def test_inverted_range_charges_nothing(self):
+        self.assertEqual(_allocated_day_count(FRIDAY, MONDAY, False), 0)
+        self.assertEqual(_chargeable_hours(FRIDAY, MONDAY, False, 8.0, NO_OVERRIDES), 0.0)
+
+    def test_hours_default_to_the_daily_rate(self):
+        self.assertAlmostEqual(_chargeable_hours(MONDAY, FRIDAY, False, 8.0, NO_OVERRIDES), 40.0)
+        self.assertAlmostEqual(_chargeable_hours(MONDAY, SUNDAY, True, 8.0, NO_OVERRIDES), 56.0)
+
+    def test_override_replaces_the_daily_rate(self):
+        self.assertAlmostEqual(_chargeable_hours(MONDAY, FRIDAY, False, 8.0, {WEDNESDAY: 4.0}), 36.0)
+        # cancelled days arrive as zero hours
+        self.assertAlmostEqual(_chargeable_hours(MONDAY, FRIDAY, False, 8.0, {WEDNESDAY: 0.0}), 32.0)
+
+    def test_override_outside_the_range_is_ignored(self):
+        self.assertAlmostEqual(_chargeable_hours(MONDAY, WEDNESDAY, False, 8.0, {FRIDAY: 4.0}), 24.0)
+
+    def test_override_adds_a_day_the_allocation_would_skip(self):
+        # An explicit entry on a Saturday outranks the weekday-only default.
+        self.assertAlmostEqual(_chargeable_hours(MONDAY, SUNDAY, False, 8.0, {SATURDAY: 3.0}), 43.0)
+
+    def test_ratio_at_range_boundaries(self):
+        # Not started yet, and finished: the whole cost is ahead / behind.
+        self.assertEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, NO_OVERRIDES, MONDAY), 1.0)
+        self.assertEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, NO_OVERRIDES, NEXT_MONDAY), 0.0)
+        # Ending today still leaves today itself in the forecast.
+        self.assertAlmostEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, NO_OVERRIDES, FRIDAY), 1 / 5)
+
+    def test_ratio_mid_range_counts_today_as_forecast(self):
+        # Mon-Fri with today = Wed: Wed, Thu, Fri remain.
+        self.assertAlmostEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, NO_OVERRIDES, WEDNESDAY), 3 / 5)
+
+    def test_ratio_skips_weekends_for_weekday_allocations(self):
+        # Fri-Mon charges 2 days when weekends are excluded, 4 when they are not.
+        self.assertAlmostEqual(_remaining_cost_ratio(FRIDAY, NEXT_MONDAY, False, 8.0, NO_OVERRIDES, SUNDAY), 1 / 2)
+        self.assertAlmostEqual(_remaining_cost_ratio(FRIDAY, NEXT_MONDAY, True, 8.0, NO_OVERRIDES, SUNDAY), 2 / 4)
+
+    def test_ratio_shrinks_when_a_remaining_day_is_shortened(self):
+        # Mon-Fri, today = Wed. Halving Thursday drops the remaining hours from
+        # 24/40 to 20/36 - a day-count split would still report 3/5.
+        self.assertAlmostEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, {THURSDAY: 4.0}, WEDNESDAY), 20 / 36)
+
+    def test_ratio_grows_when_an_elapsed_day_is_shortened(self):
+        # Same range, but the shortened day is behind today: less of the cost was
+        # spent, so more of it is still ahead.
+        self.assertAlmostEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, {TUESDAY: 4.0}, WEDNESDAY), 24 / 36)
+
+    def test_ratio_drops_a_cancelled_remaining_day(self):
+        # Cancelling Friday leaves Wed + Thu of a 32-hour allocation.
+        self.assertAlmostEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, {FRIDAY: 0.0}, WEDNESDAY), 16 / 32)
+
+    def test_ratio_is_zero_when_every_day_is_cancelled(self):
+        cancelled = dict.fromkeys((MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), 0.0)
+        self.assertEqual(_remaining_cost_ratio(MONDAY, FRIDAY, False, 8.0, cancelled, WEDNESDAY), 0.0)
+
+    def test_weekend_only_range_falls_back_to_calendar_days(self):
+        # No chargeable weekday in range: prorate on calendar days rather than
+        # dividing by zero and dropping a non-zero total_cost.
+        self.assertAlmostEqual(_remaining_cost_ratio(SATURDAY, SUNDAY, False, 8.0, NO_OVERRIDES, SUNDAY), 1 / 2)
+
+    def test_hour_split_matches_day_split_without_overrides(self):
+        # The hours model must not move the answer when every day is uniform.
+        for include_weekends in (True, False):
+            expected = _allocated_day_count(WEDNESDAY, NEXT_MONDAY, include_weekends) / _allocated_day_count(
+                MONDAY, NEXT_MONDAY, include_weekends
+            )
+            self.assertAlmostEqual(
+                _remaining_cost_ratio(MONDAY, NEXT_MONDAY, include_weekends, 8.0, NO_OVERRIDES, WEDNESDAY),
+                expected,
+                msg=f"include_weekends={include_weekends}",
+            )
+
+
+class TestCostForecastedProration(IntegrationTestCase):
+    """cost_forecasted counts only the allocation cost still ahead of today.
+
+    A running allocation has its elapsed days already realized in the project's
+    total_costing_amount (cost_accrued) via timesheets, so counting it in full
+    double-counts them. Fixtures set include_weekends so the expected split is a
+    plain calendar-day ratio whichever weekday the suite runs on.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.customer = cls._get_customer()
+        cls.employee = cls._make_employee()
+
+        cls.projects = {}
+        for suffix, (start_offset, end_offset, _) in FORECAST_FIXTURE_ROWS.items():
+            project = frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": f"{FORECAST_FIXTURE_PREFIX} {suffix}",
+                    "company": cls.company,
+                    "customer": cls.customer,
+                }
+            ).insert(ignore_permissions=True)
+            cls._make_allocation(project.name, start_offset, end_offset)
+            cls.projects[suffix] = project.name
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    @classmethod
+    def _get_customer(cls):
+        # Reuse a seeded customer; this bench enforces unique customer abbreviations,
+        # so minting one risks colliding with existing data.
+        customer = frappe.db.get_value("Customer", {"disabled": 0}, "name")
+        if customer:
+            return customer
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": f"{FORECAST_FIXTURE_PREFIX} Customer",
+                    "customer_type": "Company",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_employee(cls):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": f"{FORECAST_FIXTURE_PREFIX} Resource",
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                # An HRMS validate hook errors while auto-deriving an approver when
+                # reports_to and leave_approver are both blank.
+                "leave_approver": "Administrator",
+                "ctc": 100000,
+                "salary_currency": "INR",
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _make_allocation(cls, project, start_offset, end_offset):
+        allocation = frappe.get_doc(
+            {
+                "doctype": "Resource Allocation",
+                "employee": cls.employee,
+                "project": project,
+                "allocation_start_date": add_days(today(), start_offset),
+                "allocation_end_date": add_days(today(), end_offset),
+                "hours_allocated_per_day": 8,
+                "include_weekends": 1,
+                "status": "Confirmed",
+            }
+        ).insert(ignore_permissions=True)
+        # total_cost is read-only and derived from the employee's CTC; pin it so the
+        # expected split is exact and independent of salary setup.
+        frappe.db.set_value(
+            "Resource Allocation", allocation.name, "total_cost", ALLOCATION_COST, update_modified=False
+        )
+        return allocation.name
+
+    def expected(self, suffix):
+        return ALLOCATION_COST * FORECAST_FIXTURE_ROWS[suffix][2]
+
+    def test_map_prorates_every_allocation_state(self):
+        forecast = get_cost_forecasted_map(list(self.projects.values()))
+        for suffix, project in self.projects.items():
+            self.assertAlmostEqual(flt(forecast.get(project, 0.0)), self.expected(suffix), msg=suffix)
+
+    def test_running_allocation_drops_its_elapsed_days(self):
+        # The regression: summing total_cost in full would report 1000 here and
+        # double-count the 4 elapsed days that are already in cost_accrued.
+        forecast = get_cost_forecasted(self.projects["RUNNING"])
+        self.assertAlmostEqual(forecast, 600.0)
+        self.assertLess(forecast, ALLOCATION_COST)
+
+    def test_finished_allocation_is_not_forecast(self):
+        self.assertEqual(get_cost_forecasted(self.projects["PAST"]), 0.0)
+
+    def test_single_project_matches_map(self):
+        forecast = get_cost_forecasted_map(list(self.projects.values()))
+        for suffix, project in self.projects.items():
+            self.assertAlmostEqual(get_cost_forecasted(project), flt(forecast.get(project, 0.0)), msg=suffix)
+
+    def test_empty_input_skips_queries(self):
+        self.assertEqual(get_cost_forecasted_map([]), {})
+
+    def test_list_view_reports_prorated_forecast(self):
+        result = get_projects_view(view="list", search=FORECAST_FIXTURE_PREFIX, start=0, limit=20)
+        rows = {row["name"]: row for row in result["data"]}
+        for suffix, project in self.projects.items():
+            self.assertAlmostEqual(
+                flt(rows[project]["cost_burn"]["cost_forecasted"]), self.expected(suffix), msg=suffix
+            )
+
+
+class TestCostForecastedAdjustments(IntegrationTestCase):
+    """A running allocation is split by chargeable hours, not by days, so day
+    overrides and an employee's relieving date land on the right side of today.
+
+    Every fixture spans today-4 to today+5 with include_weekends, so a plain
+    day-count split would report 600 for all of them; each expected value below
+    is deliberately something else. hours_allocated_per_day is 8, giving 80 hours
+    before adjustments.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.customer = TestCostForecastedProration._get_customer()
+        cls.employee = cls._make_employee("Adjusted")
+        cls.relieved_employee = cls._make_employee("Relieved")
+
+        cls.projects = {}
+        for suffix in ("OVERRIDE_AHEAD", "OVERRIDE_BEHIND", "CANCELLED_AHEAD", "RELIEVED"):
+            cls.projects[suffix] = (
+                frappe.get_doc(
+                    {
+                        "doctype": "Project",
+                        "project_name": f"{ADJUSTED_FIXTURE_PREFIX} {suffix}",
+                        "company": cls.company,
+                        "customer": cls.customer,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+
+        # Thursday-hours cut in half, ahead of today: 76 total hours, 44 still ahead.
+        cls._make_allocation("OVERRIDE_AHEAD", cls.employee, {"date": add_days(today(), 1), "hours": 4.0})
+        # Same cut, but already elapsed: 76 total hours, all 48 remaining ones intact.
+        cls._make_allocation("OVERRIDE_BEHIND", cls.employee, {"date": add_days(today(), -2), "hours": 4.0})
+        # A cancelled day ahead of today: 72 total hours, 40 still ahead.
+        cls._make_allocation("CANCELLED_AHEAD", cls.employee, {"date": add_days(today(), 1), "cancelled": 1})
+        cls._make_allocation("RELIEVED", cls.relieved_employee)
+
+        # Set after the allocation exists and with db.set_value, so the Employee
+        # on_update hook does not rewrite total_cost out from under the fixture.
+        frappe.db.set_value(
+            "Employee",
+            cls.relieved_employee,
+            {"relieving_date": add_days(today(), 2), "status": "Left"},
+            update_modified=False,
+        )
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    @classmethod
+    def _make_employee(cls, label):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": f"{ADJUSTED_FIXTURE_PREFIX} {label}",
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                "leave_approver": "Administrator",
+                "ctc": 100000,
+                "salary_currency": "INR",
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _make_allocation(cls, suffix, employee, override=None):
+        allocation = frappe.get_doc(
+            {
+                "doctype": "Resource Allocation",
+                "employee": employee,
+                "project": cls.projects[suffix],
+                "allocation_start_date": add_days(today(), -4),
+                "allocation_end_date": add_days(today(), 5),
+                "hours_allocated_per_day": 8,
+                "include_weekends": 1,
+                "status": "Confirmed",
+            }
+        ).insert(ignore_permissions=True)
+
+        if override:
+            fields = {k: v for k, v in override.items() if k != "date"}
+            upsert_day_override(allocation.name, str(override["date"]), fields)
+
+        # Pinned last: adding an override re-saves the doc, which recomputes total_cost.
+        frappe.db.set_value(
+            "Resource Allocation", allocation.name, "total_cost", ALLOCATION_COST, update_modified=False
+        )
+        return allocation.name
+
+    def forecast(self, suffix):
+        return get_cost_forecasted(self.projects[suffix])
+
+    def test_shortened_day_ahead_of_today_lowers_the_forecast(self):
+        self.assertAlmostEqual(self.forecast("OVERRIDE_AHEAD"), ALLOCATION_COST * 44 / 76, places=4)
+
+    def test_shortened_day_behind_today_raises_the_forecast(self):
+        # Less was spent before today, so more of the same total is still ahead.
+        self.assertAlmostEqual(self.forecast("OVERRIDE_BEHIND"), ALLOCATION_COST * 48 / 76, places=4)
+
+    def test_cancelled_day_leaves_the_forecast(self):
+        self.assertAlmostEqual(self.forecast("CANCELLED_AHEAD"), ALLOCATION_COST * 40 / 72, places=4)
+
+    def test_forecast_stops_at_the_relieving_date(self):
+        # total_cost is already clamped to [start, relieving] by the Employee hook,
+        # so the split has to use the same window or it overstates what is left.
+        self.assertAlmostEqual(self.forecast("RELIEVED"), ALLOCATION_COST * 24 / 56, places=4)
+
+    def test_none_of_these_match_a_plain_day_split(self):
+        # Guards the whole class: a day-count split reports 600 for every fixture.
+        day_count_split = ALLOCATION_COST * 6 / 10
+        for suffix in self.projects:
+            self.assertNotAlmostEqual(self.forecast(suffix), day_count_split, places=2, msg=suffix)
+
+    def test_map_agrees_with_single_project_lookup(self):
+        forecast = get_cost_forecasted_map(list(self.projects.values()))
+        for suffix, project in self.projects.items():
+            self.assertAlmostEqual(flt(forecast.get(project, 0.0)), self.forecast(suffix), msg=suffix)

--- a/next_pms/timesheet/api/employee.py
+++ b/next_pms/timesheet/api/employee.py
@@ -12,10 +12,28 @@ from next_pms.timesheet.utils.constant import (
 )
 
 
+def _empty_working_hours() -> dict:
+    """Working hour payload used when no Employee can be resolved."""
+    return {"working_hour": 0, "working_frequency": DEFAULT_WORKING_FREQUENCY}
+
+
 @frappe.whitelist(methods=["GET"])
 def get_data():
-    """returns employee, employee_name, employee_working_detail and employee_report_to for the current user"""
+    """returns employee, employee_name, employee_working_detail and employee_report_to for the current user
+
+    Users with no linked Employee (Administrator, most System Managers) get an empty payload rather
+    than a DoesNotExistError. The SPA loads this once on boot for every route and treats a failure
+    as fatal, so raising here would break pages that never needed an employee in the first place.
+    """
     employee = get_employee_from_user()
+    if not employee:
+        return {
+            "employee": None,
+            "employee_name": None,
+            "employee_working_detail": _empty_working_hours(),
+            "employee_report_to": None,
+        }
+
     doc = frappe.get_cached_doc("Employee", employee)
 
     return {
@@ -100,7 +118,7 @@ def get_employee_working_hours(employee: str | None = None) -> dict:
     if not employee:
         employee = get_employee_from_user()
     if not employee:
-        return {"working_hour": 0, "working_frequency": DEFAULT_WORKING_FREQUENCY}
+        return _empty_working_hours()
 
     data = frappe.cache().hget(EMP_WOKING_DETAILS, employee)
     if data:

--- a/next_pms/timesheet/api/employee.py
+++ b/next_pms/timesheet/api/employee.py
@@ -1,9 +1,15 @@
 import datetime
+from collections.abc import Iterable
 from functools import wraps
 
 import frappe
+from frappe.utils import flt
 
-from next_pms.timesheet.utils.constant import EMP_WOKING_DETAILS
+from next_pms.timesheet.utils.constant import (
+    DEFAULT_DAILY_WORKING_HOURS,
+    DEFAULT_WORKING_FREQUENCY,
+    EMP_WOKING_DETAILS,
+)
 
 
 @frappe.whitelist(methods=["GET"])
@@ -11,17 +17,45 @@ def get_data():
     """returns employee, employee_name, employee_working_detail and employee_report_to for the current user"""
     employee = get_employee_from_user()
     doc = frappe.get_cached_doc("Employee", employee)
-    working_hour = doc.custom_working_hours
-    working_frequency = doc.custom_work_schedule or "Per Day"
 
     return {
         "employee": employee,
         "employee_name": doc.employee_name,
-        "employee_working_detail": get_employee_working_hours(employee)
-        if not working_hour
-        else {"working_hour": working_hour or 8, "working_frequency": working_frequency},
+        "employee_working_detail": get_employee_working_hours(employee),
         "employee_report_to": doc.reports_to,
     }
+
+
+def get_default_working_hours() -> float:
+    """returns the standard daily working hours configured in HR Settings.
+
+    Employee.custom_working_hours and Employee.custom_work_schedule are maintained by the HR team
+    and are routinely left blank, so every consumer needs a system-wide default to fall back on.
+    """
+    return flt(frappe.db.get_single_value("HR Settings", "standard_working_hours")) or DEFAULT_DAILY_WORKING_HOURS
+
+
+def apply_working_hours_fallback(employees: Iterable[dict], default_working_hours: float | None = None) -> None:
+    """Fills in the working hour fields left blank on the given Employee rows.
+
+    Without this an unset custom_work_schedule leaves consumers guessing at the frequency, which
+    reads 8 hours as 8 hours per week rather than per day.
+
+    Args:
+        employees (Iterable[dict]): Employee rows carrying custom_working_hours and
+            custom_work_schedule. Mutated in place.
+        default_working_hours (float | None): Hours to use for employees with none of their own.
+            Resolved once for the whole batch when not provided, so HR Settings is read once per
+            request instead of once per employee.
+    """
+    if default_working_hours is None:
+        default_working_hours = get_default_working_hours()
+
+    for employee in employees:
+        if not employee.get("custom_working_hours"):
+            employee["custom_working_hours"] = default_working_hours
+        if not employee.get("custom_work_schedule"):
+            employee["custom_work_schedule"] = DEFAULT_WORKING_FREQUENCY
 
 
 @frappe.whitelist(methods=["GET"])
@@ -66,7 +100,7 @@ def get_employee_working_hours(employee: str | None = None) -> dict:
     if not employee:
         employee = get_employee_from_user()
     if not employee:
-        return {"working_hour": 0, "working_frequency": "Per Day"}
+        return {"working_hour": 0, "working_frequency": DEFAULT_WORKING_FREQUENCY}
 
     data = frappe.cache().hget(EMP_WOKING_DETAILS, employee)
     if data:
@@ -77,11 +111,10 @@ def get_employee_working_hours(employee: str | None = None) -> dict:
         employee,
         ["custom_working_hours", "custom_work_schedule"],
     )
-    if not working_hour:
-        working_hour = frappe.db.get_single_value("HR Settings", "standard_working_hours")
-    if not working_frequency:
-        working_frequency = "Per Day"
-    data = {"working_hour": working_hour or 8, "working_frequency": working_frequency}
+    data = {
+        "working_hour": working_hour or get_default_working_hours(),
+        "working_frequency": working_frequency or DEFAULT_WORKING_FREQUENCY,
+    }
     frappe.cache().hset(EMP_WOKING_DETAILS, employee, data)
     return data
 

--- a/next_pms/timesheet/utils/constant.py
+++ b/next_pms/timesheet/utils/constant.py
@@ -5,6 +5,12 @@ from frappe.model import DEFAULT_FIELDS
 EMP_WOKING_DETAILS = "emp_working_details"
 EMP_TIMESHEET = "emp_timesheet"
 
+# Last resort when neither the Employee nor HR Settings define working hours.
+DEFAULT_DAILY_WORKING_HOURS = 8
+
+# Assumed when an Employee has no custom_work_schedule set.
+DEFAULT_WORKING_FREQUENCY = "Per Day"
+
 TASK_FILTER_OPERATORS = {
     "=",
     "!=",


### PR DESCRIPTION
## Description

* Refactored `get_cost_forecasted` and `get_cost_forecasted_map`  to split ongoing allocations by chargeable hours, handle per-day overrides, and avoid double-counting costs already realized via timesheets. Added helper functions  to support this logic.
* Applied `apply_working_hours_fallback` to employee objects in project and team API responses to ensure all employees have populated working hours and schedules. 
* Added comprehensive tests for the new forecasting logic, including edge cases for allocations starting, ending, or straddling today, and for allocations with per-day overrides.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

#### Employee Hours Fall Back 
**Before**: 
<img width="250" height="137" alt="image" src="https://github.com/user-attachments/assets/66cd8d6d-4c71-453b-82b3-b0ad47553c22" />


**After** : 
<img width="307" height="137" alt="image" src="https://github.com/user-attachments/assets/827dc6b3-67bb-4a85-8b16-4d4c1460a089" />


#### Cost Forecasting 

**Before** : 
<img width="872" height="170" alt="Screenshot 2026-07-27 at 1 26 58 PM" src="https://github.com/user-attachments/assets/b1c12eb0-400e-494e-a757-03513c6b1f5c" />

**After** : 
<img width="855" height="179" alt="Screenshot 2026-07-27 at 1 28 56 PM" src="https://github.com/user-attachments/assets/7ed91f8b-ba63-4172-b045-3847ec1c5799" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1816