### PR TITLE
fix: change default working schedule to Per Day

### DIFF
--- a/frontend/packages/app/src/pages/allocations/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/utils.ts
@@ -324,9 +324,7 @@ export function mapResourceAllocationSegments<T extends AllocationApiRecord>(
 function resolveWorkingFrequency(
   workSchedule: string | undefined | null,
 ): WorkingFrequency {
-  return (
-    pickAllowed(workSchedule, ALLOCATION_WORKING_FREQUENCIES) ?? "Per Week"
-  );
+  return pickAllowed(workSchedule, ALLOCATION_WORKING_FREQUENCIES) ?? "Per Day";
 }
 
 /**


### PR DESCRIPTION
## Description

This PR defaults the working schedule to "Per Day" when the API does not return a value. The backend already falls back to "Per Day", so this change simply aligns the frontend behavior with the backend.

- This resolves the issue where the employee's working schedule is not set, which caused labels such as `6.4h over` to be displayed for an employee with an 8-hour working day. With the frontend fallback in place, the correct `Full` label is now shown.


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Set an employee’s working schedule to empty in Desk.
2. Navigate to the Team Allocation page.
3. Verify that the allocation calculations still use the Per Day schedule.
4. Return to Desk and set the employee’s working schedule to Per Day.
5. Navigate back to the Team Allocation page.
6. Verify that the allocation calculations remain unchanged.
7. Return to Desk and set the employee’s working schedule to Per Week.
8. Navigate back to the Team Allocation page.
9. Verify that the Per Week schedule is respected and the allocation calculations are updated correctly.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/ff29e323-7ea0-4d6d-ae88-e974147d6c5d



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1816