### PR TITLE
fix: add owner field in tasks response

### DIFF
--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -135,6 +135,7 @@ def get_task_list(
         "actual_time",
         "expected_time",
         "_liked_by",
+        "owner",
     ]
     if fields:
         field_list.extend(fields)


### PR DESCRIPTION
## Description

- Adds owner field in response so that FE can consume and match if the owner of the task is the current user, to conditionally render `Delete` button in tasks page


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Part of: #1930 

Required for: #1941 