### PR TITLE
fix: condition to render delete task button based on owner check

### DIFF
--- a/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/index.tsx
@@ -14,6 +14,15 @@ import { TextCell } from "./textCell";
 import type { ListViewColumn } from "../../types";
 import type { TaskListItem } from "../types";
 
+const MANAGER_ROLES = ["Projects Manager", "Delivery Manager", "Delivery User"];
+
+function canUserDelete(row: TaskListItem, userId?: string, roles?: string[]) {
+  return (
+    roles &&
+    (MANAGER_ROLES.some((r) => roles.includes(r)) || row.owner === userId)
+  );
+}
+
 export function TaskListCell({
   row,
   column,
@@ -21,6 +30,8 @@ export function TaskListCell({
   onAddTime,
   onEditTask,
   onDeleteTask,
+  userId,
+  roles,
 }: {
   row: TaskListItem;
   column: ListViewColumn;
@@ -28,6 +39,8 @@ export function TaskListCell({
   onAddTime?: (prefill: OpenAddTimeDialogOptions) => void;
   onEditTask?: (task: TaskListItem) => void;
   onDeleteTask?: (name: string) => void;
+  userId?: string;
+  roles?: string[];
 }) {
   switch (column.key) {
     case "subject":
@@ -58,6 +71,7 @@ export function TaskListCell({
           name={row.name}
           onEdit={() => onEditTask?.(row)}
           onDelete={onDeleteTask}
+          canDelete={canUserDelete(row, userId, roles)}
         />
       );
     default:

--- a/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/taskRowActions.tsx
@@ -8,27 +8,39 @@ export function TaskRowActions({
   name,
   onEdit,
   onDelete,
+  canDelete = false,
 }: {
   name: string;
   onEdit?: (name: string) => void;
   onDelete?: (name: string) => void;
+  canDelete?: boolean;
 }) {
   return (
     <Dropdown
       placement="center"
-      options={[
-        {
-          key: "edit",
-          label: "Edit",
-          onClick: () => onEdit?.(name),
-        },
-        {
-          key: "delete",
-          label: "Delete",
-          theme: "red",
-          onClick: () => onDelete?.(name),
-        },
-      ]}
+      options={
+        canDelete
+          ? [
+              {
+                key: "edit",
+                label: "Edit",
+                onClick: () => onEdit?.(name),
+              },
+              {
+                key: "delete",
+                label: "Delete",
+                theme: "red",
+                onClick: () => onDelete?.(name),
+              },
+            ]
+          : [
+              {
+                key: "edit",
+                label: "Edit",
+                onClick: () => onEdit?.(name),
+              },
+            ]
+      }
     >
       {/* A native <button> can't be used here: ListRow already wraps every
       cell in a <button>, and nested buttons are invalid HTML / trigger a

--- a/frontend/packages/app/src/pages/tasks/list/types.ts
+++ b/frontend/packages/app/src/pages/tasks/list/types.ts
@@ -11,6 +11,7 @@ export type TaskListItem = {
   expected_time: number;
   custom_is_billable?: boolean;
   _liked_by: string;
+  owner: string;
 };
 
 export type ResponseTaskList = {

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -41,6 +41,7 @@ function TaskList() {
   const openEditTaskModal = useTaskList((c) => c.actions.openEditTaskModal);
   const { sort, setSort } = useTaskFilters();
   const roles = useUser(({ state }) => state.roles);
+  const userId = useUser(({ state }) => state.userId);
   const showTeamTaskLog =
     roles.includes("Projects Manager") || roles.includes("Timesheet Manager");
   const [openTask, setOpenTask] = useState<string | null>(null);
@@ -133,6 +134,8 @@ function TaskList() {
                       onAddTime={handleAddTime}
                       onEditTask={openEditTaskModal}
                       onDeleteTask={setDeleteTaskName}
+                      userId={userId}
+                      roles={roles}
                     />
                   ))}
                 </ListRow>


### PR DESCRIPTION
## Description

- Adds conditional rendering of the `Delete` button in tasks page based on owner of the task for Employee and if the user has PM/DM/DU role 

## Relevant Technical Choices

- Added the `Owner` field in the response and comparing the current User with that for Employees to conditionally render `Delete` button
- If the User has PM/DM/DU role `Delete` button for all tasks will be shown.

## Testing Instructions

- Go to Tasks page as an Employee user
- Open the kebab menu for tasks this user has created
- Observe Delete button is visible for created tasks and not visible for tasks created by others
- Login and PM/DM/DU user, open menu for tasks
- Observe all tasks have `Delete` button visible


## Screenshot/Screencast


https://github.com/user-attachments/assets/dc511b6e-c3cf-4856-b898-491e72b662fb




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes #1930 

Depends on: https://github.com/rtCamp/next-pms/pull/1939