### PR TITLE
fix: add allocation modal false over-allocation warning triggered on valid date selection

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -687,14 +687,8 @@ function AddAllocationModal({
                     value={[fromField.state.value, toField.state.value]}
                     disabled={isLockedAllocationMetadataEdit}
                     onChange={(value) => {
-                      const rawFrom = value?.[0] ?? "";
-                      const rawTo = value?.[1] ?? "";
-                      const shouldSwap = rawFrom && rawTo && rawFrom > rawTo;
-                      const nextFrom = shouldSwap ? rawTo : rawFrom;
-                      const nextTo = shouldSwap ? rawFrom : rawTo;
-
-                      fromField.handleChange(nextFrom);
-                      toField.handleChange(nextTo);
+                      fromField.handleChange(value?.[0] ?? "");
+                      toField.handleChange(value?.[1] ?? "");
                     }}
                     formatter={formatDateRange}
                     placeholder="Start Date - End Date"

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/schema.ts
@@ -27,16 +27,16 @@ export const addAllocationFormSchema = z
     includeWeekends: z.boolean(),
     fromDate: z
       .string({
-        required_error: "Please select from date.",
+        required_error: "Please select a start and end date.",
       })
       .trim()
-      .min(1, { message: "Please select from date." }),
+      .min(1, { message: "Please select a start and end date." }),
     toDate: z
       .string({
-        required_error: "Please select to date.",
+        required_error: "Please select an end date.",
       })
       .trim()
-      .min(1, { message: "Please select to date." }),
+      .min(1, { message: "Please select an end date." }),
     hoursPerDay: z
       .number({
         required_error: "Please enter hours per day.",


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
The Add Allocation modal defaults both dates to today when opened from the " + Add Allocation" button. Previously, the `DateRangePicker` only emitted `onChange` after a complete date range was selected. As a result, after selecting only a start date, the form still held today's date, causing the over-allocation warning to reference the wrong date.

The `DateRangePicker` now emits the selected start date immediately with an empty end date, ensuring the form state always matches the date displayed in the picker.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Validation messages shows "Please select an end date." after one click so a half-picked range
  blocks on submit instead of silently saving a same-day allocation.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
Precondition: pick an employee who already has an allocation covering today (i.e. in the
running week) on the project you will use, and note their hours/day. The bug only surfaced
in this case, because the check was silently running against today's date rather than the
date that was selected.

1. Go to "Allocations → Team" and click "+ Add Allocation".
2. Select that employee and project. Leave the dates as the default (today).
3. Set "Hours / day" high enough that it would over-allocate today when combined with the
   existing allocation (e.g. 8h on top of an existing 8h).
4. Open the date picker and select only a future start date that the employee has no
   allocation for.
   * Verify the field displays the selected date.
   * Verify no over-allocation warning is shown.
   * Verify no warning references today's date or the existing allocation.
   * Verify "Total Hours" is 0.
5. Click "Allocate" without selecting an end date.
   * Verify submission is blocked with "Please select an end date."
6. Reopen the date picker, select an end date, and click "Allocate".
   * Verify the allocation is created successfully without reselecting the start date.
7. Verify over-allocation warnings still work: select a range that overlaps the employee's
   existing allocation with hours that exceed their working hours.
   * Verify the warning lists the correct dates and the accordion expands to show the daily
     excess.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/6895c43a-3c30-4fc7-a25f-732b1b5a7fae



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1882