### PR TITLE
feat: allow adding multiple time entry in same open modal

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -87,7 +87,7 @@ const AddTime = ({
         date: date,
         duration: 0,
         comment: "",
-      }) as addTimeFormValues,
+      }) satisfies addTimeFormValues,
     [project, projectLabel, task, taskLabel],
   );
 

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -71,25 +71,33 @@ const AddTime = ({
   const commentEditorRef = useRef<TextEditorHandle>(null);
   const prevSelectedEventIdsRef = useRef<Set<string>>(new Set());
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [entryKey, setEntryKey] = useState(0);
   const { call: saveTime } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
   );
 
+  const getDefaultValues = useCallback(
+    (date: string): addTimeFormValues =>
+      ({
+        project: project,
+        projectLabel: projectLabel || project || undefined,
+        task: task,
+        taskLabel: taskLabel || task || undefined,
+        taskStatus: undefined,
+        date: date,
+        duration: 0,
+        comment: "",
+      }) as addTimeFormValues,
+    [project, projectLabel, task, taskLabel],
+  );
+
   const form = useForm({
-    defaultValues: {
-      project: project,
-      projectLabel: projectLabel || project || undefined,
-      task: task,
-      taskLabel: taskLabel || task || undefined,
-      taskStatus: undefined,
-      date: initialDate,
-      duration: 0,
-      comment: "",
-    } as addTimeFormValues,
+    defaultValues: getDefaultValues(initialDate),
     validators: {
       onSubmit: addTimeFormSchema,
     },
-    onSubmit: async ({ value }) => {
+    onSubmitMeta: { keepOpen: false },
+    onSubmit: async ({ value, meta }) => {
       setSubmitting(true);
       setSubmitError(null);
       try {
@@ -101,6 +109,11 @@ const AddTime = ({
           employee: employeeId,
         });
         toast.success("Time Entry submitted successfully");
+        if (meta.keepOpen) {
+          resetEntry(value.date);
+          await refreshRemainingHours();
+          return;
+        }
         closeModal();
       } catch (err) {
         setSubmitError(parseFrappeErrorMsg(err as FrappeError));
@@ -109,6 +122,18 @@ const AddTime = ({
       }
     },
   });
+
+  const resetEntry = useCallback(
+    (date: string) => {
+      setProjectSearch("");
+      setTaskSearch("");
+      setSubmitError(null);
+      form.reset(getDefaultValues(date), { keepDefaultValues: true });
+      prevSelectedEventIdsRef.current = new Set();
+      setEntryKey((key) => key + 1);
+    },
+    [form, getDefaultValues],
+  );
 
   const closeModal = useCallback(() => {
     setProjectSearch("");
@@ -168,6 +193,7 @@ const AddTime = ({
     maxDuration,
     hoursLeft,
     isLoading: isRemainingHoursLoading,
+    refresh: refreshRemainingHours,
   } = useRemainingHours({
     employee: employeeId,
     date: selectedDate,
@@ -179,18 +205,9 @@ const AddTime = ({
       return;
     }
 
-    form.reset({
-      project,
-      projectLabel: projectLabel || project || undefined,
-      task,
-      taskLabel: taskLabel || task || undefined,
-      taskStatus: undefined,
-      date: initialDate,
-      duration: 0,
-      comment: "",
-    });
+    form.reset(getDefaultValues(initialDate));
     prevSelectedEventIdsRef.current = new Set();
-  }, [form, initialDate, open, project, projectLabel, task, taskLabel]);
+  }, [form, getDefaultValues, initialDate, open]);
 
   const { options: projectOptions, isLoading: isProjectLookupLoading } =
     useProjectLookup({
@@ -253,14 +270,23 @@ const AddTime = ({
         footer: "pb-6",
       }}
       actions={
-        <Button
-          className="w-full"
-          variant="solid"
-          label="Save entry"
-          onClick={() => form.handleSubmit()}
-          disabled={submitting}
-          loading={submitting}
-        />
+        <div className="flex items-center justify-between w-full gap-2">
+          <Button
+            className="w-full"
+            variant="subtle"
+            label="Save entry and add another"
+            onClick={() => form.handleSubmit({ keepOpen: true })}
+            disabled={submitting}
+          />
+          <Button
+            className="w-full"
+            variant="solid"
+            label="Save entry and close"
+            onClick={() => form.handleSubmit()}
+            disabled={submitting}
+            loading={submitting}
+          />
+        </div>
       }
       options={{
         title: "Add time",
@@ -426,6 +452,7 @@ const AddTime = ({
         </div>
 
         <CalendarEvents
+          key={`calendar-events-${entryKey}`}
           initialDate={selectedDate}
           enabled={open}
           onSelectionChange={handleCalendarSelectionChange}
@@ -440,6 +467,7 @@ const AddTime = ({
                   Comment
                 </label>
                 <TextEditor
+                  key={`comment-${entryKey}`}
                   ref={commentEditorRef}
                   content={field.state.value}
                   onChange={(value) => field.handleChange(value)}

--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -274,14 +274,14 @@ const AddTime = ({
           <Button
             className="w-full"
             variant="subtle"
-            label="Save entry and add another"
+            label="Save and add another"
             onClick={() => form.handleSubmit({ keepOpen: true })}
             disabled={submitting}
           />
           <Button
             className="w-full"
             variant="solid"
-            label="Save entry and close"
+            label="Save and close"
             onClick={() => form.handleSubmit()}
             disabled={submitting}
             loading={submitting}

--- a/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
@@ -44,7 +44,7 @@ export const useRemainingHours = ({
   return {
     maxDuration: data?.message?.working_hour ?? FALLBACK_DAILY_WORKING_HOURS,
     hoursLeft: data?.message?.remaining_hours ?? FALLBACK_DAILY_WORKING_HOURS,
-    isLoading: shouldFetch && (isValidating || !data),
+    isLoading: shouldFetch && isValidating,
     refresh: mutate,
   };
 };

--- a/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
+++ b/frontend/packages/app/src/pages/timesheet/hooks/useRemainingHours.ts
@@ -34,15 +34,17 @@ export const useRemainingHours = ({
 }: UseRemainingHoursArgs) => {
   const shouldFetch = enabled && Boolean(employee) && Boolean(date);
 
-  const { data, isValidating } = useFrappeGetCall<RemainingHoursResponse>(
-    "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
-    { employee, date },
-    shouldFetch ? undefined : null,
-  );
+  const { data, isValidating, mutate } =
+    useFrappeGetCall<RemainingHoursResponse>(
+      "next_pms.timesheet.api.timesheet.get_remaining_hour_for_employee",
+      { employee, date },
+      shouldFetch ? undefined : null,
+    );
 
   return {
     maxDuration: data?.message?.working_hour ?? FALLBACK_DAILY_WORKING_HOURS,
     hoursLeft: data?.message?.remaining_hours ?? FALLBACK_DAILY_WORKING_HOURS,
-    isLoading: shouldFetch && isValidating,
+    isLoading: shouldFetch && (isValidating || !data),
+    refresh: mutate,
   };
 };

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -66,7 +66,7 @@ const AddEmployeeTime = ({
         date: date,
         duration: 0,
         comment: "",
-      }) as addTimeFormValues,
+      }) satisfies addTimeFormValues,
     [project, projectLabel, task, taskLabel],
   );
 

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -251,14 +251,14 @@ const AddEmployeeTime = ({
           <Button
             className="w-full"
             variant="subtle"
-            label="Save entry and add another"
+            label="Save and add another"
             onClick={() => form.handleSubmit({ keepOpen: true })}
             disabled={submitting}
           />
           <Button
             className="w-full"
             variant="solid"
-            label="Save entry and close"
+            label="Save and close"
             onClick={() => form.handleSubmit()}
             disabled={submitting}
             loading={submitting}

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -250,7 +250,7 @@ const AddEmployeeTime = ({
         <div className="flex items-center justify-between w-full gap-2">
           <Button
             className="w-full"
-            variant="ghost"
+            variant="subtle"
             label="Save entry and add another"
             onClick={() => form.handleSubmit({ keepOpen: true })}
             disabled={submitting}

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -49,26 +49,34 @@ const AddEmployeeTime = ({
   const [taskSearch, setTaskSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [entryKey, setEntryKey] = useState(0);
   const { call: saveTime } = useFrappePostCall(
     "next_pms.timesheet.api.timesheet.save",
   );
 
+  const getDefaultValues = useCallback(
+    (date: string, employee: string): addTimeFormValues =>
+      ({
+        employeeId: employee,
+        project: project,
+        projectLabel: projectLabel || project || undefined,
+        task: task,
+        taskLabel: taskLabel || task || undefined,
+        taskStatus: undefined,
+        date: date,
+        duration: 0,
+        comment: "",
+      }) as addTimeFormValues,
+    [project, projectLabel, task, taskLabel],
+  );
+
   const form = useForm({
-    defaultValues: {
-      employeeId: employeeId,
-      project: project,
-      projectLabel: projectLabel || project || undefined,
-      task: task,
-      taskLabel: taskLabel || task || undefined,
-      taskStatus: undefined,
-      date: initialDate,
-      duration: 0,
-      comment: "",
-    } as addTimeFormValues,
+    defaultValues: getDefaultValues(initialDate, employeeId),
     validators: {
       onSubmit: addTimeFormSchema,
     },
-    onSubmit: async ({ value }) => {
+    onSubmitMeta: { keepOpen: false },
+    onSubmit: async ({ value, meta }) => {
       setSubmitting(true);
       setSubmitError(null);
       try {
@@ -80,6 +88,11 @@ const AddEmployeeTime = ({
           employee: value.employeeId,
         });
         toast.success("Time Entry submitted successfully");
+        if (meta.keepOpen) {
+          resetEntry(value.date, value.employeeId);
+          await refreshRemainingHours();
+          return;
+        }
         closeModal();
       } catch (err) {
         setSubmitError(parseFrappeErrorMsg(err as FrappeError));
@@ -88,6 +101,20 @@ const AddEmployeeTime = ({
       }
     },
   });
+
+  const resetEntry = useCallback(
+    (date: string, employee: string) => {
+      setEmployeeSearch("");
+      setProjectSearch("");
+      setTaskSearch("");
+      setSubmitError(null);
+      form.reset(getDefaultValues(date, employee), {
+        keepDefaultValues: true,
+      });
+      setEntryKey((key) => key + 1);
+    },
+    [form, getDefaultValues],
+  );
 
   const closeModal = useCallback(() => {
     setEmployeeSearch("");
@@ -158,6 +185,7 @@ const AddEmployeeTime = ({
     maxDuration,
     hoursLeft,
     isLoading: isRemainingHoursLoading,
+    refresh: refreshRemainingHours,
   } = useRemainingHours({
     employee: selectedEmployeeId,
     date: selectedDate,
@@ -169,27 +197,8 @@ const AddEmployeeTime = ({
       return;
     }
 
-    form.reset({
-      employeeId,
-      project,
-      projectLabel: projectLabel || project || undefined,
-      task,
-      taskLabel: taskLabel || task || undefined,
-      taskStatus: undefined,
-      date: initialDate,
-      duration: 0,
-      comment: "",
-    });
-  }, [
-    employeeId,
-    form,
-    initialDate,
-    open,
-    project,
-    projectLabel,
-    task,
-    taskLabel,
-  ]);
+    form.reset(getDefaultValues(initialDate, employeeId));
+  }, [employeeId, form, getDefaultValues, initialDate, open]);
 
   const { options: employeeOptions, isLoading: isEmployeeLookupLoading } =
     useEmployeeLookup({
@@ -238,14 +247,23 @@ const AddEmployeeTime = ({
         footer: "pb-6",
       }}
       actions={
-        <Button
-          className="w-full"
-          variant="solid"
-          label="Save entry"
-          onClick={() => form.handleSubmit()}
-          disabled={submitting}
-          loading={submitting}
-        />
+        <div className="flex items-center justify-between w-full gap-2">
+          <Button
+            className="w-full"
+            variant="ghost"
+            label="Save entry and add another"
+            onClick={() => form.handleSubmit({ keepOpen: true })}
+            disabled={submitting}
+          />
+          <Button
+            className="w-full"
+            variant="solid"
+            label="Save entry and close"
+            onClick={() => form.handleSubmit()}
+            disabled={submitting}
+            loading={submitting}
+          />
+        </div>
       }
       options={{
         title: "Add time",
@@ -447,6 +465,7 @@ const AddEmployeeTime = ({
                   Comment
                 </label>
                 <TextEditor
+                  key={`comment-${entryKey}`}
                   content={field.state.value}
                   onChange={(value) => field.handleChange(value)}
                   fixedMenu={false}

--- a/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
@@ -125,30 +125,25 @@ export const TotalRow: React.FC<TotalRowProps> = ({
               }}
               aria-label="Add time"
             >
-              {totalTimeEntry.time === "" ? (
-                <>
-                  <span
-                    className={cn(
-                      "flex-1 text-center text-ink-gray-4",
-                      !isCellDisabled &&
-                        "group-hover:hidden group-disabled:group-hover:flex",
-                    )}
-                  >
-                    -
-                  </span>
-                  <span
-                    className={cn(
-                      "hidden absolute top-0 left-0 justify-center items-center w-full h-full text-ink-gray-6",
-                      !isCellDisabled &&
-                        "group-hover:flex group-disabled:group-hover:hidden",
-                    )}
-                  >
-                    <AddMd size={16} className="" />
-                  </span>
-                </>
-              ) : (
-                <span>{totalTimeEntry.time}</span>
-              )}
+              <span
+                className={cn(
+                  "flex-1 text-center",
+                  totalTimeEntry.time === "" && "text-ink-gray-4",
+                  !isCellDisabled &&
+                    "group-hover:hidden group-disabled:group-hover:flex",
+                )}
+              >
+                {totalTimeEntry.time === "" ? "-" : totalTimeEntry.time}
+              </span>
+              <span
+                className={cn(
+                  "hidden absolute top-0 left-0 justify-center items-center w-full h-full text-ink-gray-6",
+                  !isCellDisabled &&
+                    "group-hover:flex group-disabled:group-hover:hidden",
+                )}
+              >
+                <AddMd size={16} className="" />
+              </span>
             </Button>
           </div>
         );


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds a new action to the Add Time modal that allows users to save a time entry and immediately add another without closing the modal.

After saving, the form is reset based on how the modal was opened, preserving any contextual values where appropriate. This makes it easier to add multiple time entries without repeatedly closing and reopening the Add Time modal.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* The form reset is context-aware. The values that are preserved depend on how the Add Time modal was opened.
  * When opened using the "+ Add Time" button, only the selected date is preserved.
  * When opened from a Project/Tasks (total row), only the selected date is preserved.
  * When opened from a project row, the selected date and project are preserved.
  * On the Team and Project Timesheet pages, any preselected employee, project, and date are preserved based on the context from which row the Add Time modal was opened.
* The "+" icon is now displayed when hovering over the "Project/Tasks" total row dates, even if the row already contains time entries.


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Hover over the "Project/Tasks" total row on the Personal Timesheet page.
   * Verify the "+" button is displayed even when the row already contains time entries.
2. Open the "Add Time" modal using the "+ Add Time" button.
   * Select a project, task, and date.
   * Add a time entry and click "Save Entry and Add Another".
   * Verify that only the date is preserved and all other fields are cleared.
3. Open the "Add Time" modal from a date in the "Project/Tasks" total row.
   * Add a time entry and click "Save Entry and Add Another".
   * Verify that only the date is preserved.
4. Open the "Add Time" modal from an existing project row.
   * Add a time entry and click "Save Entry and Add Another".
   * Verify that the project and date are preserved while all other fields are cleared.
5. Repeat the same test on the Team Timesheet and Project Timesheet pages.
   * Verify that the employee, project, and date are preserved based on the context from which the modal was opened.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/80c28b32-5b77-4603-9346-d68095d6cb1e



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1894