### PR TITLE
feat(project-tracking): make total project value card link to filtered sales orders

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
@@ -34,7 +34,7 @@ export function KnowledgePoint({ title, value, href }: KnowledgePointProps) {
         rel="noreferrer noopener"
         className={cn(
           CARD_CLASSNAME,
-          "cursor-pointer transition-colors hover:border-outline-gray-3",
+          "cursor-pointer transition-colors hover:border-outline-gray-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
         )}
       >
         {content}

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
@@ -1,11 +1,20 @@
+/**
+ * Internal dependencies.
+ */
+import { mergeClassNames as cn } from "@/lib/utils";
+
 type KnowledgePointProps = {
   title: string;
   value: string;
+  href?: string;
 };
 
-export function KnowledgePoint({ title, value }: KnowledgePointProps) {
-  return (
-    <div className="flex h-20 flex-1 min-w-0 flex-col justify-between rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
+const CARD_CLASSNAME =
+  "flex h-20 flex-1 min-w-0 flex-col justify-between rounded-xl border border-outline-gray-1 bg-surface-cards p-3";
+
+export function KnowledgePoint({ title, value, href }: KnowledgePointProps) {
+  const content = (
+    <>
       <div className="flex min-w-0 items-center justify-between gap-2">
         <span className="truncate text-base font-normal text-ink-gray-5">
           {title}
@@ -14,6 +23,24 @@ export function KnowledgePoint({ title, value }: KnowledgePointProps) {
       <span className="truncate text-xl font-medium text-ink-gray-8">
         {value}
       </span>
-    </div>
+    </>
   );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        className={cn(
+          CARD_CLASSNAME,
+          "cursor-pointer transition-colors hover:border-outline-gray-3",
+        )}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <div className={CARD_CLASSNAME}>{content}</div>;
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
@@ -34,7 +34,7 @@ export function KnowledgePoint({ title, value, href }: KnowledgePointProps) {
         rel="noreferrer noopener"
         className={cn(
           CARD_CLASSNAME,
-          "cursor-pointer transition-colors hover:border-outline-gray-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
+          "cursor-pointer transition-colors hover:bg-surface-gray-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
         )}
       >
         {content}

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies.
  */
+import { ROUTES } from "@/lib/constant";
 import { currencyFormat, formatPercentage } from "@/lib/utils";
 import { ContractsTable } from "./components/contractsTable";
 import { CostBurnCell } from "./components/costBurn";
@@ -22,6 +23,7 @@ export function Tracking() {
 }
 
 function TrackingContent() {
+  const projectId = useProjectDetail((s) => s.projectId);
   const currency = useProjectDetail((s) => s.project?.custom_currency);
   const tracking = useTracking((state) => state.tracking);
 
@@ -34,6 +36,9 @@ function TrackingContent() {
           value={currencyFormat(currency).format(
             tracking.total_project_value ?? 0,
           )}
+          href={`${ROUTES.desk}/sales-order?status=Cancelled&project=${encodeURIComponent(
+            projectId,
+          )}`}
         />
         <KnowledgePoint
           title="Projected profit"


### PR DESCRIPTION
## Description
- Made the "Total project value" card in the Project Tracking tab clickable - opens the Sales Order List View in a new tab, pre-filtered to status=Cancelled and project=current project.

## Relevant Technical Choices
- KnowledgePoint now accepts an optional href prop; when passed, the card renders as an <a target="_blank" rel="noreferrer noopener"> with hover affordance instead of a plain div. All other 6 KnowledgePoint cards in the tab (Company, Projected profit, etc.) are unaffected since they don't pass href.

## Screenshot/Screencast
https://github.com/user-attachments/assets/55595f04-a0ce-4695-8eef-49390410e3ad

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1917