### PR TITLE
fix: realtime leave application display

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/personal/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/personal/utils.ts
@@ -2,10 +2,12 @@
  * Internal dependencies
  */
 import type { DataProp } from "@/types/timesheet";
-import { formatTimesheetWeekLabel } from "../utils";
+import { formatTimesheetWeekLabel, replaceLeavesForWeeks } from "../utils";
 
 /**
- * Merges existing timesheet data with new payload, ensuring no duplicate leaves and combining holidays and data.
+ * Merges existing timesheet data with new payload, combining holidays and data.
+ * The payload is authoritative for the leaves of the weeks it covers, so leaves
+ * cancelled or deleted on the server are dropped from the merged result.
  * @param existing The existing timesheet data to be merged with the new payload.
  * @param payload The new timesheet data that needs to be merged with the existing data.
  */
@@ -13,11 +15,6 @@ export const mergeTimesheetData = (
   existing: DataProp,
   payload: DataProp,
 ): DataProp => {
-  const existingLeaveIds = new Set(existing.leaves.map((leave) => leave.name));
-  const newLeaves = payload.leaves.filter(
-    (leave) => !existingLeaveIds.has(leave.name),
-  );
-
   return {
     ...existing,
     data: {
@@ -25,7 +22,11 @@ export const mergeTimesheetData = (
       ...payload.data,
     },
     holidays: [...existing.holidays, ...payload.holidays],
-    leaves: [...existing.leaves, ...newLeaves],
+    leaves: replaceLeavesForWeeks(
+      existing.leaves,
+      payload.leaves,
+      Object.values(payload.data),
+    ),
   };
 };
 

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetData.ts
@@ -16,7 +16,7 @@ import type { TeamMember } from "@/components/timesheet-row/teamTimesheetRow";
 import { NUMBER_OF_WEEKS_TO_FETCH } from "@/lib/constant";
 import { buildCompositeFilters } from "@/lib/utils";
 import type { DataProp, TimesheetFilters } from "@/types/timesheet";
-import { formatTimesheetWeekLabel } from "../utils";
+import { formatTimesheetWeekLabel, replaceLeavesForWeeks } from "../utils";
 import type { EmployeeRecord, WeekGroup } from "./context";
 
 type WeekEntry = {
@@ -367,6 +367,11 @@ export function useTeamTimesheetData({
           nextData[empName] = {
             ...nextData[empName],
             timesheet_details: mergedDetails,
+            leaves: replaceLeavesForWeeks(
+              nextData[empName].leaves ?? [],
+              updatedEmp.leaves ?? [],
+              Object.values(updatedEmp.timesheet_details),
+            ),
           };
           changed = true;
         }

--- a/frontend/packages/app/src/pages/timesheet/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/utils.ts
@@ -4,6 +4,23 @@
 import { getTodayDate, getUTCDateTime } from "@next-pms/design-system/date";
 import { format, isSameMonth, isSameYear, subWeeks } from "date-fns";
 
+import type { LeaveProps } from "@/types/timesheet";
+
+export const replaceLeavesForWeeks = (
+  existing: LeaveProps[],
+  incoming: LeaveProps[],
+  weeks: Array<{ start_date: string; end_date: string }>,
+): LeaveProps[] => {
+  const overlapsWeek = (leave: LeaveProps) =>
+    weeks.some(
+      (week) =>
+        leave.from_date <= week.end_date && leave.to_date >= week.start_date,
+    );
+  const kept = existing.filter((leave) => !overlapsWeek(leave));
+  const keptIds = new Set(kept.map((leave) => leave.name));
+  return [...kept, ...incoming.filter((leave) => !keptIds.has(leave.name))];
+};
+
 /**
  * Formats the label for a timesheet week based on the start and end dates.
  * @param startDate - The start date of the week in string format.

--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -251,6 +251,9 @@ doc_events = {
             "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
             "next_pms.timesheet.doc_events.leave_application.on_cancel",
         ],
+        "after_delete": [
+            "next_pms.timesheet.doc_events.leave_application.after_delete",
+        ],
     },
     "Employee Skill Map": {
         "on_update": [

--- a/next_pms/tests/timesheet/doc_events/test_leave_application_realtime.py
+++ b/next_pms/tests/timesheet/doc_events/test_leave_application_realtime.py
@@ -1,0 +1,151 @@
+from unittest.mock import patch
+
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+from frappe.utils import getdate
+
+from next_pms.resource_management.api.utils.query import get_employee_leaves
+
+EMPLOYEE_USER = "leave-realtime-test@example.com"
+LEAVE_TYPE = "Leave Realtime Test LWP"
+
+PUBLISH_TARGET = "next_pms.timesheet.doc_events.timesheet.publish_timesheet_update"
+
+# All dates below are in 2026 with first_day_of_the_week forced to Monday, so
+# every expected week start is a known Monday.
+WED_OCT_7, THU_OCT_8, MON_OCT_5 = "2026-10-07", "2026-10-08", "2026-10-05"
+WED_OCT_14, MON_OCT_12 = "2026-10-14", "2026-10-12"
+SAT_OCT_24, MON_OCT_26, MON_OCT_19 = "2026-10-24", "2026-10-26", "2026-10-19"
+WED_NOV_4, TUE_NOV_17 = "2026-11-04", "2026-11-17"
+NOV_WEEK_STARTS = ["2026-11-02", "2026-11-09", "2026-11-16"]
+WED_DEC_2, THU_DEC_3, MON_NOV_30 = "2026-12-02", "2026-12-03", "2026-11-30"
+WED_DEC_9, MON_DEC_7 = "2026-12-09", "2026-12-07"
+
+
+class LeaveRealtimeTestCase(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._prev_first_day_of_the_week = frappe.db.get_default("first_day_of_the_week")
+        frappe.db.set_default("first_day_of_the_week", "Monday")
+
+        from next_pms.tests.utils import make_employee
+
+        cls.employee = make_employee(EMPLOYEE_USER, company=get_default_company(), leave_approver="Administrator")
+
+        if not frappe.db.exists("Leave Type", LEAVE_TYPE):
+            frappe.get_doc({"doctype": "Leave Type", "leave_type_name": LEAVE_TYPE, "is_lwp": 1}).insert()
+
+        # A previous aborted run can leave applications behind and trip the overlap check.
+        for leave in frappe.get_all("Leave Application", filters={"employee": cls.employee}, pluck="name"):
+            frappe.delete_doc("Leave Application", leave, force=1, ignore_permissions=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.db.set_default("first_day_of_the_week", cls._prev_first_day_of_the_week)
+        super().tearDownClass()
+
+    def tearDown(self):
+        get_employee_leaves.clear_cache()
+        frappe.cache().delete_keys("emp_timesheet")
+
+    def _make_leave(self, from_date, to_date):
+        return frappe.get_doc(
+            {
+                "doctype": "Leave Application",
+                "employee": self.employee,
+                "leave_type": LEAVE_TYPE,
+                "from_date": from_date,
+                "to_date": to_date,
+                "description": "realtime publish test",
+                "leave_approver": "Administrator",
+                "status": "Open",
+            }
+        ).insert()
+
+
+class TestLeaveRealtimeTrigger(LeaveRealtimeTestCase):
+    """Leave Application doc events publish a timesheet update for every week the leave touches."""
+
+    def _published_weeks(self, mock_publish):
+        return sorted({call.args for call in mock_publish.call_args_list})
+
+    def test_create_publishes_the_leaves_week(self):
+        with patch(PUBLISH_TARGET) as mock_publish:
+            self._make_leave(WED_OCT_7, THU_OCT_8)
+
+        self.assertEqual(self._published_weeks(mock_publish), [(self.employee, getdate(MON_OCT_5))])
+
+    def test_multi_week_leave_publishes_every_week(self):
+        with patch(PUBLISH_TARGET) as mock_publish:
+            self._make_leave(WED_NOV_4, TUE_NOV_17)
+
+        expected = [(self.employee, getdate(week_start)) for week_start in NOV_WEEK_STARTS]
+        self.assertEqual(self._published_weeks(mock_publish), expected)
+
+    def test_leave_crossing_week_boundary_publishes_both_weeks(self):
+        """A 7-day stride from a late-week start date skips past the final week.
+
+        Saturday to Monday spans two weeks, but sampling every 7 days from the
+        Saturday never lands inside the second one; the publisher must still
+        cover the week containing to_date.
+        """
+        with patch(PUBLISH_TARGET) as mock_publish:
+            self._make_leave(SAT_OCT_24, MON_OCT_26)
+
+        expected = [(self.employee, getdate(MON_OCT_19)), (self.employee, getdate(MON_OCT_26))]
+        self.assertEqual(self._published_weeks(mock_publish), expected)
+
+    def test_cancel_publishes(self):
+        leave = self._make_leave(WED_DEC_2, THU_DEC_3)
+        leave.status = "Approved"
+        leave.submit()
+
+        with patch(PUBLISH_TARGET) as mock_publish:
+            leave.cancel()
+
+        self.assertEqual(self._published_weeks(mock_publish), [(self.employee, getdate(MON_NOV_30))])
+
+    def test_delete_publishes(self):
+        leave = self._make_leave(WED_DEC_9, WED_DEC_9)
+
+        with patch(PUBLISH_TARGET) as mock_publish:
+            leave.delete()
+
+        self.assertEqual(self._published_weeks(mock_publish), [(self.employee, getdate(MON_DEC_7))])
+
+
+class TestLeaveRealtimePayload(LeaveRealtimeTestCase):
+    """The pushed snapshot is recomputed after the cache flush, so it reflects the change."""
+
+    def _timesheet_update_payloads(self, mock_publish):
+        event = f"timesheet_update::{self.employee}"
+        return [call.args[1]["message"] for call in mock_publish.call_args_list if call.args[0] == event]
+
+    def test_created_leave_is_in_the_pushed_snapshot(self):
+        get_employee_leaves(self.employee, MON_OCT_12, WED_OCT_14)  # warm the cache the flush must clear
+
+        with patch("frappe.publish_realtime") as mock_publish:
+            leave = self._make_leave(WED_OCT_14, WED_OCT_14)
+
+        payloads = self._timesheet_update_payloads(mock_publish)
+        self.assertTrue(payloads)
+        for payload in payloads:
+            self.assertIn(leave.name, [row["name"] for row in payload["leaves"]])
+
+        team_events = [call.args[0] for call in mock_publish.call_args_list]
+        self.assertIn("timesheet_info", team_events)
+
+    def test_cancelled_leave_is_dropped_from_the_pushed_snapshot(self):
+        leave = self._make_leave(WED_OCT_7, THU_OCT_8)
+        leave.status = "Approved"
+        leave.submit()
+
+        with patch("frappe.publish_realtime") as mock_publish:
+            leave.cancel()
+
+        payloads = self._timesheet_update_payloads(mock_publish)
+        self.assertTrue(payloads)
+        for payload in payloads:
+            self.assertNotIn(leave.name, [row["name"] for row in payload["leaves"]])

--- a/next_pms/tests/timesheet/doc_events/test_leave_application_realtime.py
+++ b/next_pms/tests/timesheet/doc_events/test_leave_application_realtime.py
@@ -9,6 +9,7 @@ from next_pms.resource_management.api.utils.query import get_employee_leaves
 
 EMPLOYEE_USER = "leave-realtime-test@example.com"
 LEAVE_TYPE = "Leave Realtime Test LWP"
+HOLIDAY_LIST = "Leave Realtime Test Holiday List"
 
 PUBLISH_TARGET = "next_pms.timesheet.doc_events.timesheet.publish_timesheet_update"
 
@@ -30,9 +31,27 @@ class LeaveRealtimeTestCase(IntegrationTestCase):
         cls._prev_first_day_of_the_week = frappe.db.get_default("first_day_of_the_week")
         frappe.db.set_default("first_day_of_the_week", "Monday")
 
-        from next_pms.tests.utils import make_employee
+        from next_pms.tests.utils import make_employee, make_holiday_list
 
         cls.employee = make_employee(EMPLOYEE_USER, company=get_default_company(), leave_approver="Administrator")
+
+        # HRMS refuses to insert a Leave Application unless the employee resolves a
+        # holiday list, and resolution goes through Holiday List Assignment, not
+        # Employee.holiday_list. Spans all of 2026 to cover every fixed test date.
+        holiday_list = make_holiday_list(HOLIDAY_LIST, from_date="2026-01-01", to_date="2026-12-31")
+        if not frappe.db.exists(
+            "Holiday List Assignment",
+            {"assigned_to": cls.employee, "from_date": "2026-01-01", "docstatus": 1},
+        ):
+            frappe.get_doc(
+                {
+                    "doctype": "Holiday List Assignment",
+                    "applicable_for": "Employee",
+                    "assigned_to": cls.employee,
+                    "holiday_list": holiday_list.name,
+                    "from_date": "2026-01-01",
+                }
+            ).insert(ignore_permissions=True).submit()
 
         if not frappe.db.exists("Leave Type", LEAVE_TYPE):
             frappe.get_doc({"doctype": "Leave Type", "leave_type_name": LEAVE_TYPE, "is_lwp": 1}).insert()

--- a/next_pms/timesheet/doc_events/leave_application.py
+++ b/next_pms/timesheet/doc_events/leave_application.py
@@ -1,13 +1,36 @@
 def on_update(doc, mehod=None):
     flush_cache(doc)
+    publish_updates(doc)
 
 
 def on_cancel(doc, method=None):
     flush_cache(doc)
+    publish_updates(doc)
 
 
 def on_trash(doc, method=None):
     flush_cache(doc)
+
+
+def after_delete(doc, method=None):
+    publish_updates(doc)
+
+
+def publish_updates(doc):
+    from frappe.utils import add_days, getdate
+
+    from next_pms.timesheet.api.utils import get_week_dates
+    from next_pms.timesheet.doc_events.timesheet import publish_timesheet_update
+
+    week_starts = set()
+    current, end = getdate(doc.from_date), getdate(doc.to_date)
+    while current <= end:
+        week_starts.add(get_week_dates(current)["start_date"])
+        current = add_days(current, 7)
+    week_starts.add(get_week_dates(end)["start_date"])
+
+    for week_start in sorted(week_starts):
+        publish_timesheet_update(doc.employee, week_start)
 
 
 def flush_cache(doc):

--- a/next_pms/timesheet/doc_events/leave_application.py
+++ b/next_pms/timesheet/doc_events/leave_application.py
@@ -1,4 +1,4 @@
-def on_update(doc, mehod=None):
+def on_update(doc, method=None):
     flush_cache(doc)
     publish_updates(doc)
 


### PR DESCRIPTION
## Description

realtime leave application display in the UI.

## Relevant Technical Choices

the same websocket wiring is reused for leave application also. the frontend is updated to merge the updated data & old data so the UI looks fresh.

## Testing Instructions

1. add a time off
2. observe the UI updating instantly

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1517