### PR TITLE
feat(project-details): add searchable list view to calendar timeline tab

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarContent.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarContent.tsx
@@ -14,6 +14,7 @@ import { CreateMilestoneModal } from "./create-milestone";
 import { CreateTouchpointModal } from "./create-touchpoint";
 import { GanttView } from "./ganttView";
 import { MilestonesTable } from "./milestonesTable";
+import { TimelineListView } from "./timelineListView";
 import { TouchpointsTable } from "./touchpointsTable";
 import type { TableTab } from "./types";
 
@@ -43,9 +44,11 @@ export function CalendarContent() {
       </div>
 
       {/* Calendar or Gantt view */}
-      <div className="border-b border-gray-100 -mx-5">
-        {activeView === "calendar" ? <CalendarGrid /> : <GanttView />}
-      </div>
+      {activeView !== "list" && (
+        <div className="border-b border-gray-100 -mx-5">
+          {activeView === "calendar" ? <CalendarGrid /> : <GanttView />}
+        </div>
+      )}
 
       {/* Table section */}
       <div className="mt-4">
@@ -76,7 +79,9 @@ export function CalendarContent() {
 
         {/* Table */}
         <div className="overflow-x-auto">
-          {tableTab === "milestones" ? (
+          {activeView === "list" ? (
+            <TimelineListView />
+          ) : tableTab === "milestones" ? (
             <MilestonesTable items={items} />
           ) : (
             <TouchpointsTable items={items} />

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarContent.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarContent.tsx
@@ -78,15 +78,13 @@ export function CalendarContent() {
         </div>
 
         {/* Table */}
-        <div className="overflow-x-auto">
-          {activeView === "list" ? (
-            <TimelineListView />
-          ) : tableTab === "milestones" ? (
-            <MilestonesTable items={items} />
-          ) : (
-            <TouchpointsTable items={items} />
-          )}
-        </div>
+        {activeView === "list" ? (
+          <TimelineListView />
+        ) : tableTab === "milestones" ? (
+          <MilestonesTable items={items} />
+        ) : (
+          <TouchpointsTable items={items} />
+        )}
       </div>
 
       <CreateMilestoneModal

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarToolbar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarToolbar.tsx
@@ -6,6 +6,7 @@ import {
   DatePicker,
   Select,
   TabButtons,
+  TextInput,
 } from "@rtcamp/frappe-ui-react";
 import {
   SmallLeftChevron,
@@ -30,62 +31,82 @@ export function CalendarToolbar() {
   const currentDate = useCalendar((c) => c.state.currentDate);
   const activeView = useCalendar((c) => c.state.activeView);
   const filterValue = useCalendar((c) => c.state.filterType);
+  const tableTab = useCalendar((c) => c.state.tableTab);
+  const searchInput = useCalendar((c) => c.state.searchInput);
   const handlePeriodChange = useCalendar((c) => c.actions.handlePeriodChange);
   const goToPrev = useCalendar((c) => c.actions.goToPrev);
   const goToToday = useCalendar((c) => c.actions.goToToday);
   const goToNext = useCalendar((c) => c.actions.goToNext);
   const setActiveView = useCalendar((c) => c.actions.setActiveView);
   const setFilterType = useCalendar((c) => c.actions.setFilterType);
+  const setSearchInput = useCalendar((c) => c.actions.setSearchInput);
 
   const currentPeriodValue = format(currentDate, "yyyy-MM-dd");
+  const isListView = activeView === "list";
 
   return (
     <div className="flex justify-between items-center w-full">
       <div className="flex items-center">
-        <DatePicker
-          value={currentPeriodValue}
-          formatter={(d) => format(parseISO(d), "MMMM yyyy")}
-          placement="bottom-start"
-          clearable={false}
-          onChange={(val) => {
-            const v = Array.isArray(val) ? val[0] : val;
-            if (v) handlePeriodChange(v);
-          }}
-        >
-          {({ displayValue }) => (
-            <Button
-              type="button"
-              variant="ghost"
-              className="flex items-center gap-2 shrink-0 cursor-pointer"
-            >
-              <span className="text-lg font-medium text-ink-gray-7 whitespace-nowrap mr-2">
-                {displayValue}
-              </span>
-              <SmallDown className="size-4 shrink-0" />
-            </Button>
-          )}
-        </DatePicker>
+        {isListView ? (
+          <TextInput
+            className="w-56 text-ink-gray-7"
+            size="sm"
+            placeholder={
+              tableTab === "milestones"
+                ? "Search milestone"
+                : "Search touchpoint"
+            }
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+        ) : (
+          <DatePicker
+            value={currentPeriodValue}
+            formatter={(d) => format(parseISO(d), "MMMM yyyy")}
+            placement="bottom-start"
+            clearable={false}
+            onChange={(val) => {
+              const v = Array.isArray(val) ? val[0] : val;
+              if (v) handlePeriodChange(v);
+            }}
+          >
+            {({ displayValue }) => (
+              <Button
+                type="button"
+                variant="ghost"
+                className="flex items-center gap-2 shrink-0 cursor-pointer"
+              >
+                <span className="text-lg font-medium text-ink-gray-7 whitespace-nowrap mr-2">
+                  {displayValue}
+                </span>
+                <SmallDown className="size-4 shrink-0" />
+              </Button>
+            )}
+          </DatePicker>
+        )}
       </div>
 
       <div className="flex items-center justify-end gap-2">
-        <div className="flex items-center py-0.5">
-          <Button
-            variant="ghost"
-            icon={() => <SmallLeftChevron className="size-4" />}
-            onClick={goToPrev}
-          />
-          <Button
-            className="text-ink-gray-7"
-            variant="ghost"
-            label="Today"
-            onClick={goToToday}
-          />
-          <Button
-            variant="ghost"
-            icon={() => <SmallRightChevron className="size-4" />}
-            onClick={goToNext}
-          />
-        </div>
+        {!isListView && (
+          <div className="flex items-center py-0.5">
+            <Button
+              variant="ghost"
+              icon={() => <SmallLeftChevron className="size-4" />}
+              onClick={goToPrev}
+            />
+            <Button
+              className="text-ink-gray-7"
+              variant="ghost"
+              label="Today"
+              onClick={goToToday}
+            />
+            <Button
+              variant="ghost"
+              icon={() => <SmallRightChevron className="size-4" />}
+              onClick={goToNext}
+            />
+          </div>
+        )}
 
         <TabButtons
           value={activeView}
@@ -94,17 +115,20 @@ export function CalendarToolbar() {
           buttons={[
             { label: "Calendar", value: "calendar" },
             { label: "Gantt", value: "gantt" },
+            { label: "List", value: "list" },
           ]}
         />
 
-        <Select
-          className="w-min"
-          value={filterValue}
-          options={filterOptions}
-          onChange={(val) => setFilterType(val ?? "all")}
-          size="sm"
-          variant="subtle"
-        />
+        {!isListView && (
+          <Select
+            className="w-min"
+            value={filterValue}
+            options={filterOptions}
+            onChange={(val) => setFilterType(val ?? "all")}
+            size="sm"
+            variant="subtle"
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/constants.ts
@@ -7,3 +7,6 @@ export const MIN_CARD_DAYS = 1; // minimum card width in days
 
 // Calendar grid constants
 export const DAY_HEADERS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+// List view constants
+export const TIMELINE_LIST_PAGE_SIZE = 20;

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/context.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/context.ts
@@ -24,6 +24,10 @@ export interface CalendarContextProps {
     createMilestoneOpen: boolean;
     createTouchpointOpen: boolean;
     editItem: ProjectTimelineItem | null;
+    searchInput: string;
+    listItems: ProjectTimelineItem[];
+    hasMoreList: boolean;
+    isLoadingList: boolean;
   };
   actions: {
     setActiveView: (view: CalendarView) => void;
@@ -41,6 +45,8 @@ export interface CalendarContextProps {
     setCreateTouchpointOpen: (open: boolean) => void;
     closeEditItem: () => void;
     mutate: () => void;
+    setSearchInput: (value: string) => void;
+    loadMoreList: () => void;
   };
 }
 
@@ -62,6 +68,10 @@ export const CalendarContext = createContext<CalendarContextProps>({
     createMilestoneOpen: false,
     createTouchpointOpen: false,
     editItem: null,
+    searchInput: "",
+    listItems: [],
+    hasMoreList: false,
+    isLoadingList: false,
   },
   actions: {
     setActiveView: noop,
@@ -79,6 +89,8 @@ export const CalendarContext = createContext<CalendarContextProps>({
     setCreateTouchpointOpen: noop,
     closeEditItem: noop,
     mutate: noop,
+    setSearchInput: noop,
+    loadMoreList: noop,
   },
 });
 

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/milestonesTable.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/milestonesTable.tsx
@@ -1,13 +1,8 @@
 /**
- * External dependencies.
- */
-import { mergeClassNames as cn } from "@next-pms/design-system";
-
-/**
  * Internal dependencies.
  */
-import { TimelineCell } from "./table/cells";
 import { MILESTONE_COLUMNS } from "./table/columns";
+import { TimelineTable } from "./table/timelineTable";
 import type { ProjectTimelineItem } from "./types";
 
 type MilestonesTableProps = {
@@ -17,42 +12,11 @@ type MilestonesTableProps = {
 export function MilestonesTable({ items }: MilestonesTableProps) {
   const milestones = items.filter((i) => i.type === "Milestone");
 
-  if (milestones.length === 0) {
-    return (
-      <div className="py-10 text-center text-sm text-ink-gray-4">
-        No milestones yet
-      </div>
-    );
-  }
-
   return (
-    <table className="w-full text-sm whitespace-nowrap">
-      <thead>
-        <tr className="border-b border-outline-gray-1 text-ink-gray-5 text-left">
-          {MILESTONE_COLUMNS.map((column) => (
-            <th
-              key={column.key}
-              className={cn("px-2 py-1.5 text-sm", column.width)}
-            >
-              {column.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {milestones.map((item) => (
-          <tr
-            key={item.id}
-            className="border-b border-outline-gray-1 last:border-b-0 hover:bg-surface-gray-1 transition-colors text-base text-ink-gray-6"
-          >
-            {MILESTONE_COLUMNS.map((column) => (
-              <td key={column.key} className="py-3 px-2">
-                <TimelineCell item={item} column={column} />
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <TimelineTable
+      items={milestones}
+      columns={MILESTONE_COLUMNS}
+      emptyMessage="No milestones yet"
+    />
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/provider.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/provider.tsx
@@ -13,11 +13,13 @@ import {
 /**
  * Internal dependencies.
  */
+import { useDebounce } from "@/hooks/useDebounce";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
 import { CalendarContext, type CalendarContextProps } from "./context";
 import type { CalendarView, ProjectTimelineItem, TableTab } from "./types";
 import { useProjectTimelineItems } from "./useProjectTimelineItems";
+import { useTimelineItemsList } from "./useTimelineItemsList";
 
 interface CalendarProviderProps extends PropsWithChildren {
   projectId: string;
@@ -51,11 +53,31 @@ export function CalendarProvider({
   const [createMilestoneOpen, setCreateMilestoneOpen] = useState(false);
   const [createTouchpointOpen, setCreateTouchpointOpen] = useState(false);
   const [editItem, setEditItem] = useState<ProjectTimelineItem | null>(null);
+  const [searchInput, setSearchInput] = useState("");
+  const search = useDebounce(searchInput, 400);
 
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
   const { items, mutate } = useProjectTimelineItems(projectId, year, month);
+
+  const {
+    items: listItems,
+    hasMore: hasMoreList,
+    isLoading: isLoadingList,
+    loadMore: loadMoreList,
+    mutate: mutateList,
+  } = useTimelineItemsList(
+    projectId,
+    tableTab === "milestones" ? "Milestone" : "Touchpoint",
+    search,
+    activeView === "list",
+  );
+
+  const mutateAll = useCallback(() => {
+    void mutate();
+    void mutateList();
+  }, [mutate, mutateList]);
 
   const filteredItems =
     filterType === "all"
@@ -98,12 +120,12 @@ export function CalendarProvider({
         toast.success(
           item.isComplete ? "Marked as incomplete" : "Marked as completed",
         );
-        void mutate();
+        mutateAll();
       } catch (err) {
         toast.error(parseFrappeErrorMsg(err as FrappeError));
       }
     },
-    [markComplete, mutate, toast],
+    [markComplete, mutateAll, toast],
   );
 
   const onEdit = useCallback((item: ProjectTimelineItem) => {
@@ -130,12 +152,12 @@ export function CalendarProvider({
         toast.success(
           isFollowing ? "Unfollowed document" : "Following document",
         );
-        void mutate();
+        mutateAll();
       } catch (err) {
         toast.error(parseFrappeErrorMsg(err as FrappeError));
       }
     },
-    [mutate, toast, updateFollow, userId],
+    [mutateAll, toast, updateFollow, userId],
   );
 
   const onDelete = useCallback(
@@ -143,12 +165,12 @@ export function CalendarProvider({
       try {
         await deleteDoc("Project Timeline Item", item.id);
         toast.success(`${item.type} deleted`);
-        void mutate();
+        mutateAll();
       } catch (err) {
         toast.error(parseFrappeErrorMsg(err as FrappeError));
       }
     },
-    [deleteDoc, mutate, toast],
+    [deleteDoc, mutateAll, toast],
   );
 
   const value = useMemo<CalendarContextProps>(
@@ -168,6 +190,10 @@ export function CalendarProvider({
         createMilestoneOpen,
         createTouchpointOpen,
         editItem,
+        searchInput,
+        listItems,
+        hasMoreList,
+        isLoadingList,
       },
       actions: {
         setActiveView,
@@ -184,7 +210,9 @@ export function CalendarProvider({
         setCreateMilestoneOpen,
         setCreateTouchpointOpen,
         closeEditItem,
-        mutate,
+        mutate: mutateAll,
+        setSearchInput,
+        loadMoreList,
       },
     }),
     [
@@ -202,6 +230,10 @@ export function CalendarProvider({
       createMilestoneOpen,
       createTouchpointOpen,
       editItem,
+      searchInput,
+      listItems,
+      hasMoreList,
+      isLoadingList,
       handlePeriodChange,
       goToPrev,
       goToNext,
@@ -211,7 +243,8 @@ export function CalendarProvider({
       onFollowDocument,
       onDelete,
       closeEditItem,
-      mutate,
+      mutateAll,
+      loadMoreList,
     ],
   );
 

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/table/timelineTable.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/table/timelineTable.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies.
+ */
+import { mergeClassNames as cn } from "@next-pms/design-system";
+
+/**
+ * Internal dependencies.
+ */
+import type { ProjectTimelineItem } from "../types";
+import { TimelineCell } from "./cells";
+import type { TableColumn } from "./columns";
+
+type TimelineTableProps = {
+  items: ProjectTimelineItem[];
+  columns: TableColumn[];
+  emptyMessage: string;
+};
+
+export function TimelineTable({
+  items,
+  columns,
+  emptyMessage,
+}: TimelineTableProps) {
+  if (items.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-ink-gray-4">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <table className="w-full text-sm whitespace-nowrap">
+      <thead>
+        <tr className="border-b border-outline-gray-1 text-ink-gray-5 text-left">
+          {columns.map((column) => (
+            <th
+              key={column.key}
+              className={cn("px-2 py-1.5 text-sm", column.width)}
+            >
+              {column.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((item) => (
+          <tr
+            key={item.id}
+            className="border-b border-outline-gray-1 last:border-b-0 hover:bg-surface-gray-1 transition-colors text-base text-ink-gray-6"
+          >
+            {columns.map((column) => (
+              <td key={column.key} className="py-3 px-2">
+                <TimelineCell item={item} column={column} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/table/timelineTable.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/table/timelineTable.tsx
@@ -30,33 +30,35 @@ export function TimelineTable({
   }
 
   return (
-    <table className="w-full text-sm whitespace-nowrap">
-      <thead>
-        <tr className="border-b border-outline-gray-1 text-ink-gray-5 text-left">
-          {columns.map((column) => (
-            <th
-              key={column.key}
-              className={cn("px-2 py-1.5 text-sm", column.width)}
-            >
-              {column.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {items.map((item) => (
-          <tr
-            key={item.id}
-            className="border-b border-outline-gray-1 last:border-b-0 hover:bg-surface-gray-1 transition-colors text-base text-ink-gray-6"
-          >
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm whitespace-nowrap">
+        <thead>
+          <tr className="border-b border-outline-gray-1 text-ink-gray-5 text-left">
             {columns.map((column) => (
-              <td key={column.key} className="py-3 px-2">
-                <TimelineCell item={item} column={column} />
-              </td>
+              <th
+                key={column.key}
+                className={cn("px-2 py-1.5 text-sm", column.width)}
+              >
+                {column.label}
+              </th>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.id}
+              className="border-b border-outline-gray-1 last:border-b-0 hover:bg-surface-gray-1 transition-colors text-base text-ink-gray-6"
+            >
+              {columns.map((column) => (
+                <td key={column.key} className="py-3 px-2">
+                  <TimelineCell item={item} column={column} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/timelineListView.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/timelineListView.tsx
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies.
+ */
+import { InfiniteScroll } from "@/components/infiniteScroll";
+import { TIMELINE_LIST_PAGE_SIZE } from "./constants";
+import { useCalendar } from "./context";
+import { MILESTONE_COLUMNS, TOUCHPOINT_COLUMNS } from "./table/columns";
+import { TimelineTable } from "./table/timelineTable";
+
+export function TimelineListView() {
+  const tableTab = useCalendar((c) => c.state.tableTab);
+  const searchInput = useCalendar((c) => c.state.searchInput);
+  const listItems = useCalendar((c) => c.state.listItems);
+  const hasMoreList = useCalendar((c) => c.state.hasMoreList);
+  const isLoadingList = useCalendar((c) => c.state.isLoadingList);
+  const loadMoreList = useCalendar((c) => c.actions.loadMoreList);
+
+  const isMilestones = tableTab === "milestones";
+  const columns = isMilestones ? MILESTONE_COLUMNS : TOUCHPOINT_COLUMNS;
+  const itemLabel = isMilestones ? "milestones" : "touchpoints";
+  const emptyMessage = searchInput
+    ? `No ${itemLabel} found`
+    : `No ${itemLabel} yet`;
+
+  return (
+    <InfiniteScroll
+      isLoading={isLoadingList}
+      hasMore={hasMoreList}
+      verticalLodMore={loadMoreList}
+      count={TIMELINE_LIST_PAGE_SIZE}
+    >
+      {listItems.length === 0 && isLoadingList ? null : (
+        <TimelineTable
+          items={listItems}
+          columns={columns}
+          emptyMessage={emptyMessage}
+        />
+      )}
+    </InfiniteScroll>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/touchpointsTable.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/touchpointsTable.tsx
@@ -1,13 +1,8 @@
 /**
- * External dependencies.
- */
-import { mergeClassNames as cn } from "@next-pms/design-system";
-
-/**
  * Internal dependencies.
  */
-import { TimelineCell } from "./table/cells";
 import { TOUCHPOINT_COLUMNS } from "./table/columns";
+import { TimelineTable } from "./table/timelineTable";
 import type { ProjectTimelineItem } from "./types";
 
 type TouchpointsTableProps = {
@@ -17,42 +12,11 @@ type TouchpointsTableProps = {
 export function TouchpointsTable({ items }: TouchpointsTableProps) {
   const touchpoints = items.filter((i) => i.type === "Touchpoint");
 
-  if (touchpoints.length === 0) {
-    return (
-      <div className="py-10 text-center text-sm text-ink-gray-4">
-        No touchpoints yet
-      </div>
-    );
-  }
-
   return (
-    <table className="w-full text-sm whitespace-nowrap">
-      <thead>
-        <tr className="border-b border-outline-gray-1 text-ink-gray-5 text-left">
-          {TOUCHPOINT_COLUMNS.map((column) => (
-            <th
-              key={column.key}
-              className={cn("px-2 py-1.5 text-sm", column.width)}
-            >
-              {column.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {touchpoints.map((item) => (
-          <tr
-            key={item.id}
-            className="border-b border-outline-gray-1 last:border-b-0 hover:bg-surface-gray-1 transition-colors text-base text-ink-gray-6"
-          >
-            {TOUCHPOINT_COLUMNS.map((column) => (
-              <td key={column.key} className="py-3 px-2">
-                <TimelineCell item={item} column={column} />
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <TimelineTable
+      items={touchpoints}
+      columns={TOUCHPOINT_COLUMNS}
+      emptyMessage="No touchpoints yet"
+    />
   );
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/types.ts
@@ -1,6 +1,6 @@
 export type TimelineItemType = "Milestone" | "Touchpoint";
 
-export type CalendarView = "calendar" | "gantt";
+export type CalendarView = "calendar" | "gantt" | "list";
 
 export type TableTab = "milestones" | "touchpoints";
 
@@ -22,3 +22,28 @@ export type ProjectTimelineItem = {
   owner: UserRef;
   watchers: UserRef[];
 };
+
+export interface ApiUserRef {
+  user: string;
+  full_name: string;
+  image: string | null;
+}
+
+export interface ApiTimelineItem {
+  name: string;
+  title: string;
+  project: string;
+  type: TimelineItemType;
+  is_complete: 0 | 1;
+  start_date: string | null;
+  planned_end_date: string | null;
+  actual_end_date: string | null;
+  owner: ApiUserRef | null;
+  watchers: ApiUserRef[];
+}
+
+export interface ApiTimelineItemsResponse {
+  data: ApiTimelineItem[];
+  total_count: number;
+  has_more: boolean;
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useProjectTimelineItems.ts
@@ -7,58 +7,11 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
-import type { ProjectTimelineItem, UserRef } from "./types";
+import type { ApiTimelineItemsResponse } from "./types";
+import { mapTimelineItem } from "./utils";
 
 // Generous upper limit - avoids multiple round-trips for a single month
 const ITEMS_LIMIT = 200;
-
-interface ApiUserRef {
-  user: string;
-  full_name: string;
-  image: string | null;
-}
-
-interface ApiTimelineItem {
-  name: string;
-  title: string;
-  project: string;
-  type: "Milestone" | "Touchpoint";
-  is_complete: 0 | 1;
-  start_date: string | null;
-  planned_end_date: string | null;
-  actual_end_date: string | null;
-  owner: ApiUserRef | null;
-  watchers: ApiUserRef[];
-}
-
-interface ApiResponse {
-  data: ApiTimelineItem[];
-  total_count: number;
-  has_more: boolean;
-}
-
-function mapUserRef(raw: ApiUserRef): UserRef {
-  return {
-    name: raw.user,
-    fullName: raw.full_name,
-    avatar: raw.image ?? undefined,
-  };
-}
-
-function mapItem(raw: ApiTimelineItem): ProjectTimelineItem {
-  return {
-    id: raw.name,
-    title: raw.title,
-    project: raw.project,
-    type: raw.type,
-    isComplete: Boolean(raw.is_complete),
-    startDate: raw.start_date ?? undefined,
-    plannedEndDate: raw.planned_end_date as string,
-    actualEndDate: raw.actual_end_date ?? undefined,
-    owner: raw.owner ? mapUserRef(raw.owner) : { name: "", fullName: "" },
-    watchers: (raw.watchers ?? []).map(mapUserRef),
-  };
-}
 
 export function useProjectTimelineItems(
   projectId: string,
@@ -72,7 +25,7 @@ export function useProjectTimelineItems(
   const endDate = format(viewEnd, "yyyy-MM-dd");
 
   const { data, isLoading, error, mutate } = useFrappeGetCall<{
-    message: ApiResponse;
+    message: ApiTimelineItemsResponse;
   }>(
     "next_pms.next_projects.api.project_timeline_item.get_project_timeline_items",
     {
@@ -93,7 +46,7 @@ export function useProjectTimelineItems(
     .filter(
       (item) => item.start_date !== null && item.planned_end_date !== null,
     )
-    .map(mapItem);
+    .map(mapTimelineItem);
 
   return { items: allItems, isLoading, error, mutate };
 }

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useTimelineItemsList.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useTimelineItemsList.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { type PaginationKey, usePagination } from "@next-pms/hooks";
 
 /**
@@ -17,11 +17,19 @@ export function useTimelineItemsList(
   projectId: string,
   type: TimelineItemType,
   search: string,
-  enabled: boolean,
+  active: boolean,
 ) {
+  // Latches true once the list is first viewed, so the SWR key stays live even
+  // after switching views — otherwise mutate() from other views is a no-op and
+  // edits never invalidate this list's cache.
+  const [everActive, setEverActive] = useState(active);
+  useEffect(() => {
+    if (active) setEverActive(true);
+  }, [active]);
+
   const querySignature = useMemo(
-    () => JSON.stringify({ projectId, type, search, enabled }),
-    [projectId, type, search, enabled],
+    () => JSON.stringify({ projectId, type, search, everActive }),
+    [projectId, type, search, everActive],
   );
 
   const getKey = useCallback(
@@ -29,11 +37,11 @@ export function useTimelineItemsList(
       pageIndex: number,
       previousPageData: ListPage | null,
     ): PaginationKey | null => {
-      if (!enabled || !projectId) return null;
+      if (!everActive || !projectId) return null;
       if (previousPageData && !previousPageData.message.has_more) return null;
       return [querySignature, pageIndex] as const;
     },
-    [enabled, projectId, querySignature],
+    [everActive, projectId, querySignature],
   );
 
   const { data, error, isLoading, isValidating, size, setSize, mutate } =

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useTimelineItemsList.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useTimelineItemsList.ts
@@ -64,7 +64,11 @@ export function useTimelineItemsList(
 
   const items = useMemo(
     () =>
-      (data ?? []).flatMap((page) => page.message.data.map(mapTimelineItem)),
+      (data ?? []).flatMap((page) =>
+        page.message.data
+          .filter((item) => item.planned_end_date !== null)
+          .map(mapTimelineItem),
+      ),
     [data],
   );
 

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/useTimelineItemsList.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/useTimelineItemsList.ts
@@ -1,0 +1,74 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useMemo } from "react";
+import { type PaginationKey, usePagination } from "@next-pms/hooks";
+
+/**
+ * Internal dependencies.
+ */
+import { TIMELINE_LIST_PAGE_SIZE } from "./constants";
+import type { ApiTimelineItemsResponse, TimelineItemType } from "./types";
+import { mapTimelineItem } from "./utils";
+
+type ListPage = { message: ApiTimelineItemsResponse };
+
+export function useTimelineItemsList(
+  projectId: string,
+  type: TimelineItemType,
+  search: string,
+  enabled: boolean,
+) {
+  const querySignature = useMemo(
+    () => JSON.stringify({ projectId, type, search, enabled }),
+    [projectId, type, search, enabled],
+  );
+
+  const getKey = useCallback(
+    (
+      pageIndex: number,
+      previousPageData: ListPage | null,
+    ): PaginationKey | null => {
+      if (!enabled || !projectId) return null;
+      if (previousPageData && !previousPageData.message.has_more) return null;
+      return [querySignature, pageIndex] as const;
+    },
+    [enabled, projectId, querySignature],
+  );
+
+  const { data, error, isLoading, isValidating, size, setSize, mutate } =
+    usePagination<ListPage>(
+      "next_pms.next_projects.api.project_timeline_item.get_project_timeline_items",
+      getKey,
+      {
+        project: projectId,
+        type,
+        search: search || undefined,
+        page_length: TIMELINE_LIST_PAGE_SIZE,
+      },
+      {
+        revalidateOnFocus: false,
+        revalidateAll: false,
+        revalidateFirstPage: false,
+        keepPreviousData: false,
+      },
+    );
+
+  const items = useMemo(
+    () =>
+      (data ?? []).flatMap((page) => page.message.data.map(mapTimelineItem)),
+    [data],
+  );
+
+  const lastPage = data?.at(-1);
+  const hasMore = lastPage ? lastPage.message.has_more : true;
+  const isNextPageLoading =
+    !isLoading && isValidating && typeof data?.[size - 1] === "undefined";
+
+  const loadMore = useCallback(() => {
+    if (isLoading || isNextPageLoading || !hasMore) return;
+    setSize((s) => s + 1);
+  }, [isLoading, isNextPageLoading, hasMore, setSize]);
+
+  return { items, hasMore, isLoading, error, loadMore, mutate };
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/utils.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/utils.ts
@@ -20,7 +20,12 @@ import {
  * Internal dependencies.
  */
 import { COLUMN_WIDTH, MIN_CARD_DAYS } from "./constants";
-import type { ProjectTimelineItem } from "./types";
+import type {
+  ApiTimelineItem,
+  ApiUserRef,
+  ProjectTimelineItem,
+  UserRef,
+} from "./types";
 
 // Gantt utils
 
@@ -182,4 +187,29 @@ export function groupByDate(
     map.get(key)!.push(item);
   }
   return map;
+}
+
+// API mapping utils
+
+export function mapUserRef(raw: ApiUserRef): UserRef {
+  return {
+    name: raw.user,
+    fullName: raw.full_name,
+    avatar: raw.image ?? undefined,
+  };
+}
+
+export function mapTimelineItem(raw: ApiTimelineItem): ProjectTimelineItem {
+  return {
+    id: raw.name,
+    title: raw.title,
+    project: raw.project,
+    type: raw.type,
+    isComplete: Boolean(raw.is_complete),
+    startDate: raw.start_date ?? undefined,
+    plannedEndDate: raw.planned_end_date as string,
+    actualEndDate: raw.actual_end_date ?? undefined,
+    owner: raw.owner ? mapUserRef(raw.owner) : { name: "", fullName: "" },
+    watchers: (raw.watchers ?? []).map(mapUserRef),
+  };
 }

--- a/next_pms/next_projects/api/project_timeline_item.py
+++ b/next_pms/next_projects/api/project_timeline_item.py
@@ -99,6 +99,7 @@ def get_project_timeline_items(
     start_date: str | None = None,
     end_date: str | None = None,
     is_calendar: bool = False,
+    search: str | None = None,
 ):
     """
     Get all Project Timeline Items (complete and incomplete) for a project.
@@ -123,6 +124,8 @@ def get_project_timeline_items(
             interval-overlap date filtering
         is_calendar: Pass "1"/1/True to skip owner images and watchers (used for
             calendar/gantt views). Accepts "0"/"1" strings — coerced via cint().
+        search: Optional title substring filter (case-insensitive), used by the
+            List view to search across all of a project's items.
 
     Returns:
         {"data": [...], "total_count": int, "has_more": bool}
@@ -146,6 +149,9 @@ def get_project_timeline_items(
         # Interval overlap: item overlaps with [range_start, range_end) when
         # start_date < range_end AND planned_end_date > range_start
         query_base = query_base.where((PTI.start_date < range_end) & (PTI.planned_end_date > range_start))
+
+    if search:
+        query_base = query_base.where(PTI.title.like(f"%{search}%"))
 
     items = (
         query_base.select(*[PTI[field] for field in TIMELINE_ITEM_FIELDS])

--- a/next_pms/tests/next_projects/api/test_project_timeline_item.py
+++ b/next_pms/tests/next_projects/api/test_project_timeline_item.py
@@ -1,0 +1,93 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, nowdate
+
+from next_pms.next_projects.api.project_timeline_item import get_project_timeline_items
+
+
+class TestProjectTimelineItemSearch(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = get_default_company()
+
+        def make_project(project_name):
+            return (
+                frappe.get_doc(
+                    {
+                        "doctype": "Project",
+                        "project_name": project_name,
+                        "company": company,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+
+        cls.project = make_project("TimelineSearch Primary")
+        cls.other_project = make_project("TimelineSearch Other")
+
+        titles = [
+            ("Alpha Launch", cls.project),
+            ("alpha internal sync", cls.project),
+            ("Beta Review", cls.project),
+            ("Roadmap checkpoint", cls.project),
+            ("Alpha Launch", cls.other_project),
+        ]
+        for index, (title, project) in enumerate(titles):
+            frappe.get_doc(
+                {
+                    "doctype": "Project Timeline Item",
+                    "title": title,
+                    "project": project,
+                    "type": "Milestone",
+                    "start_date": add_days(nowdate(), index),
+                    "planned_end_date": add_days(nowdate(), index + 1),
+                    "item_owner": "Administrator",
+                }
+            ).insert(ignore_permissions=True)
+
+        frappe.set_user("Administrator")
+
+    def test_search_filters_by_title_substring(self):
+        result = get_project_timeline_items(self.project, search="Alpha")
+        titles = [item["title"] for item in result["data"]]
+        self.assertEqual(sorted(titles), ["Alpha Launch", "alpha internal sync"])
+        self.assertEqual(result["total_count"], 2)
+
+    def test_search_is_case_insensitive(self):
+        for term in ("ALPHA", "alpha", "aLpHa"):
+            result = get_project_timeline_items(self.project, search=term)
+            self.assertEqual(result["total_count"], 2, msg=term)
+
+    def test_search_matches_middle_of_title(self):
+        result = get_project_timeline_items(self.project, search="checkpoint")
+        titles = [item["title"] for item in result["data"]]
+        self.assertEqual(titles, ["Roadmap checkpoint"])
+
+    def test_no_search_returns_all_items(self):
+        for search in (None, ""):
+            result = get_project_timeline_items(self.project, search=search)
+            self.assertEqual(result["total_count"], 4, msg=repr(search))
+
+    def test_search_with_no_matches_returns_empty(self):
+        result = get_project_timeline_items(self.project, search="nonexistent")
+        self.assertEqual(result["data"], [])
+        self.assertEqual(result["total_count"], 0)
+        self.assertFalse(result["has_more"])
+
+    def test_search_is_scoped_to_project(self):
+        result = get_project_timeline_items(self.other_project, search="Alpha")
+        self.assertEqual(result["total_count"], 1)
+        self.assertEqual(result["data"][0]["project"], self.other_project)
+
+    def test_search_total_count_drives_pagination(self):
+        result = get_project_timeline_items(self.project, limit=1, search="Alpha")
+        self.assertEqual(len(result["data"]), 1)
+        self.assertEqual(result["total_count"], 2)
+        self.assertTrue(result["has_more"])
+
+        last_page = get_project_timeline_items(self.project, start=1, limit=1, search="Alpha")
+        self.assertEqual(len(last_page["data"]), 1)
+        self.assertFalse(last_page["has_more"])


### PR DESCRIPTION
## Description
Adds a List view (alongside the existing Calendar view) to the Project Details Timeline tab, with search-by-title support.

### Frontend
- New timelineListView.tsx + table/timelineTable.tsx render timeline items in a shared table, replacing the duplicated milestone/touchpoint table logic
- Toolbar (calendarToolbar.tsx) gains a search input and view-switcher wiring via context.ts / provider.tsx

### Backend
- get_project_timeline_items accepts an optional search param, filtering by case-insensitive title substring

## Screenshot/Screencast

https://github.com/user-attachments/assets/f5f14fbd-367b-4a13-8e91-7a8122bb2a20

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1893 