### PR TITLE
fix(allocations): make project hover-card hours a rolling remaining forecast

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/type.ts
+++ b/frontend/packages/app/src/pages/allocations/project/type.ts
@@ -65,7 +65,7 @@ export interface ProjectRecord {
   custom_project_manager?: string | null;
   custom_project_manager_name?: string | null;
   custom_total_hours_remaining?: number | null;
-  weekly_capacity?: number;
+  remaining_hours?: number;
   all_week_data: ProjectWeekData[];
   all_dates_data: Record<string, ProjectDateData>;
   project_allocations:

--- a/frontend/packages/app/src/pages/allocations/project/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/project/utils.ts
@@ -202,7 +202,7 @@ function mapProjectRecord(
     dateRange: allocationDateRange,
     projectDateRange: getProjectHoverDateRange(project) ?? allocationDateRange,
     projectManager: project.custom_project_manager_name ?? undefined,
-    weeklyCapacity: project.weekly_capacity ?? undefined,
+    remainingHours: project.remaining_hours ?? undefined,
     members,
   };
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectHoverCard.tsx
@@ -27,14 +27,14 @@ function GanttProjectHoverCard({
   canOpenProject = false,
 }: GanttProjectHoverCardProps) {
   const dateRange = project.projectDateRange ?? project.dateRange;
-  const weeklyCapacityLabel =
-    project.weeklyCapacity !== undefined
-      ? `${formatHours(project.weeklyCapacity)}h remaining`
+  const remainingHoursLabel =
+    project.remainingHours !== undefined
+      ? `${formatHours(project.remainingHours)}h remaining`
       : undefined;
   const hasDetails =
     project.client ||
     dateRange ||
-    weeklyCapacityLabel ||
+    remainingHoursLabel ||
     project.projectManager;
   const projectHref =
     canOpenProject && project.id
@@ -88,11 +88,11 @@ function GanttProjectHoverCard({
               </span>
             </div>
           )}
-          {weeklyCapacityLabel && (
+          {remainingHoursLabel && (
             <div className="flex gap-2 items-center">
               <Time className="size-4 text-ink-gray-6 shrink-0" />
               <span className="text-sm text-ink-gray-6 truncate">
-                {weeklyCapacityLabel}
+                {remainingHoursLabel}
               </span>
             </div>
           )}

--- a/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttProjectItem.tsx
@@ -33,7 +33,7 @@ export function GanttProjectItem({
   projectDateRange,
   client,
   projectManager,
-  weeklyCapacity,
+  remainingHours,
   badge,
   isExpanded = false,
   canExpand = false,
@@ -165,7 +165,7 @@ export function GanttProjectItem({
                   dateRange,
                   projectDateRange,
                   projectManager,
-                  weeklyCapacity,
+                  remainingHours,
                 }}
                 canOpenProject={hasRoleAccess}
               />

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -65,7 +65,7 @@ export interface Project {
   projectDateRange?: string;
   client?: string;
   projectManager?: string;
-  weeklyCapacity?: number;
+  remainingHours?: number;
   badge?: string;
   allocations?: Allocation[];
 }

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -19,6 +19,7 @@ from next_pms.resource_management.api.utils.query import (
     get_allocation_worked_hours_for_given_employee,
     get_allocation_worked_hours_for_given_projects,
     get_projects_with_allocations,
+    get_remaining_allocation_hours_by_project,
     has_active_allocation_filter,
 )
 from next_pms.timesheet.api.employee import apply_working_hours_fallback
@@ -107,7 +108,9 @@ def get_resource_management_project_view_data(
             - data (list): one entry per project, the project fields plus
               all_week_data (per-week allocated/worked hours), all_dates_data
               (per-date allocation detail), project_allocations (the allocations
-              keyed by name), and weekly_capacity. When no allocation-level filter
+              keyed by name), and remaining_hours (hours still allocated from today
+              to each allocation's end, across the allocation's full span rather than
+              the requested window). When no allocation-level filter
               (is_billable / allocation_status) is active, projects with at least
               one allocation in the window are listed before projects with none.
             - customer (dict): customer metadata referenced by the allocations.
@@ -122,6 +125,7 @@ def get_resource_management_project_view_data(
     permissions = resource_api_permissions_check()
     return _get_resource_management_project_view_data(
         json.dumps(permissions),
+        frappe.utils.today(),
         date,
         max_week,
         project_name,
@@ -142,6 +146,7 @@ def get_resource_management_project_view_data(
 @redis_cache()
 def _get_resource_management_project_view_data(
     permissions: str,
+    today: str,
     date: str,
     max_week: int = 2,
     project_name: str | None = None,
@@ -290,16 +295,16 @@ def _get_resource_management_project_view_data(
     )
     apply_working_hours_fallback(employees.values())
 
+    remaining_hours_map = get_remaining_allocation_hours_by_project(
+        [project.name for project in projects],
+        getdate(today),
+        is_billable,
+        allocation_status=allocation_status,
+    )
+
     for project in projects:
         all_week_data, all_dates_data = [], {}
         project_resource_allocation = resource_allocation_map.get(project.name, {})
-        weekly_capacity = sum(
-            alloc.hours_allocated_per_day
-            for week in weeks
-            for date in week.get("dates")
-            for alloc in project_resource_allocation.values()
-            if alloc.allocation_start_date <= date <= alloc.allocation_end_date
-        )
 
         for week in weeks:
             total_allocated_hours_for_given_week = 0
@@ -364,7 +369,7 @@ def _get_resource_management_project_view_data(
                 "all_week_data": all_week_data,
                 "all_dates_data": all_dates_data,
                 "project_allocations": project_resource_allocation,
-                "weekly_capacity": weekly_capacity,
+                "remaining_hours": remaining_hours_map.get(project.name, 0.0),
             }
         )
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -202,8 +202,8 @@ def _working_days_between(start: datetime.date, end: datetime.date) -> int:
 def get_remaining_allocation_hours_by_project(
     projects: list[str],
     on_or_after: datetime.date,
-    is_billable: list | int | None = None,
-    allocation_status: list | None = None,
+    is_billable: list[int] | int | None = None,
+    allocation_status: list[str] | None = None,
 ) -> dict[str, float]:
     """Return still-to-come allocated hours per project, keyed by project name.
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -250,13 +250,13 @@ def get_remaining_allocation_hours_by_project(
         days = (end - start).days + 1 if includes_weekends else _working_days_between(start, end)
         hours = days * hours_per_day
 
-        for entry in allocation.get("override") or []:
-            date = getdate(entry["date"])
+        for entry in allocation.override or []:
+            date = getdate(entry.date)
             if not start <= date <= end:
                 continue
             if not includes_weekends and date.weekday() >= 5:
                 continue
-            hours += (0 if cint(entry["cancelled"]) else flt(entry["hours"])) - hours_per_day
+            hours += (0 if cint(entry.cancelled) else flt(entry.hours)) - hours_per_day
 
         remaining_hours[allocation.project] = remaining_hours.get(allocation.project, 0.0) + hours
 

--- a/next_pms/resource_management/api/utils/query.py
+++ b/next_pms/resource_management/api/utils/query.py
@@ -184,6 +184,85 @@ def attach_extra_entries(allocations: list[dict]) -> list[dict]:
     return allocations
 
 
+def _working_days_between(start: datetime.date, end: datetime.date) -> int:
+    """Count Mon-Fri days in the inclusive range, in constant time.
+
+    Allocations routinely span months, so this must not iterate days.
+    """
+    total_days = (end - start).days + 1
+    if total_days <= 0:
+        return 0
+
+    full_weeks, remainder = divmod(total_days, 7)
+    weekday = start.weekday()
+
+    return full_weeks * 5 + sum(1 for offset in range(remainder) if (weekday + offset) % 7 < 5)
+
+
+def get_remaining_allocation_hours_by_project(
+    projects: list[str],
+    on_or_after: datetime.date,
+    is_billable: list | int | None = None,
+    allocation_status: list | None = None,
+) -> dict[str, float]:
+    """Return still-to-come allocated hours per project, keyed by project name.
+
+    Sums each allocation's hours from ``on_or_after`` to its end date over the allocation's
+    full span — deliberately not bounded by the view's week window, so the figure stays
+    stable as the user scrolls. Per-day overrides (cancelled days, adjusted hours) are
+    applied so the total agrees with the bars the grid draws.
+
+    Costs two queries regardless of how many projects or weeks are on the page.
+    """
+    if not projects:
+        return {}
+
+    ResourceAllocation = frappe.qb.DocType("Resource Allocation")
+    query = (
+        frappe.qb.from_(ResourceAllocation)
+        .select(
+            ResourceAllocation.name,
+            ResourceAllocation.project,
+            ResourceAllocation.allocation_start_date,
+            ResourceAllocation.allocation_end_date,
+            ResourceAllocation.hours_allocated_per_day,
+            ResourceAllocation.include_weekends,
+        )
+        .where(ResourceAllocation.project.isin(projects))
+        .where(ResourceAllocation.allocation_end_date >= on_or_after)
+    )
+
+    billable_values = _normalize_is_billable_filter(is_billable)
+    if billable_values:
+        query = query.where(ResourceAllocation.is_billable.isin(billable_values))
+    if allocation_status:
+        query = query.where(ResourceAllocation.status.isin(allocation_status))
+
+    allocations = attach_extra_entries(query.run(as_dict=True))
+
+    remaining_hours = {}
+    for allocation in allocations:
+        start = max(getdate(allocation.allocation_start_date), on_or_after)
+        end = getdate(allocation.allocation_end_date)
+        includes_weekends = cint(allocation.include_weekends)
+        hours_per_day = flt(allocation.hours_allocated_per_day)
+
+        days = (end - start).days + 1 if includes_weekends else _working_days_between(start, end)
+        hours = days * hours_per_day
+
+        for entry in allocation.get("override") or []:
+            date = getdate(entry["date"])
+            if not start <= date <= end:
+                continue
+            if not includes_weekends and date.weekday() >= 5:
+                continue
+            hours += (0 if cint(entry["cancelled"]) else flt(entry["hours"])) - hours_per_day
+
+        remaining_hours[allocation.project] = remaining_hours.get(allocation.project, 0.0) + hours
+
+    return remaining_hours
+
+
 def get_allocation_worked_hours_for_given_projects(project: str, start_date: str, end_date: str):
     """Get the total hours spend for given projects for given time range.
 

--- a/next_pms/tests/resource_management/api/test_project_view.py
+++ b/next_pms/tests/resource_management/api/test_project_view.py
@@ -3,8 +3,14 @@ import json
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
+from frappe.utils import getdate
 
-from next_pms.resource_management.api.project import get_resource_management_project_view_data
+from next_pms.resource_management.api.project import (
+    _get_resource_management_project_view_data,
+    get_resource_management_project_view_data,
+)
+from next_pms.resource_management.api.utils.helpers import resource_api_permissions_check
+from next_pms.resource_management.api.utils.query import get_remaining_allocation_hours_by_project
 
 WRITE_USER = "pv.write@example.com"
 READ_ONLY_USER = "pv.readonly@example.com"
@@ -115,23 +121,33 @@ class _ProjectViewBase(IntegrationTestCase):
         return doc.name
 
     @classmethod
-    def _make_allocation(cls, employee, project, start, end, is_billable=0, status="Confirmed"):
-        return (
-            frappe.get_doc(
-                {
-                    "doctype": "Resource Allocation",
-                    "employee": employee,
-                    "project": project,
-                    "allocation_start_date": start,
-                    "allocation_end_date": end,
-                    "hours_allocated_per_day": 8,
-                    "status": status,
-                    "is_billable": is_billable,
-                }
-            )
-            .insert(ignore_permissions=True)
-            .name
+    def _make_allocation(
+        cls,
+        employee,
+        project,
+        start,
+        end,
+        is_billable=0,
+        status="Confirmed",
+        include_weekends=0,
+        override=(),
+    ):
+        doc = frappe.get_doc(
+            {
+                "doctype": "Resource Allocation",
+                "employee": employee,
+                "project": project,
+                "allocation_start_date": start,
+                "allocation_end_date": end,
+                "hours_allocated_per_day": 8,
+                "status": status,
+                "is_billable": is_billable,
+                "include_weekends": include_weekends,
+            }
         )
+        for date, hours, cancelled in override:
+            doc.append("override", {"date": date, "hours": hours, "cancelled": cancelled})
+        return doc.insert(ignore_permissions=True).name
 
     def tearDown(self):
         frappe.set_user("Administrator")
@@ -430,3 +446,128 @@ class TestProjectViewAllocationProjectFiltering(_ProjectViewBase):
         empty, empty_count = filter_project_list(customer=self.customer, prioritized_ids=[])
         self.assertEqual([p.name for p in empty], [p.name for p in plain])
         self.assertEqual(empty_count, plain_count)
+
+
+class TestProjectViewRemainingHours(_ProjectViewBase):
+    """remaining_hours — the rolling forecast behind the project hover card.
+
+    Every assertion pins "today" explicitly (AS_OF / the today argument) rather than
+    letting it default to the wall clock. The figure is by definition today-relative,
+    so a test that let it float would drift into asserting 0 once the fixture dates
+    fell into the past, and would keep passing after the feature broke.
+    """
+
+    # A Wednesday, mid-way through the straddling allocation below.
+    AS_OF = getdate("2026-06-17")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(WRITE_USER, projects_user=True)
+        cls.customer = cls._make_customer("PV Remaining Customer")
+        cls.employee = cls._make_employee("PV Remaining Employee")
+
+        # One project per scenario: the overlap guard rejects concurrent allocations
+        # for the same employee+project, and per-project totals stay independently
+        # assertable.
+        def project(name):
+            return cls._make_project(name, cls.customer)
+
+        cls.p_straddle = project("PV Rem Straddle")
+        cls.p_past = project("PV Rem Past")
+        cls.p_future = project("PV Rem Future")
+        cls.p_cross = project("PV Rem Cross")
+        cls.p_weekend = project("PV Rem Weekend")
+        cls.p_cancelled = project("PV Rem Cancelled")
+        cls.p_adjusted = project("PV Rem Adjusted")
+        cls.p_billable = project("PV Rem Billable")
+
+        # Mon 06-15 -> Fri 06-19. From Wed 06-17: Wed/Thu/Fri = 3 * 8h.
+        cls._make_allocation(cls.employee, cls.p_straddle, "2026-06-15", "2026-06-19")
+        # Entirely elapsed.
+        cls._make_allocation(cls.employee, cls.p_past, "2026-06-01", "2026-06-05")
+        # Entirely ahead: full 5 * 8h span survives.
+        cls._make_allocation(cls.employee, cls.p_future, "2026-06-22", "2026-06-26")
+        # Two months long — the case a window-bounded sum cannot report.
+        cls._make_allocation(cls.employee, cls.p_cross, "2026-06-15", "2026-08-14")
+        # Mon 06-15 -> Sun 06-21 counting weekends. From Wed: 5 calendar days.
+        cls._make_allocation(cls.employee, cls.p_weekend, "2026-06-15", "2026-06-21", include_weekends=1)
+        # Straddling span with Thu 06-18 cancelled.
+        cls._make_allocation(cls.employee, cls.p_cancelled, "2026-06-15", "2026-06-19", override=[("2026-06-18", 0, 1)])
+        # Straddling span with Thu 06-18 cut from 8h to 3h.
+        cls._make_allocation(cls.employee, cls.p_adjusted, "2026-06-15", "2026-06-19", override=[("2026-06-18", 3, 0)])
+        cls._make_allocation(cls.employee, cls.p_billable, "2026-06-15", "2026-06-19", is_billable=1)
+
+        frappe.clear_cache()
+
+    def _remaining(self, projects=None, **kwargs):
+        return get_remaining_allocation_hours_by_project(projects or [self.p_straddle], self.AS_OF, **kwargs)
+
+    def test_elapsed_days_are_dropped(self):
+        # 40h allocated Mon-Fri; on Wednesday only Wed/Thu/Fri remain.
+        self.assertEqual(self._remaining()[self.p_straddle], 24.0)
+
+    def test_finished_allocation_contributes_nothing(self):
+        self.assertNotIn(self.p_past, self._remaining([self.p_past]))
+
+    def test_future_allocation_counts_in_full(self):
+        self.assertEqual(self._remaining([self.p_future])[self.p_future], 40.0)
+
+    def test_span_longer_than_any_window_is_counted_whole(self):
+        # 06-17..08-14 is 43 weekdays. Bounding this to a 2-week view would report 24h.
+        self.assertEqual(self._remaining([self.p_cross])[self.p_cross], 344.0)
+
+    def test_include_weekends_counts_calendar_days(self):
+        self.assertEqual(self._remaining([self.p_weekend])[self.p_weekend], 40.0)
+
+    def test_cancelled_day_is_deducted(self):
+        self.assertEqual(self._remaining([self.p_cancelled])[self.p_cancelled], 16.0)
+
+    def test_adjusted_day_uses_override_hours(self):
+        self.assertEqual(self._remaining([self.p_adjusted])[self.p_adjusted], 19.0)
+
+    def test_overrides_before_today_are_ignored(self):
+        # Mon 06-15 is inside the allocation but already elapsed, so cancelling it
+        # must not move a forecast that never counted it.
+        project = self._make_project("PV Rem Past Override", self.customer)
+        self._make_allocation(self.employee, project, "2026-06-15", "2026-06-19", override=[("2026-06-15", 0, 1)])
+        self.assertEqual(self._remaining([project])[project], 24.0)
+
+    def test_allocation_filters_are_honored(self):
+        both = [self.p_straddle, self.p_billable]
+        self.assertEqual(set(self._remaining(both)), {self.p_straddle, self.p_billable})
+        self.assertEqual(set(self._remaining(both, is_billable=[1])), {self.p_billable})
+        self.assertEqual(set(self._remaining(both, allocation_status=["Tentative"])), set())
+
+    def test_empty_project_list_short_circuits(self):
+        self.assertEqual(get_remaining_allocation_hours_by_project([], self.AS_OF), {})
+
+    def test_payload_exposes_remaining_hours(self):
+        result = self._view(project_id=json.dumps([self.p_straddle]))
+        entry = self._entry(result, self.p_straddle)
+        self.assertEqual(entry["remaining_hours"], 24.0)
+        self.assertNotIn("weekly_capacity", entry)
+
+    def test_figure_does_not_move_with_the_requested_window(self):
+        # The whole point of the change: scrolling the grid must not restate the
+        # forecast. Same today, three different anchors and week counts.
+        windows = [
+            {"date": "2026-06-15", "max_week": 2},
+            {"date": "2026-06-15", "max_week": 8},
+            {"date": "2026-05-04", "max_week": 2},
+            {"date": "2026-08-03", "max_week": 4},
+        ]
+        values = {
+            self._entry(self._view(project_id=json.dumps([self.p_cross]), **window), self.p_cross)["remaining_hours"]
+            for window in windows
+        }
+        self.assertEqual(values, {344.0})
+
+    def _view(self, project_id, date=DATE, max_week=2):
+        """Call the endpoint with "today" injected, bypassing the wall-clock wrapper."""
+        frappe.set_user(WRITE_USER)
+        permissions = json.dumps(resource_api_permissions_check())
+        return _get_resource_management_project_view_data(
+            permissions, str(self.AS_OF), date, max_week, project_id=project_id
+        )


### PR DESCRIPTION
## Description

* Added a new function `get_remaining_allocation_hours_by_project` to compute the total remaining allocated hours per project, accounting for allocation overrides and working days, and integrated it into the project data API. 
* Updated the project API to include the new `remaining_hours` field instead of `weekly_capacity`, and updated related documentation and function signatures. 
* Updated the `ProjectRecord` and `Project` types to use `remaining_hours` instead of `weekly_capacity`. 
* Updated utility and component props to use `remainingHours` instead of `weeklyCapacity`. 
* Updated the Gantt project hover card to display the new remaining hours label and removed references to weekly capacity.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1476