### PR TITLE
fix: delete legacy saved PMS views for Project

### DIFF
--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -34,3 +34,4 @@ next_pms.next_pms.patches.backfill_notification_title
 next_pms.resource_management.patches.update_active_allocation_currency_and_cost
 next_pms.next_projects.patches.share_projects_with_managers
 next_pms.next_projects.patches.setup_task_permissions
+next_pms.timesheet.patches.delete_legacy_project_views

--- a/next_pms/timesheet/patches/delete_legacy_project_views.py
+++ b/next_pms/timesheet/patches/delete_legacy_project_views.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+    """Delete saved PMS views for Project.
+
+    The view layer reuses the PMS View Setting doctype but stores `order_by` as a list
+    instead of a dict, so views saved by the previous implementation break the Projects
+    page when it applies them.
+    """
+    if not frappe.db.table_exists("PMS View Setting"):
+        return
+
+    frappe.db.delete("PMS View Setting", {"dt": "Project"})


### PR DESCRIPTION
## Description

Adds a patch that deletes all `PMS View Setting` rows for `dt = "Project"`.

Fixes #1960

## Root cause

PR #1938 reuses the `PMS View Setting` doctype and the `pms_view_setting.get_view` endpoint, but changed the stored payload shape. `order_by` is now a JSON **array** of `"field order"` strings; the previous implementation stored a JSON **object** `{"field": …, "order": …}`.

`get_view` runs `frappe.parse_json` on the column, so that object reaches the client intact, and `ViewsProvider` array-destructures it:

```ts
// frontend/packages/app/src/providers/views/provider.tsx:95
const [sort] = view.order_by ?? [];
// TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
```

It fires on first paint rather than only when a legacy view is picked, because of the initial-view election:

```ts
// provider.tsx:109-121
const initialView = views.find((view) => view.default === 1) ?? views[0];
applyView(initialView, { replace: true });   // throws inside useEffect
```

Every entry in `DEFAULT_PROJECT_VIEWS` carries `default: 0`, so a legacy row with `default: 1` always wins. On a bench with pre-#1938 data, 2 of 3 `dt="Project"` rows had `default: 1` — so `/next-pms/projects` was dead for any user who had ever opened the old Projects list.

Secondary mismatches in the same rows (non-fatal, but they confirm the format drift): `columns` is a `{fieldname: width}` object where `View.columns` is typed as an array; `route: "project"` is a dead field; and a row with `type: "Custom"` renders a saved *list* view as a Kanban board.

## Safety

Checked before deleting, on a bench with real legacy data:

- **0** Link fields anywhere point at `PMS View Setting` (both `DocField` and `Custom Field` came back empty).
- **0** `Version` / `DocShare` / `Comment` side records attached to the doctype.
- No child tables.

Nothing can be orphaned, which is why this uses `frappe.db.delete` rather than `frappe.delete_doc` — the document API would only add per-row overhead here. The patch is idempotent and guarded with `frappe.db.table_exists`.

## Testing

`bench --site … migrate`:

| check | before | after |
|---|---|---|
| `PMS View Setting` where `dt='Project'` | 3 | **0** |
| `dt='Task'` | 4 | 4 (untouched) |
| `dt IS NULL` | 9 | 9 (untouched) |

- `Patch Log` entry created; re-running `migrate` is a no-op.
- `get_view?dt=Project` now returns `{"message":[]}`, so `savedViews` is empty, no row claims `default: 1`, and the provider falls back to `views[0]` (List view).
- `ruff check` / `ruff format --check` clean; pre-commit hooks pass.

## Notes for the reviewer

Two things I deliberately left out of scope — flagging rather than silently expanding this PR:

1. **`dt = "Task"` rows are the same unexploded landmine.** They carry the identical object-shaped `order_by` and `default: 1` (verified via `get_view?dt=Task`). Nothing renders them through `ViewsProvider` today, so they are harmless right now — but a Tasks page wired to the new view layer will crash identically. Probably worth a follow-up issue.

2. **This cleans data but does not remove the fragility.** A restored backup, a hand-edited row, or a site that skips this release can reintroduce a crashing row. A defensive guard at `provider.tsx:95` — `Array.isArray(view.order_by) ? view.order_by[0] : undefined` — would make the page degrade instead of die. Happy to add it here or in a separate PR, whichever you prefer.

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
