### PR TITLE
feat: patch to delete old project view

### DIFF
--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -34,3 +34,4 @@ next_pms.next_pms.patches.backfill_notification_title
 next_pms.resource_management.patches.update_active_allocation_currency_and_cost
 next_pms.next_projects.patches.share_projects_with_managers
 next_pms.next_projects.patches.setup_task_permissions
+next_pms.timesheet.patches.delete_legacy_project_views

--- a/next_pms/timesheet/patches/delete_legacy_project_views.py
+++ b/next_pms/timesheet/patches/delete_legacy_project_views.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+    """Delete saved PMS views for Project.
+
+    The current view layer stores `order_by` as a list where the previous implementation stored
+    a dict, so views saved by it break the Projects page when they are applied. Views for other
+    doctypes are left alone — no page reads them today, and whether they can be carried forward
+    is decided when those pages adopt the new view layer.
+    """
+    if not frappe.db.table_exists("PMS View Setting"):
+        return
+
+    frappe.db.delete("PMS View Setting", {"dt": "Project"})


### PR DESCRIPTION
## Description

* Added `next_pms/timesheet/patches/delete_legacy_project_views.py` to delete old `Project` views from the `PMS View Setting` table, ensuring that incompatible saved views do not break the Projects page.
* Registered the new patch in `next_pms/patches.txt` so it runs during the patch process.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add v#1960  aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1960