### PR TITLE
fix: loading indicator in add time modals

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -67,7 +67,9 @@ const AddTime = ({
   const toast = useToasts();
   const [projectSearch, setProjectSearch] = useState("");
   const [taskSearch, setTaskSearch] = useState("");
-  const [submitting, setSubmitting] = useState(false);
+  const [submittingAction, setSubmittingAction] = useState<
+    "addAnother" | "close" | null
+  >(null);
   const commentEditorRef = useRef<TextEditorHandle>(null);
   const prevSelectedEventIdsRef = useRef<Set<string>>(new Set());
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -98,7 +100,7 @@ const AddTime = ({
     },
     onSubmitMeta: { keepOpen: false },
     onSubmit: async ({ value, meta }) => {
-      setSubmitting(true);
+      setSubmittingAction(meta.keepOpen ? "addAnother" : "close");
       setSubmitError(null);
       try {
         await saveTime({
@@ -118,7 +120,7 @@ const AddTime = ({
       } catch (err) {
         setSubmitError(parseFrappeErrorMsg(err as FrappeError));
       } finally {
-        setSubmitting(false);
+        setSubmittingAction(null);
       }
     },
   });
@@ -276,15 +278,16 @@ const AddTime = ({
             variant="subtle"
             label="Save and add another"
             onClick={() => form.handleSubmit({ keepOpen: true })}
-            disabled={submitting}
+            disabled={submittingAction !== null}
+            loading={submittingAction === "addAnother"}
           />
           <Button
             className="w-full"
             variant="solid"
             label="Save and close"
             onClick={() => form.handleSubmit()}
-            disabled={submitting}
-            loading={submitting}
+            disabled={submittingAction !== null}
+            loading={submittingAction === "close"}
           />
         </div>
       }

--- a/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/add-employee-time/index.tsx
@@ -47,7 +47,9 @@ const AddEmployeeTime = ({
   const [employeeSearch, setEmployeeSearch] = useState("");
   const [projectSearch, setProjectSearch] = useState("");
   const [taskSearch, setTaskSearch] = useState("");
-  const [submitting, setSubmitting] = useState(false);
+  const [submittingAction, setSubmittingAction] = useState<
+    "addAnother" | "close" | null
+  >(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [entryKey, setEntryKey] = useState(0);
   const { call: saveTime } = useFrappePostCall(
@@ -77,7 +79,7 @@ const AddEmployeeTime = ({
     },
     onSubmitMeta: { keepOpen: false },
     onSubmit: async ({ value, meta }) => {
-      setSubmitting(true);
+      setSubmittingAction(meta.keepOpen ? "addAnother" : "close");
       setSubmitError(null);
       try {
         await saveTime({
@@ -97,7 +99,7 @@ const AddEmployeeTime = ({
       } catch (err) {
         setSubmitError(parseFrappeErrorMsg(err as FrappeError));
       } finally {
-        setSubmitting(false);
+        setSubmittingAction(null);
       }
     },
   });
@@ -253,15 +255,16 @@ const AddEmployeeTime = ({
             variant="subtle"
             label="Save and add another"
             onClick={() => form.handleSubmit({ keepOpen: true })}
-            disabled={submitting}
+            disabled={submittingAction !== null}
+            loading={submittingAction === "addAnother"}
           />
           <Button
             className="w-full"
             variant="solid"
             label="Save and close"
             onClick={() => form.handleSubmit()}
-            disabled={submitting}
-            loading={submitting}
+            disabled={submittingAction !== null}
+            loading={submittingAction === "close"}
           />
         </div>
       }


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes an issue where the loading indicator was shown on the wrong button in the **Add Time** modal. The loading indicator is now displayed on the button that was clicked.


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/ee0e6cc9-e9e3-4273-9c91-aae484d40140



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1894