### PR TITLE
fix(project-details): float label outside single-day milestone bars

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/constants.ts
@@ -5,8 +5,9 @@ export const DAY_HEADER_HEIGHT = 30; // px – day numbers row
 export const ROW_HEIGHT = 60; // px – each item row
 export const MIN_CARD_DAYS = 1; // minimum card width in days
 export const FLOATING_LABEL_FLIP_THRESHOLD = 150; // px – space needed on the right before a floating label flips left
-// Bars this narrow (a single-day span) can't fit their label inside, so the
-// label floats outside the icon chip instead of truncating.
+
+// Bars this narrow (a single-day span) can't fit their label inside,
+// so the label floats outside the icon chip instead of truncating.
 export const MIN_BAR_WIDTH = COLUMN_WIDTH * MIN_CARD_DAYS;
 
 // Calendar grid constants

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/constants.ts
@@ -4,6 +4,10 @@ export const WEEK_LABEL_HEIGHT = 30; // px – week range row
 export const DAY_HEADER_HEIGHT = 30; // px – day numbers row
 export const ROW_HEIGHT = 60; // px – each item row
 export const MIN_CARD_DAYS = 1; // minimum card width in days
+export const FLOATING_LABEL_FLIP_THRESHOLD = 150; // px – space needed on the right before a floating label flips left
+// Bars this narrow (a single-day span) can't fit their label inside, so the
+// label floats outside the icon chip instead of truncating.
+export const MIN_BAR_WIDTH = COLUMN_WIDTH * MIN_CARD_DAYS;
 
 // Calendar grid constants
 export const DAY_HEADERS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies.
+ */
+import type { ComponentType, SVGProps } from "react";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import { FLOATING_LABEL_FLIP_THRESHOLD } from "./constants";
+import type { ProjectTimelineItem } from "./types";
+
+type ItemPosition = { left: number; width: number };
+
+type FloatingChipProps = {
+  item: ProjectTimelineItem;
+  pos: ItemPosition;
+  totalWidth: number;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  chipClassName: string;
+  textClassName: string;
+};
+
+// Icon chip + floating label, flipped to the left when near the right edge.
+export function FloatingChip({
+  item,
+  pos,
+  totalWidth,
+  icon: Icon,
+  chipClassName,
+  textClassName,
+}: FloatingChipProps) {
+  const spaceRight = totalWidth - (pos.left + pos.width);
+  const flipLeft = spaceRight < FLOATING_LABEL_FLIP_THRESHOLD;
+
+  return (
+    <Tooltip text={item.title}>
+      <div
+        className="absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-2"
+        style={
+          flipLeft
+            ? {
+                right: totalWidth - (pos.left + pos.width),
+                flexDirection: "row-reverse",
+              }
+            : { left: pos.left }
+        }
+      >
+        <div
+          className={`flex items-center justify-center rounded-md mx-0.5 shrink-0 ${chipClassName}`}
+          style={{ width: pos.width, height: 32 }}
+        >
+          <Icon className="size-3.5" />
+        </div>
+        <span
+          className={`text-sm whitespace-nowrap ${textClassName}${item.isComplete ? " line-through opacity-60" : ""}`}
+        >
+          {item.title}
+        </span>
+      </div>
+    </Tooltip>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
@@ -45,10 +45,10 @@ export function FloatingChip({
       >
         <div
           className={cn(
-            "flex items-center justify-center rounded-md mx-0.5 shrink-0",
+            "flex items-center justify-center rounded-md mx-0.5 shrink-0 h-8",
             chipClassName,
           )}
-          style={{ width: pos.width, height: 32 }}
+          style={{ width: pos.width }}
         >
           <Icon className="size-3.5" />
         </div>

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
+import { mergeClassNames as cn } from "@/lib/utils";
 import { FLOATING_LABEL_FLIP_THRESHOLD } from "./constants";
 import type { ProjectTimelineItem } from "./types";
 
@@ -47,13 +48,20 @@ export function FloatingChip({
         }
       >
         <div
-          className={`flex items-center justify-center rounded-md mx-0.5 shrink-0 ${chipClassName}`}
+          className={cn(
+            "flex items-center justify-center rounded-md mx-0.5 shrink-0",
+            chipClassName,
+          )}
           style={{ width: pos.width, height: 32 }}
         >
           <Icon className="size-3.5" />
         </div>
         <span
-          className={`text-sm whitespace-nowrap ${textClassName}${item.isComplete ? " line-through opacity-60" : ""}`}
+          className={cn(
+            "text-sm whitespace-nowrap",
+            textClassName,
+            item.isComplete && "line-through opacity-60",
+          )}
         >
           {item.title}
         </span>

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/floatingChip.tsx
@@ -37,15 +37,11 @@ export function FloatingChip({
   return (
     <Tooltip text={item.title}>
       <div
-        className="absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-2"
-        style={
-          flipLeft
-            ? {
-                right: totalWidth - (pos.left + pos.width),
-                flexDirection: "row-reverse",
-              }
-            : { left: pos.left }
-        }
+        className={cn(
+          "absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-2",
+          flipLeft && "flex-row-reverse",
+        )}
+        style={flipLeft ? { right: spaceRight } : { left: pos.left }}
       >
         <div
           className={cn(

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies.
  */
-import type { ComponentType, SVGProps } from "react";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { Sparkle, Zap } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
  */
-import { COLUMN_WIDTH, MIN_CARD_DAYS } from "./constants";
+import { MIN_BAR_WIDTH } from "./constants";
+import { FloatingChip } from "./floatingChip";
 import type { ProjectTimelineItem } from "./types";
 
 type ItemPosition = { left: number; width: number };
@@ -18,60 +18,6 @@ type GanttBarProps = {
   pos: ItemPosition;
   totalWidth: number;
 };
-
-// Bars this narrow (a single-day span) can't fit their label inside, so the
-// label floats outside the icon chip instead of truncating.
-const MIN_BAR_WIDTH = COLUMN_WIDTH * MIN_CARD_DAYS;
-
-type FloatingChipProps = {
-  item: ProjectTimelineItem;
-  pos: ItemPosition;
-  totalWidth: number;
-  icon: ComponentType<SVGProps<SVGSVGElement>>;
-  chipClassName: string;
-  textClassName: string;
-};
-
-// Icon chip + floating label, flipped to the left when near the right edge.
-function FloatingChip({
-  item,
-  pos,
-  totalWidth,
-  icon: Icon,
-  chipClassName,
-  textClassName,
-}: FloatingChipProps) {
-  const spaceRight = totalWidth - (pos.left + pos.width);
-  const flipLeft = spaceRight < 150;
-
-  return (
-    <Tooltip text={item.title}>
-      <div
-        className="absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-2"
-        style={
-          flipLeft
-            ? {
-                right: totalWidth - (pos.left + pos.width),
-                flexDirection: "row-reverse",
-              }
-            : { left: pos.left }
-        }
-      >
-        <div
-          className={`flex items-center justify-center rounded-md mx-0.5 shrink-0 ${chipClassName}`}
-          style={{ width: pos.width, height: 32 }}
-        >
-          <Icon className="size-3.5" />
-        </div>
-        <span
-          className={`text-sm whitespace-nowrap ${textClassName}${item.isComplete ? " line-through opacity-60" : ""}`}
-        >
-          {item.title}
-        </span>
-      </div>
-    </Tooltip>
-  );
-}
 
 export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
   if (item.type === "Milestone") {

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
@@ -1,12 +1,14 @@
 /**
  * External dependencies.
  */
+import type { ComponentType, SVGProps } from "react";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { Sparkle, Zap } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
  */
+import { COLUMN_WIDTH, MIN_CARD_DAYS } from "./constants";
 import type { ProjectTimelineItem } from "./types";
 
 type ItemPosition = { left: number; width: number };
@@ -17,8 +19,75 @@ type GanttBarProps = {
   totalWidth: number;
 };
 
+// Bars this narrow (a single-day span) can't fit their label inside, so the
+// label floats outside the icon chip instead of truncating.
+const MIN_BAR_WIDTH = COLUMN_WIDTH * MIN_CARD_DAYS;
+
+type FloatingChipProps = {
+  item: ProjectTimelineItem;
+  pos: ItemPosition;
+  totalWidth: number;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  chipClassName: string;
+  textClassName: string;
+};
+
+// Icon chip + floating label, flipped to the left when near the right edge.
+function FloatingChip({
+  item,
+  pos,
+  totalWidth,
+  icon: Icon,
+  chipClassName,
+  textClassName,
+}: FloatingChipProps) {
+  const spaceRight = totalWidth - (pos.left + pos.width);
+  const flipLeft = spaceRight < 150;
+
+  return (
+    <Tooltip text={item.title}>
+      <div
+        className="absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-2"
+        style={
+          flipLeft
+            ? {
+                right: totalWidth - (pos.left + pos.width),
+                flexDirection: "row-reverse",
+              }
+            : { left: pos.left }
+        }
+      >
+        <div
+          className={`flex items-center justify-center rounded-md mx-0.5 shrink-0 ${chipClassName}`}
+          style={{ width: pos.width, height: 32 }}
+        >
+          <Icon className="size-3.5" />
+        </div>
+        <span
+          className={`text-sm whitespace-nowrap ${textClassName}${item.isComplete ? " line-through opacity-60" : ""}`}
+        >
+          {item.title}
+        </span>
+      </div>
+    </Tooltip>
+  );
+}
+
 export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
   if (item.type === "Milestone") {
+    if (pos.width <= MIN_BAR_WIDTH) {
+      return (
+        <FloatingChip
+          item={item}
+          pos={pos}
+          totalWidth={totalWidth}
+          icon={Sparkle}
+          chipClassName="bg-surface-blue-2 text-blue-700"
+          textClassName="text-blue-700"
+        />
+      );
+    }
+
     return (
       <Tooltip text={item.title}>
         <div
@@ -37,35 +106,14 @@ export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
     );
   }
 
-  // Touchpoint: icon chip + floating label, flipped to the left when near the right edge
-  const spaceRight = totalWidth - (pos.left + pos.width);
-  const flipLeft = spaceRight < 150;
-
   return (
-    <Tooltip text={item.title}>
-      <div
-        className="absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-2"
-        style={
-          flipLeft
-            ? {
-                right: totalWidth - (pos.left + pos.width),
-                flexDirection: "row-reverse",
-              }
-            : { left: pos.left }
-        }
-      >
-        <div
-          className="flex items-center justify-center rounded-md bg-surface-violet-1 text-violet-700 mx-0.5 shrink-0"
-          style={{ width: pos.width, height: 32 }}
-        >
-          <Zap className="size-3.5" />
-        </div>
-        <span
-          className={`text-sm text-violet-700 whitespace-nowrap${item.isComplete ? " line-through opacity-60" : ""}`}
-        >
-          {item.title}
-        </span>
-      </div>
-    </Tooltip>
+    <FloatingChip
+      item={item}
+      pos={pos}
+      totalWidth={totalWidth}
+      icon={Zap}
+      chipClassName="bg-surface-violet-1 text-violet-700"
+      textClassName="text-violet-700"
+    />
   );
 }


### PR DESCRIPTION
## Description
- Milestones whose start and end date fall on the same day resolve to the minimum single-day bar width, which was too narrow to hold the icon + title, so the title truncated to nothing.
- This reuses the touchpoint's floating-label pattern (icon chip with the title floating alongside, flipping left near the right edge) for narrow milestone bars, while wider milestone bars keep the existing inline label.

## Screenshot/Screencast
<img width="2526" height="1922" alt="image" src="https://github.com/user-attachments/assets/25cb89d6-806b-427b-840b-9c2dfbfcfc74" />

<img width="2514" height="1756" alt="image" src="https://github.com/user-attachments/assets/5e2d9438-748b-4c1f-910a-b4680e622f73" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1948