### PR TITLE
feat: add rtcamp app to ci and fix ci perms

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,9 @@
 name: Gitleaks
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -1,5 +1,8 @@
 name: Semantic Commits
 
+permissions:
+  contents: read
+
 on:
   pull_request:
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,8 +66,9 @@ jobs:
             git config --global "url.https://rtbot:${RTBOT_TOKEN}@github.com/.insteadOf" "https://github.com/"
             bench get-app telephony --branch develop --skip-assets
             bench get-app helpdesk --branch main --skip-assets
+            bench get-app crm --branch main --skip-assets
             bench get-app rtcamp "https://${RTCAMP_APP}" --branch version-16-hotfix --skip-assets
-            PRIVATE_APPS="telephony helpdesk rtcamp"
+            PRIVATE_APPS="telephony helpdesk crm rtcamp"
           else
             echo "RTBOT_TOKEN unavailable (fork PR) — skipping private rtcamp app; rtcamp-gated tests will skip"
             PRIVATE_APPS=""

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,10 +62,11 @@ jobs:
           bench get-app hrms --branch version-16 --skip-assets
           bench get-app frappe_gmail_thread https://github.com/rtCamp/frappe-gmail-thread --branch version-16-hotfix --skip-assets
           bench get-app frappe_comment_xt https://github.com/rtCamp/frappe-comment-xt --branch version-16-hotfix --skip-assets
+          bench get-app helpdesk --branch main --skip-assets
           bench get-app rtcamp "https://rtbot:${{ secrets.RTBOT_TOKEN }}@${{ secrets.RTCAMP_APP }}" --branch version-16-hotfix --skip-assets
           bench get-app next_pms "$GITHUB_WORKSPACE" --skip-assets
           bench new-site --db-root-password root --admin-password admin --no-mariadb-socket test_site
-          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt rtcamp next_pms
+          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt helpdesk rtcamp next_pms
         env:
           CI: "Yes"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,6 +67,9 @@ jobs:
             bench get-app telephony --branch develop --skip-assets
             bench get-app helpdesk --branch main --skip-assets
             bench get-app crm --branch main --skip-assets
+            bench get-app frappe_appointment https://github.com/rtCamp/frappe-appointment --branch version-16-hotfix --skip-assets
+            bench get-app careers https://github.com/rtCamp/frappe-careers --branch version-16-hotfix --skip-assets
+            bench get-app india_compliance https://github.com/resilient-tech/india-compliance --branch version-16 --skip-assets
             bench get-app rtcamp "https://${RTCAMP_APP}" --branch version-16-hotfix --skip-assets
             PRIVATE_APPS="telephony helpdesk crm rtcamp"
           else

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.cache/uv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          key: ${{ runner.os }}-pip-uv-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Setup bench
@@ -65,13 +65,14 @@ jobs:
           bench get-app frappe_gmail_thread https://github.com/rtCamp/frappe-gmail-thread --branch version-16-hotfix --skip-assets
           bench get-app frappe_comment_xt https://github.com/rtCamp/frappe-comment-xt --branch version-16-hotfix --skip-assets
           if [ -n "$RTBOT_TOKEN" ]; then
-            git config --global "url.https://rtbot:${RTBOT_TOKEN}@github.com/.insteadOf" "https://github.com/"
+            git config --global "url.https://rtbot:${RTBOT_TOKEN}@github.com/rtCamp/.insteadOf" "https://github.com/rtCamp/"
             bench get-app telephony --branch develop --skip-assets
             bench get-app helpdesk --branch main --skip-assets
             bench get-app crm --branch main --skip-assets
             bench get-app frappe_appointment https://github.com/rtCamp/frappe-appointment --branch version-16-hotfix --skip-assets
             bench get-app india_compliance https://github.com/resilient-tech/india-compliance --branch version-16 --skip-assets
             bench get-app rtcamp "https://${RTCAMP_APP}" --branch version-16-hotfix --skip-assets
+            git config --global --unset "url.https://rtbot:${RTBOT_TOKEN}@github.com/rtCamp/.insteadOf"
             PRIVATE_APPS="telephony helpdesk crm frappe_appointment india_compliance rtcamp"
           else
             echo "RTBOT_TOKEN unavailable (fork PR) — skipping private rtcamp app; rtcamp-gated tests will skip"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,7 +44,9 @@ jobs:
 
       - uses: actions/cache@v6
         with:
-          path: ~/.cache/pip
+          path: |
+            ~/.cache/pip
+            ~/.cache/uv
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: ${{ runner.os }}-pip-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,11 +60,12 @@ jobs:
         run: |
           bench get-app erpnext --branch version-16 --skip-assets
           bench get-app hrms --branch version-16 --skip-assets
-          bench get-app frappe_gmail_thread https://github.com/rtCamp/frappe-gmail-thread --branch version-16 --skip-assets
+          bench get-app frappe_gmail_thread https://github.com/rtCamp/frappe-gmail-thread --branch version-16-hotfix --skip-assets
           bench get-app frappe_comment_xt https://github.com/rtCamp/frappe-comment-xt --branch version-16-hotfix --skip-assets
+          bench get-app rtcamp "https://rtbot:${{ secrets.RTBOT_TOKEN }}@${{ secrets.RTCAMP_APP }}" --branch version-16-hotfix --skip-assets
           bench get-app next_pms "$GITHUB_WORKSPACE" --skip-assets
           bench new-site --db-root-password root --admin-password admin --no-mariadb-socket test_site
-          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt next_pms
+          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt rtcamp next_pms
         env:
           CI: "Yes"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -68,10 +68,9 @@ jobs:
             bench get-app helpdesk --branch main --skip-assets
             bench get-app crm --branch main --skip-assets
             bench get-app frappe_appointment https://github.com/rtCamp/frappe-appointment --branch version-16-hotfix --skip-assets
-            bench get-app careers https://github.com/rtCamp/frappe-careers --branch version-16-hotfix --skip-assets
             bench get-app india_compliance https://github.com/resilient-tech/india-compliance --branch version-16 --skip-assets
             bench get-app rtcamp "https://${RTCAMP_APP}" --branch version-16-hotfix --skip-assets
-            PRIVATE_APPS="telephony helpdesk crm rtcamp"
+            PRIVATE_APPS="telephony helpdesk crm frappe_appointment india_compliance rtcamp"
           else
             echo "RTBOT_TOKEN unavailable (fork PR) — skipping private rtcamp app; rtcamp-gated tests will skip"
             PRIVATE_APPS=""

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,13 +62,23 @@ jobs:
           bench get-app hrms --branch version-16 --skip-assets
           bench get-app frappe_gmail_thread https://github.com/rtCamp/frappe-gmail-thread --branch version-16-hotfix --skip-assets
           bench get-app frappe_comment_xt https://github.com/rtCamp/frappe-comment-xt --branch version-16-hotfix --skip-assets
-          bench get-app helpdesk --branch main --skip-assets
-          bench get-app rtcamp "https://rtbot:${{ secrets.RTBOT_TOKEN }}@${{ secrets.RTCAMP_APP }}" --branch version-16-hotfix --skip-assets
+          if [ -n "$RTBOT_TOKEN" ]; then
+            git config --global "url.https://rtbot:${RTBOT_TOKEN}@github.com/.insteadOf" "https://github.com/"
+            bench get-app telephony --branch develop --skip-assets
+            bench get-app helpdesk --branch main --skip-assets
+            bench get-app rtcamp "https://${RTCAMP_APP}" --branch version-16-hotfix --skip-assets
+            PRIVATE_APPS="telephony helpdesk rtcamp"
+          else
+            echo "RTBOT_TOKEN unavailable (fork PR) — skipping private rtcamp app; rtcamp-gated tests will skip"
+            PRIVATE_APPS=""
+          fi
           bench get-app next_pms "$GITHUB_WORKSPACE" --skip-assets
           bench new-site --db-root-password root --admin-password admin --no-mariadb-socket test_site
-          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt helpdesk rtcamp next_pms
+          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt $PRIVATE_APPS next_pms
         env:
           CI: "Yes"
+          RTBOT_TOKEN: ${{ secrets.RTBOT_TOKEN }}
+          RTCAMP_APP: ${{ secrets.RTCAMP_APP }}
 
       - name: Run tests
         working-directory: /home/runner/frappe-bench

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -76,6 +76,8 @@ jobs:
             PRIVATE_APPS="telephony helpdesk crm frappe_appointment india_compliance rtcamp"
           else
             echo "RTBOT_TOKEN unavailable (fork PR) — skipping private rtcamp app; rtcamp-gated tests will skip"
+            echo "> [!WARNING]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> RTBOT_TOKEN unavailable (fork PR) — private apps were not installed; rtcamp-gated tests will skip." >> "$GITHUB_STEP_SUMMARY"
             PRIVATE_APPS=""
           fi
           bench get-app next_pms "$GITHUB_WORKSPACE" --skip-assets


### PR DESCRIPTION
add the rtcamp and depended apps to ci to avoid test skips
if a fork pr, skip those tests to prevent secret sharing
fix the permission issues
gmail thread branch flipped to dev

fixes https://github.com/rtCamp/next-pms/security/code-scanning/24 and https://github.com/rtCamp/next-pms/issues/1901