### PR TITLE
fix(project-details): exclude cancelled sales orders from total project value link

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
@@ -36,9 +36,9 @@ function TrackingContent() {
           value={currencyFormat(currency).format(
             tracking.total_project_value ?? 0,
           )}
-          href={`${ROUTES.desk}/sales-order?status=Cancelled&project=${encodeURIComponent(
-            projectId,
-          )}`}
+          href={`${ROUTES.desk}/sales-order?status=${encodeURIComponent(
+            JSON.stringify(["!=", "Cancelled"]),
+          )}&project=${encodeURIComponent(projectId)}`}
         />
         <KnowledgePoint
           title="Projected profit"


### PR DESCRIPTION
## Description
The "Total project value" KnowledgePoint on the Tracking tab linked to sales orders with status=Cancelled, showing only cancelled orders instead of excluding them. Updated the filter to use Frappe's JSON filter syntax (status=["!=","Cancelled"]) so the link correctly excludes cancelled sales orders.

## Screenshot/Screencast
<img width="3380" height="858" alt="image" src="https://github.com/user-attachments/assets/1687f166-d8b1-48d0-9101-7b2571945378" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1917