### PR TITLE
fix(risks): widen toolbar select triggers to prevent dropdown overlap

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/risks/toolbar/toolbar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/toolbar/toolbar.tsx
@@ -51,7 +51,7 @@ export function RisksToolbar() {
           size="sm"
           placeholder="Owner"
           placeholderClassName="text-ink-gray-7"
-          className="w-fit text-ink-gray-7"
+          className="w-36 text-ink-gray-7"
           value={filters.owner}
           onChange={(v) => setFilters({ owner: (v ?? "") as string })}
           options={ownerOptions}
@@ -60,7 +60,7 @@ export function RisksToolbar() {
           size="sm"
           placeholder="Status"
           placeholderClassName="text-ink-gray-7"
-          className="w-fit text-ink-gray-7"
+          className="w-30 text-ink-gray-7"
           value={filters.status}
           onChange={(v) => setFilters({ status: (v ?? "") as RiskStatus | "" })}
           options={STATUS_OPTIONS}
@@ -69,7 +69,7 @@ export function RisksToolbar() {
           size="sm"
           placeholder="Risk level"
           placeholderClassName="text-ink-gray-7"
-          className="w-fit text-ink-gray-7"
+          className="w-30 text-ink-gray-7"
           value={filters.riskLevel}
           onChange={(v) => setFilters({ riskLevel: (v ?? "") as string })}
           options={RISK_LEVEL_OPTIONS}

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/toolbar/toolbar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/toolbar/toolbar.tsx
@@ -52,6 +52,7 @@ export function RisksToolbar() {
           placeholder="Owner"
           placeholderClassName="text-ink-gray-7"
           className="w-36 text-ink-gray-7"
+          matchTriggerWidth
           value={filters.owner}
           onChange={(v) => setFilters({ owner: (v ?? "") as string })}
           options={ownerOptions}
@@ -61,6 +62,7 @@ export function RisksToolbar() {
           placeholder="Status"
           placeholderClassName="text-ink-gray-7"
           className="w-30 text-ink-gray-7"
+          matchTriggerWidth
           value={filters.status}
           onChange={(v) => setFilters({ status: (v ?? "") as RiskStatus | "" })}
           options={STATUS_OPTIONS}
@@ -70,6 +72,7 @@ export function RisksToolbar() {
           placeholder="Risk level"
           placeholderClassName="text-ink-gray-7"
           className="w-30 text-ink-gray-7"
+          matchTriggerWidth
           value={filters.riskLevel}
           onChange={(v) => setFilters({ riskLevel: (v ?? "") as string })}
           options={RISK_LEVEL_OPTIONS}


### PR DESCRIPTION
## Description
The Owner/Status/Risk level selects in the Risks tab toolbar used w-fit, sizing the trigger to its placeholder text while the dropdown grew to fit its widest option - so the Owner dropdown (e.g. "All owners") visually overlapped the adjacent Status select.

Sets fixed trigger widths and opts each select into the new matchTriggerWidth prop (added in the frappe-ui-react bump) so every dropdown is capped to its own trigger's width instead of expanding past it.

## Screenshot/Screencast
<img width="2278" height="1380" alt="image" src="https://github.com/user-attachments/assets/f6474a49-a286-4992-99f5-63b5bdfc4fc4" />

<img width="2272" height="1432" alt="image" src="https://github.com/user-attachments/assets/5b879de9-9ea5-4e91-be5c-8a338b5eb235" />

<img width="1796" height="914" alt="image" src="https://github.com/user-attachments/assets/ac9fa375-0105-49e9-89cd-3ea1fd9de9a4" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1968