### PR TITLE
feat: weekly rejection reason

### DIFF
--- a/next_pms/install.py
+++ b/next_pms/install.py
@@ -12,6 +12,7 @@ def after_install():
     setup_project_custom_fields()
     setup_project_target_hours_field()
     setup_timesheet_rejection_reason_field()
+    setup_timesheet_weekly_rejection_reason_field()
     setup_task_permissions()
 
 
@@ -27,6 +28,27 @@ def setup_timesheet_rejection_reason_field():
                     "label": "Rejection Reason",
                     "insert_after": "note",
                     "depends_on": 'eval:doc.custom_approval_status=="Rejected"',
+                    "read_only": 1,
+                    "no_copy": 1,
+                    "module": "Timesheet",
+                },
+            ]
+        }
+    )
+
+
+def setup_timesheet_weekly_rejection_reason_field():
+    from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+    create_custom_fields(
+        {
+            "Timesheet": [
+                {
+                    "fieldname": "custom_weekly_rejection_reason",
+                    "fieldtype": "Text Editor",
+                    "label": "Weekly Rejection Reason",
+                    "insert_after": "custom_rejection_reason",
+                    "depends_on": 'eval:doc.custom_weekly_approval_status=="Rejected"',
                     "read_only": 1,
                     "no_copy": 1,
                     "module": "Timesheet",

--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -36,3 +36,4 @@ next_pms.next_projects.patches.share_projects_with_managers
 next_pms.next_projects.patches.setup_task_permissions
 next_pms.timesheet.patches.delete_legacy_project_views
 next_pms.timesheet.patches.add_team_timesheet_indexes
+next_pms.timesheet.patches.setup_timesheet_weekly_rejection_reason_field

--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -3,11 +3,17 @@ from collections import defaultdict
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, getdate
 
-from next_pms.tests.utils import make_employee
+from next_pms.install import (
+    setup_timesheet_rejection_reason_field,
+    setup_timesheet_weekly_rejection_reason_field,
+)
+from next_pms.tests.utils import make_employee, make_holiday_list
 from next_pms.timesheet.api.team import _approve_or_reject_timesheet, get_team_timesheet_data
 from next_pms.timesheet.api.timesheet import get_timesheet_data, submit_for_approval
 from next_pms.timesheet.api.timesheet import save as save_timesheet
+from next_pms.timesheet.api.utils import get_holidays
 
 MANAGER_USER = "rejection-reason-test-manager@example.com"
 EMPLOYEE_USER = "rejection-reason-test-employee@example.com"
@@ -15,12 +21,21 @@ EMPLOYEE_USER = "rejection-reason-test-employee@example.com"
 CUSTOMER_NAME = "Rejection Reason Test Customer"
 PROJECT_NAME = "Rejection Reason Test Project"
 TASK_SUBJECT = "Rejection Reason Test Task"
+HOLIDAY_LIST = "Rejection Reason Test Holiday List"
 
 MON, TUE, WED, THU, FRI = "2026-09-07", "2026-09-08", "2026-09-09", "2026-09-10", "2026-09-11"
 WEEK_DATES = [MON, TUE, WED, THU, FRI]
 
 TUE_REASON = "Please add a task breakdown before resubmitting Tuesday's entry."
 THU_REASON = "Thursday's hours need the billable split corrected."
+WEEK_REASON = "Please rework the entire week's entries before resubmitting."
+DAY_REASONS = {
+    MON: "Monday needs a clearer description.",
+    TUE: TUE_REASON,
+    WED: "Wednesday hours look duplicated.",
+    THU: THU_REASON,
+    FRI: "Friday is missing the client reference.",
+}
 
 
 class TestTimesheetRejectionReason(IntegrationTestCase):
@@ -35,10 +50,45 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         # Week start is read via frappe.db.get_default, not System Settings directly.
         frappe.db.set_default("first_day_of_the_week", "Monday")
 
+        setup_timesheet_rejection_reason_field()
+        setup_timesheet_weekly_rejection_reason_field()
+
+        weekends = []
+        date = getdate("2026-01-01")
+        while date <= getdate("2026-12-31"):
+            if date.weekday() >= 5:
+                weekends.append(
+                    {
+                        "holiday_date": date,
+                        "description": date.strftime("%A"),
+                        "weekly_off": 1,
+                    }
+                )
+            date = add_days(date, 1)
+
+        # Sat/Sun weekly offs so a 5-day reject/approve can become a full-week status.
+        holiday_list = make_holiday_list(
+            HOLIDAY_LIST, from_date="2026-01-01", to_date="2026-12-31", holiday_dates=weekends
+        )
+
         cls.manager = make_employee(MANAGER_USER, company=cls.company, leave_approver="Administrator")
         cls.employee = make_employee(
             EMPLOYEE_USER, company=cls.company, reports_to=cls.manager, leave_approver="Administrator"
         )
+
+        if not frappe.db.exists(
+            "Holiday List Assignment",
+            {"assigned_to": cls.employee, "from_date": "2026-01-01", "docstatus": 1},
+        ):
+            frappe.get_doc(
+                {
+                    "doctype": "Holiday List Assignment",
+                    "applicable_for": "Employee",
+                    "assigned_to": cls.employee,
+                    "holiday_list": holiday_list.name,
+                    "from_date": "2026-01-01",
+                }
+            ).insert(ignore_permissions=True).submit()
 
         if not frappe.db.exists("Customer", {"customer_name": CUSTOMER_NAME}):
             frappe.get_doc(
@@ -70,6 +120,7 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         cls.task = frappe.db.get_value("Task", {"subject": TASK_SUBJECT})
 
         frappe.clear_cache()
+        get_holidays.clear_cache()
 
     def setUp(self):
         super().setUp()
@@ -115,11 +166,26 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
                 "end_date": ["<=", FRI],
                 "docstatus": ["!=", 2],
             },
-            fields=["name", "start_date", "custom_approval_status", "custom_rejection_reason", "docstatus"],
+            fields=[
+                "name",
+                "start_date",
+                "custom_approval_status",
+                "custom_rejection_reason",
+                "custom_weekly_approval_status",
+                "custom_weekly_rejection_reason",
+                "docstatus",
+            ],
         )
         by_date = {str(row.start_date): row for row in rows}
         self.assertEqual(len(by_date), 5, "expected exactly 5 daily timesheets for the test week")
         return by_date
+
+    def assert_weekly_rejection_reason(self, by_date, expected_reasons):
+        """Weekly reason is duplicated on every timesheet in the week."""
+        expected = set(expected_reasons) if expected_reasons is not None else set()
+        for date in WEEK_DATES:
+            actual = {line for line in (by_date[date].custom_weekly_rejection_reason or "").split("\n") if line}
+            self.assertEqual(actual, expected, f"unexpected weekly rejection reason on {date}")
 
     def decide_timesheets(self, status, dates, note=""):
         drafts = frappe.get_all(
@@ -202,6 +268,9 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         for date in (MON, WED, FRI):
             self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
             self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+        # Partial reject must not populate the weekly reason.
+        self.assertEqual(by_date[MON].custom_weekly_approval_status, "Partially Rejected")
+        self.assert_weekly_rejection_reason(by_date, None)
 
         # Step 3: employee fixes things and resubmits the whole week. Status resets
         # to pending, but the rejection reason is kept until the day is re-decided.
@@ -211,8 +280,10 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         for date in WEEK_DATES:
             self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
             self.assertEqual(by_date[date].docstatus, 0)
+            self.assertEqual(by_date[date].custom_weekly_approval_status, "Approval Pending")
         self.assertEqual(by_date[TUE].custom_rejection_reason, TUE_REASON)
         self.assertEqual(by_date[THU].custom_rejection_reason, THU_REASON)
+        self.assert_weekly_rejection_reason(by_date, None)
 
         # Step 4: manager approves the whole week; reasons are cleared on approval.
         self.decide_timesheets("Approved", WEEK_DATES)
@@ -222,3 +293,50 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             self.assertEqual(by_date[date].custom_approval_status, "Approved")
             self.assertEqual(by_date[date].docstatus, 1)
             self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assertEqual(by_date[date].custom_weekly_approval_status, "Approved")
+        self.assert_weekly_rejection_reason(by_date, None)
+
+    def test_full_week_reject_sets_shared_weekly_rejection_reason(self):
+        self.decide_timesheets("Rejected", WEEK_DATES, note=WEEK_REASON)
+
+        by_date = self.get_timesheets_by_date()
+        for date in WEEK_DATES:
+            self.assertEqual(by_date[date].custom_approval_status, "Rejected")
+            self.assertEqual(by_date[date].custom_rejection_reason, WEEK_REASON)
+            self.assertEqual(by_date[date].custom_weekly_approval_status, "Rejected")
+        self.assert_weekly_rejection_reason(by_date, [WEEK_REASON])
+
+    def test_distinct_day_reasons_combined_when_week_rejected(self):
+        for date, reason in DAY_REASONS.items():
+            self.decide_timesheets("Rejected", [date], note=reason)
+
+        by_date = self.get_timesheets_by_date()
+        for date, reason in DAY_REASONS.items():
+            self.assertEqual(by_date[date].custom_approval_status, "Rejected")
+            self.assertEqual(by_date[date].custom_rejection_reason, reason)
+            self.assertEqual(by_date[date].custom_weekly_approval_status, "Rejected")
+        self.assert_weekly_rejection_reason(by_date, DAY_REASONS.values())
+
+    def test_weekly_rejection_reason_cleared_when_leaving_rejected(self):
+        self.decide_timesheets("Rejected", WEEK_DATES, note=WEEK_REASON)
+        by_date = self.get_timesheets_by_date()
+        self.assert_weekly_rejection_reason(by_date, [WEEK_REASON])
+
+        # Resubmit moves the week off Rejected and clears the weekly reason, while
+        # day-level reasons remain until each day is approved/rejected again.
+        submit_for_approval(start_date=MON, employee=self.employee, approver=self.manager)
+
+        by_date = self.get_timesheets_by_date()
+        for date in WEEK_DATES:
+            self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
+            self.assertEqual(by_date[date].custom_rejection_reason, WEEK_REASON)
+            self.assertEqual(by_date[date].custom_weekly_approval_status, "Approval Pending")
+        self.assert_weekly_rejection_reason(by_date, None)
+
+        self.decide_timesheets("Approved", WEEK_DATES)
+        by_date = self.get_timesheets_by_date()
+        for date in WEEK_DATES:
+            self.assertEqual(by_date[date].custom_approval_status, "Approved")
+            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assertEqual(by_date[date].custom_weekly_approval_status, "Approved")
+        self.assert_weekly_rejection_reason(by_date, None)

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -409,8 +409,15 @@ def approve_or_reject_timesheet(employee: str, status: str, dates: list[str] | N
     for timesheet in timesheets:
         if str(timesheet.start_date) not in dates:
             continue
-        db.set_value("Timesheet", timesheet.name, "custom_approval_status", "Processing Timesheet")
-        db.set_value("Timesheet", timesheet.name, "custom_weekly_approval_status", "Processing Timesheet")
+        db.set_value(
+            "Timesheet",
+            timesheet.name,
+            {
+                "custom_approval_status": "Processing Timesheet",
+                "custom_weekly_approval_status": "Processing Timesheet",
+                "custom_weekly_rejection_reason": None,
+            },
+        )
     doc = _dict(
         {
             "employee": employee,

--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -399,8 +399,10 @@ def submit_for_approval(start_date: str, notes: str = None, employee: str = None
         frappe.db.set_value(
             "Timesheet",
             timesheet.name,
-            "custom_weekly_approval_status",
-            "Approval Pending",
+            {
+                "custom_weekly_approval_status": "Approval Pending",
+                "custom_weekly_rejection_reason": None,
+            },
         )
     frappe.db.commit()  # nosemgrep Need to do as we need to publish status changes.
 

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -145,7 +145,7 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
             "end_date": ["<=", end_date],
             "docstatus": ["<", 2],
         },
-        ["name", "custom_approval_status", "start_date"],
+        ["name", "custom_approval_status", "custom_rejection_reason", "start_date"],
     )
     if not current_week_timesheet:
         return
@@ -209,9 +209,28 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
     elif status_count["Approved"] > 0:
         week_status = "Partially Approved"
 
+    weekly_rejection_reason = None
+    if week_status == "Rejected":
+        reasons = []
+        seen = set()
+        for ts in current_week_timesheet:
+            if ts.get("custom_approval_status") != "Rejected":
+                continue
+            reason = (ts.get("custom_rejection_reason") or "").strip()
+            if reason and reason not in seen:
+                seen.add(reason)
+                reasons.append(reason)
+        weekly_rejection_reason = "\n".join(reasons) if reasons else None
+
     for timesheet in current_week_timesheet:
         frappe.db.set_value(
-            "Timesheet", timesheet.name, "custom_weekly_approval_status", week_status, update_modified=False
+            "Timesheet",
+            timesheet.name,
+            {
+                "custom_weekly_approval_status": week_status,
+                "custom_weekly_rejection_reason": weekly_rejection_reason,
+            },
+            update_modified=False,
         )
 
 

--- a/next_pms/timesheet/patches/setup_timesheet_weekly_rejection_reason_field.py
+++ b/next_pms/timesheet/patches/setup_timesheet_weekly_rejection_reason_field.py
@@ -1,0 +1,5 @@
+from next_pms.install import setup_timesheet_weekly_rejection_reason_field
+
+
+def execute():
+    setup_timesheet_weekly_rejection_reason_field()


### PR DESCRIPTION
## Description

a weekly rejection reason field is added to timesheets. it gets filled when the full week is `rejected` and is removed when the weekly status != rejected.

it is auto filled from appending all the daily reasons.

## Relevant Technical Choices

added a patch and install script.

## Testing Instructions

set 1:
1. add a full week timesheet
2. reject it 
3. observe the rejected weekly reason in the backend 

set 2:
1. add a full week timesheet
2. reject each day with different reasons
3. observe the full weekly rejection reason in the backend (appended newline)

set 3:
1. add a full week timesheet
2. reject some days 
3. approve some days
4. only see the daily rejection reasons in the backend (and frontend)

## Screenshot/Screencast

<img width="643" height="134" alt="image" src="https://github.com/user-attachments/assets/f4ca46dd-a44a-4d5d-8a41-56c5f6e6d962" />

## Checklist
- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1902 