### PR TITLE
feat(projects): forecast budget burn from billable rates

### DIFF
--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -200,10 +200,15 @@ def get_forecast_map(
     stops at the employee's relieving date, which total_cost is already clamped to. Today
     counts as forecast, since today's timesheet is typically not submitted yet.
 
-    Cost is always forecast. Budget is only forecast when with_budget is set, because it
-    costs a row scan the database-side sum would otherwise avoid: budget needs each
-    allocation's own employee and rate, where cost can be summed blind. Callers that only
-    read cost therefore pay exactly what they paid before this argument existed.
+    Every entry carries both a "cost" and a "budget" key. Cost is always forecast. Budget
+    is only forecast when with_budget is set, and reads 0.0 otherwise — a caller that did
+    not ask for budget cannot tell that zero apart from a project that genuinely bills
+    nothing, and should not read the key at all.
+
+    Budget is opt-in because it costs a row scan the database-side sum would otherwise
+    avoid: budget needs each allocation's own employee and rate, where cost can be summed
+    blind. Callers that only read cost therefore pay exactly what they paid before this
+    argument existed.
     """
     if not project_names:
         return {}

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -23,6 +23,7 @@ from next_pms.next_projects.api.constant import (
     TASK_TRACKING_TOTAL_STATUSES,
 )
 from next_pms.next_projects.api.utils import build_person_data, get_employee_image_map, get_user_image_map
+from next_pms.project_currency.billing_rate import get_billing_rate_context, resolve_billing_rate
 from next_pms.timesheet.api import get_count
 from next_pms.utils.employee import (
     get_employee_salary,
@@ -166,20 +167,43 @@ def get_cost_forecasted(project_name: str) -> float:
 
 
 def get_cost_forecasted_map(project_names: list[str]) -> dict[str, float]:
-    """Forecasted costs for multiple projects, keyed by project name.
+    """Forecasted costs for multiple projects, keyed by project name."""
+    return {name: value["cost"] for name, value in get_forecast_map(project_names).items()}
 
-    Only cost that is still ahead of today counts: elapsed allocation days are already
-    realized in the project's total_costing_amount (cost_accrued) via timesheets, so
-    counting them here would double-count them.
 
-    An allocation that has not started yet is still fully ahead whatever its internal
-    shape, so those are summed in the database and never inspected row by row. Only
-    allocations straddling today need splitting, and that set holds at most one row per
-    (employee, project) because the allocation API chunks every allocation into a single
-    week. The split runs on chargeable hours so day overrides land on the right side of
-    today, and stops at the employee's relieving date, which total_cost is already
-    clamped to. Today counts as forecast, since today's timesheet is typically not
-    submitted yet.
+def get_project_forecast(project_name: str, project: dict) -> dict[str, float]:
+    """Forecasted cost and budget burn for one project, keyed "cost" and "budget".
+
+    Takes the already-fetched Project row so resolving billable rates costs no extra
+    lookup for it.
+    """
+    return get_forecast_map([project_name], with_budget=True, project_map={project_name: project}).get(
+        project_name, {"cost": 0.0, "budget": 0.0}
+    )
+
+
+def get_forecast_map(
+    project_names: list[str],
+    with_budget: bool = False,
+    project_map: dict[str, dict] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Forecasts still ahead of today for multiple projects, keyed by project name.
+
+    Only what is still ahead of today counts: elapsed allocation days are already realized
+    in the project's totals via timesheets, so counting them here would double-count them.
+
+    An allocation that has not started yet is still fully ahead whatever its internal shape,
+    so those are summed in the database and never inspected row by row. Only allocations
+    straddling today need splitting, and that set holds at most one row per (employee,
+    project) because the allocation API chunks every allocation into a single week. The
+    split runs on chargeable hours so day overrides land on the right side of today, and
+    stops at the employee's relieving date, which total_cost is already clamped to. Today
+    counts as forecast, since today's timesheet is typically not submitted yet.
+
+    Cost is always forecast. Budget is only forecast when with_budget is set, because it
+    costs a row scan the database-side sum would otherwise avoid: budget needs each
+    allocation's own employee and rate, where cost can be summed blind. Callers that only
+    read cost therefore pay exactly what they paid before this argument existed.
     """
     if not project_names:
         return {}
@@ -188,27 +212,79 @@ def get_cost_forecasted_map(project_names: list[str]) -> dict[str, float]:
     ResourceAllocation = frappe.qb.DocType("Resource Allocation")
     Employee = frappe.qb.DocType("Employee")
 
-    not_started = (
-        frappe.qb.from_(ResourceAllocation)
-        .select(
-            ResourceAllocation.project,
-            Coalesce(Sum(ResourceAllocation.total_cost), 0).as_("total"),
+    forecast: dict[str, dict[str, float]] = {}
+
+    def accrue(project: str, cost: float, budget: float = 0.0) -> None:
+        entry = forecast.setdefault(project, {"cost": 0.0, "budget": 0.0})
+        entry["cost"] += cost
+        entry["budget"] += budget
+
+    rate_context = {}
+    if with_budget:
+        if project_map is None:
+            project_map = {
+                row.name: row
+                for row in frappe.get_all(
+                    "Project",
+                    filters={"name": ["in", project_names]},
+                    fields=["name", "custom_billing_type", "custom_default_hourly_billing_rate"],
+                )
+            }
+        rate_context = get_billing_rate_context(project_map)
+
+    def budget_of(row: dict, ratio: float) -> float:
+        """Forecast budget for one allocation, for the fraction of it still ahead.
+
+        A non-billable resource on a billable project burns the project's cost but never
+        its budget, mirroring a non-billable Timesheet Detail row.
+        """
+        if not with_budget or not cint(row.is_billable):
+            return 0.0
+
+        rate = resolve_billing_rate(row.project, row.employee, row.hourly_cost_rate, as_on, project_map, rate_context)
+        return rate * flt(row.total_allocated_hours) * ratio
+
+    allocation_fields = [
+        ResourceAllocation.name,
+        ResourceAllocation.project,
+        ResourceAllocation.employee,
+        ResourceAllocation.is_billable,
+        ResourceAllocation.total_cost,
+        ResourceAllocation.total_allocated_hours,
+        ResourceAllocation.hourly_cost_rate,
+    ]
+
+    if with_budget:
+        not_started = (
+            frappe.qb.from_(ResourceAllocation)
+            .select(*allocation_fields)
+            .where(ResourceAllocation.project.isin(project_names))
+            .where(ResourceAllocation.allocation_start_date >= as_on)
+            .run(as_dict=True)
         )
-        .where(ResourceAllocation.project.isin(project_names))
-        .where(ResourceAllocation.allocation_start_date >= as_on)
-        .groupby(ResourceAllocation.project)
-        .run(as_dict=True)
-    )
-    forecast = {row.project: flt(row.total) for row in not_started}
+        for row in not_started:
+            accrue(row.project, flt(row.total_cost), budget_of(row, 1.0))
+    else:
+        not_started = (
+            frappe.qb.from_(ResourceAllocation)
+            .select(
+                ResourceAllocation.project,
+                Coalesce(Sum(ResourceAllocation.total_cost), 0).as_("total"),
+            )
+            .where(ResourceAllocation.project.isin(project_names))
+            .where(ResourceAllocation.allocation_start_date >= as_on)
+            .groupby(ResourceAllocation.project)
+            .run(as_dict=True)
+        )
+        for row in not_started:
+            accrue(row.project, flt(row.total))
 
     in_flight = (
         frappe.qb.from_(ResourceAllocation)
         .left_join(Employee)
         .on(Employee.name == ResourceAllocation.employee)
         .select(
-            ResourceAllocation.name,
-            ResourceAllocation.project,
-            ResourceAllocation.total_cost,
+            *allocation_fields,
             ResourceAllocation.allocation_start_date,
             ResourceAllocation.allocation_end_date,
             ResourceAllocation.include_weekends,
@@ -236,7 +312,7 @@ def get_cost_forecasted_map(project_names: list[str]) -> dict[str, float]:
             as_on,
         )
         if ratio:
-            forecast[row.project] = forecast.get(row.project, 0.0) + flt(row.total_cost) * ratio
+            accrue(row.project, flt(row.total_cost) * ratio, budget_of(row, ratio))
 
     return forecast
 
@@ -976,6 +1052,10 @@ def get_project_tracking(project: str):
         invoice_burn : dict
             currency (company default), invoiced_and_paid, invoiced_but_not_paid,
             total_project_amount. Omitted for Non-Billable projects.
+        budget_burn : dict or None
+            actual (amount billed to date), forecasted (remaining allocation hours priced
+            at each member's billable rate), total_budget. None for Non-Billable, which
+            has no budget to burn.
         total_project_value : float
             Total budget/value for the project.
         project_profit : float
@@ -1020,6 +1100,7 @@ def get_project_tracking(project: str):
             "custom_billing_type",
             "total_costing_amount",
             "total_sales_amount",
+            "total_billable_amount",
             "custom_currency",
             "custom_target_cost",
             "custom_total_hours_purchased",
@@ -1041,8 +1122,8 @@ def get_project_tracking(project: str):
     invoice_burn = _get_invoice_burn(project) if is_billable else None
     task_counts = _get_task_counts(project)
     actual_cost_incurred = flt(p.total_costing_amount)
-    total_forecasted_cost = get_cost_forecasted(project)
-    forecasted_cost_to_completion = max(0, total_forecasted_cost)
+    forecast = get_project_forecast(project, p)
+    forecasted_cost_to_completion = max(0, forecast["cost"])
 
     total_project_value = flt(p.total_sales_amount)
     projected_profit = total_project_value - (actual_cost_incurred + forecasted_cost_to_completion)
@@ -1142,6 +1223,13 @@ def get_project_tracking(project: str):
             **(invoice_burn or {}),
             "total_project_amount": flt(p.total_sales_amount) if is_billable else None,
         },
+        "budget_burn": {
+            "actual": get_budget_burn_accrued(p),
+            "forecasted": forecast["budget"],
+            "total_budget": total_project_value,
+        }
+        if is_billable
+        else None,
         "contracts": contracts,
         "project_rates": project_rates,
         "lifetime_values": lifetime_values,
@@ -1158,7 +1246,8 @@ def get_project_sidebar(project: str):
         summary       - short summary text
         details       - project name, phase, status, customer
         links         - slack, google_drive, website, github, opportunity
-        burn          - total_budget, cost_accrued, cost_forecasted, target_cost
+        burn          - total_budget, cost_accrued, cost_forecasted, budget_forecasted,
+                        target_cost
         progress      - actual_time; total_hours_purchased (Retainer) or custom_target_hours (all other billing types)
         members       - users the project has been shared with
         customers     - contacts from custom_customer_contacts
@@ -1179,7 +1268,7 @@ def get_project_sidebar(project: str):
 
     total_budget = get_total_budget(project_doc)
     cost_accrued = get_budget_burn_accrued(project_doc)
-    cost_forecasted = get_cost_forecasted(project)
+    forecast = get_project_forecast(project, project_doc)
     target_cost = flt(project_doc.custom_target_cost)
 
     return {
@@ -1200,7 +1289,8 @@ def get_project_sidebar(project: str):
         "burn": {
             "total_budget": total_budget,
             "cost_accrued": cost_accrued,
-            "cost_forecasted": cost_forecasted,
+            "cost_forecasted": forecast["cost"],
+            "budget_forecasted": forecast["budget"],
             "target_cost": target_cost,
         },
         "progress": {

--- a/next_pms/project_currency/billing_rate.py
+++ b/next_pms/project_currency/billing_rate.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, rtCamp and contributors
 # For license information, please see license.txt
 
+from datetime import date
+
 import frappe
 from frappe.utils import flt, getdate
 
@@ -38,7 +40,7 @@ def resolve_billing_rate(
     project: str,
     employee: str,
     hourly_cost_rate: float,
-    as_on,
+    as_on: date | str,
     project_map: dict[str, dict],
     context: dict[tuple[str, str], list],
 ) -> float:
@@ -52,6 +54,8 @@ def resolve_billing_rate(
     conversion happens here. Unlike the timesheet path this never throws — a missing rate
     degrades to the fallback rather than blocking a page that is only forecasting.
     """
+    as_on = getdate(as_on)
+
     project_row = project_map.get(project)
     if not project_row:
         return 0.0

--- a/next_pms/project_currency/billing_rate.py
+++ b/next_pms/project_currency/billing_rate.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.utils import flt, getdate
+
+# Applied to an employee's hourly cost rate when a project defines no billable rate.
+# Shared with next_pms.project_currency.overrides.timesheet, which stamps the same
+# multiplier onto Timesheet Detail rows, so forecasts and actuals cannot drift apart.
+BILLING_RATE_COST_MULTIPLIER = 3
+
+
+def get_billing_rate_context(project_map: dict[str, dict]) -> dict[tuple[str, str], list]:
+    """Per-employee billing rates for the Time and Material projects in project_map.
+
+    Keyed by (project, employee) and ordered newest valid_from first, so a caller picks a
+    rate with a single scan. Only Time and Material projects consult the billing team, so
+    projects on any other billing type are never queried for.
+    """
+    time_and_material = [
+        name for name, project in project_map.items() if project.get("custom_billing_type") == "Time and Material"
+    ]
+    if not time_and_material:
+        return {}
+
+    context: dict[tuple[str, str], list] = {}
+    for row in frappe.get_all(
+        "Project Billing Team",
+        filters={"parent": ["in", time_and_material], "parenttype": "Project"},
+        fields=["parent", "employee", "hourly_billing_rate", "valid_from"],
+        order_by="valid_from desc",
+    ):
+        context.setdefault((row.parent, row.employee), []).append(row)
+    return context
+
+
+def resolve_billing_rate(
+    project: str,
+    employee: str,
+    hourly_cost_rate: float,
+    as_on,
+    project_map: dict[str, dict],
+    context: dict[tuple[str, str], list],
+) -> float:
+    """Hourly rate an employee's work bills at on a project, as on a date.
+
+    Mirrors Timesheet.get_activity_billing_rate: a Time and Material project rates each
+    member off its billing team, every other billing type rates the whole project off its
+    default rate, and a project with no rate at all falls back to a multiple of cost.
+
+    Rates and hourly_cost_rate are both denominated in the project's currency, so no
+    conversion happens here. Unlike the timesheet path this never throws — a missing rate
+    degrades to the fallback rather than blocking a page that is only forecasting.
+    """
+    project_row = project_map.get(project)
+    if not project_row:
+        return 0.0
+
+    billing_type = project_row.get("custom_billing_type")
+    if not billing_type or billing_type == "Non-Billable":
+        return 0.0
+
+    if billing_type == "Time and Material":
+        for row in context.get((project, employee), []):
+            if row.valid_from and getdate(row.valid_from) <= as_on:
+                return flt(row.hourly_billing_rate)
+
+    if default_rate := flt(project_row.get("custom_default_hourly_billing_rate")):
+        return default_rate
+
+    return BILLING_RATE_COST_MULTIPLIER * flt(hourly_cost_rate)

--- a/next_pms/project_currency/overrides/timesheet.py
+++ b/next_pms/project_currency/overrides/timesheet.py
@@ -4,6 +4,7 @@ from erpnext.projects.doctype.timesheet.timesheet import Timesheet
 from erpnext.setup.utils import get_exchange_rate
 from frappe.utils.data import flt, nowdate
 
+from next_pms.project_currency.billing_rate import BILLING_RATE_COST_MULTIPLIER
 from next_pms.utils.employee import get_employee_salary
 
 
@@ -96,8 +97,8 @@ class TimesheetOverwrite(Timesheet):
                 )
 
                 if billing_rate == "Take Costing Rate":
-                    billing_rate = 3 * costing_rate
-                    base_billing_rate = 3 * base_costing_rate
+                    billing_rate = BILLING_RATE_COST_MULTIPLIER * costing_rate
+                    base_billing_rate = BILLING_RATE_COST_MULTIPLIER * base_costing_rate
 
                 if billing_rate or custom_billing_type == "Time and Material":
                     data.billing_rate = billing_rate

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -11,9 +11,16 @@ from next_pms.next_projects.api.project import (
     _remaining_cost_ratio,
     get_cost_forecasted,
     get_cost_forecasted_map,
+    get_forecast_map,
+    get_project_forecast,
     get_project_sidebar,
     get_project_tracking,
     get_projects_view,
+)
+from next_pms.project_currency.billing_rate import (
+    BILLING_RATE_COST_MULTIPLIER,
+    get_billing_rate_context,
+    resolve_billing_rate,
 )
 from next_pms.resource_management.api.allocation import upsert_day_override
 
@@ -22,6 +29,7 @@ FIXTURE_PREFIX = "CompSort"
 BURN_FIXTURE_PREFIX = "BurnAccrued"
 FORECAST_FIXTURE_PREFIX = "CostForecast"
 ADJUSTED_FIXTURE_PREFIX = "CostAdjusted"
+BUDGET_FIXTURE_PREFIX = "BudgetForecast"
 
 # 2026-05-04 is a Monday, so 05-08 is Friday and 05-09/05-10 are the weekend.
 MONDAY = date(2026, 5, 4)
@@ -735,3 +743,288 @@ class TestTrackingBillingTables(IntegrationTestCase):
         tracking = get_project_tracking(self.projects["NONBILL"])
         self.assertIsNone(tracking["contracts"])
         self.assertIsNone(tracking["project_rates"])
+
+
+class TestResolveBillingRate(IntegrationTestCase):
+    """The rate an employee's forecast work bills at, resolved in the same order
+    Timesheet.get_activity_billing_rate applies: a Time and Material project rates each
+    member off its billing team, every other billing type rates the whole project off its
+    default rate, and a project with no rate at all falls back to a multiple of cost.
+
+    resolve_billing_rate takes its project and billing team rows as plain data, so every
+    case below is exercised without touching the database.
+    """
+
+    COST_RATE = 100.0
+
+    def project(self, billing_type, default_rate=0.0):
+        return {"PROJ": frappe._dict(custom_billing_type=billing_type, custom_default_hourly_billing_rate=default_rate)}
+
+    def team(self, *rows):
+        return {("PROJ", "EMP"): [frappe._dict(**row) for row in rows]}
+
+    def resolve(self, project_map, context=None, employee="EMP"):
+        return resolve_billing_rate("PROJ", employee, self.COST_RATE, date(2026, 6, 1), project_map, context or {})
+
+    def test_non_billable_project_never_bills(self):
+        self.assertEqual(self.resolve(self.project("Non-Billable", default_rate=500)), 0.0)
+
+    def test_unknown_project_never_bills(self):
+        self.assertEqual(self.resolve({}), 0.0)
+
+    def test_flat_rate_projects_use_the_project_default(self):
+        for billing_type in ("Fixed Cost", "Retainer", "Time and Material"):
+            self.assertEqual(self.resolve(self.project(billing_type, default_rate=500)), 500.0, msg=billing_type)
+
+    def test_missing_rate_falls_back_to_a_multiple_of_cost(self):
+        for billing_type in ("Fixed Cost", "Retainer", "Time and Material"):
+            self.assertEqual(
+                self.resolve(self.project(billing_type)),
+                BILLING_RATE_COST_MULTIPLIER * self.COST_RATE,
+                msg=billing_type,
+            )
+
+    def test_time_and_material_prefers_the_member_rate(self):
+        context = self.team({"hourly_billing_rate": 700, "valid_from": date(2026, 1, 1)})
+        self.assertEqual(self.resolve(self.project("Time and Material", default_rate=500), context), 700.0)
+
+    def test_flat_rate_projects_ignore_the_billing_team(self):
+        # The regression: a member rate on a Fixed Cost or Retainer project is not
+        # contractual, so billing it would overstate the forecast.
+        context = self.team({"hourly_billing_rate": 700, "valid_from": date(2026, 1, 1)})
+        for billing_type in ("Fixed Cost", "Retainer"):
+            self.assertEqual(
+                self.resolve(self.project(billing_type, default_rate=500), context), 500.0, msg=billing_type
+            )
+
+    def test_latest_effective_member_rate_wins(self):
+        context = self.team(
+            {"hourly_billing_rate": 900, "valid_from": date(2026, 5, 1)},
+            {"hourly_billing_rate": 700, "valid_from": date(2026, 1, 1)},
+        )
+        self.assertEqual(self.resolve(self.project("Time and Material"), context), 900.0)
+
+    def test_member_rate_that_has_not_taken_effect_is_skipped(self):
+        context = self.team(
+            {"hourly_billing_rate": 900, "valid_from": date(2026, 9, 1)},
+            {"hourly_billing_rate": 700, "valid_from": date(2026, 1, 1)},
+        )
+        self.assertEqual(self.resolve(self.project("Time and Material"), context), 700.0)
+
+    def test_member_rate_without_a_start_date_is_skipped(self):
+        context = self.team({"hourly_billing_rate": 900, "valid_from": None})
+        self.assertEqual(self.resolve(self.project("Time and Material", default_rate=500), context), 500.0)
+
+    def test_another_employees_rate_is_not_borrowed(self):
+        context = self.team({"hourly_billing_rate": 700, "valid_from": date(2026, 1, 1)})
+        self.assertEqual(
+            self.resolve(self.project("Time and Material", default_rate=500), context, employee="OTHER"), 500.0
+        )
+
+
+class TestBudgetForecasted(IntegrationTestCase):
+    """Forecast budget burn is remaining allocation hours priced at each member's
+    billable rate, which is a different figure from forecast cost (hours priced at CTC).
+
+    Every allocation below books 40 hours and a pinned total_cost, so a fixture's budget
+    is never confusable with its cost.
+    """
+
+    HOURS = 40.0
+    COST_RATE = 100.0
+    FLAT_RATE = 500.0
+    MEMBER_RATE = 700.0
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.customer = TestCostForecastedProration._get_customer()
+        cls.employee = cls._make_employee("Member")
+        cls.other_employee = cls._make_employee("Other")
+
+        # suffix -> (billing type, project default rate)
+        specs = {
+            "FLAT": ("Fixed Cost", cls.FLAT_RATE),
+            "RETAINER": ("Retainer", cls.FLAT_RATE),
+            "MULTIPLIER": ("Fixed Cost", 0),
+            "NON_BILLABLE_RESOURCE": ("Fixed Cost", cls.FLAT_RATE),
+            "NON_BILLABLE_PROJECT": ("Non-Billable", 0),
+            "TIME_AND_MATERIAL": ("Time and Material", cls.FLAT_RATE),
+            "TIME_AND_MATERIAL_NO_ROW": ("Time and Material", cls.FLAT_RATE),
+            "RUNNING": ("Fixed Cost", cls.FLAT_RATE),
+        }
+        cls.projects = {
+            suffix: cls._make_project(suffix, billing_type, rate) for suffix, (billing_type, rate) in specs.items()
+        }
+
+        # Only the Time and Material project rates its members individually.
+        for suffix in ("TIME_AND_MATERIAL", "TIME_AND_MATERIAL_NO_ROW"):
+            project = frappe.get_doc("Project", cls.projects[suffix])
+            project.append(
+                "custom_project_billing_team",
+                {
+                    "employee": cls.employee if suffix == "TIME_AND_MATERIAL" else cls.other_employee,
+                    "hourly_billing_rate": cls.MEMBER_RATE,
+                    "valid_from": add_days(today(), -30),
+                },
+            )
+            project.save(ignore_permissions=True)
+
+        for suffix in cls.projects:
+            if suffix == "RUNNING":
+                continue
+            cls._make_allocation(suffix, start=1, end=5, is_billable=suffix != "NON_BILLABLE_RESOURCE")
+        # 10 days with weekends, today..+5 still ahead: 60% of both cost and budget.
+        cls._make_allocation("RUNNING", start=-4, end=5)
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    @classmethod
+    def _make_employee(cls, label):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": f"{BUDGET_FIXTURE_PREFIX} {label}",
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                "leave_approver": "Administrator",
+                "ctc": 100000,
+                "salary_currency": "INR",
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _make_project(cls, suffix, billing_type, default_rate):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": f"{BUDGET_FIXTURE_PREFIX} {suffix}",
+                    "company": cls.company,
+                    "customer": cls.customer,
+                    "custom_billing_type": billing_type,
+                    "custom_default_hourly_billing_rate": default_rate,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_allocation(cls, suffix, start, end, is_billable=True):
+        allocation = frappe.get_doc(
+            {
+                "doctype": "Resource Allocation",
+                "employee": cls.employee,
+                "project": cls.projects[suffix],
+                "allocation_start_date": add_days(today(), start),
+                "allocation_end_date": add_days(today(), end),
+                "hours_allocated_per_day": 8,
+                "total_allocated_hours": cls.HOURS,
+                "include_weekends": 1,
+                "is_billable": int(is_billable),
+                "status": "Confirmed",
+            }
+        ).insert(ignore_permissions=True)
+        # Both are read-only and derived from the employee's CTC; pin them so every
+        # expectation below is exact and independent of salary setup.
+        frappe.db.set_value(
+            "Resource Allocation",
+            allocation.name,
+            {"total_cost": ALLOCATION_COST, "hourly_cost_rate": cls.COST_RATE},
+            update_modified=False,
+        )
+        return allocation.name
+
+    def forecast(self, suffix):
+        project = frappe.db.get_value(
+            "Project",
+            self.projects[suffix],
+            ["custom_billing_type", "custom_default_hourly_billing_rate"],
+            as_dict=True,
+        )
+        return get_project_forecast(self.projects[suffix], project)
+
+    def test_flat_rate_projects_bill_hours_at_the_project_rate(self):
+        for suffix in ("FLAT", "RETAINER"):
+            self.assertAlmostEqual(self.forecast(suffix)["budget"], self.HOURS * self.FLAT_RATE, msg=suffix)
+
+    def test_project_without_a_rate_bills_a_multiple_of_cost(self):
+        self.assertAlmostEqual(
+            self.forecast("MULTIPLIER")["budget"],
+            self.HOURS * BILLING_RATE_COST_MULTIPLIER * self.COST_RATE,
+        )
+
+    def test_time_and_material_bills_the_member_rate(self):
+        self.assertAlmostEqual(self.forecast("TIME_AND_MATERIAL")["budget"], self.HOURS * self.MEMBER_RATE)
+
+    def test_time_and_material_without_a_member_row_bills_the_project_rate(self):
+        self.assertAlmostEqual(self.forecast("TIME_AND_MATERIAL_NO_ROW")["budget"], self.HOURS * self.FLAT_RATE)
+
+    def test_non_billable_resource_burns_cost_but_not_budget(self):
+        forecast = self.forecast("NON_BILLABLE_RESOURCE")
+        self.assertEqual(forecast["budget"], 0.0)
+        self.assertAlmostEqual(forecast["cost"], ALLOCATION_COST)
+
+    def test_non_billable_project_has_no_budget_to_burn(self):
+        forecast = self.forecast("NON_BILLABLE_PROJECT")
+        self.assertEqual(forecast["budget"], 0.0)
+        self.assertAlmostEqual(forecast["cost"], ALLOCATION_COST)
+
+    def test_running_allocation_prorates_budget_like_cost(self):
+        forecast = self.forecast("RUNNING")
+        self.assertAlmostEqual(forecast["budget"], 0.6 * self.HOURS * self.FLAT_RATE)
+        self.assertAlmostEqual(forecast["cost"], 0.6 * ALLOCATION_COST)
+
+    def test_budget_is_not_a_restatement_of_cost(self):
+        # Guards the whole class: reporting cost as budget passes nothing here.
+        for suffix in ("FLAT", "RETAINER", "MULTIPLIER", "TIME_AND_MATERIAL", "RUNNING"):
+            forecast = self.forecast(suffix)
+            self.assertNotAlmostEqual(forecast["budget"], forecast["cost"], places=2, msg=suffix)
+
+    def test_cost_is_unchanged_by_forecasting_budget(self):
+        # The regression guard for generalising get_cost_forecasted_map: asking for budget
+        # must not perturb the cost figure the project list view has always read.
+        names = list(self.projects.values())
+        cost_only = get_cost_forecasted_map(names)
+        with_budget = get_forecast_map(names, with_budget=True)
+        for suffix, project in self.projects.items():
+            self.assertAlmostEqual(with_budget[project]["cost"], flt(cost_only.get(project, 0.0)), places=6, msg=suffix)
+
+    def test_billing_rate_context_only_loads_time_and_material_projects(self):
+        project_map = {
+            name: frappe.db.get_value(
+                "Project", name, ["custom_billing_type", "custom_default_hourly_billing_rate"], as_dict=True
+            )
+            for name in self.projects.values()
+        }
+        context = get_billing_rate_context(project_map)
+        self.assertEqual(
+            {project for project, _employee in context},
+            {self.projects["TIME_AND_MATERIAL"], self.projects["TIME_AND_MATERIAL_NO_ROW"]},
+        )
+
+    def test_tracking_reports_the_budget_burn(self):
+        tracking = get_project_tracking(self.projects["FLAT"])
+        self.assertAlmostEqual(tracking["budget_burn"]["forecasted"], self.HOURS * self.FLAT_RATE)
+        self.assertEqual(tracking["budget_burn"]["actual"], 0.0)
+        self.assertEqual(tracking["budget_burn"]["total_budget"], tracking["total_project_value"])
+        # Cost burn keeps reporting cost, not budget.
+        self.assertAlmostEqual(tracking["forecasted_cost_to_completion"], ALLOCATION_COST)
+
+    def test_tracking_omits_budget_burn_for_non_billable(self):
+        self.assertIsNone(get_project_tracking(self.projects["NON_BILLABLE_PROJECT"])["budget_burn"])
+
+    def test_sidebar_reports_budget_and_cost_forecasts_apart(self):
+        burn = get_project_sidebar(self.projects["FLAT"])["burn"]
+        self.assertAlmostEqual(burn["budget_forecasted"], self.HOURS * self.FLAT_RATE)
+        self.assertAlmostEqual(burn["cost_forecasted"], ALLOCATION_COST)


### PR DESCRIPTION
## Description

* Added budget forecasting to project APIs, including new fields such as `budget_burn` and `budget_forecasted` in `get_project_tracking` and `get_project_sidebar`, providing both actual and forecasted budget values for billable projects. 
* Refactored cost forecasting logic into `get_forecast_map` and `get_project_forecast`, supporting combined cost and budget forecasts with efficient lookups and minimal database queries. 
* Introduced `next_pms/project_currency/billing_rate.py` containing `get_billing_rate_context`, `resolve_billing_rate`, and a shared `BILLING_RATE_COST_MULTIPLIER`, ensuring that both forecasts and actuals use consistent billing rate calculations.
* Updated timesheet override logic to use the shared multiplier, preventing drift between forecasted and actual billing rates. 


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1141" height="694" alt="Screenshot 2026-08-10 at 12 01 33 PM" src="https://github.com/user-attachments/assets/48f4fa21-297c-45db-bc04-fbd7fdab0202" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
#22
See #834
-->

Partially addresses  #1937