### PR TITLE
feat(tasks): add priority and due date to add-task form

### DIFF
--- a/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
@@ -229,6 +229,42 @@ const AddTask = ({
           )}
         />
 
+        <form.Field
+          name="project"
+          children={(field) => (
+            <div>
+              <label className="block text-base text-ink-gray-5 mb-1.5">
+                Project
+              </label>
+              <Combobox
+                inputClassName="bg-surface-white h-8 border-outline-gray-2 text-ink-gray-7"
+                loading={isProjectLookupLoading}
+                options={projectOptions}
+                placeholder="Select project"
+                searchValue={projectSearch}
+                onSearchChange={setProjectSearch}
+                value={field.state.value}
+                onChange={(value, option) => {
+                  const nextProject = value ?? "";
+                  const nextProjectOption =
+                    option as ProjectLookupOption | null;
+                  form.setFieldValue(
+                    "projectLabel",
+                    nextProjectOption?.label ?? nextProject,
+                  );
+                  field.handleChange(nextProject);
+                }}
+                openOnFocus
+              />
+              {!field.state.meta.isValid && (
+                <div className="mt-4">
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                </div>
+              )}
+            </div>
+          )}
+        />
+
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <form.Field
             name="priority"
@@ -326,42 +362,6 @@ const AddTask = ({
             )}
           />
         </div>
-
-        <form.Field
-          name="project"
-          children={(field) => (
-            <div>
-              <label className="block text-base text-ink-gray-5 mb-1.5">
-                Project
-              </label>
-              <Combobox
-                inputClassName="bg-surface-white h-8 border-outline-gray-2 text-ink-gray-7"
-                loading={isProjectLookupLoading}
-                options={projectOptions}
-                placeholder="Select project"
-                searchValue={projectSearch}
-                onSearchChange={setProjectSearch}
-                value={field.state.value}
-                onChange={(value, option) => {
-                  const nextProject = value ?? "";
-                  const nextProjectOption =
-                    option as ProjectLookupOption | null;
-                  form.setFieldValue(
-                    "projectLabel",
-                    nextProjectOption?.label ?? nextProject,
-                  );
-                  field.handleChange(nextProject);
-                }}
-                openOnFocus
-              />
-              {!field.state.meta.isValid && (
-                <div className="mt-4">
-                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
-                </div>
-              )}
-            </div>
-          )}
-        />
 
         <form.Field
           name="description"

--- a/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/index.tsx
@@ -5,13 +5,16 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   Combobox,
+  DatePicker,
   Dialog,
   ErrorMessage,
+  Select,
   TextEditor,
   TextInput,
   useToasts,
   type TextEditorProps,
 } from "@rtcamp/frappe-ui-react";
+import { Calendar } from "@rtcamp/frappe-ui-react/icons";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
 import { useFrappePostCall, useFrappeUpdateDoc } from "frappe-react-sdk";
@@ -31,6 +34,7 @@ import {
   type AddTaskFormValues,
 } from "./schema";
 import type { AddTaskProps } from "./type";
+import { TASK_PRIORITY_OPTIONS } from "../../constants";
 
 const DESCRIPTION_EDITOR_STARTERKIT_OPTIONS: NonNullable<
   TextEditorProps["starterkitOptions"]
@@ -41,6 +45,8 @@ const emptyValues: AddTaskFormValues = {
   project: "",
   projectLabel: "",
   expected_time: "",
+  priority: "Low",
+  exp_end_date: "",
   description: "",
 };
 
@@ -84,6 +90,8 @@ const AddTask = ({
             subject: value.subject.trim(),
             project: value.project.trim(),
             expected_time: value.expected_time.trim(),
+            priority: value.priority?.trim() || "",
+            exp_end_date: value.exp_end_date?.trim() || "",
             description: value.description.trim(),
           });
         } else {
@@ -91,6 +99,8 @@ const AddTask = ({
             subject: value.subject.trim(),
             project: value.project.trim(),
             expected_time: value.expected_time.trim(),
+            priority: value.priority?.trim() || "",
+            exp_end_date: value.exp_end_date?.trim() || "",
             description: value.description.trim(),
           });
         }
@@ -196,20 +206,48 @@ const AddTask = ({
       }
     >
       <div className="space-y-4">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-12">
+        <form.Field
+          name="subject"
+          children={(field) => (
+            <div>
+              <label className="block text-base text-ink-gray-5 mb-1.5">
+                Subject
+              </label>
+              <TextInput
+                size="md"
+                variant="outline"
+                placeholder="Add subject"
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+              {!field.state.meta.isValid && (
+                <div className="mt-4">
+                  <ErrorMessage message={field.state.meta.errors[0]?.message} />
+                </div>
+              )}
+            </div>
+          )}
+        />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <form.Field
-            name="subject"
+            name="priority"
             children={(field) => (
-              <div className="sm:col-span-9">
+              <div>
                 <label className="block text-base text-ink-gray-5 mb-1.5">
-                  Subject
+                  Priority
                 </label>
-                <TextInput
+                <Select
                   size="md"
                   variant="outline"
-                  placeholder="Add subject"
+                  placeholder="Priority"
+                  options={TASK_PRIORITY_OPTIONS}
                   value={field.state.value}
-                  onChange={(event) => field.handleChange(event.target.value)}
+                  onChange={(value) =>
+                    field.handleChange(
+                      (value ?? "") as AddTaskFormValues["priority"],
+                    )
+                  }
                 />
                 {!field.state.meta.isValid && (
                   <div className="mt-4">
@@ -225,7 +263,7 @@ const AddTask = ({
           <form.Field
             name="expected_time"
             children={(field) => (
-              <div className="sm:col-span-3">
+              <div>
                 <label className="block text-base text-ink-gray-5 mb-1.5">
                   Expected Time
                 </label>
@@ -237,6 +275,46 @@ const AddTask = ({
                   value={field.state.value}
                   onChange={(event) => field.handleChange(event.target.value)}
                 />
+                {!field.state.meta.isValid && (
+                  <div className="mt-4">
+                    <ErrorMessage
+                      message={field.state.meta.errors[0]?.message}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          />
+
+          <form.Field
+            name="exp_end_date"
+            children={(field) => (
+              <div>
+                <label className="block text-base text-ink-gray-5 mb-1.5">
+                  Due Date
+                </label>
+                <DatePicker
+                  variant="outline"
+                  placeholder="Due Date"
+                  value={field.state.value}
+                  onChange={(value) => field.handleChange(value as string)}
+                >
+                  {({ displayValue, onTriggerKeyDown }) => (
+                    <div className="flex h-8 items-center gap-2 rounded border border-outline-gray-2 bg-surface-white px-2.5">
+                      <input
+                        type="text"
+                        value={displayValue}
+                        readOnly
+                        tabIndex={-1}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onKeyDown={onTriggerKeyDown}
+                        placeholder="Due Date"
+                        className="min-w-0 flex-1 text-base text-ink-gray-7"
+                      />
+                      <Calendar className="size-4 shrink-0" />
+                    </div>
+                  )}
+                </DatePicker>
                 {!field.state.meta.isValid && (
                   <div className="mt-4">
                     <ErrorMessage

--- a/frontend/packages/app/src/pages/tasks/components/add-task/schema.ts
+++ b/frontend/packages/app/src/pages/tasks/components/add-task/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TASK_PRIORITIES } from "../../constants";
 
 const expectedTimeSchema = z
   .string()
@@ -18,6 +19,11 @@ export const addTaskFormSchema = z.object({
     .min(1, { message: "Please select a project." }),
   projectLabel: z.string().optional().default(""),
   expected_time: expectedTimeSchema,
+  priority: z
+    .enum([...TASK_PRIORITIES, ""] as const)
+    .optional()
+    .default(""),
+  exp_end_date: z.string().trim().optional().default(""),
   description: z
     .string({ required_error: "Please enter description." })
     .trim()

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -9,12 +9,16 @@ import { type FrappeError, useFrappeDeleteDoc } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
-import { buildFilterConditions, parseFrappeErrorMsg } from "@/lib/utils";
-import AddTask from "../components/add-task";
-import type { AddTaskPrefill } from "../components/add-task/type";
-import { TASK_LIST_PAGE_SIZE } from "../constants";
+import {
+  buildFilterConditions,
+  parseFrappeErrorMsg,
+  pickAllowed,
+} from "@/lib/utils";
 import { TaskListContext, type TaskListContextProps } from "./context";
 import type { ResponseTaskList } from "./types";
+import AddTask from "../components/add-task";
+import type { AddTaskPrefill } from "../components/add-task/type";
+import { TASK_LIST_PAGE_SIZE, TASK_PRIORITIES } from "../constants";
 import { useTaskFilters } from "../useTaskFilters";
 
 export function TaskListProvider({ children }: PropsWithChildren) {
@@ -39,6 +43,8 @@ export function TaskListProvider({ children }: PropsWithChildren) {
         project: task.project,
         projectLabel: task.project_name ?? task.project,
         expected_time: String(task.expected_time ?? ""),
+        priority: pickAllowed(task.priority, TASK_PRIORITIES) ?? "",
+        exp_end_date: task.exp_end_date ?? "",
         description: task.description ?? "",
       });
       setAddTaskOpen(true);

--- a/next_pms/tests/timesheet/api/test_add_task.py
+++ b/next_pms/tests/timesheet/api/test_add_task.py
@@ -1,0 +1,143 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.timesheet.api.task import add_task
+
+CUSTOMER_NAME = "Add Task Test Customer"
+PROJECT_NAME = "Add Task Test Project"
+
+
+class TestAddTask(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.customer = cls._make_customer(CUSTOMER_NAME)
+        cls.project = cls._make_project(PROJECT_NAME, cls.customer)
+
+    @classmethod
+    def _make_customer(cls, customer_name):
+        existing = frappe.db.get_value("Customer", {"customer_name": customer_name})
+        if existing:
+            return existing
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": customer_name,
+                    "customer_type": "Company",
+                    "default_currency": frappe.get_cached_value("Company", cls.company, "default_currency"),
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project(cls, project_name, customer):
+        if frappe.db.exists("Project", {"project_name": project_name}):
+            return frappe.db.get_value("Project", {"project_name": project_name}, "name")
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": project_name,
+                    "company": cls.company,
+                    "customer": customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def _get_task(self, subject):
+        return frappe.get_doc("Task", {"subject": subject, "project": self.project})
+
+    def test_add_task_creates_task_with_required_fields(self):
+        result = add_task(
+            subject="Minimal task",
+            expected_time="4",
+            project=self.project,
+            description="A minimal task",
+        )
+        self.assertEqual(result, frappe._("Task Created Successfully"))
+
+        task = self._get_task("Minimal task")
+        self.assertEqual(task.expected_time, 4)
+        self.assertEqual(task.description, "A minimal task")
+        # Task.priority is a Select field; with no priority kwarg, Frappe falls
+        # back to the first option ("Low") rather than leaving it blank.
+        self.assertEqual(task.priority, "Low")
+        self.assertFalse(task.exp_end_date)
+
+    def test_add_task_sets_priority_when_provided(self):
+        add_task(
+            subject="Prioritized task",
+            expected_time="2",
+            project=self.project,
+            description="Has a priority",
+            priority="Urgent",
+        )
+        task = self._get_task("Prioritized task")
+        self.assertEqual(task.priority, "Urgent")
+
+    def test_add_task_sets_exp_end_date_when_provided(self):
+        add_task(
+            subject="Due dated task",
+            expected_time="2",
+            project=self.project,
+            description="Has a due date",
+            exp_end_date="2026-09-15",
+        )
+        task = self._get_task("Due dated task")
+        self.assertEqual(frappe.utils.getdate(task.exp_end_date), frappe.utils.getdate("2026-09-15"))
+
+    def test_add_task_sets_both_priority_and_exp_end_date(self):
+        add_task(
+            subject="Fully specified task",
+            expected_time="3",
+            project=self.project,
+            description="Has both",
+            priority="High",
+            exp_end_date="2026-10-01",
+        )
+        task = self._get_task("Fully specified task")
+        self.assertEqual(task.priority, "High")
+        self.assertEqual(frappe.utils.getdate(task.exp_end_date), frappe.utils.getdate("2026-10-01"))
+
+    def test_add_task_treats_empty_string_priority_as_unset(self):
+        add_task(
+            subject="Empty priority task",
+            expected_time="1",
+            project=self.project,
+            description="Priority sent as empty string",
+            priority="",
+        )
+        task = self._get_task("Empty priority task")
+        # add_task only assigns priority when truthy, so an empty string is
+        # ignored and the field is left at Frappe's own Select default ("Low").
+        self.assertEqual(task.priority, "Low")
+
+    def test_add_task_treats_empty_string_exp_end_date_as_unset(self):
+        add_task(
+            subject="Empty due date task",
+            expected_time="1",
+            project=self.project,
+            description="Due date sent as empty string",
+            exp_end_date="",
+        )
+        task = self._get_task("Empty due date task")
+        self.assertFalse(task.exp_end_date)
+
+    def test_add_task_defaults_priority_and_exp_end_date_when_omitted(self):
+        add_task(
+            subject="Omitted optional fields task",
+            expected_time="1",
+            project=self.project,
+            description="No priority/exp_end_date kwargs at all",
+        )
+        task = self._get_task("Omitted optional fields task")
+        self.assertEqual(task.priority, "Low")
+        self.assertFalse(task.exp_end_date)

--- a/next_pms/timesheet/api/task.py
+++ b/next_pms/timesheet/api/task.py
@@ -260,9 +260,16 @@ def get_task_list(
 
 
 @frappe.whitelist(methods=["POST"])
-def add_task(subject: str, expected_time: str, project: str, description: str):
+def add_task(
+    subject: str,
+    expected_time: str,
+    project: str,
+    description: str,
+    priority: str | None = None,
+    exp_end_date: str | None = None,
+):
     """API to add task, it will create a task under the given project with the given details."""
-    frappe.get_doc(
+    task = frappe.get_doc(
         {
             "doctype": "Task",
             "subject": subject,
@@ -270,7 +277,12 @@ def add_task(subject: str, expected_time: str, project: str, description: str):
             "project": project,
             "description": description,
         }
-    ).insert(ignore_permissions=True)
+    )
+    if priority:
+        task.priority = priority
+    if exp_end_date:
+        task.exp_end_date = exp_end_date
+    task.insert(ignore_permissions=True)
     return frappe._("Task Created Successfully")
 
 


### PR DESCRIPTION
## Description
- Adds priority and exp_end_date fields to the "Add Task" dialog, backed by a Select and DatePicker respectively.
- Extends the add_task whitelisted API to accept optional priority and exp_end_date and set them on the created Task doc.
- Updates the task list provider to prefill priority/exp_end_date when editing an existing task.
- Bumps the frappe-ui-react submodule.

## Screenshot/Screencast
https://github.com/user-attachments/assets/7b532d93-7c45-4967-ac69-8a50b6269a3f


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1980