### PR TITLE
feat(allocations): show free capacity for unallocated team members

### DIFF
--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -119,8 +119,9 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
   ) {
     const isTimeoff = variant === "timeoff";
     const isCrosshatch = theme === "crosshatch";
-    const isInteractive = resizable || typeof onClick === "function";
-    const showPointerCursor = typeof onClick === "function";
+    const isResizable = resizable && !passive;
+    const showPointerCursor = !passive && typeof onClick === "function";
+    const isInteractive = isResizable || showPointerCursor;
     const {
       isInteracting,
       liveLeft,
@@ -136,7 +137,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
       snapUnitPx,
       minLeft,
       maxRight,
-      onResizeEnd: resizable ? onResizeEnd : undefined,
+      onResizeEnd: isResizable ? onResizeEnd : undefined,
     });
 
     return (
@@ -160,9 +161,10 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
           top: (CELL_HEIGHT - BAR_HEIGHT) / 2,
         }}
       >
-        {!isTimeoff && variant !== "draft" && isCrosshatch && (
-          <CrosshatchLayer variant={variant ?? "allocation"} />
-        )}
+        {!isTimeoff &&
+          variant !== "draft" &&
+          variant !== "empty" &&
+          isCrosshatch && <CrosshatchLayer variant={variant ?? "allocation"} />}
         {isTimeoff ? (
           <Tooltip text={label}>
             <div className="absolute inset-0 px-2.5 py-2 w-full flex items-center justify-center gap-1.5">
@@ -199,7 +201,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
             {billable === false ? (
               <span className="block ml-1 w-1 h-1 rounded-full bg-surface-amber-3"></span>
             ) : null}
-            {resizable ? (
+            {isResizable ? (
               <>
                 <span
                   className="absolute shrink-0 inset-y-0 left-0 w-2.5 pl-1 flex cursor-ew-resize items-center justify-start touch-none"

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -38,6 +38,7 @@ const ganttBarVariants = cva(
         allocation:
           "bg-surface-white text-ink-gray-5 shadow-[0px_0px_1px_0px_rgba(0,0,0,0.14),0px_1px_3px_0px_rgba(0,0,0,0.14)]",
         draft: "bg-surface-gray-2 text-ink-gray-5",
+        empty: "bg-surface-gray-2/60 text-ink-gray-4",
       },
     },
   },
@@ -80,6 +81,12 @@ interface GanttBarProps
   showInlineLabel?: boolean;
   trailingLabel?: React.ReactNode;
   trailingLabelVariant?: GanttBarTrailingLabelVariant;
+  /**
+   * Renders the bar as a non-interactive background layer: adds
+   * pointer-events-none and omits `data-gantt-bar`, so it doesn't trip the
+   * row's add-allocation hover/occupancy detection (see RowAllocationOverlay).
+   */
+  passive?: boolean;
 }
 
 export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
@@ -103,6 +110,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
       showInlineLabel = true,
       trailingLabel,
       trailingLabelVariant,
+      passive = false,
       onClick,
       style,
       ...htmlProps
@@ -134,11 +142,12 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
     return (
       <div
         ref={ref}
-        data-gantt-bar="true"
+        data-gantt-bar={passive ? undefined : "true"}
         className={cn(
           ganttBarVariants({ variant }),
           isInteracting && "z-5",
           showPointerCursor && "cursor-pointer",
+          passive && "pointer-events-none",
           className,
         )}
         {...htmlProps}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
@@ -48,6 +48,23 @@ export function GanttMemberSummaryBar({
   const left = summary.barOffset + headerWidth;
   const { width } = summary;
 
+  if (summary.type === "free") {
+    const { label } = getCapacityStatus(
+      0,
+      members[memberInd].capacityHoursPerDay,
+    );
+
+    return (
+      <GanttBar
+        variant="empty"
+        passive
+        label={label}
+        left={left}
+        width={width}
+      />
+    );
+  }
+
   if (summary.type === "timeoff") {
     const leaveDays =
       differenceInCalendarDays(summary.endDate, summary.startDate) + 1;

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -141,10 +141,10 @@ export function getFreeCapacitySegments(
     const dayOfWeek = day.getDay();
     if (dayOfWeek === 0 || dayOfWeek === 6) continue;
 
-    const key = startOfDay(day).getTime();
-    if (coveredDays.has(key)) continue;
+    const dayStart = startOfDay(day);
+    if (coveredDays.has(dayStart.getTime())) continue;
 
-    freeDays.push(startOfDay(day));
+    freeDays.push(dayStart);
   }
 
   const merged: MemberBarAllocation[] = [];

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -61,8 +61,7 @@ export function getAllocationSummary(
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
       type: (dayIsTimeoff.get(ts) ? "timeoff" : "default") as
-        | "default"
-        | "timeoff",
+        "default" | "timeoff",
     }));
 
   const merged: MemberBarAllocation[] = [];

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -61,7 +61,8 @@ export function getAllocationSummary(
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
       type: (dayIsTimeoff.get(ts) ? "timeoff" : "default") as
-        "default" | "timeoff",
+        | "default"
+        | "timeoff",
     }));
 
   const merged: MemberBarAllocation[] = [];
@@ -101,4 +102,65 @@ export function getMemberAllocation(
 ): MemberBarAllocation[] {
   const allAllocs = projects.flatMap((p) => p.allocations ?? []);
   return getAllocationSummary(allAllocs, leaves);
+}
+
+/**
+ * Collects the local-midnight day keys already covered by an allocation or
+ * leave segment (i.e. everything `getAllocationSummary` already emitted a
+ * bar for).
+ */
+export function getCoveredDayKeys(summary: MemberBarAllocation[]): Set<number> {
+  const coveredDays = new Set<number>();
+
+  for (const segment of summary) {
+    for (const day of eachDayOfInterval({
+      start: segment.startDate,
+      end: segment.endDate,
+    })) {
+      coveredDays.add(startOfDay(day).getTime());
+    }
+  }
+
+  return coveredDays;
+}
+
+/**
+ * Builds merged "free capacity" segments for every weekday in
+ * [rangeStart, rangeEnd] that isn't already covered by an allocation or
+ * leave. Weekends are always excluded, regardless of the showWeekend toggle.
+ */
+export function getFreeCapacitySegments(
+  coveredDays: Set<number>,
+  rangeStart: Date,
+  rangeEnd: Date,
+): MemberBarAllocation[] {
+  if (rangeEnd < rangeStart) return [];
+
+  const freeDays: Date[] = [];
+  for (const day of eachDayOfInterval({ start: rangeStart, end: rangeEnd })) {
+    const dayOfWeek = day.getDay();
+    if (dayOfWeek === 0 || dayOfWeek === 6) continue;
+
+    const key = startOfDay(day).getTime();
+    if (coveredDays.has(key)) continue;
+
+    freeDays.push(startOfDay(day));
+  }
+
+  const merged: MemberBarAllocation[] = [];
+  for (const date of freeDays) {
+    const last = merged[merged.length - 1];
+    if (last && isSameDay(addDays(last.endDate, 1), date)) {
+      last.endDate = date;
+    } else {
+      merged.push({
+        hours: 0,
+        startDate: date,
+        endDate: date,
+        type: "free",
+      });
+    }
+  }
+
+  return merged;
 }

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -85,16 +85,16 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
           />
         ))}
         <GanttRowOverlayCell>
-          {member.freeCapacityBars.map((summary, idx) => (
+          {member.freeCapacityBars.map((summary) => (
             <GanttMemberSummaryBar
-              key={`free-${idx}`}
+              key={`${summary.type}-${summary.startDate.getTime()}-${summary.endDate.getTime()}`}
               summary={summary}
               memberInd={memberInd}
             />
           ))}
-          {member.memberSummaryBars.map((summary, idx) => (
+          {member.memberSummaryBars.map((summary) => (
             <GanttMemberSummaryBar
-              key={idx}
+              key={`${summary.type}-${summary.startDate.getTime()}-${summary.endDate.getTime()}`}
               summary={summary}
               memberInd={memberInd}
             />

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRows.tsx
@@ -85,6 +85,13 @@ export const GanttMemberRows: React.FC<GanttMemberRowsProps> = ({
           />
         ))}
         <GanttRowOverlayCell>
+          {member.freeCapacityBars.map((summary, idx) => (
+            <GanttMemberSummaryBar
+              key={`free-${idx}`}
+              summary={summary}
+              memberInd={memberInd}
+            />
+          ))}
           {member.memberSummaryBars.map((summary, idx) => (
             <GanttMemberSummaryBar
               key={idx}

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,5 +1,7 @@
 export type DeleteAllocationMode =
-  "only_this" | "this_and_future" | "all_in_series";
+  | "only_this"
+  | "this_and_future"
+  | "all_in_series";
 
 export interface Allocation {
   /** Unique identifier for the allocation. */
@@ -48,7 +50,7 @@ export interface Allocation {
 }
 
 export interface MemberBarAllocation extends Allocation {
-  type?: "default" | "timeoff";
+  type?: "default" | "timeoff" | "free";
 }
 
 export interface LeaveAllocation {

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,7 +1,5 @@
 export type DeleteAllocationMode =
-  | "only_this"
-  | "this_and_future"
-  | "all_in_series";
+  "only_this" | "this_and_future" | "all_in_series";
 
 export interface Allocation {
   /** Unique identifier for the allocation. */

--- a/frontend/packages/design-system/src/components/gantt-view/utils.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/utils.ts
@@ -6,7 +6,11 @@ import { addDays, eachDayOfInterval, isSameDay, startOfDay } from "date-fns";
 /**
  * Internal dependencies.
  */
-import { getMemberAllocation } from "./gantt-bar/utils/getMemberAllocation";
+import {
+  getCoveredDayKeys,
+  getFreeCapacitySegments,
+  getMemberAllocation,
+} from "./gantt-bar/utils/getMemberAllocation";
 import { getNumDays } from "./gantt-bar/utils/getNumDays";
 import type {
   Allocation,
@@ -48,6 +52,7 @@ export interface MemberProject extends SourceProject {
 export interface Member extends SourceMember {
   projects: MemberProject[];
   memberSummaryBars: MemberSummaryBar[];
+  freeCapacityBars: MemberSummaryBar[];
 }
 
 export type ProjectMemberAllocationBar = ProjectAllocationBar;
@@ -324,10 +329,26 @@ export const prepareMemberBars = (
       columnWidth,
     );
 
+    const coveredDays = getCoveredDayKeys(rawMemberSummaryAllocations);
+    const rangeStart = getDateAtColumnIndex(0, weekStart, showWeekend);
+    const rangeEnd = getDateAtColumnIndex(
+      columnCount - 1,
+      weekStart,
+      showWeekend,
+    );
+    const freeCapacityBars = prepareMemberSummaryBars(
+      getFreeCapacitySegments(coveredDays, rangeStart, rangeEnd),
+      weekStart,
+      columnCount,
+      showWeekend,
+      columnWidth,
+    );
+
     return {
       ...member,
       projects,
       memberSummaryBars,
+      freeCapacityBars,
     };
   });
 };


### PR DESCRIPTION
## Description
- Team Allocations previously left a day cell blank when a member had no allocation, making it impossible to tell "fully available" apart from "missing data". Blank weekdays now show the member's full daily capacity (e.g. "8h free"), using the same `capacityHoursPerDay` resolution that already drives "Full"/"Xh free".
- Free-capacity bars render as a separate, non-interactive layer (new `empty` variant + `passive` prop on `GanttBar`) so the existing "+" add-allocation hover/click affordance is completely unaffected.
- Weekends stay blank regardless of the 5-day/7-day view toggle; leave days still render "N day(s) off" unchanged.

## Screenshot/Screencast

https://github.com/user-attachments/assets/1b2850a7-3805-4e65-98f1-2e2a1214f0e2

<img width="2430" height="1544" alt="image" src="https://github.com/user-attachments/assets/189f18f4-b3fb-442b-bae4-2660efe31926" />

Dark Mode:
<img width="2910" height="1538" alt="image (1)" src="https://github.com/user-attachments/assets/c31449df-f062-4dbb-a400-607c7c55cde5" />

With Weekends:
<img width="3820" height="1906" alt="image" src="https://github.com/user-attachments/assets/9177ad58-a0f0-4737-ac34-9a31b59a1821" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1952