### PR TITLE
Feat: Add weekly rejection message in manager's weekly approval popup

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/approvalPopup.tsx
@@ -35,18 +35,9 @@ const ApprovalPopup = () => {
   } = useWeeklyApproval();
 
   const allEntries = groupedByDay.flatMap((dayGroup) => dayGroup.entries);
-  const rejectedEntriesCount = allEntries.filter(
-    (entry) => entry.approvalStatus === "Rejected",
-  ).length;
-  const hasRejectedEntries = rejectedEntriesCount > 0;
-  const isFullyRejected =
-    hasRejectedEntries && rejectedEntriesCount === allEntries.length;
-
-  const summaryText = hasRejectedEntries
-    ? isFullyRejected
-      ? "This timesheet is rejected."
-      : "This timesheet is partially rejected."
-    : null;
+  const weeklyRejectionReason = allEntries
+    .map((entry) => entry.weeklyRejectionReason?.trim())
+    .find((reason) => Boolean(reason));
 
   return (
     <Dialog.Popup className="fixed right-0 top-0 max-w-120 w-full h-[calc(100vh-20px)] m-2.5 z-101 bg-surface-modal rounded-xl shadow-xl flex flex-col">
@@ -68,8 +59,15 @@ const ApprovalPopup = () => {
           </Dialog.Close>
         </div>
       </div>
-      {summaryText ? (
-        <p className="p-4 text-sm text-ink-red-4">{summaryText}</p>
+      {weeklyRejectionReason ? (
+        <div className="p-4 text-sm text-ink-red-4 space-y-1">
+          <p className="font-medium text-md text-ink-red-4">
+            Weekly Rejection Reason:
+          </p>
+          <p className="text-ink-red-5 whitespace-pre-line">
+            {weeklyRejectionReason}
+          </p>
+        </div>
       ) : null}
       {/* Content */}
       <div className="flex-1 overflow-y-auto scrollbar">

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/types.ts
@@ -40,6 +40,7 @@ export interface TimesheetEntry {
   leaveLabel?: string;
   approvalStatus?: ApprovalStatusLabelType;
   rejectionReason?: string;
+  weeklyRejectionReason?: string;
 }
 
 export interface TaskDataEntry {
@@ -56,6 +57,7 @@ export interface TaskDataEntry {
   docstatus: number;
   custom_approval_status?: ApprovalStatusLabelType | null;
   custom_rejection_reason?: string | null;
+  custom_weekly_rejection_reason?: string | null;
 }
 
 export interface Task {

--- a/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/weekly-approval/utils.ts
@@ -139,6 +139,8 @@ export const convertTimesheetToEntries = (response: TimesheetApiResponse) => {
             leaveHours > 0 ? getLeaveLabelForDate(leaves, date) : undefined,
           approvalStatus: entry.custom_approval_status || undefined,
           rejectionReason: entry.custom_rejection_reason || undefined,
+          weeklyRejectionReason:
+            entry.custom_weekly_rejection_reason || undefined,
         });
       });
     }

--- a/frontend/packages/app/src/types/timesheet.ts
+++ b/frontend/packages/app/src/types/timesheet.ts
@@ -39,7 +39,6 @@ export interface TaskDataItemProps {
   project_name?: string | null;
   custom_approval_status?: ApprovalStatusLabelType | null;
   custom_rejection_reason?: string | null;
-  custom_weekly_rejection_reason?: string | null;
 }
 
 export interface LeaveProps {

--- a/frontend/packages/app/src/types/timesheet.ts
+++ b/frontend/packages/app/src/types/timesheet.ts
@@ -39,6 +39,7 @@ export interface TaskDataItemProps {
   project_name?: string | null;
   custom_approval_status?: ApprovalStatusLabelType | null;
   custom_rejection_reason?: string | null;
+  custom_weekly_rejection_reason?: string | null;
 }
 
 export interface LeaveProps {

--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -548,7 +548,7 @@ def get_timesheet(dates: list, employee: str, search: str | None = None, parsed_
     timesheets = frappe.get_all(
         "Timesheet",
         filters=ts_filters,
-        fields=["name", "custom_approval_status", "custom_rejection_reason"],
+        fields=["name", "custom_approval_status", "custom_rejection_reason", "custom_weekly_rejection_reason"],
         ignore_permissions=employee_has_higher_access(employee, ptype="read"),
     )
 
@@ -638,6 +638,7 @@ def get_timesheet(dates: list, employee: str, search: str | None = None, parsed_
         parent_ts = ts_parent_map.get(log.get("parent"))
         entry["custom_approval_status"] = parent_ts.get("custom_approval_status") if parent_ts else None
         entry["custom_rejection_reason"] = parent_ts.get("custom_rejection_reason") if parent_ts else None
+        entry["custom_weekly_rejection_reason"] = parent_ts.get("custom_weekly_rejection_reason") if parent_ts else None
         data[task_name]["data"].append(entry)
 
     return [data, total_hours]


### PR DESCRIPTION
## Description

Display the weekly rejection message in the manager's weekly approval popup


## Testing Instructions

- Open the team Timesheet page as a manager
- Open weekly approval popup for a week that is fully rejected
- Observe the weekly rejection reason to be displayed at top of the popup

## Screenshot/Screencast


https://github.com/user-attachments/assets/41a321ea-75ff-4584-a22a-4e3f24f353dd




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Part of: https://github.com/rtCamp/next-pms/issues/1741