### PR TITLE
feat: time report frequency option in project

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,6 +64,7 @@ jobs:
           bench get-app hrms --branch version-16 --skip-assets
           bench get-app frappe_gmail_thread https://github.com/rtCamp/frappe-gmail-thread --branch version-16-hotfix --skip-assets
           bench get-app frappe_comment_xt https://github.com/rtCamp/frappe-comment-xt --branch version-16-hotfix --skip-assets
+          bench get-app frappe_slack_connector https://github.com/rtCamp/frappe-slack-connector --branch version-16-hotfix --skip-assets
           if [ -n "$RTBOT_TOKEN" ]; then
             git config --global "url.https://rtbot:${RTBOT_TOKEN}@github.com/rtCamp/.insteadOf" "https://github.com/rtCamp/"
             bench get-app telephony --branch develop --skip-assets
@@ -82,7 +83,7 @@ jobs:
           fi
           bench get-app next_pms "$GITHUB_WORKSPACE" --skip-assets
           bench new-site --db-root-password root --admin-password admin --no-mariadb-socket test_site
-          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt $PRIVATE_APPS next_pms
+          bench --site test_site install-app erpnext hrms frappe_gmail_thread frappe_comment_xt frappe_slack_connector $PRIVATE_APPS next_pms
         env:
           CI: "Yes"
           RTBOT_TOKEN: ${{ secrets.RTBOT_TOKEN }}

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Button,
   Skeleton,
@@ -73,23 +73,28 @@ export function Overview() {
 function OverviewForm() {
   const { project, projectId, mutate } = useProjectDetail((state) => state);
 
-  const defaultValues: OverviewFormValues = {
-    summary: project?.custom_executive_summary ?? "",
-    keyGoals: project?.custom_key_goals ?? "",
-    priority: project?.priority ?? "",
-    host: project?.custom_host ?? "",
-    complexity: project?.custom_complexity ?? "",
-    keyAccount: project?.custom_key_account ?? "",
-    source: project?.custom_source ?? "",
-    primaryLocation: project?.custom_territory ?? "",
-    previousCms: project?.custom_previous_cms ?? "",
-    pointOfContact: project?.custom_client_point_of_contact ?? "",
-    frequency: project?.frequency ?? "",
-    ndaSigned: toBoolStr(project?.custom_restricted_under_nda),
-    caseStudyApproved: toBoolStr(project?.custom_permission_for_case_study),
-    testimonialApproval: toBoolStr(project?.custom_permission_for_testimonial),
-    testimonialContact: project?.custom_testimonial_contact ?? "",
-  };
+  const defaultValues: OverviewFormValues = useMemo(
+    () => ({
+      summary: project?.custom_executive_summary ?? "",
+      keyGoals: project?.custom_key_goals ?? "",
+      priority: project?.priority ?? "",
+      host: project?.custom_host ?? "",
+      complexity: project?.custom_complexity ?? "",
+      keyAccount: project?.custom_key_account ?? "",
+      source: project?.custom_source ?? "",
+      primaryLocation: project?.custom_territory ?? "",
+      previousCms: project?.custom_previous_cms ?? "",
+      pointOfContact: project?.custom_client_point_of_contact ?? "",
+      timeReportFrequency: project?.custom_time_report_frequency ?? "",
+      ndaSigned: toBoolStr(project?.custom_restricted_under_nda),
+      caseStudyApproved: toBoolStr(project?.custom_permission_for_case_study),
+      testimonialApproval: toBoolStr(
+        project?.custom_permission_for_testimonial,
+      ),
+      testimonialContact: project?.custom_testimonial_contact ?? "",
+    }),
+    [project],
+  );
 
   const [isEditing, setIsEditing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -110,7 +115,7 @@ function OverviewForm() {
         custom_territory: value.primaryLocation,
         custom_previous_cms: value.previousCms,
         custom_client_point_of_contact: value.pointOfContact,
-        frequency: value.frequency,
+        custom_time_report_frequency: value.timeReportFrequency,
         custom_restricted_under_nda: Number(value.ndaSigned) as 0 | 1,
         custom_permission_for_case_study: Number(value.caseStudyApproved) as
           0 | 1,

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/schema.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/schema.ts
@@ -11,7 +11,7 @@ export const overviewSchema = z.object({
   primaryLocation: z.string(),
   previousCms: z.string(),
   pointOfContact: z.string(),
-  frequency: z.string(),
+  timeReportFrequency: z.string(),
   ndaSigned: z.string(),
   caseStudyApproved: z.string(),
   testimonialApproval: z.string(),

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/sections/communication.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/sections/communication.tsx
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { Combobox, Select } from "@rtcamp/frappe-ui-react";
 import { CalendarDeadline, Contact } from "@rtcamp/frappe-ui-react/icons";
+import { useFrappeGetDocList } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
@@ -15,13 +16,6 @@ import { OverviewSection } from "../components/overviewSection";
 import type { OverviewFormApi } from "../index";
 
 const EMPTY = "—";
-
-const FREQUENCY_OPTIONS = [
-  { label: "Hourly", value: "Hourly" },
-  { label: "Twice Daily", value: "Twice Daily" },
-  { label: "Daily", value: "Daily" },
-  { label: "Weekly", value: "Weekly" },
-];
 
 type CommunicationProps = {
   form: OverviewFormApi;
@@ -36,6 +30,18 @@ export function Communication({
 }: CommunicationProps) {
   const customer = useProjectDetail((state) => state.project?.customer ?? "");
   const [contactSearch, setContactSearch] = useState("");
+  const { data: frequencies } = useFrappeGetDocList<{ name: string }>(
+    "Project Time Report Frequency",
+    {
+      fields: ["name"],
+      limit: 100,
+      orderBy: { field: "creation", order: "asc" },
+    },
+  );
+  const frequencyOptions = (frequencies ?? []).map((f) => ({
+    label: f.name,
+    value: f.name,
+  }));
   const { options: contactOptions, isLoading: isContactLoading } =
     useCustomerContactLookup({
       customer,
@@ -69,7 +75,7 @@ export function Communication({
           )}
         </form.Field>
 
-        <form.Field name="frequency">
+        <form.Field name="timeReportFrequency">
           {(field) => (
             <EditableField
               icon={<CalendarDeadline className="size-[18px]" />}
@@ -80,7 +86,7 @@ export function Communication({
               <Select
                 value={field.state.value}
                 onChange={(v) => field.handleChange(v || "")}
-                options={FREQUENCY_OPTIONS}
+                options={frequencyOptions}
                 disabled={submitting}
               />
             </EditableField>

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/sections/communication.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/sections/communication.tsx
@@ -38,10 +38,10 @@ export function Communication({
       orderBy: { field: "creation", order: "asc" },
     },
   );
-  const frequencyOptions = (frequencies ?? []).map((f) => ({
-    label: f.name,
-    value: f.name,
-  }));
+  const frequencyOptions = [
+    { label: "None", value: "" },
+    ...(frequencies ?? []).map((f) => ({ label: f.name, value: f.name })),
+  ];
   const { options: contactOptions, isLoading: isContactLoading } =
     useCustomerContactLookup({
       customer,

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/sections/communication.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/sections/communication.tsx
@@ -37,6 +37,7 @@ export function Communication({
       limit: 100,
       orderBy: { field: "creation", order: "asc" },
     },
+    isEditing ? undefined : null,
   );
   const frequencyOptions = [
     { label: "None", value: "" },

--- a/frontend/packages/app/src/pages/project-details/types.ts
+++ b/frontend/packages/app/src/pages/project-details/types.ts
@@ -113,6 +113,7 @@ export interface ProjectDoc {
   users?: ProjectUser[];
   copied_from?: string;
   notes?: string;
+  custom_time_report_frequency?: string;
   collect_progress?: 0 | 1;
   holiday_list?: string;
   frequency?: "Hourly" | "Twice Daily" | "Daily" | "Weekly";

--- a/next_pms/install.py
+++ b/next_pms/install.py
@@ -14,6 +14,7 @@ def after_install():
     setup_timesheet_rejection_reason_field()
     setup_timesheet_weekly_rejection_reason_field()
     setup_task_permissions()
+    setup_time_report_frequency()
 
 
 def setup_timesheet_rejection_reason_field():
@@ -73,6 +74,34 @@ def setup_project_target_hours_field():
             ]
         }
     )
+
+
+def setup_time_report_frequency():
+    import frappe
+    from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+    from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+    create_custom_fields(
+        {
+            "Project": [
+                {
+                    "fieldname": "custom_time_report_frequency",
+                    "fieldtype": "Link",
+                    "label": "Time Report Frequency",
+                    "options": "Project Time Report Frequency",
+                    "insert_after": "custom_duration",
+                },
+            ]
+        }
+    )
+
+    for frequency in ("Weekly", "Bi-weekly", "Monthly"):
+        if not frappe.db.exists("Project Time Report Frequency", frequency):
+            frappe.get_doc({"doctype": "Project Time Report Frequency", "name": frequency}).insert(
+                ignore_permissions=True
+            )
+
+    make_property_setter("Project", "collect_progress", "hidden", 1, "Check")
 
 
 def setup_project_custom_fields():

--- a/next_pms/next_pms/doctype/project_time_report_frequency/project_time_report_frequency.js
+++ b/next_pms/next_pms/doctype/project_time_report_frequency/project_time_report_frequency.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, rtCamp and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Project Time Report Frequency", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/next_pms/next_pms/doctype/project_time_report_frequency/project_time_report_frequency.json
+++ b/next_pms/next_pms/doctype/project_time_report_frequency/project_time_report_frequency.json
@@ -1,0 +1,106 @@
+{
+ "actions": [],
+ "allow_bulk_edit": 1,
+ "allow_rename": 1,
+ "autoname": "prompt",
+ "creation": "2026-08-10 14:52:02.549271",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_phle"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_phle",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-10 14:57:00.799596",
+ "modified_by": "Administrator",
+ "module": "Next PMS",
+ "name": "Project Time Report Frequency",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Delivery Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Delivery User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Timesheet Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/next_pms/next_pms/doctype/project_time_report_frequency/project_time_report_frequency.py
+++ b/next_pms/next_pms/doctype/project_time_report_frequency/project_time_report_frequency.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ProjectTimeReportFrequency(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+    # end: auto-generated types
+
+    pass

--- a/next_pms/next_pms/doctype/project_time_report_frequency/test_project_time_report_frequency.py
+++ b/next_pms/next_pms/doctype/project_time_report_frequency/test_project_time_report_frequency.py
@@ -48,7 +48,7 @@ class IntegrationTestProjectTimeReportFrequency(IntegrationTestCase):
         )
 
     def make_frequency(self, name):
-        return frappe.get_doc({"doctype": FREQUENCY_DOCTYPE, "__newname": name}).insert()
+        return frappe.get_doc({"doctype": FREQUENCY_DOCTYPE, "name": name}).insert()
 
     def make_project(self, project_name, frequency=None):
         return frappe.get_doc(

--- a/next_pms/next_pms/doctype/project_time_report_frequency/test_project_time_report_frequency.py
+++ b/next_pms/next_pms/doctype/project_time_report_frequency/test_project_time_report_frequency.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, rtCamp and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestProjectTimeReportFrequency(IntegrationTestCase):
+    """
+    Integration tests for ProjectTimeReportFrequency.
+    Use this class for testing interactions between multiple components.
+    """
+
+    pass

--- a/next_pms/next_pms/doctype/project_time_report_frequency/test_project_time_report_frequency.py
+++ b/next_pms/next_pms/doctype/project_time_report_frequency/test_project_time_report_frequency.py
@@ -1,14 +1,20 @@
 # Copyright (c) 2026, rtCamp and Contributors
 # See license.txt
 
-# import frappe
+import frappe
+from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
+
+from next_pms.install import setup_time_report_frequency
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+FREQUENCY_DOCTYPE = "Project Time Report Frequency"
+DEFAULT_FREQUENCIES = ("Weekly", "Bi-weekly", "Monthly")
 
 
 class IntegrationTestProjectTimeReportFrequency(IntegrationTestCase):
@@ -17,4 +23,86 @@ class IntegrationTestProjectTimeReportFrequency(IntegrationTestCase):
     Use this class for testing interactions between multiple components.
     """
 
-    pass
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        setup_time_report_frequency()
+        cls.company = get_default_company()
+        cls.customer = cls._ensure_customer()
+
+    @classmethod
+    def _ensure_customer(cls):
+        customer = frappe.db.get_value("Customer", {}, "name")
+        if customer:
+            return customer
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": "_Test Time Report Customer",
+                    "customer_type": "Company",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    def make_frequency(self, name):
+        return frappe.get_doc({"doctype": FREQUENCY_DOCTYPE, "__newname": name}).insert()
+
+    def make_project(self, project_name, frequency=None):
+        return frappe.get_doc(
+            {
+                "doctype": "Project",
+                "project_name": project_name,
+                "company": self.company,
+                "customer": self.customer,
+                "custom_time_report_frequency": frequency,
+            }
+        ).insert()
+
+    def test_frequency_is_named_from_prompt(self):
+        frequency = self.make_frequency("_Test Time Report Frequency Naming")
+        self.assertEqual(frequency.name, "_Test Time Report Frequency Naming")
+        self.assertTrue(frappe.db.exists(FREQUENCY_DOCTYPE, frequency.name))
+
+    def test_project_links_to_frequency(self):
+        frequency = self.make_frequency("_Test Time Report Frequency Linked")
+        project = self.make_project("_Test Time Report Project Linked", frequency.name)
+        self.assertEqual(project.custom_time_report_frequency, frequency.name)
+
+    def test_project_rejects_unknown_frequency(self):
+        self.assertRaises(
+            frappe.LinkValidationError,
+            self.make_project,
+            "_Test Time Report Project Bad Link",
+            "_Test Time Report Frequency Missing",
+        )
+
+    def test_rename_propagates_to_linked_projects(self):
+        frequency = self.make_frequency("_Test Time Report Frequency Old Name")
+        project = self.make_project("_Test Time Report Project Renamed", frequency.name)
+        frappe.rename_doc(FREQUENCY_DOCTYPE, frequency.name, "_Test Time Report Frequency New Name")
+        project.reload()
+        self.assertEqual(project.custom_time_report_frequency, "_Test Time Report Frequency New Name")
+
+    def test_delete_is_blocked_while_projects_reference_frequency(self):
+        frequency = self.make_frequency("_Test Time Report Frequency Referenced")
+        self.make_project("_Test Time Report Project Reference", frequency.name)
+        self.assertRaises(frappe.LinkExistsError, frequency.delete)
+
+    def test_delete_unreferenced_frequency(self):
+        frequency = self.make_frequency("_Test Time Report Frequency Deletable")
+        frequency.delete()
+        self.assertFalse(frappe.db.exists(FREQUENCY_DOCTYPE, "_Test Time Report Frequency Deletable"))
+
+    def test_setup_creates_default_frequencies(self):
+        setup_time_report_frequency()
+        for frequency in DEFAULT_FREQUENCIES:
+            self.assertTrue(frappe.db.exists(FREQUENCY_DOCTYPE, frequency))
+
+    def test_setup_is_idempotent(self):
+        setup_time_report_frequency()
+        setup_time_report_frequency()
+        for frequency in DEFAULT_FREQUENCIES:
+            self.assertEqual(frappe.db.count(FREQUENCY_DOCTYPE, {"name": frequency}), 1)

--- a/next_pms/next_pms/patches/setup_time_report_frequency.py
+++ b/next_pms/next_pms/patches/setup_time_report_frequency.py
@@ -1,0 +1,13 @@
+import frappe
+
+from next_pms.install import setup_time_report_frequency
+
+
+def execute():
+    setup_time_report_frequency()
+
+    project = frappe.qb.DocType("Project")
+    frappe.qb.update(project).set(project.collect_progress, 0).where(project.collect_progress == 1).run()
+    frappe.qb.update(project).set(project.custom_time_report_frequency, "Weekly").where(
+        project.frequency == "Weekly"
+    ).run()

--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -37,3 +37,4 @@ next_pms.next_projects.patches.setup_task_permissions
 next_pms.timesheet.patches.delete_legacy_project_views
 next_pms.timesheet.patches.add_team_timesheet_indexes
 next_pms.timesheet.patches.setup_timesheet_weekly_rejection_reason_field
+next_pms.next_pms.patches.setup_time_report_frequency


### PR DESCRIPTION
## Description

added the time report frequency option in projects

## Relevant Technical Choices

1. added a new doctype to hold the types 
2. added patch and install scripts for migrations 
3. added frontend ui changes
4. added frappe slack connector to the ci

## Testing Instructions

1. a new field called `custom_time_report_frequency` now holds the data
2. the old `collect progress` button in `connections` tab backend is now hidden and completely dormant
3. the new field will have the data of `weekly` if the `frequency` was `weekly` (remaining will all go to empty)

## Screenshot/Screencast

<img width="1240" height="306" alt="image" src="https://github.com/user-attachments/assets/0c0e2654-7bca-4da5-b761-81542e16fd87" />

<img width="242" height="190" alt="image" src="https://github.com/user-attachments/assets/8c1a5010-141a-4139-b6aa-2567181bb238" />

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1910