### PR TITLE
fix: timesheet daily rejection reason propagated to new (day, project) timesheet pair

### DIFF
--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -20,7 +20,9 @@ EMPLOYEE_USER = "rejection-reason-test-employee@example.com"
 
 CUSTOMER_NAME = "Rejection Reason Test Customer"
 PROJECT_NAME = "Rejection Reason Test Project"
+PROJECT_NAME_B = "Rejection Reason Test Project B"
 TASK_SUBJECT = "Rejection Reason Test Task"
+TASK_SUBJECT_B = "Rejection Reason Test Task B"
 HOLIDAY_LIST = "Rejection Reason Test Holiday List"
 
 MON, TUE, WED, THU, FRI = "2026-09-07", "2026-09-08", "2026-09-09", "2026-09-10", "2026-09-11"
@@ -118,6 +120,24 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
                 ignore_permissions=True
             )
         cls.task = frappe.db.get_value("Task", {"subject": TASK_SUBJECT})
+
+        if not frappe.db.exists("Project", {"project_name": PROJECT_NAME_B}):
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": PROJECT_NAME_B,
+                    "company": cls.company,
+                    "customer": cls.customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            ).insert(ignore_permissions=True)
+        cls.project_b = frappe.db.get_value("Project", {"project_name": PROJECT_NAME_B})
+
+        if not frappe.db.exists("Task", {"subject": TASK_SUBJECT_B}):
+            frappe.get_doc({"doctype": "Task", "subject": TASK_SUBJECT_B, "project": cls.project_b}).insert(
+                ignore_permissions=True
+            )
+        cls.task_b = frappe.db.get_value("Task", {"subject": TASK_SUBJECT_B})
 
         frappe.clear_cache()
         get_holidays.clear_cache()
@@ -295,6 +315,51 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             self.assertEqual(by_date[date].custom_rejection_reason or "", "")
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Approved")
         self.assert_weekly_rejection_reason(by_date, None)
+
+    def test_day_rejection_propagates_to_new_same_day_timesheet(self):
+        # Reject Tuesday on project A, then open a new project B timesheet that day.
+        self.decide_timesheets("Rejected", [TUE], note=TUE_REASON)
+        save_timesheet(
+            date=TUE,
+            description="New project work after Tuesday was rejected",
+            task=self.task_b,
+            hours=1,
+            employee=self.employee,
+        )
+
+        tue_timesheets = frappe.get_all(
+            "Timesheet",
+            filters={
+                "employee": self.employee,
+                "start_date": TUE,
+                "end_date": TUE,
+                "docstatus": ["!=", 2],
+            },
+            fields=["name", "parent_project", "custom_approval_status", "custom_rejection_reason"],
+        )
+        self.assertEqual(len(tue_timesheets), 2)
+        for ts in tue_timesheets:
+            self.assertEqual(ts.custom_approval_status, "Rejected")
+            self.assertEqual(ts.custom_rejection_reason, TUE_REASON)
+
+        # Other days stay pending and untouched.
+        by_date = {
+            str(row.start_date): row
+            for row in frappe.get_all(
+                "Timesheet",
+                filters={
+                    "employee": self.employee,
+                    "start_date": [">=", MON],
+                    "end_date": ["<=", FRI],
+                    "parent_project": self.project,
+                    "docstatus": ["!=", 2],
+                },
+                fields=["start_date", "custom_approval_status", "custom_rejection_reason"],
+            )
+        }
+        for date in (MON, WED, THU, FRI):
+            self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
+            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
 
     def test_full_week_reject_sets_shared_weekly_rejection_reason(self):
         self.decide_timesheets("Rejected", WEEK_DATES, note=WEEK_REASON)

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -176,6 +176,29 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
                 highest_value = priority[status]
         final_status_per_day[day] = highest_status or "Not Submitted"
 
+    # propagate day rejection reason to new timesheets created on the same day
+    day_rejection_updates = {}
+    for day, timesheets in timesheet_by_start_date.items():
+        if final_status_per_day.get(day) != "Rejected":
+            continue
+        reasons = []
+        seen = set()
+        for ts in timesheets:
+            if ts.get("custom_approval_status") != "Rejected":
+                continue
+            reason = (ts.get("custom_rejection_reason") or "").strip()
+            if reason and reason not in seen:
+                seen.add(reason)
+                reasons.append(reason)
+        day_reason = "\n".join(reasons) if reasons else None
+        for ts in timesheets:
+            if ts.get("custom_approval_status") not in (None, "Not Submitted"):
+                continue
+            day_rejection_updates[ts["name"]] = {
+                "custom_approval_status": "Rejected",
+                "custom_rejection_reason": day_reason,
+            }
+
     week_status = "Not Submitted"
 
     status_count = {
@@ -229,6 +252,7 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
             {
                 "custom_weekly_approval_status": week_status,
                 "custom_weekly_rejection_reason": weekly_rejection_reason,
+                **day_rejection_updates.get(timesheet.name, {}),
             },
             update_modified=False,
         )


### PR DESCRIPTION
## Description

timesheet daily rejection reason propagated to new (day, project) timesheet pair

## Relevant Technical Choices

1. added a check for it every time a timesheet is submitted

## Testing Instructions

https://github.com/rtCamp/next-pms/issues/1741#issuecomment-5251351775

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #https://github.com/rtCamp/next-pms/issues/1741#issuecomment-5251351775