### PR TITLE
Feature: add disallowAfter to report duration input

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/reports/reportGenerationForm.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/reports/reportGenerationForm.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { useEffect, useMemo } from "react";
-import { formatDateRange } from "@next-pms/design-system/date";
+import { formatDateRange, getTodayDate } from "@next-pms/design-system/date";
 import {
   Button,
   Checkbox,
@@ -140,6 +140,7 @@ export function ReportGenerationForm() {
                 onChange={(value) => field.handleChange(value)}
                 formatter={formatDateRange}
                 placeholder="Select duration"
+                disallowAfter={getTodayDate()}
                 footer={({ setRange, close }) => (
                   <div className="flex flex-wrap items-center gap-1">
                     {durationPresets.map((preset) => (


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
Modifies Report Date range picker to disallow days after today.

## Additional Information:

Depends on https://github.com/rtCamp/frappe-ui-react/pull/330

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1983