### PR TITLE
Fix: Add "Yesterday" option in date picker

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
+++ b/frontend/packages/app/src/pages/timesheet/components/add-time/index.tsx
@@ -18,6 +18,7 @@ import {
 import { Calendar, Folder } from "@rtcamp/frappe-ui-react/icons";
 import { useForm } from "@tanstack/react-form";
 import { useSelector } from "@tanstack/react-store";
+import { format, subDays } from "date-fns";
 import { FrappeError, useFrappePostCall } from "frappe-react-sdk";
 
 /**
@@ -393,6 +394,35 @@ const AddTime = ({
                     onChange={(val) => field.handleChange(val as string)}
                     placeholder="Placeholder"
                     value={field.state.value}
+                    footer={(props, { setValue, clear, close }) => (
+                      <div {...props} className="flex gap-1 justify-between">
+                        <div className="flex gap-1">
+                          <Button
+                            variant="outline"
+                            onClick={() => {
+                              setValue(
+                                format(subDays(new Date(), 1), "yyyy-MM-dd"),
+                              );
+                              close();
+                            }}
+                          >
+                            Yesterday
+                          </Button>
+                          <Button
+                            variant="outline"
+                            onClick={() => {
+                              setValue(format(new Date(), "yyyy-MM-dd"));
+                              close();
+                            }}
+                          >
+                            Today
+                          </Button>
+                        </div>
+                        <Button variant="outline" onClick={clear}>
+                          Clear
+                        </Button>
+                      </div>
+                    )}
                   >
                     {({ displayValue }) => {
                       return (


### PR DESCRIPTION
## Description

Add yesterday option into date picker in add time modal.

## Additional Information:

Depends on https://github.com/rtCamp/frappe-ui-react/pull/332 to add a footer prop,

## Screenshot/Screencast
<img width="759" height="767" alt="image" src="https://github.com/user-attachments/assets/b326d643-53d0-45f8-8ecb-14592243bccb" />


<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1839