### PR TITLE
Feat: add clear icon to the currency combobox component

### DIFF
--- a/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
+++ b/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
@@ -89,6 +89,7 @@ export function ProjectFilters() {
             value={currency || null}
             onChange={(v) => setCurrency(v || "")}
             options={currencies}
+            clearable
           />
         </div>
         <Select


### PR DESCRIPTION
## Description

Wires the new clearable prop to the currency combobox control so it can be cleared using the icon


## Testing Instructions

- Go to the Projects page
- Select any currency
- Observe the "x" icon to appear
- click the icon to clear the selected currency, and observe the currencies to be set as default

## Screenshot/Screencast


https://github.com/user-attachments/assets/a0cd7cab-b3e0-4cfd-9c2a-afe97225f8b5




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Depends on: https://github.com/rtCamp/frappe-ui-react/pull/333
Fixes: #2023