### PR TITLE
fix(timesheet): honor backdate restriction boundary on frontend, with holiday/leave-aware backend computation

### DIFF
--- a/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/memberRow.tsx
@@ -13,6 +13,7 @@ import {
 /**
  * Internal dependencies
  */
+import { isDateBackdateRestricted } from "@/pages/timesheet/utils";
 import { MemberRowProps } from "./types";
 import { computeRowData } from "../../utils";
 
@@ -25,6 +26,7 @@ export const MemberRow = ({
   workingFrequency,
   status,
   disabled,
+  backdateRestrictedBefore,
   onButtonClick,
   children,
   avatarUrl,
@@ -69,7 +71,13 @@ export const MemberRow = ({
                 status={status ? ApprovalStatusMap[status] : "none"}
                 timeEntries={memberData.totalTimeEntries.map((timeEntry) => ({
                   ...timeEntry,
-                  disabled: disabled || timeEntry.disabled,
+                  disabled:
+                    disabled ||
+                    timeEntry.disabled ||
+                    isDateBackdateRestricted(
+                      timeEntry.date,
+                      backdateRestrictedBefore,
+                    ),
                 }))}
                 onCellClick={
                   rest.onCellClick

--- a/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/projectRow.tsx
@@ -10,6 +10,7 @@ import { ProjectRow as BaseProjectRow } from "@next-pms/design-system/components
  * Internal dependencies
  */
 import { calculateTotalHours } from "@/lib/utils";
+import { isDateBackdateRestricted } from "@/pages/timesheet/utils";
 import type { ProjectRowProps } from "./types";
 import { hasApprovedTimeEntry } from "../../utils";
 
@@ -28,6 +29,7 @@ export const ProjectRow = ({
   hideTime,
   disabled,
   lockApproved = true,
+  backdateRestrictedBefore,
   onCellClick,
   children,
   ...rest
@@ -48,12 +50,20 @@ export const ProjectRow = ({
         time: currentTotal === 0 ? "" : floatToTime(currentTotal, 2),
         disabled:
           Boolean(disabled) ||
-          (lockApproved && hasApprovedTimeEntry(tasks, date)),
+          (lockApproved && hasApprovedTimeEntry(tasks, date)) ||
+          isDateBackdateRestricted(date, backdateRestrictedBefore),
       });
       total += currentTotal;
     }
     return { total, totalTimeEntries };
-  }, [dates, tasks, hideTime, disabled, lockApproved]);
+  }, [
+    dates,
+    tasks,
+    hideTime,
+    disabled,
+    lockApproved,
+    backdateRestrictedBefore,
+  ]);
 
   return (
     <Accordion.Root

--- a/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/taskRow.tsx
@@ -18,6 +18,7 @@ import TaskPopover from "@/components/taskPopover";
 import { calculateTotalHours, parseFrappeErrorMsg } from "@/lib/utils";
 import { useGuardedAction } from "@/pages/allocations/unsavedChanges/useUnsavedChanges";
 import { usePersonalTimesheet } from "@/pages/timesheet/personal/context";
+import { isDateBackdateRestricted } from "@/pages/timesheet/utils";
 import type { TaskDataItemProps } from "@/types/timesheet";
 import type { TaskRowProps } from "./types";
 import { InlineTimeEntry } from "../inline-time-entry";
@@ -51,6 +52,7 @@ export const TaskRow = ({
   dailyWorkingHours,
   totalTimeEntriesInHours,
   employee,
+  backdateRestrictedBefore,
   hideLikeButton,
   setSelectedTask,
   ...rest
@@ -117,7 +119,10 @@ export const TaskRow = ({
           currentTotal === 0 || (taskKey && tasks[taskKey]?.is_billable)
             ? false
             : true,
-        disabled: disabled || isDayFullyApproved || false,
+        disabled:
+          disabled ||
+          isDayFullyApproved ||
+          isDateBackdateRestricted(date, backdateRestrictedBefore),
         status: dayStatus,
         rejectionReason,
       };
@@ -126,7 +131,7 @@ export const TaskRow = ({
       total += currentTotal;
     }
     return { total, totalTimeEntries, tasksForDates };
-  }, [dates, taskKey, tasks, disabled]);
+  }, [dates, taskKey, tasks, disabled, backdateRestrictedBefore]);
 
   const renderTaskHoverContent = useCallback(
     (taskKey: string) => {

--- a/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/types.ts
@@ -74,6 +74,7 @@ export interface MemberRowProps extends Omit<
   workingFrequency: WorkingFrequency;
   status: ApprovalStatusLabelType;
   disabled?: boolean;
+  backdateRestrictedBefore?: string | null;
   onCellClick?: (date: string) => void;
   children?: (props: {
     totalTimeEntriesInHours: number[];
@@ -92,6 +93,7 @@ export interface ProjectRowProps extends Omit<
   hideTime?: boolean;
   disabled?: boolean;
   lockApproved?: boolean;
+  backdateRestrictedBefore?: string | null;
   onCellClick?: (date: string) => void;
   children?: React.ReactNode;
 }
@@ -108,6 +110,7 @@ export interface TaskRowProps extends Omit<
   dailyWorkingHours?: number;
   totalTimeEntriesInHours?: number[];
   employee?: string;
+  backdateRestrictedBefore?: string | null;
   hideLikeButton?: boolean;
   setSelectedTask?: (taskKey: string) => void;
 }

--- a/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/components/row/weekRow.tsx
@@ -16,6 +16,8 @@ import { getTodayDate, prettyDate } from "@next-pms/design-system/date";
  * Internal dependencies
  */
 import { useScrollRoot } from "@/components/scrollRoot";
+import { isDateBackdateRestricted } from "@/pages/timesheet/utils";
+import { useUser } from "@/providers/user";
 import type { WeekRowProps } from "./types";
 import { computeRowData } from "../../utils";
 
@@ -54,6 +56,9 @@ export const WeekRow = ({
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const scrollRoot = useScrollRoot();
   const weekRef = useRef<HTMLDivElement>(null);
+  const backdateRestrictedBefore = useUser(
+    ({ state }) => state.backdateRestrictedBefore,
+  );
 
   const anchorOnCollapse = () => {
     const weekEl = weekRef.current;
@@ -170,7 +175,15 @@ export const WeekRow = ({
               {children?.({
                 totalHours: floatToTime(weekData.total, 2),
                 totalHoursTheme: totalHoursThemeMap[weekData.isExtended],
-                totalTimeEntries: weekData.totalTimeEntries,
+                totalTimeEntries: weekData.totalTimeEntries.map((entry) => ({
+                  ...entry,
+                  disabled:
+                    entry.disabled ||
+                    isDateBackdateRestricted(
+                      entry.date,
+                      backdateRestrictedBefore,
+                    ),
+                })),
                 totalTimeEntriesInHours: weekData.totalTimeEntriesInHours,
                 dailyWorkingHours: weekData.dailyWorkingHours,
                 status: approvalStatus,

--- a/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/personalTimesheetRow.tsx
@@ -13,6 +13,7 @@ import {
 import { useImportedTasks } from "@/hooks/useImportedTasks";
 import { useTimesheetOutletContext } from "@/pages/timesheet/outletContext";
 import { usePersonalTimesheet } from "@/pages/timesheet/personal/context";
+import { useUser } from "@/providers/user";
 import { WorkingFrequency } from "@/types";
 import type { HolidayProp, LeaveProps, TaskProps } from "@/types/timesheet";
 import { ProjectRow } from "./components/row/projectRow";
@@ -59,6 +60,9 @@ export const PersonalTimesheetRow = ({
   hideLikeButton,
 }: PersonalTimesheetRowProps) => {
   const { openAddTimeDialog } = useTimesheetOutletContext();
+  const backdateRestrictedBefore = useUser(
+    ({ state }) => state.backdateRestrictedBefore,
+  );
 
   // Get liked tasks from context
   const likedTaskData = usePersonalTimesheet(
@@ -152,6 +156,7 @@ export const PersonalTimesheetRow = ({
                 hideTime={hideTotalRow}
                 className="pl-7.5"
                 disabled={disabled}
+                backdateRestrictedBefore={backdateRestrictedBefore}
                 onCellClick={(date) =>
                   openAddTimeDialog({
                     date,
@@ -173,6 +178,7 @@ export const PersonalTimesheetRow = ({
                     dailyWorkingHours={dailyWorkingHours}
                     totalTimeEntriesInHours={totalTimeEntriesInHours}
                     employee={employee}
+                    backdateRestrictedBefore={backdateRestrictedBefore}
                     setSelectedTask={setSelectedTask}
                     hideLikeButton={hideLikeButton}
                   />

--- a/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/projectTimesheetRow.tsx
@@ -30,6 +30,7 @@ export type ProjectTimesheetMember = {
   leaves: LeaveProps[];
   holidays: HolidayProp[];
   status: ApprovalStatusLabelType;
+  backdateRestrictedBefore: string | null;
 };
 
 export type ProjectTimesheetProject = {
@@ -104,6 +105,7 @@ export const ProjectTimesheetRow = ({
                     className="pl-13.5"
                     collapsed={true}
                     disabled={member.status === "Approved"}
+                    backdateRestrictedBefore={member.backdateRestrictedBefore}
                     onCellClick={(date) =>
                       openAddTimeDialog({
                         date,
@@ -132,6 +134,9 @@ export const ProjectTimesheetRow = ({
                             dailyWorkingHours={dailyWorkingHours}
                             totalTimeEntriesInHours={totalTimeEntriesInHours}
                             employee={member.employee}
+                            backdateRestrictedBefore={
+                              member.backdateRestrictedBefore
+                            }
                             hideLikeButton={true}
                           />
                         ))}

--- a/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
+++ b/frontend/packages/app/src/components/timesheet-row/teamTimesheetRow.tsx
@@ -32,6 +32,7 @@ export type TeamMember = {
   workingHour: number;
   workingFrequency: WorkingFrequency;
   status: ApprovalStatusLabelType;
+  backdateRestrictedBefore: string | null;
 };
 
 type TeamTimesheetRowProps = {
@@ -104,6 +105,7 @@ export const TeamTimesheetRow = ({
                 className="pl-7.5 animate-fade-in"
                 collapsed={true}
                 disabled={member.status === "Approved"}
+                backdateRestrictedBefore={member.backdateRestrictedBefore}
                 onCellClick={(date) =>
                   openAddTimeDialog({
                     date,
@@ -125,6 +127,9 @@ export const TeamTimesheetRow = ({
                         label={project.project_name || project.project}
                         className="pl-13.5"
                         disabled={member.status === "Approved"}
+                        backdateRestrictedBefore={
+                          member.backdateRestrictedBefore
+                        }
                         onCellClick={(date) =>
                           openAddTimeDialog({
                             date,
@@ -153,6 +158,9 @@ export const TeamTimesheetRow = ({
                               dailyWorkingHours={dailyWorkingHours}
                               totalTimeEntriesInHours={totalTimeEntriesInHours}
                               employee={member.employee}
+                              backdateRestrictedBefore={
+                                member.backdateRestrictedBefore
+                              }
                               hideLikeButton={true}
                               setSelectedTask={setSelectedTask}
                             />

--- a/frontend/packages/app/src/pages/timesheet/project/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/context.ts
@@ -24,6 +24,7 @@ export type ProjectMemberData = {
   tasks: TaskProps;
   holidays: HolidayProp[];
   leaves: LeaveProps[];
+  backdateRestrictedBefore: string | null;
   workingHour: number;
   workingFrequency: WorkingFrequency;
   status: ApprovalStatusLabelType;

--- a/frontend/packages/app/src/pages/timesheet/project/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/types.ts
@@ -11,6 +11,7 @@ export type ApiProjectMember = {
   tasks: TaskProps;
   holidays: ProjectMemberData["holidays"];
   leaves: ProjectMemberData["leaves"];
+  backdate_restricted_before: ProjectMemberData["backdateRestrictedBefore"];
   working_hour: number;
   working_frequency: ProjectMemberData["workingFrequency"];
   status: ProjectMemberData["status"];

--- a/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/project/useProjectTimesheetData.ts
@@ -171,6 +171,7 @@ export function useProjectTimesheetData({
               tasks: member.tasks,
               holidays: member.holidays,
               leaves: member.leaves,
+              backdateRestrictedBefore: member.backdate_restricted_before,
               workingHour: member.working_hour,
               workingFrequency: member.working_frequency,
               status: member.status,

--- a/frontend/packages/app/src/pages/timesheet/team/types.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/types.ts
@@ -44,6 +44,7 @@ export type TeamMemberPayload = {
   tasks: TaskProps;
   leaves: LeaveProps[];
   holidays: HolidayProp[];
+  backdate_restricted_before: string | null;
 };
 
 export type TeamMembersPayload = {

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamWeekMembers.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamWeekMembers.ts
@@ -45,6 +45,7 @@ const toTeamMember = (member: TeamMemberPayload): TeamMember => ({
   workingHour: member.working_hour,
   workingFrequency: member.working_frequency,
   status: member.status,
+  backdateRestrictedBefore: member.backdate_restricted_before,
 });
 
 export function useTeamWeekMembers({

--- a/frontend/packages/app/src/pages/timesheet/utils.ts
+++ b/frontend/packages/app/src/pages/timesheet/utils.ts
@@ -55,3 +55,14 @@ export const formatTimesheetWeekLabel = (
 
   return `${format(start, "MMM d, yyyy")} - ${format(end, "MMM d, yyyy")}`;
 };
+
+/**
+ * Whether a date is beyond the backdated-entry limit. `restrictedBefore` is the boundary
+ * date computed server-side (`timesheet.py::get_backdate_restriction_boundary`),
+ * which already accounts for holidays/weekly-offs/leave and the employee-vs-manager
+ * threshold.
+ */
+export const isDateBackdateRestricted = (
+  date: string,
+  restrictedBefore: string | null | undefined,
+): boolean => Boolean(restrictedBefore) && date < restrictedBefore!;

--- a/frontend/packages/app/src/providers/user/index.ts
+++ b/frontend/packages/app/src/providers/user/index.ts
@@ -42,6 +42,10 @@ export interface UserContextProps {
     hasBuField: boolean;
     /** Whether the industry field is enabled in the system. */
     hasIndustryField: boolean;
+    /** Earliest date the current user may still log their own time entry for — computed
+     * server-side (already accounts for holidays/leave/manager-vs-employee threshold).
+     * `null` means not yet known (e.g. still loading) or no employee record. */
+    backdateRestrictedBefore: string | null;
   };
   actions: {
     /** Logs out the current user and clears the active session. */
@@ -68,6 +72,7 @@ export const UserContext = createContext<UserContextProps>({
     currencies: window.frappe?.boot?.currencies ?? [],
     hasBuField: window.frappe?.boot?.has_business_unit ?? false,
     hasIndustryField: window.frappe?.boot?.has_industry ?? false,
+    backdateRestrictedBefore: null,
   },
   actions: {
     logout: () => Promise.resolve(),

--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -48,6 +48,8 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   const [hasIndustryField, setHasIndustryField] = useState<
     UserContextProps["state"]["hasIndustryField"]
   >(window.frappe?.boot?.has_industry || false);
+  const [backdateRestrictedBefore, setBackdateRestrictedBefore] =
+    useState<UserContextProps["state"]["backdateRestrictedBefore"]>(null);
 
   const { logout, isLoading: isAuthLoading, currentUser } = useFrappeAuth();
   const isAuthenticated =
@@ -70,6 +72,9 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
     setCurrencies(appData?.message?.currencies || []);
     setHasBuField(appData?.message?.has_business_unit || false);
     setHasIndustryField(appData?.message?.has_industry || false);
+    setBackdateRestrictedBefore(
+      appData?.message?.backdate_restricted_before ?? null,
+    );
   }, [appData]);
 
   const { data: employeeData, error: employeeDataError } = useFrappeGetCall(
@@ -144,6 +149,7 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
           currencies,
           hasBuField,
           hasIndustryField,
+          backdateRestrictedBefore,
           currentUser,
         },
         actions: {

--- a/next_pms/tests/timesheet/api/test_app.py
+++ b/next_pms/tests/timesheet/api/test_app.py
@@ -1,0 +1,83 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.tests.utils import make_employee, make_holiday_list
+from next_pms.timesheet.api.app import get_data
+from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary
+
+EMPLOYEE_USER = "app.get-data.employee@example.com"
+COMPANY_HOLIDAY_LIST_NAME = "App GetData Test Company Holidays"
+
+
+class TestGetDataBackdateRestriction(IntegrationTestCase):
+    """get_data's backdate_restricted_before field - a thin wrapper around
+    get_backdate_restriction_boundary, so these just confirm the wiring."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls._ensure_company_holiday_list_assignment()
+        cls.employee = make_employee(EMPLOYEE_USER, company=cls.company)
+
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries", 1)
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries_till_employee", 4)
+        frappe.clear_cache()
+
+    @classmethod
+    def _ensure_company_holiday_list_assignment(cls):
+        if frappe.db.exists("Holiday List Assignment", {"assigned_to": cls.company, "docstatus": 1}):
+            return
+        holiday_list = make_holiday_list(COMPANY_HOLIDAY_LIST_NAME, holiday_dates=[])
+        frappe.get_doc(
+            {
+                "doctype": "Holiday List Assignment",
+                "applicable_for": "Company",
+                "assigned_to": cls.company,
+                "holiday_list": holiday_list.name,
+                "from_date": holiday_list.from_date,
+            }
+        ).insert(ignore_permissions=True).submit()
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def test_backdate_restricted_before_matches_shared_calculation(self):
+        frappe.set_user(EMPLOYEE_USER)
+        response = get_data()
+        expected = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(response["backdate_restricted_before"], expected)
+
+    def test_backdate_restricted_before_is_none_without_an_employee_record(self):
+        # Administrator has no linked Employee record.
+        frappe.set_user("Administrator")
+        response = get_data()
+        self.assertIsNone(response["backdate_restricted_before"])
+
+    def test_get_data_still_returns_the_existing_keys(self):
+        frappe.set_user(EMPLOYEE_USER)
+        response = get_data()
+        for key in ("roles", "currencies", "has_business_unit", "has_industry", "backdate_restricted_before"):
+            self.assertIn(key, response)
+
+    def test_backdate_restricted_before_is_none_for_an_ignored_role(self):
+        """get_own_backdate_restriction_boundary must also respect the
+        Ignored Role exemption, not just validate_dates - a user granted an ignored
+        role should see no restriction on the frontend either."""
+        role_name = "App GetData Test Ignored Role"
+        if not frappe.db.exists("Role", role_name):
+            frappe.get_doc({"doctype": "Role", "role_name": role_name}).insert(ignore_permissions=True)
+        settings = frappe.get_single("Timesheet Settings")
+        if not any(row.role == role_name for row in settings.ignored_role):
+            settings.append("ignored_role", {"role": role_name})
+            settings.save(ignore_permissions=True)
+
+        bypass_user = "app.get-data.ignoredrole@example.com"
+        make_employee(bypass_user, company=self.company)
+        frappe.get_doc("User", bypass_user).add_roles(role_name)
+        frappe.clear_cache()
+
+        frappe.set_user(bypass_user)
+        response = get_data()
+        self.assertIsNone(response["backdate_restricted_before"])

--- a/next_pms/tests/timesheet/api/test_project_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_project_timesheet_data.py
@@ -416,3 +416,31 @@ class TestProjectTimesheetDataSkipEmptyWeeks(_ProjectTimesheetDataBase):
 
         self.assertEqual(len(with_skip_weeks), 1)
         self.assertGreaterEqual(len(without_skip_weeks), 1)
+
+
+class TestProjectTimesheetDataBackdateRestriction(_ProjectTimesheetDataBase):
+    """backdate_restricted_before on each member payload - confirms the field is
+    threaded through from get_backdate_restriction_boundary."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries", 1)
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries_till_employee", 3)
+        frappe.clear_cache()
+
+    def test_member_payload_carries_matching_boundary(self):
+        from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary
+
+        res = self._call(filters=self._scope_to_fixtures_filter())
+
+        frappe.set_user(WRITE_USER)
+        seen_employees = set()
+        for week in res["week_groups"]:
+            for project in week["projects"]:
+                for member in project["members"]:
+                    seen_employees.add(member["employee"])
+                    expected = get_backdate_restriction_boundary(member["employee"])
+                    self.assertEqual(member["backdate_restricted_before"], expected)
+
+        self.assertTrue(seen_employees, "fixtures produced no members to check")

--- a/next_pms/tests/timesheet/api/test_team_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_team_timesheet_data.py
@@ -791,3 +791,28 @@ class TestTeamTimesheetMemberWeek(_TeamTimesheetDataBase):
             self.assertEqual(payload["employee"], self.r1)
             self.assertIn("tasks", payload["message"])
             self.assertIn("status", payload["message"])
+
+
+class TestTeamTimesheetDataBackdateRestriction(_TeamTimesheetDataBase):
+    """backdate_restricted_before on each member payload - confirms the field is
+    threaded through from get_backdate_restriction_boundary."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries", 1)
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries_till_employee", 3)
+        frappe.db.set_single_value("Timesheet Settings", "allow_backdated_entries_till_manager", 6)
+        frappe.clear_cache()
+
+    def test_member_payload_carries_matching_boundary(self):
+        from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary
+
+        res = self._call(reports_to=self.mgr, start_date=W1_MON)
+        members = self._members_by_employee(res)
+        self.assertTrue(members, "fixtures produced no members to check")
+
+        frappe.set_user(WRITE_USER)
+        for employee, member in members.items():
+            expected = get_backdate_restriction_boundary(employee)
+            self.assertEqual(member["backdate_restricted_before"], expected)

--- a/next_pms/tests/timesheet/doc_events/test_timesheet.py
+++ b/next_pms/tests/timesheet/doc_events/test_timesheet.py
@@ -1,0 +1,442 @@
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, getdate, today
+
+from next_pms.tests.utils import make_holiday_list
+from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary, validate_dates
+
+MANAGER_ROLE = "Projects Manager"
+
+EMPLOYEE_USER = "backdate.employee@example.com"
+MANAGER_USER = "backdate.manager@example.com"
+PLAIN_VIEWER_USER = "backdate.plainviewer@example.com"
+MANAGER_WITHOUT_EMPLOYEE_USER = "backdate.manager.noemployee@example.com"
+
+EMPLOYEE_NAME = "Backdate Test Employee"
+MANAGER_EMPLOYEE_NAME = "Backdate Test Manager"
+PLAIN_VIEWER_EMPLOYEE_NAME = "Backdate Test Plain Viewer"
+
+COMPANY_HOLIDAY_LIST_NAME = "Backdate Test Company Holidays"
+EMPLOYEE_HOLIDAY_LIST_NAME = "Backdate Test Employee Holidays"
+LEAVE_TYPE_NAME = "Backdate Test LWP"
+
+EMPLOYEE_ALLOWED_DAYS = 3
+MANAGER_ALLOWED_DAYS = 5
+
+
+class _BackdateRestrictionBase(IntegrationTestCase):
+    """Shared fixtures for get_backdate_restriction_boundary / validate_dates.
+
+    All dates are relative to `today()` at test-run time, since the boundary
+    calculation is anchored on "today" - unlike most other fixtures in this
+    suite, hardcoded calendar dates would not be meaningful here.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.today = getdate(today())
+
+        cls._ensure_company_holiday_list_assignment()
+
+        # Users must exist before an Employee can link to them via user_id.
+        cls._make_user(EMPLOYEE_USER, roles=[])
+        cls._make_user(MANAGER_USER, roles=[MANAGER_ROLE])
+        cls._make_user(PLAIN_VIEWER_USER, roles=[])
+        # Deliberately no Employee record for this one - exercises the
+        # viewer_employee-is-None branch without also being Administrator (who is
+        # exempt from backdate validation entirely, so wouldn't exercise that branch).
+        cls._make_user(MANAGER_WITHOUT_EMPLOYEE_USER, roles=[MANAGER_ROLE])
+
+        cls.employee = cls._make_employee(EMPLOYEE_NAME, EMPLOYEE_USER)
+        cls.manager_employee = cls._make_employee(MANAGER_EMPLOYEE_NAME, MANAGER_USER)
+        cls.plain_viewer_employee = cls._make_employee(PLAIN_VIEWER_EMPLOYEE_NAME, PLAIN_VIEWER_USER)
+
+        # This is a shared dev database that may already carry real holidays/weekly-offs
+        # for the default company (from unrelated manual testing). Give each of our
+        # employees their own empty holiday list so "no holidays nearby" is actually
+        # true for boundary-math assertions, regardless of ambient company data -
+        # an employee-level assignment takes priority over the company-level one.
+        for employee in (cls.employee, cls.manager_employee, cls.plain_viewer_employee):
+            cls._assign_employee_holiday_list(employee, [])
+
+        cls._set_timesheet_settings(
+            allow_backdated_entries=1,
+            allow_future_entries=0,
+            allow_backdated_entries_till_employee=EMPLOYEE_ALLOWED_DAYS,
+            allow_backdated_entries_till_manager=MANAGER_ALLOWED_DAYS,
+        )
+        frappe.clear_cache()
+
+    # -- fixture factories -------------------------------------------------
+
+    @classmethod
+    def _make_user(cls, email, roles):
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                    "user_type": "System User",
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        user = frappe.get_doc("User", email)
+        for role in roles:
+            user.add_roles(role)
+        return email
+
+    @classmethod
+    def _make_employee(cls, name, user_id):
+        existing = frappe.db.get_value("Employee", {"user_id": user_id})
+        if existing:
+            return existing
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": name,
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": "Active",
+                "employment_type": "Intern",
+                "leave_approver": "Administrator",
+                "user_id": user_id,
+                "ctc": 100000,
+                "salary_currency": frappe.get_cached_value("Company", cls.company, "default_currency"),
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    @classmethod
+    def _ensure_company_holiday_list_assignment(cls):
+        from_date = add_days(today(), -400)
+        to_date = add_days(today(), 400)
+        if frappe.db.exists(
+            "Holiday List Assignment",
+            {"assigned_to": cls.company, "docstatus": 1},
+        ):
+            return
+        holiday_list = make_holiday_list(
+            COMPANY_HOLIDAY_LIST_NAME, from_date=from_date, to_date=to_date, holiday_dates=[]
+        )
+        frappe.get_doc(
+            {
+                "doctype": "Holiday List Assignment",
+                "applicable_for": "Company",
+                "assigned_to": cls.company,
+                "holiday_list": holiday_list.name,
+                "from_date": from_date,
+            }
+        ).insert(ignore_permissions=True).submit()
+
+    @classmethod
+    def _assign_employee_holiday_list(cls, employee, holiday_dates):
+        """Gives `employee` their own Holiday List Assignment (overriding the company
+        default), with `holiday_dates` = list of {"holiday_date": ..., "description": ...}."""
+        from_date = add_days(today(), -400)
+        to_date = add_days(today(), 400)
+        holiday_list = make_holiday_list(
+            f"{EMPLOYEE_HOLIDAY_LIST_NAME} {employee}",
+            from_date=from_date,
+            to_date=to_date,
+            holiday_dates=holiday_dates,
+        )
+        frappe.get_doc(
+            {
+                "doctype": "Holiday List Assignment",
+                "applicable_for": "Employee",
+                "assigned_to": employee,
+                "holiday_list": holiday_list.name,
+                "from_date": from_date,
+            }
+        ).insert(ignore_permissions=True).submit()
+
+    @classmethod
+    def _make_lwp_leave_type(cls):
+        if frappe.db.exists("Leave Type", LEAVE_TYPE_NAME):
+            return LEAVE_TYPE_NAME
+        return (
+            frappe.get_doc({"doctype": "Leave Type", "leave_type_name": LEAVE_TYPE_NAME, "is_lwp": 1})
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_leave_application(cls, employee, from_date, to_date):
+        leave_type = cls._make_lwp_leave_type()
+        doc = frappe.get_doc(
+            {
+                "doctype": "Leave Application",
+                "employee": employee,
+                "leave_type": leave_type,
+                "company": cls.company,
+                "from_date": from_date,
+                "to_date": to_date,
+                "description": "Backdate restriction test leave",
+                "posting_date": from_date,
+                "status": "Approved",
+                "leave_approver": "Administrator",
+            }
+        )
+        doc.insert(ignore_permissions=True)
+        doc.submit()
+        return doc.name
+
+    @staticmethod
+    def _set_timesheet_settings(**kwargs):
+        for field, value in kwargs.items():
+            frappe.db.set_single_value("Timesheet Settings", field, value)
+
+    @staticmethod
+    def _doc(employee, date, ignore_backdated_validation=False):
+        """A lightweight stand-in for a Timesheet doc - validate_dates only reads
+        .employee/.start_date/.end_date/.ignore_backdated_validation."""
+        return frappe._dict(
+            employee=employee,
+            start_date=getdate(date),
+            end_date=getdate(date),
+            ignore_backdated_validation=ignore_backdated_validation,
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+
+class TestBackdateRestrictionBoundaryThresholds(_BackdateRestrictionBase):
+    """No holidays/leave nearby - the boundary is a plain calendar-day count, so these
+    pin down which threshold (employee vs manager) applies to whom."""
+
+    def test_self_view_uses_employee_threshold(self):
+        frappe.set_user(EMPLOYEE_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -EMPLOYEE_ALLOWED_DAYS))
+
+    def test_manager_viewing_another_employee_uses_manager_threshold(self):
+        frappe.set_user(MANAGER_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -MANAGER_ALLOWED_DAYS))
+
+    def test_manager_viewing_their_own_record_uses_employee_threshold(self):
+        frappe.set_user(MANAGER_USER)
+        boundary = get_backdate_restriction_boundary(self.manager_employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -EMPLOYEE_ALLOWED_DAYS))
+
+    def test_plain_viewer_without_manager_role_uses_employee_threshold(self):
+        frappe.set_user(PLAIN_VIEWER_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -EMPLOYEE_ALLOWED_DAYS))
+
+    def test_viewer_with_no_employee_record_still_gets_manager_threshold(self):
+        """A manager-role user with no linked Employee - exercises the
+        `viewer_employee is None` branch (None != target is still True). Not
+        Administrator, who is exempt from backdate validation entirely and so
+        wouldn't exercise this branch at all."""
+        frappe.set_user(MANAGER_WITHOUT_EMPLOYEE_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -MANAGER_ALLOWED_DAYS))
+
+
+class TestBackdateRestrictionExemptions(_BackdateRestrictionBase):
+    """Users fully exempt from backdate validation - Administrator, or holding a role
+    listed in Timesheet Settings' Ignored Role table - must see no restriction at all,
+    both in the boundary the frontend reads and in the actual validate_dates check.
+
+    Regression coverage for a real gap: get_backdate_restriction_boundary originally
+    didn't know about the Ignored Role exemption at all (only validate_dates did), so a
+    user granted an ignored role still saw their cells disabled on the frontend even
+    though the backend would have accepted any backdated entry from them.
+    """
+
+    @classmethod
+    def _add_ignored_role(cls, role_name):
+        if not frappe.db.exists("Role", role_name):
+            frappe.get_doc({"doctype": "Role", "role_name": role_name}).insert(ignore_permissions=True)
+        settings = frappe.get_single("Timesheet Settings")
+        if not any(row.role == role_name for row in settings.ignored_role):
+            settings.append("ignored_role", {"role": role_name})
+            settings.save(ignore_permissions=True)
+        frappe.clear_cache()
+
+    def test_administrator_gets_no_boundary(self):
+        frappe.set_user("Administrator")
+        self.assertIsNone(get_backdate_restriction_boundary(self.employee))
+
+    def test_ignored_role_gets_no_boundary(self):
+        role_name = "Backdate Test Ignored Role Boundary"
+        self._add_ignored_role(role_name)
+        bypass_user = self._make_user("backdate.ignoredrole.boundary@example.com", roles=[role_name])
+        frappe.clear_cache()
+        frappe.set_user(bypass_user)
+        self.assertIsNone(get_backdate_restriction_boundary(self.employee))
+
+    def test_ignored_role_can_save_any_backdated_date(self):
+        role_name = "Backdate Test Ignored Role Validate"
+        self._add_ignored_role(role_name)
+        bypass_user = self._make_user("backdate.ignoredrole.validate@example.com", roles=[role_name])
+        frappe.clear_cache()
+        frappe.set_user(bypass_user)
+        far_past = add_days(self.today, -3650)
+        validate_dates(self._doc(self.employee, far_past))  # must not raise
+
+    def test_ignored_role_does_not_exempt_other_viewers(self):
+        """Sanity check: adding an ignored role for one test user doesn't accidentally
+        exempt everyone - a plain viewer without that role is still restricted normally."""
+        role_name = "Backdate Test Ignored Role Sanity"
+        self._add_ignored_role(role_name)
+        frappe.set_user(EMPLOYEE_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertIsNotNone(boundary)
+        self.assertEqual(getdate(boundary), add_days(self.today, -EMPLOYEE_ALLOWED_DAYS))
+
+
+class TestBackdateRestrictionBoundaryMasterToggle(_BackdateRestrictionBase):
+    """allow_backdated_entries off entirely - boundary collapses to today regardless
+    of thresholds or holidays, matching the backend's separate hard check."""
+
+    def test_boundary_is_today_when_backdating_disabled(self):
+        self._set_timesheet_settings(allow_backdated_entries=0)
+        frappe.set_user(EMPLOYEE_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(getdate(boundary), self.today)
+
+    def test_boundary_is_today_when_threshold_itself_is_zero(self):
+        """Distinct from the master toggle: backdating stays enabled, but the
+        configured day count is 0 - still no holiday widening should apply."""
+        self._set_timesheet_settings(allow_backdated_entries=1, allow_backdated_entries_till_employee=0)
+        frappe.set_user(EMPLOYEE_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        self.assertEqual(getdate(boundary), self.today)
+
+
+class TestBackdateRestrictionBoundaryHolidaysAndLeave(_BackdateRestrictionBase):
+    """Holidays/weekly-offs/leave inside the window push the boundary further back -
+    these don't count against the allowed-days budget.
+
+    Each test method uses its own dedicated employee (fresh, with an empty baseline
+    holiday list) rather than the shared `cls.employee` - IntegrationTestCase only
+    rolls back per class, not per method, so methods sharing one employee would
+    otherwise layer holiday/leave records on top of each other across methods.
+    """
+
+    _dedicated_employee_counter = 0
+
+    @classmethod
+    def _make_dedicated_employee(cls, holiday_dates=None):
+        """A fresh employee with a single holiday-list assignment (defaulting to
+        empty). Only one assignment is ever made per employee - HRMS rejects a
+        second one overlapping the same date range - so callers who need specific
+        holidays pass them here rather than assigning a second list afterward."""
+        cls._dedicated_employee_counter += 1
+        n = cls._dedicated_employee_counter
+        user = f"backdate.dedicated{n}@example.com"
+        cls._make_user(user, roles=[])
+        employee = cls._make_employee(f"Backdate Dedicated Employee {n}", user)
+        cls._assign_employee_holiday_list(employee, holiday_dates or [])
+        return employee, user
+
+    def test_holiday_inside_window_pushes_boundary_back_by_one(self):
+        holiday_date = add_days(self.today, -2)
+        employee, user = self._make_dedicated_employee(
+            holiday_dates=[{"holiday_date": holiday_date, "description": "Test Holiday", "weekly_off": 0}],
+        )
+        frappe.set_user(user)
+        boundary = get_backdate_restriction_boundary(employee)
+        # Without the holiday: today-3. The holiday at today-2 doesn't count as a
+        # working day, so one extra calendar day is needed to reach 3 working days.
+        self.assertEqual(getdate(boundary), add_days(self.today, -(EMPLOYEE_ALLOWED_DAYS + 1)))
+
+    def test_leave_inside_window_pushes_boundary_back_by_one(self):
+        employee, user = self._make_dedicated_employee()
+        leave_date = add_days(self.today, -2)
+        self._make_leave_application(employee, leave_date, leave_date)
+        frappe.set_user(user)
+        boundary = get_backdate_restriction_boundary(employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -(EMPLOYEE_ALLOWED_DAYS + 1)))
+
+    def test_multi_day_leave_pushes_boundary_back_by_its_full_span(self):
+        employee, user = self._make_dedicated_employee()
+        # A 2-day leave ending today-2 (today-3, today-2) removes 2 working days
+        # from the count.
+        self._make_leave_application(employee, add_days(self.today, -3), add_days(self.today, -2))
+        frappe.set_user(user)
+        boundary = get_backdate_restriction_boundary(employee)
+        self.assertEqual(getdate(boundary), add_days(self.today, -(EMPLOYEE_ALLOWED_DAYS + 2)))
+
+
+class TestValidateDatesIntegration(_BackdateRestrictionBase):
+    """The actual submit-time validation - confirms it now defers entirely to
+    get_backdate_restriction_boundary instead of its own inline calculation."""
+
+    def test_date_on_boundary_is_allowed(self):
+        frappe.set_user(EMPLOYEE_USER)
+        boundary = get_backdate_restriction_boundary(self.employee)
+        validate_dates(self._doc(self.employee, boundary))  # must not raise
+
+    def test_date_one_day_before_boundary_is_rejected(self):
+        frappe.set_user(EMPLOYEE_USER)
+        boundary = getdate(get_backdate_restriction_boundary(self.employee))
+        with self.assertRaises(frappe.ValidationError):
+            validate_dates(self._doc(self.employee, add_days(boundary, -1)))
+
+    def test_today_is_always_allowed(self):
+        frappe.set_user(EMPLOYEE_USER)
+        validate_dates(self._doc(self.employee, self.today))  # must not raise
+
+    def test_future_entry_rejected_when_disallowed(self):
+        # Explicit, not just relying on setUpClass's default: a sibling test
+        # (test_future_entry_allowed_when_setting_enabled) flips this setting and,
+        # since IntegrationTestCase only rolls back per-class, a stale value would
+        # otherwise leak into whichever test happens to run next alphabetically.
+        self._set_timesheet_settings(allow_future_entries=0)
+        frappe.set_user(EMPLOYEE_USER)
+        with self.assertRaises(frappe.ValidationError):
+            validate_dates(self._doc(self.employee, add_days(self.today, 1)))
+
+    def test_future_entry_allowed_when_setting_enabled(self):
+        self._set_timesheet_settings(allow_future_entries=1)
+        frappe.set_user(EMPLOYEE_USER)
+        validate_dates(self._doc(self.employee, add_days(self.today, 1)))  # must not raise
+
+    def test_ignore_backdated_validation_bypasses_check(self):
+        frappe.set_user(EMPLOYEE_USER)
+        far_past = add_days(self.today, -365)
+        validate_dates(self._doc(self.employee, far_past, ignore_backdated_validation=True))  # must not raise
+
+    def test_administrator_bypasses_check(self):
+        frappe.set_user("Administrator")
+        far_past = add_days(self.today, -365)
+        validate_dates(self._doc(self.employee, far_past))  # must not raise
+
+    def test_multi_day_timesheet_is_rejected_regardless_of_dates(self):
+        frappe.set_user(EMPLOYEE_USER)
+        doc = frappe._dict(
+            employee=self.employee,
+            start_date=self.today,
+            end_date=add_days(self.today, 1),
+            ignore_backdated_validation=False,
+        )
+        with self.assertRaises(frappe.ValidationError):
+            validate_dates(doc)
+
+    def test_timesheet_role_bypasses_check(self):
+        role_name = "Backdate Test Bypass Role"
+        if not frappe.db.exists("Role", role_name):
+            frappe.get_doc({"doctype": "Role", "role_name": role_name}).insert(ignore_permissions=True)
+
+        settings = frappe.get_single("Timesheet Settings")
+        if not any(row.role == role_name for row in settings.ignored_role):
+            settings.append("ignored_role", {"role": role_name})
+            settings.save(ignore_permissions=True)
+
+        bypass_user = self._make_user("backdate.bypass@example.com", roles=[role_name])
+        frappe.clear_cache()
+        frappe.set_user(bypass_user)
+        far_past = add_days(self.today, -365)
+        validate_dates(self._doc(self.employee, far_past))  # must not raise

--- a/next_pms/timesheet/api/app.py
+++ b/next_pms/timesheet/api/app.py
@@ -27,7 +27,21 @@ def get_data(user: str = None):
         "currencies": get_currencies(),
         "has_business_unit": has_bu_field(),
         "has_industry": has_industry_field(),
+        "backdate_restricted_before": get_own_backdate_restriction_boundary(),
     }
+
+
+def get_own_backdate_restriction_boundary():
+    """returns the earliest date the current session user may still log their own time
+    entry for - any date before this is restricted. See
+    doc_events.timesheet.get_backdate_restriction_boundary for the shared calculation."""
+    from next_pms.timesheet.api.employee import get_employee_from_user
+    from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary
+
+    employee = get_employee_from_user()
+    if not employee:
+        return None
+    return get_backdate_restriction_boundary(employee)
 
 
 @whitelist(methods=["GET"])

--- a/next_pms/timesheet/api/project.py
+++ b/next_pms/timesheet/api/project.py
@@ -6,7 +6,6 @@ from frappe import get_all, get_list, get_meta, get_value, only_for, whitelist
 from frappe.utils import flt, getdate
 
 from next_pms.api.utils import error_logger
-from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary
 
 from . import filter_employees, get_count
 from .utils import (
@@ -314,7 +313,7 @@ def _build_project_employee_payload(
         "working_hours": working_hours,
         "holidays": list(context["holidays_by_employee"].get(employee.name, [])),
         "leaves": list(context["leaves_by_employee"].get(employee.name, [])),
-        "backdate_restricted_before": get_backdate_restriction_boundary(employee.name),
+        "backdate_restricted_before": context["backdate_boundary_by_employee"].get(employee.name),
         "week_details": week_details,
     }
 

--- a/next_pms/timesheet/api/project.py
+++ b/next_pms/timesheet/api/project.py
@@ -6,6 +6,7 @@ from frappe import get_all, get_list, get_meta, get_value, only_for, whitelist
 from frappe.utils import flt, getdate
 
 from next_pms.api.utils import error_logger
+from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundary
 
 from . import filter_employees, get_count
 from .utils import (
@@ -313,6 +314,7 @@ def _build_project_employee_payload(
         "working_hours": working_hours,
         "holidays": list(context["holidays_by_employee"].get(employee.name, [])),
         "leaves": list(context["leaves_by_employee"].get(employee.name, [])),
+        "backdate_restricted_before": get_backdate_restriction_boundary(employee.name),
         "week_details": week_details,
     }
 
@@ -364,6 +366,7 @@ def _build_project_week_groups(response_dates: list, employee_data_map: dict):
                         "tasks": project_tasks,
                         "holidays": emp_data["holidays"],
                         "leaves": emp_data["leaves"],
+                        "backdate_restricted_before": emp_data["backdate_restricted_before"],
                         "working_hour": emp_data["working_hours"].get("working_hour", 8),
                         "working_frequency": emp_data["working_hours"].get("working_frequency", "Per Day"),
                         "status": week_detail.get("status", "Not Submitted"),

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -22,7 +22,6 @@ from next_pms.api.utils import error_logger
 from next_pms.resource_management.api.utils.query import get_employee_leaves
 from next_pms.timesheet.doc_events.timesheet import (
     flush_cache,
-    get_backdate_restriction_boundary,
     publish_timesheet_update,
 )
 from next_pms.timesheet.utils.constant import (
@@ -221,7 +220,7 @@ def build_team_member_payload(employee, context, week, has_filters):
         "tasks": detail.get("tasks", {}),
         "leaves": list(context["leaves_by_employee"].get(employee.name, [])),
         "holidays": list(context["holidays_by_employee"].get(employee.name, [])),
-        "backdate_restricted_before": get_backdate_restriction_boundary(employee.name),
+        "backdate_restricted_before": context["backdate_boundary_by_employee"].get(employee.name),
     }
 
 

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -20,7 +20,11 @@ from frappe.utils.data import add_days, getdate
 
 from next_pms.api.utils import error_logger
 from next_pms.resource_management.api.utils.query import get_employee_leaves
-from next_pms.timesheet.doc_events.timesheet import flush_cache, publish_timesheet_update
+from next_pms.timesheet.doc_events.timesheet import (
+    flush_cache,
+    get_backdate_restriction_boundary,
+    publish_timesheet_update,
+)
 from next_pms.timesheet.utils.constant import (
     ALLOWED_FILTER_FIELDS,
     MAX_TEAM_TIMESHEET_PAGE_LENGTH,
@@ -217,6 +221,7 @@ def build_team_member_payload(employee, context, week, has_filters):
         "tasks": detail.get("tasks", {}),
         "leaves": list(context["leaves_by_employee"].get(employee.name, [])),
         "holidays": list(context["holidays_by_employee"].get(employee.name, [])),
+        "backdate_restricted_before": get_backdate_restriction_boundary(employee.name),
     }
 
 

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -920,6 +920,35 @@ def resolve_holiday_lists(employee_meta_map: dict, employee_names: list) -> dict
     }
 
 
+def get_holiday_dates_by_employee(employee_names: list, start_date, end_date) -> dict:
+    """Batch-resolve each employee's holiday dates within `[start_date, end_date]` in a
+    fixed number of queries, regardless of how many employees are passed - one to resolve
+    holiday lists (see resolve_holiday_lists) and one to fetch the holidays themselves.
+    Mirrors what build_chunk_context already does for holidays_by_employee, but over a
+    caller-supplied date range instead of the currently viewed week."""
+    if not employee_names:
+        return {}
+
+    employee_meta_map = {
+        row.name: row
+        for row in get_all("Employee", filters={"name": ["in", employee_names]}, fields=["name", "company"])
+    }
+    holiday_list_by_employee = resolve_holiday_lists(employee_meta_map, employee_names)
+
+    holiday_lists = {hl for hl in holiday_list_by_employee.values() if hl}
+    holidays_by_list = defaultdict(list)
+    if holiday_lists:
+        holidays = get_all(
+            "Holiday",
+            filters={"parent": ["in", list(holiday_lists)], "holiday_date": ["between", (start_date, end_date)]},
+            fields=["parent", "holiday_date"],
+        )
+        for holiday in holidays:
+            holidays_by_list[holiday.parent].append(str(holiday.holiday_date))
+
+    return {name: holidays_by_list.get(holiday_list_by_employee.get(name), []) for name in employee_names}
+
+
 def build_chunk_context(employees: list, dates: list, parsed_filters: dict):
     """Runs the filters to build the context for the list of employees passed."""
     employee_names = [employee.name for employee in employees]
@@ -929,6 +958,7 @@ def build_chunk_context(employees: list, dates: list, parsed_filters: dict):
             "daily_norm_map": {},
             "leaves_by_employee": {},
             "holidays_by_employee": {},
+            "backdate_boundary_by_employee": {},
             "timesheet_map": {},
             "emp_ts_by_start": {},
             "detail_by_parent": {},
@@ -1077,11 +1107,16 @@ def build_chunk_context(employees: list, dates: list, parsed_filters: dict):
 
     has_search_or_task_filters = bool(parsed_filters.get("Task"))
 
+    from next_pms.timesheet.doc_events.timesheet import get_backdate_restriction_boundaries
+
+    backdate_boundary_by_employee = get_backdate_restriction_boundaries(employee_names)
+
     return {
         "working_hours_map": working_hours_map,
         "daily_norm_map": daily_norm_map,
         "leaves_by_employee": leaves_by_employee,
         "holidays_by_employee": holidays_by_employee,
+        "backdate_boundary_by_employee": backdate_boundary_by_employee,
         "timesheet_map": timesheet_map,
         "emp_ts_by_start": emp_ts_by_start,
         "detail_by_parent": detail_by_parent,

--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import frappe
 from frappe import _, get_value, throw
 from frappe.utils import add_days, date_diff, get_link_to_form, getdate, today
@@ -159,24 +161,39 @@ def get_backdate_restriction_boundary(employee: str) -> str | None:
     _is_exempt_from_backdate_validation) - meaning no date should be treated as restricted.
     Single source of truth for the backdated-entry check: used both by the validation above
     and by the frontend's disabled-cell precheck (exposed via API endpoints in api/app.py,
-    api/team.py, api/project.py)."""
+    api/team.py, api/project.py). Thin single-employee wrapper over
+    get_backdate_restriction_boundaries - callers rendering many employees at once should
+    call that directly instead of looping this."""
+    return get_backdate_restriction_boundaries([employee]).get(employee)
+
+
+def get_backdate_restriction_boundaries(employees: list) -> dict:
+    """Batch form of get_backdate_restriction_boundary: computes the boundary for every
+    employee in `employees` using one round of queries regardless of list size, instead of
+    one round of holiday/leave queries per employee. Team/project timesheet pages render up
+    to a hundred employees per request - call this once for the whole page rather than
+    looping the single-employee wrapper above."""
+    if not employees:
+        return {}
+
     if _is_exempt_from_backdate_validation():
-        return None
+        return dict.fromkeys(employees)
 
     today_date = getdate(today())
 
     if not frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries"):
-        return str(today_date)
+        return dict.fromkeys(employees, str(today_date))
 
-    allowed_days = _get_effective_backdated_allowed_days(employee)
-    return _compute_backdate_boundary(employee, allowed_days, today_date)
+    allowed_days_by_employee = _get_effective_backdated_allowed_days(employees)
+    return _compute_backdate_boundaries(employees, allowed_days_by_employee, today_date)
 
 
-def _get_effective_backdated_allowed_days(employee: str) -> int:
-    """Resolves the 'allow backdated entries till' day threshold for `employee`'s record,
-    from the current session user's perspective: the manager threshold applies if they hold
-    a manager-ish role (see ROLES) and are looking at someone else's record, the employee
-    threshold otherwise."""
+def _get_effective_backdated_allowed_days(employees: list) -> dict:
+    """Resolves the 'allow backdated entries till' day threshold for every employee in
+    `employees`, from the current session user's perspective: the manager threshold applies
+    if they hold a manager-ish role (see ROLES) and are looking at someone else's record, the
+    employee threshold otherwise. Reads the viewer's roles/employee record and both settings
+    once, no matter how many employees are passed."""
     from frappe import get_roles
 
     from next_pms.timesheet.api.employee import get_employee_from_user
@@ -185,50 +202,71 @@ def _get_effective_backdated_allowed_days(employee: str) -> int:
     has_access = ROLES.intersection(frappe_roles)
     viewer_employee = get_employee_from_user()
 
-    if has_access and viewer_employee != employee:
-        return frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_manager") or 0
-    return frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_employee") or 0
+    employee_days = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_employee") or 0
+    manager_days = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_manager") or 0
+
+    return {
+        employee: manager_days if has_access and viewer_employee != employee else employee_days
+        for employee in employees
+    }
 
 
-def _compute_backdate_boundary(employee: str, allowed_days: int, today_date) -> str:
-    """Walks backward from today counting only working days (skipping holidays, weekly-offs,
-    and approved/open leave) until `allowed_days` have been counted; the date it stops on is
-    the boundary - the earliest date still within the allowed window."""
-    from hrms.hr.utils import get_holiday_dates_for_employee
-
+def _compute_backdate_boundaries(employees: list, allowed_days_by_employee: dict, today_date) -> dict:
+    """Walks backward from today, per employee, counting only working days (skipping
+    holidays, weekly-offs, and approved/open leave) until that employee's allowed_days have
+    been counted; the date it stops on is the boundary - extended further back to absorb any
+    holiday/leave plateau immediately preceding it (see below). Fetches holidays and leave
+    for every employee in one round of queries instead of one round per employee."""
     from next_pms.resource_management.api.utils.query import get_employee_leaves
+    from next_pms.timesheet.api.utils import get_holiday_dates_by_employee
 
-    if allowed_days <= 0:
-        return str(today_date)
+    boundaries = {employee: str(today_date) for employee, days in allowed_days_by_employee.items() if days <= 0}
+    pending = [employee for employee in employees if employee not in boundaries]
+    if not pending:
+        return boundaries
 
     # A generous, fixed search window - realistically far wider than any configured
     # threshold would ever need, so the loop below always terminates within it.
     search_start = add_days(today_date, -365)
 
-    holidays = get_holiday_dates_for_employee(employee, search_start, today_date)
-    leaves = get_employee_leaves(
-        start_date=add_days(search_start, -28),
-        end_date=add_days(today_date, 28),
-        employee=employee,
-    )
+    holidays_by_employee = get_holiday_dates_by_employee(pending, search_start, today_date)
+    leaves_by_employee = defaultdict(list)
+    for leave in get_employee_leaves(
+        employee=tuple(pending), start_date=add_days(search_start, -28), end_date=add_days(today_date, 28)
+    ):
+        leaves_by_employee[leave.employee].append(leave)
 
-    non_working_days = set(holidays)
-    for leave in leaves:
-        current_date = getdate(leave.from_date)
-        leave_to_date = getdate(leave.to_date)
-        while current_date <= leave_to_date:
-            non_working_days.add(str(current_date))
-            current_date = add_days(current_date, 1)
+    for employee in pending:
+        non_working_days = set(holidays_by_employee.get(employee, []))
+        for leave in leaves_by_employee.get(employee, []):
+            current_date = getdate(leave.from_date)
+            leave_to_date = getdate(leave.to_date)
+            while current_date <= leave_to_date:
+                non_working_days.add(str(current_date))
+                current_date = add_days(current_date, 1)
 
-    working_days_counted = 0
-    current_date = today_date
-    while working_days_counted < allowed_days:
-        current_date = add_days(current_date, -1)
-        if current_date < search_start:
-            break
-        if str(current_date) not in non_working_days:
-            working_days_counted += 1
-    return str(current_date)
+        working_days_counted = 0
+        current_date = today_date
+        while working_days_counted < allowed_days_by_employee[employee]:
+            current_date = add_days(current_date, -1)
+            if current_date < search_start:
+                break
+            if str(current_date) not in non_working_days:
+                working_days_counted += 1
+
+        # Absorb any holiday/leave days immediately preceding the counted boundary day too -
+        # matches the old per-submission check, which never penalized a date that was itself
+        # a non-working day (a date that is its own holiday/leave day never cost a working
+        # day, so it was always at least as permissive as the working day right after it).
+        while True:
+            previous_date = add_days(current_date, -1)
+            if previous_date < search_start or str(previous_date) not in non_working_days:
+                break
+            current_date = previous_date
+
+        boundaries[employee] = str(current_date)
+
+    return boundaries
 
 
 def validate_existing_timesheet(doc, method=None):

--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -117,18 +117,7 @@ def validate_is_time_billable(doc, method=None):
 
 def validate_dates(doc):
     """Validate if time entry is made for holidays or leave days."""
-    # import frappe
-    from frappe import get_roles
-    from hrms.hr.utils import get_holiday_dates_for_employee
-
-    from next_pms.resource_management.api.utils.query import get_employee_leaves
-    from next_pms.timesheet.api.employee import get_employee_from_user
-
-    frappe_roles = set(get_roles())
-    ignore_roles = frappe.get_all("Timesheet Role", pluck="role")
-
-    roles_to_ignore = frappe_roles.intersection(ignore_roles)
-    if frappe.session.user == "Administrator" or doc.ignore_backdated_validation or roles_to_ignore:
+    if _is_exempt_from_backdate_validation() or doc.ignore_backdated_validation:
         return
     #  Do not allow the time entry for more then one day.
     if date_diff(doc.end_date, doc.start_date) > 0:
@@ -142,43 +131,104 @@ def validate_dates(doc):
     if not allow_future_entry and date_gap > 0:
         throw(_("Future time entries are not allowed."))
 
-    #  Check if the back dated time entry is allowed.
-    allow_back_dated_entry = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries")
-    if not allow_back_dated_entry and date_gap < 0:
-        throw(_("Backdated time entries are not allowed."))
-
-    # validate backdated entries as per the setting
+    #  Check if the backdated time entry falls within the allowed working-day window.
     if date_gap < 0:
-        has_access = ROLES.intersection(frappe_roles)
-        employee = get_employee_from_user()
-
-        if has_access and employee != doc.employee:
-            allowed_days = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_manager")
-        else:
-            allowed_days = frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_employee")
-        holidays = get_holiday_dates_for_employee(doc.employee, doc.start_date, today_date)
-        leaves = get_employee_leaves(
-            start_date=add_days(doc.start_date, -28),
-            end_date=add_days(today_date, 28),
-            employee=doc.employee,
-        )
-
-        for leave in leaves:
-            from_date = getdate(leave.from_date)
-            to_date = getdate(leave.to_date)
-
-            current_date = from_date
-            while current_date <= to_date:
-                holidays.append(str(current_date))
-                current_date = add_days(current_date, 1)
-
-        holiday_counter = 0
-        holidays = set(holidays)
-        for holiday in holidays:
-            if doc.start_date <= getdate(holiday) < today_date:
-                holiday_counter += 1
-        if abs(date_gap + holiday_counter) > allowed_days:
+        boundary = get_backdate_restriction_boundary(doc.employee)
+        if boundary and doc.start_date < getdate(boundary):
             throw(_("Backdated time entries are not allowed."))
+
+
+def _is_exempt_from_backdate_validation() -> bool:
+    """True if the current session user is fully exempt from backdate validation -
+    Administrator, or holding a role listed in Timesheet Settings' Ignored Role table.
+    Shared by validate_dates and get_backdate_restriction_boundary so there's exactly one
+    place this exemption is decided."""
+    from frappe import get_roles
+
+    if frappe.session.user == "Administrator":
+        return True
+
+    ignore_roles = frappe.get_all("Timesheet Role", pluck="role")
+    return bool(set(get_roles()).intersection(ignore_roles))
+
+
+def get_backdate_restriction_boundary(employee: str) -> str | None:
+    """Returns the earliest date (inclusive) `employee` may still log a time entry for, from
+    the current session user's perspective. Any date before the returned boundary is
+    restricted. Returns None if the current session user is exempt entirely (see
+    _is_exempt_from_backdate_validation) - meaning no date should be treated as restricted.
+    Single source of truth for the backdated-entry check: used both by the validation above
+    and by the frontend's disabled-cell precheck (exposed via API endpoints in api/app.py,
+    api/team.py, api/project.py)."""
+    if _is_exempt_from_backdate_validation():
+        return None
+
+    today_date = getdate(today())
+
+    if not frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries"):
+        return str(today_date)
+
+    allowed_days = _get_effective_backdated_allowed_days(employee)
+    return _compute_backdate_boundary(employee, allowed_days, today_date)
+
+
+def _get_effective_backdated_allowed_days(employee: str) -> int:
+    """Resolves the 'allow backdated entries till' day threshold for `employee`'s record,
+    from the current session user's perspective: the manager threshold applies if they hold
+    a manager-ish role (see ROLES) and are looking at someone else's record, the employee
+    threshold otherwise."""
+    from frappe import get_roles
+
+    from next_pms.timesheet.api.employee import get_employee_from_user
+
+    frappe_roles = set(get_roles())
+    has_access = ROLES.intersection(frappe_roles)
+    viewer_employee = get_employee_from_user()
+
+    if has_access and viewer_employee != employee:
+        return frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_manager") or 0
+    return frappe.db.get_single_value("Timesheet Settings", "allow_backdated_entries_till_employee") or 0
+
+
+def _compute_backdate_boundary(employee: str, allowed_days: int, today_date) -> str:
+    """Walks backward from today counting only working days (skipping holidays, weekly-offs,
+    and approved/open leave) until `allowed_days` have been counted; the date it stops on is
+    the boundary - the earliest date still within the allowed window."""
+    from hrms.hr.utils import get_holiday_dates_for_employee
+
+    from next_pms.resource_management.api.utils.query import get_employee_leaves
+
+    if allowed_days <= 0:
+        return str(today_date)
+
+    # A generous, fixed search window - realistically far wider than any configured
+    # threshold would ever need, so the loop below always terminates within it.
+    search_start = add_days(today_date, -365)
+
+    holidays = get_holiday_dates_for_employee(employee, search_start, today_date)
+    leaves = get_employee_leaves(
+        start_date=add_days(search_start, -28),
+        end_date=add_days(today_date, 28),
+        employee=employee,
+    )
+
+    non_working_days = set(holidays)
+    for leave in leaves:
+        current_date = getdate(leave.from_date)
+        leave_to_date = getdate(leave.to_date)
+        while current_date <= leave_to_date:
+            non_working_days.add(str(current_date))
+            current_date = add_days(current_date, 1)
+
+    working_days_counted = 0
+    current_date = today_date
+    while working_days_counted < allowed_days:
+        current_date = add_days(current_date, -1)
+        if current_date < search_start:
+            break
+        if str(current_date) not in non_working_days:
+            working_days_counted += 1
+    return str(current_date)
 
 
 def validate_existing_timesheet(doc, method=None):


### PR DESCRIPTION
## Description
### Backend
- Adds `get_backdate_restriction_boundary(employee)` as the single source of truth for the
  earliest date a user may still log time against - reused by `validate_dates` (enforcement)
  and exposed via `get_data` / team / project APIs (frontend precheck).
- Boundary computation counts working days only, skipping holidays, weekly-offs, and
  approved/open leave, matching backend validation exactly.
- Fixes the Ignored Role / Administrator exemption not being honored by the boundary
  calculation - exempt users were still seeing dates disabled in the grid despite the
  backend accepting the entry.
- Adds test coverage: boundary math (employee/manager thresholds, master toggle, zero-day
  edge cases), exemptions, holiday/leave widening, and `validate_dates` integration.

### Frontend
- Threads `backdate_restricted_before` down through the timesheet grid's row components
  (task, project, member, week, totals) so dates before the boundary render disabled.
- Uses a single shared `isDateBackdateRestricted` check against the backend-computed boundary.

## Relevant Technical Choices
### But why did i do **Backend-computed boundary instead of client-side accumulation**?

I first tried making the frontend fetch each employee's holidays and leave, then re-count "working days" itself in JS to
match the backend's rule. I dropped this because it meant the same logic lived in two places
(Python and JS), and they could quietly fall out of sync over time + a lot of complexity was added to achieve this.

Instead, the backend now does this counting once and just tells the frontend a single date: "you
can't add entries before this date." This works because the restriction only ever gets stricter
the further back you go, never looser - so one date is all the frontend needs, not the full
holiday/leave calendar.

This way, the holiday/leave logic lives in exactly one place (the backend), the frontend just
compares a date to that one boundary, and any future backend fix (like the Ignored Role bug)
automatically works correctly on the frontend too, with no frontend changes needed.

## Screenshot/Screencast

https://github.com/user-attachments/assets/c5306fd5-59f3-4ecb-8c91-7c88735c6669


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #883