### PR TITLE
fix: empty weeks on team timesheet page skipped

### DIFF
--- a/next_pms/tests/timesheet/api/test_team_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_team_timesheet_data.py
@@ -526,6 +526,38 @@ class TestTeamTimesheetDataFilters(_TeamTimesheetDataBase):
         )
         self.assertNotIn(self.r3, self._members_by_employee(res))
 
+    def test_timesheet_detail_task_filter_excludes_a_week_of_unrelated_work(self):
+        """#2011: the team UI sends Task as Timesheet Detail.task. Time on a
+        different task in W2 must not produce an empty member row."""
+        self._save(self.r1, W2_MON, self.task_beta, 2, "r1 w2 other task")
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Timesheet Detail", "task", "=", self.task_alpha]]),
+            start_date=W2_MON,
+        )
+        self.assertEqual(res["members"], [])
+        self.assertEqual(res["total_count"], 0)
+
+    def test_timesheet_detail_project_filter_excludes_a_week_of_unrelated_work(self):
+        """#2011: the team UI sends Project as Timesheet Detail.project."""
+        self._save(self.r1, W2_MON, self.task_beta, 2, "r1 w2 other project")
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Timesheet Detail", "project", "=", self.project_alpha]]),
+            start_date=W2_MON,
+        )
+        self.assertEqual(res["members"], [])
+        self.assertEqual(res["total_count"], 0)
+
+    def test_timesheet_detail_task_filter_keeps_the_week_that_matches(self):
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Timesheet Detail", "task", "=", self.task_alpha]]),
+            start_date=W1_MON,
+        )
+        self.assertEqual(sorted(self._members_by_employee(res)), [self.r1, self.r2])
+        self.assertEqual(res["total_count"], 2)
+
 
 LEFT_EMP_NAME = "Meera Joshi"
 BU_ALPHA_NAME = "Ttf BU Alpha"
@@ -691,6 +723,30 @@ class TestTeamTimesheetWeeks(_TeamTimesheetDataBase):
         self.assertEqual(res["weeks"], [])
         self.assertFalse(res["has_more_weeks"])
 
+    def test_timesheet_detail_task_filter_hides_weeks_without_that_task(self):
+        """#2011: W2 has time, just not on the filtered task, so it must not
+        render as an empty week row."""
+        self._save(self.r1, W2_MON, self.task_beta, 2, "r1 w2 other task")
+        res = self._weeks(
+            reports_to=self.mgr,
+            max_week=2,
+            filters=json.dumps([["Timesheet Detail", "task", "=", self.task_alpha]]),
+        )
+        starts = [week["start_date"] for week in res["weeks"]]
+        self.assertEqual(starts, [frappe.utils.getdate(W1_MON)])
+        self.assertEqual(res["weeks"][0]["member_count"], 2)
+
+    def test_timesheet_detail_project_filter_hides_weeks_without_that_project(self):
+        self._save(self.r1, W2_MON, self.task_beta, 2, "r1 w2 other project")
+        res = self._weeks(
+            reports_to=self.mgr,
+            max_week=2,
+            filters=json.dumps([["Timesheet Detail", "project", "=", self.project_alpha]]),
+        )
+        starts = [week["start_date"] for week in res["weeks"]]
+        self.assertEqual(starts, [frappe.utils.getdate(W1_MON)])
+        self.assertEqual(res["weeks"][0]["member_count"], 2)
+
     def test_has_more_weeks_ignores_timesheets_outside_the_scope(self):
         # E1 is outside the manager's team; their older week must not keep the frontend
         # paging backwards through weeks that can never produce a row.
@@ -744,6 +800,12 @@ class TestTeamTimesheetConsistency(_TeamTimesheetDataBase):
 
     def test_consistent_with_task_project_filter(self):
         self._assert_consistent(filters=json.dumps([["Task", "project", "=", self.project_alpha]]))
+
+    def test_consistent_with_timesheet_detail_task_filter(self):
+        self._assert_consistent(filters=json.dumps([["Timesheet Detail", "task", "=", self.task_alpha]]))
+
+    def test_consistent_with_timesheet_detail_project_filter(self):
+        self._assert_consistent(filters=json.dumps([["Timesheet Detail", "project", "=", self.project_alpha]]))
 
 
 class TestTeamTimesheetMemberWeek(_TeamTimesheetDataBase):

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -307,7 +307,7 @@ def get_team_timesheet_weeks(
 
     Feeds first paint: the page can render its week rows and pending-approval badges
     before any member data is fetched, and `get_team_timesheet_data` then fills one week
-    at a time. Touches no Timesheet Detail rows.
+    at a time. Timesheet Detail is read only when Task / Project filters need it.
     """
     only_for(["Timesheet Manager", "Timesheet User", "Projects Manager"], message=True)
 

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -400,6 +400,58 @@ def build_aggregate_dates(date: str, max_week: int, has_filters: bool):
     return dates, max_lookback
 
 
+def timesheet_names_matching_work_filters(
+    timesheets: list,
+    parsed_filters: dict,
+    require_project_tasks: bool = False,
+) -> set[str]:
+    """Timesheet names whose details/tasks survive Task / Timesheet Detail filters.
+
+    The team UI sends Project and Task as Timesheet Detail filters. Without this
+    scan, a week that only has time on some other project/task still looks occupied.
+    No work filter means every name is kept, so callers can share one code path.
+    """
+    timesheet_by_name = {timesheet.name: timesheet for timesheet in timesheets}
+    if not timesheet_by_name:
+        return set()
+
+    requires_detail_scan = bool(
+        require_project_tasks or parsed_filters.get("Task") or parsed_filters.get("Timesheet Detail")
+    )
+    if not requires_detail_scan:
+        return set(timesheet_by_name)
+
+    details = get_all(
+        "Timesheet Detail",
+        filters=build_filters({"parent": ["in", list(timesheet_by_name)]}, parsed_filters.get("Timesheet Detail", [])),
+        fields=["parent", "task"],
+    )
+    if not details:
+        return set()
+
+    requires_task_scan = bool(require_project_tasks or parsed_filters.get("Task"))
+    if not requires_task_scan:
+        return {detail.parent for detail in details if detail.parent in timesheet_by_name}
+
+    task_ids = list({detail.task for detail in details if detail.task})
+    if not task_ids:
+        return set()
+
+    tasks = get_all(
+        "Task",
+        filters=build_filters({"name": ["in", task_ids]}, parsed_filters.get("Task", [])),
+        fields=["name", "project"],
+    )
+    if require_project_tasks:
+        tasks = [task for task in tasks if task.get("project")]
+
+    valid_task_ids = {task.name for task in tasks}
+    if not valid_task_ids:
+        return set()
+
+    return {detail.parent for detail in details if detail.task in valid_task_ids and detail.parent in timesheet_by_name}
+
+
 def get_matching_timesheet_employee_ids(
     dates: list,
     parsed_filters: dict,
@@ -422,42 +474,11 @@ def get_matching_timesheet_employee_ids(
     if not timesheets:
         return []
 
-    requires_detail_scan = bool(
-        require_project_tasks or parsed_filters.get("Task") or parsed_filters.get("Timesheet Detail")
+    matched_names = timesheet_names_matching_work_filters(
+        timesheets, parsed_filters, require_project_tasks=require_project_tasks
     )
-    if not requires_detail_scan:
-        return list({timesheet.employee for timesheet in timesheets})
-
     timesheet_by_name = {timesheet.name: timesheet for timesheet in timesheets}
-    detail_filters = build_filters(
-        {"parent": ["in", list(timesheet_by_name)]}, parsed_filters.get("Timesheet Detail", [])
-    )
-    details = get_all("Timesheet Detail", filters=detail_filters, fields=["parent", "task"])
-    if not details:
-        return []
-
-    requires_task_scan = bool(require_project_tasks or parsed_filters.get("Task"))
-    if not requires_task_scan:
-        matched_parent_names = {detail.parent for detail in details}
-        return list(
-            {timesheet_by_name[parent].employee for parent in matched_parent_names if parent in timesheet_by_name}
-        )
-
-    task_ids = list({detail.task for detail in details if detail.task})
-    if not task_ids:
-        return []
-
-    task_filters = build_filters({"name": ["in", task_ids]}, parsed_filters.get("Task", []))
-    tasks = get_all("Task", filters=task_filters, fields=["name", "project"])
-    if require_project_tasks:
-        tasks = [task for task in tasks if task.get("project")]
-
-    valid_task_ids = {task.name for task in tasks}
-    if not valid_task_ids:
-        return []
-
-    matched_parent_names = {detail.parent for detail in details if detail.task in valid_task_ids}
-    return list({timesheet_by_name[parent].employee for parent in matched_parent_names if parent in timesheet_by_name})
+    return list({timesheet_by_name[name].employee for name in matched_names})
 
 
 def sanitize_employee_conditions(employee_conditions: list | None) -> list:
@@ -627,6 +648,10 @@ def get_team_week_participation(scope: TeamEmployeeScope, weeks: list) -> dict:
     `get_first_day_of_week` so the week boundary matches the rest of the app rather
     than a hand-rolled SQL date expression that would ignore System Settings.
 
+    Task / Project filters are Timesheet Detail predicates, so a week only counts
+    when that week's timesheet actually matches them. Counting any timesheet in
+    the week is what produced empty rows for #2011.
+
     Returns `{week_start: {"members": set, "pending": set}}`. Sets rather than counts
     because API 2 intersects them with its own employee page, and a count cannot be
     intersected.
@@ -644,19 +669,22 @@ def get_team_week_participation(scope: TeamEmployeeScope, weeks: list) -> dict:
 
     rows = get_all(
         "Timesheet",
-        filters=timesheet_filters,
-        fields=["employee", "start_date", "custom_weekly_approval_status"],
+        filters=build_filters(timesheet_filters, scope.parsed_filters.get("Timesheet", [])),
+        fields=["name", "employee", "start_date", "custom_weekly_approval_status"],
         distinct=True,
         # Unordered on purpose: the result is folded into sets, and the default
         # `creation` sort costs a filesort over the whole match set.
         order_by=None,
     )
+    matching_names = timesheet_names_matching_work_filters(rows, scope.parsed_filters)
 
     status_filter = set(scope.status_filter or [])
     participation = {
         week["start_date"]: {"members": set(), "pending": set(), "status_matched": set()} for week in weeks
     }
     for row in rows:
+        if row.name not in matching_names:
+            continue
         week_start = get_first_day_of_week(row.start_date)
         bucket = participation.get(week_start)
         if bucket is None:


### PR DESCRIPTION
## Description

empty weeks on team timesheet page skipped

## Testing Instructions

1. select a filter and see empty weeks skipped from backend

## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #2011