### PR TITLE
feat: backend comment notifications

### DIFF
--- a/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
@@ -3,7 +3,7 @@
  */
 import type { ComponentType } from "react";
 import type { NotificationEntry } from "@next-pms/design-system/components";
-import { File, Fire, Folder, Time, Check } from "@rtcamp/frappe-ui-react/icons";
+import { AtSign, File, Fire, Folder, Time, Check } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -15,10 +15,21 @@ const DOCTYPE_ICON_MAP: Record<string, ComponentType<{ size?: number }>> = {
   Timesheet: Time,
   "Customer Feedback": File,
   Project: Folder,
+  "Project Status Update": AtSign,
+  "Project RAG Status": AtSign,
 };
 
-const NotificationIcon = ({ linkedDoctype }: { linkedDoctype: string }) => {
-  const Icon = DOCTYPE_ICON_MAP[linkedDoctype] ?? Check;
+const NotificationIcon = ({
+  linkedDoctype,
+  title,
+}: {
+  linkedDoctype: string;
+  title?: string;
+}) => {
+  const Icon =
+    title?.toLowerCase().includes("mention")
+      ? AtSign
+      : (DOCTYPE_ICON_MAP[linkedDoctype] ?? Check);
   return (
     <div
       aria-hidden="true"
@@ -85,7 +96,10 @@ export default function NotificationsCard() {
                   }}
                   className="flex cursor-pointer items-start gap-2"
                 >
-                  <NotificationIcon linkedDoctype={item.linkedDoctype} />
+                  <NotificationIcon
+                    linkedDoctype={item.linkedDoctype}
+                    title={item.title}
+                  />
                   <div className="flex w-full flex-col gap-1">
                     <div className="flex items-baseline justify-between gap-2">
                       {item.title && (

--- a/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/notificationsCard.tsx
@@ -3,7 +3,14 @@
  */
 import type { ComponentType } from "react";
 import type { NotificationEntry } from "@next-pms/design-system/components";
-import { AtSign, File, Fire, Folder, Time, Check } from "@rtcamp/frappe-ui-react/icons";
+import {
+  AtSign,
+  File,
+  Fire,
+  Folder,
+  Time,
+  Check,
+} from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -26,10 +33,9 @@ const NotificationIcon = ({
   linkedDoctype: string;
   title?: string;
 }) => {
-  const Icon =
-    title?.toLowerCase().includes("mention")
-      ? AtSign
-      : (DOCTYPE_ICON_MAP[linkedDoctype] ?? Check);
+  const Icon = title?.toLowerCase().includes("mention")
+    ? AtSign
+    : (DOCTYPE_ICON_MAP[linkedDoctype] ?? Check);
   return (
     <div
       aria-hidden="true"

--- a/frontend/packages/app/src/pages/project-details/tabs/feedback/teamFeedbackView/feedbackDetailBody.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/feedback/teamFeedbackView/feedbackDetailBody.tsx
@@ -46,12 +46,12 @@ export function FeedbackDetailBody({ feedbackId }: { feedbackId: string }) {
         },
       );
 
-      const mentions = response.message.data.map(
-        (emp: { name: string; employee_name: string }) => ({
-          id: emp.name,
+      const mentions = response.message.data
+        .filter((emp: { user_id?: string }) => emp.user_id)
+        .map((emp: { user_id: string; employee_name: string }) => ({
+          id: emp.user_id,
           label: emp.employee_name,
-        }),
-      );
+        }));
 
       return mentions || [];
     },

--- a/frontend/packages/app/src/pages/project-details/tabs/feedback/useFeedbackComments.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/feedback/useFeedbackComments.ts
@@ -14,6 +14,7 @@ import {
  * Internal dependencies.
  */
 import { parseFrappeErrorMsg } from "@/lib/utils";
+import { useProjectDetail } from "@/pages/project-details/context";
 import type { FeedbackComment } from "./types";
 
 function mapFeedbackComment(comment: FeedbackComment): CommentNode {
@@ -34,6 +35,7 @@ function mapFeedbackComment(comment: FeedbackComment): CommentNode {
 
 export function useFeedbackComments(feedbackName: string) {
   const toast = useToasts();
+  const projectId = useProjectDetail((s) => s.projectId);
 
   const { data, isLoading, isValidating, error, mutate } = useFrappeGetCall<{
     message: FeedbackComment[];
@@ -56,11 +58,12 @@ export function useFeedbackComments(feedbackName: string) {
       await addCall({
         feedback: feedbackName,
         comment,
+        project: projectId,
         ...(replyTo && { reply_to: replyTo }),
       });
       await mutate();
     },
-    [addCall, feedbackName, mutate],
+    [addCall, feedbackName, mutate, projectId],
   );
 
   const addComment = useCallback(

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/detail/comments/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/detail/comments/index.tsx
@@ -47,12 +47,12 @@ export function NoteComments({ noteId }: NoteCommentsProps) {
         },
       );
 
-      const mentions = response.message.data.map(
-        (emp: { name: string; employee_name: string }) => ({
-          id: emp.name,
+      const mentions = response.message.data
+        .filter((emp: { user_id?: string }) => emp.user_id)
+        .map((emp: { user_id: string; employee_name: string }) => ({
+          id: emp.user_id,
           label: emp.employee_name,
-        }),
-      );
+        }));
 
       return mentions || [];
     },

--- a/frontend/packages/app/src/pages/project-details/tabs/rag-stats/comments.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/rag-stats/comments.tsx
@@ -56,12 +56,12 @@ export function RagComments() {
         },
       );
 
-      const mentions = response.message.data.map(
-        (emp: { name: string; employee_name: string }) => ({
-          id: emp.name,
+      const mentions = response.message.data
+        .filter((emp: { user_id?: string }) => emp.user_id)
+        .map((emp: { user_id: string; employee_name: string }) => ({
+          id: emp.user_id,
           label: emp.employee_name,
-        }),
-      );
+        }));
 
       return mentions || [];
     },

--- a/frontend/packages/design-system/src/components/notificationTray/notificationItem.tsx
+++ b/frontend/packages/design-system/src/components/notificationTray/notificationItem.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import React, { type ComponentType } from "react";
-import { Folder, Fire, File, Time, Check } from "@rtcamp/frappe-ui-react/icons";
+import { AtSign, Folder, Fire, File, Time, Check } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -15,10 +15,21 @@ const DOCTYPE_ICON_MAP: Record<string, ComponentType<{ size?: number }>> = {
   Timesheet: Time,
   "Customer Feedback": File,
   Project: Folder,
+  "Project Status Update": AtSign,
+  "Project RAG Status": AtSign,
 };
 
-const NotificationIcon = ({ linkedDoctype }: { linkedDoctype: string }) => {
-  const Icon = DOCTYPE_ICON_MAP[linkedDoctype] ?? Check;
+const NotificationIcon = ({
+  linkedDoctype,
+  title,
+}: {
+  linkedDoctype: string;
+  title?: string;
+}) => {
+  const Icon =
+    title?.toLowerCase().includes("mention")
+      ? AtSign
+      : (DOCTYPE_ICON_MAP[linkedDoctype] ?? Check);
   return (
     <div
       aria-hidden="true"
@@ -66,7 +77,7 @@ const NotificationItem = ({
           read ? "bg-transparent" : "bg-surface-blue-5",
         )}
       />
-      <NotificationIcon linkedDoctype={linkedDoctype} />
+      <NotificationIcon linkedDoctype={linkedDoctype} title={title} />
       <div className="flex min-w-0 flex-col gap-1">
         <div className="flex items-baseline justify-between gap-2">
           {title && (

--- a/frontend/packages/design-system/src/components/notificationTray/notificationItem.tsx
+++ b/frontend/packages/design-system/src/components/notificationTray/notificationItem.tsx
@@ -2,7 +2,14 @@
  * External dependencies.
  */
 import React, { type ComponentType } from "react";
-import { AtSign, Folder, Fire, File, Time, Check } from "@rtcamp/frappe-ui-react/icons";
+import {
+  AtSign,
+  Folder,
+  Fire,
+  File,
+  Time,
+  Check,
+} from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -26,10 +33,9 @@ const NotificationIcon = ({
   linkedDoctype: string;
   title?: string;
 }) => {
-  const Icon =
-    title?.toLowerCase().includes("mention")
-      ? AtSign
-      : (DOCTYPE_ICON_MAP[linkedDoctype] ?? Check);
+  const Icon = title?.toLowerCase().includes("mention")
+    ? AtSign
+    : (DOCTYPE_ICON_MAP[linkedDoctype] ?? Check);
   return (
     <div
       aria-hidden="true"

--- a/next_pms/next_pms/notifications.py
+++ b/next_pms/next_pms/notifications.py
@@ -27,7 +27,9 @@ def send_mention_notifications(
 
     current_user = frappe.session.user
     full_url = frappe.utils.get_url(url_path)
-    email_content = frappe.render_template(MENTION_EMAIL_TEMPLATE, {"content": content})  # nosemgrep - trusted template file
+    email_content = frappe.render_template(  # nosemgrep - trusted template file
+        MENTION_EMAIL_TEMPLATE, {"content": content}
+    )
 
     for user_email in mentioned_users:
         if not user_email or user_email == current_user:

--- a/next_pms/next_pms/notifications.py
+++ b/next_pms/next_pms/notifications.py
@@ -3,9 +3,67 @@ from urllib.parse import urlencode
 
 import frappe
 from frappe import _
+from frappe.desk.notifications import extract_mentions
 from frappe.utils import formatdate, get_fullname, getdate
 
 from next_pms.next_pms.doctype.nextpms_notifications.nextpms_notifications import create_notification
+
+MENTION_EMAIL_TEMPLATE = "next_pms/templates/mention_notification.html"
+
+
+def send_mention_notifications(
+    content: str,
+    title: str,
+    label: str,
+    linked_doctype: str,
+    linked_document: str,
+    url_path: str,
+) -> dict:
+    """Notify mentioned users via Notification Log and NextPMS Notifications."""
+
+    mentioned_users = extract_mentions(content)
+    if not mentioned_users:
+        return {"message": "No mentions found"}
+
+    current_user = frappe.session.user
+    full_url = frappe.utils.get_url(url_path)
+    email_content = frappe.render_template(MENTION_EMAIL_TEMPLATE, {"content": content})  # nosemgrep - trusted template file
+
+    for user_email in mentioned_users:
+        if not user_email or user_email == current_user:
+            continue
+        if not frappe.db.exists("User", user_email):
+            continue
+
+        frappe.get_doc(
+            {
+                "doctype": "Notification Log",
+                "subject": label,
+                "for_user": user_email,
+                "type": "Mention",
+                "document_type": linked_doctype,
+                "document_name": linked_document,
+                "from_user": current_user,
+                "link": full_url,
+                "email_header": title,
+                "email_content": email_content,
+                "read": 0,
+            }
+        ).insert(ignore_permissions=True)
+
+        frappe.get_doc(
+            {
+                "doctype": "NextPMS Notifications",
+                "user": user_email,
+                "title": title,
+                "label": label,
+                "linked_doctype": linked_doctype,
+                "linked_document": linked_document,
+                "url": url_path,
+            }
+        ).insert(ignore_permissions=True)
+
+    return {"message": f"Notifications sent successfully to {len(mentioned_users)} users"}
 
 
 def get_followers(doctype, name):

--- a/next_pms/next_projects/api/feedback.py
+++ b/next_pms/next_projects/api/feedback.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2026, rtCamp and contributors
 # For license information, please see license.txt
 
-
 import frappe
-from frappe import _, only_for
+from frappe import _, enqueue, only_for
+from frappe.desk.notifications import extract_mentions
 from frappe.query_builder import DocType, Order
 from frappe.utils import cint, getdate, strip_html_tags
 from frappe.utils.user import get_user_fullname
@@ -385,7 +385,7 @@ def get_feedback_comments(feedback: str):
 
 
 @frappe.whitelist(methods=["POST"])
-def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = None):
+def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = None, project: str | None = None):
     """Add a comment or reply to a Customer Feedback record.
 
     The author is always the session user. The commenting roles have no
@@ -396,6 +396,7 @@ def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = 
         feedback: Customer Feedback name to comment on.
         comment: Comment body (HTML).
         reply_to: Name of the parent comment when posting a reply.
+        project: Project the commenter is viewing, used for mention deep-links.
 
     Returns:
         list[dict]: The refreshed comment tree, as in get_feedback_comments.
@@ -423,12 +424,22 @@ def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = 
             "comment_type": "Comment",
             "reference_doctype": "Customer Feedback",
             "reference_name": feedback,
-            "content": comment,
+            "content": comment.replace(' data-type="mention"', ""),
             "comment_email": frappe.session.user,
             "comment_by": get_user_fullname(frappe.session.user),
             "custom_reply_to": reply_to,
         }
     ).insert(ignore_permissions=True)
+
+    enqueue(
+        notify_feedback_nextpms_mentions,
+        content=comment,
+        feedback=feedback,
+        project=project,
+        queue="short",
+        enqueue_after_commit=True,
+        job_name=f"Mention Notifications for Feedback Comment {feedback}",
+    )
     return get_feedback_comment_tree(feedback)
 
 
@@ -455,8 +466,9 @@ def update_comment_in_feedback(comment_name: str, comment: str):
     if is_blank(comment):
         frappe.throw(_("Comment cannot be empty"))
 
-    doc.content = comment
+    doc.content = comment.replace(' data-type="mention"', "")
     doc.save(ignore_permissions=True)
+
     return get_feedback_comment_tree(doc.reference_name)
 
 
@@ -560,3 +572,26 @@ def serialize_feedback_comment(row, user_map: dict, children_by_parent: dict) ->
         "reply_count": len(replies),
         "replies": replies,
     }
+
+
+def notify_feedback_nextpms_mentions(content: str, feedback: str, project: str) -> None:
+    """Create NextPMS notifications for users mentioned in a feedback comment."""
+    project_title = frappe.db.get_value("Project", project, "project_name")
+    actor = get_user_fullname(frappe.session.user)
+    title = _("You got a Feedback mention")
+    label = _("{0} mentioned you in feedback from {1} project").format(actor, project_title)
+
+    for user in extract_mentions(content):
+        if user == frappe.session.user or not frappe.db.exists("User", user):
+            continue
+        frappe.get_doc(
+            {
+                "doctype": "NextPMS Notifications",
+                "user": user,
+                "title": title,
+                "label": label,
+                "linked_doctype": "Customer Feedback",
+                "linked_document": feedback,
+                "url": f"/next-pms/projects/{project}?tab=feedback",
+            }
+        ).insert(ignore_permissions=True)

--- a/next_pms/next_projects/api/feedback.py
+++ b/next_pms/next_projects/api/feedback.py
@@ -385,7 +385,7 @@ def get_feedback_comments(feedback: str):
 
 
 @frappe.whitelist(methods=["POST"])
-def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = None, project: str | None = None):
+def add_comment_to_feedback(feedback: str, comment: str, project: str, reply_to: str | None = None):
     """Add a comment or reply to a Customer Feedback record.
 
     The author is always the session user. The commenting roles have no
@@ -395,8 +395,8 @@ def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = 
     Args:
         feedback: Customer Feedback name to comment on.
         comment: Comment body (HTML).
-        reply_to: Name of the parent comment when posting a reply.
         project: Project the commenter is viewing, used for mention deep-links.
+        reply_to: Name of the parent comment when posting a reply.
 
     Returns:
         list[dict]: The refreshed comment tree, as in get_feedback_comments.
@@ -404,6 +404,7 @@ def add_comment_to_feedback(feedback: str, comment: str, reply_to: str | None = 
     only_for(ALLOWED_ROLES, message=True)
     ensure_customer_feedback_available()
     ensure_feedback_exists(feedback)
+    ensure_feedback_belongs_to_project(feedback, project)
     if is_blank(comment):
         frappe.throw(_("Comment cannot be empty"))
     if reply_to:
@@ -499,9 +500,20 @@ def delete_comment_from_feedback(comment_name: str):
 
 
 def ensure_feedback_exists(feedback: str):
-    """Guard: throw when the Customer Feedback record does not exist."""
+    """throw when the Customer Feedback record does not exist."""
     if not feedback or not frappe.db.exists("Customer Feedback", feedback):
         frappe.throw(_("Customer Feedback {0} not found").format(feedback), frappe.DoesNotExistError)
+
+
+def ensure_feedback_belongs_to_project(feedback: str, project: str):
+    """the project must exist and expose this customer's feedback."""
+    if not frappe.db.exists("Project", project):
+        frappe.throw(_("Project {0} not found").format(project), frappe.DoesNotExistError)
+
+    feedback_customer = frappe.db.get_value("Customer Feedback", feedback, "customer")
+    project_customer = frappe.db.get_value("Project", project, "customer")
+    if not feedback_customer or feedback_customer != project_customer:
+        frappe.throw(_("Customer Feedback {0} is not available for Project {1}").format(feedback, project))
 
 
 def get_feedback_comment_doc(comment_name: str):

--- a/next_pms/templates/mention_notification.html
+++ b/next_pms/templates/mention_notification.html
@@ -1,0 +1,3 @@
+<div style="padding: 15px; border-left: 4px solid #007bff; margin: 10px 0;">
+    {{ content }}
+</div>

--- a/next_pms/tests/next_projects/api/test_feedback_comments.py
+++ b/next_pms/tests/next_projects/api/test_feedback_comments.py
@@ -1,6 +1,7 @@
 import unittest
 
 import frappe
+from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
 
 from next_pms.next_projects.api.feedback import (
@@ -47,6 +48,20 @@ class TestFeedbackComments(IntegrationTestCase):
         if not frappe.db.exists("DocType", "Customer Feedback"):
             raise unittest.SkipTest("Customer Feedback doctypes not installed on this site")
         cls.feedback = cls.make_feedback()
+        customer = frappe.db.get_value("Customer Feedback", cls.feedback, "customer")
+        cls.project = (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": f"Feedback Comment Project {frappe.generate_hash(length=8)}",
+                    "company": get_default_company(),
+                    "customer": customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
 
         # Projects Manager clears the ALLOWED_ROLES gate on the endpoints; the
         # doctypes themselves grant this role no CRUD, so the API is the sole gate.
@@ -117,7 +132,12 @@ class TestFeedbackComments(IntegrationTestCase):
 
     def add_comment(self, comment, reply_to=None, user=None):
         frappe.set_user(user or self.author_user)
-        tree = add_comment_to_feedback(feedback=self.feedback, comment=comment, reply_to=reply_to)
+        tree = add_comment_to_feedback(
+            feedback=self.feedback,
+            comment=comment,
+            project=self.project,
+            reply_to=reply_to,
+        )
         added = frappe.get_all(
             "Comment",
             filters={"reference_doctype": "Customer Feedback", "reference_name": self.feedback},
@@ -137,7 +157,7 @@ class TestFeedbackComments(IntegrationTestCase):
         with self.assertRaises(frappe.PermissionError):
             get_feedback_comments(feedback=self.feedback)
         with self.assertRaises(frappe.PermissionError):
-            add_comment_to_feedback(feedback=self.feedback, comment="<p>nope</p>")
+            add_comment_to_feedback(feedback=self.feedback, comment="<p>nope</p>", project=self.project)
 
     def test_allowed_role_has_no_direct_doctype_access(self):
         frappe.set_user(self.author_user)
@@ -155,10 +175,7 @@ class TestFeedbackComments(IntegrationTestCase):
         self.assertEqual(root["replies"], [])
 
     def test_add_comment_with_mention(self):
-        mention = (
-            f'<span class="mention" data-type="mention" data-id="{OTHER_USER}" '
-            'data-label="Other">@Other</span>'
-        )
+        mention = f'<span class="mention" data-type="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span>'
         name, tree = self.add_comment(f"<p>{mention} ping</p>")
         comment = find_comment(tree, name)
 
@@ -169,7 +186,16 @@ class TestFeedbackComments(IntegrationTestCase):
     def test_add_blank_comment_raises(self):
         frappe.set_user(self.author_user)
         with self.assertRaises(frappe.ValidationError):
-            add_comment_to_feedback(feedback=self.feedback, comment="<p>  </p>")
+            add_comment_to_feedback(feedback=self.feedback, comment="<p>  </p>", project=self.project)
+
+    def test_add_comment_requires_existing_project(self):
+        frappe.set_user(self.author_user)
+        with self.assertRaises(frappe.DoesNotExistError):
+            add_comment_to_feedback(
+                feedback=self.feedback,
+                comment="<p>comment</p>",
+                project="PROJ-DOES-NOT-EXIST",
+            )
 
     def test_add_reply_nests_under_parent(self):
         parent, _ = self.add_comment("<p>parent</p>")
@@ -183,7 +209,12 @@ class TestFeedbackComments(IntegrationTestCase):
     def test_reply_to_unknown_parent_raises(self):
         frappe.set_user(self.author_user)
         with self.assertRaises(frappe.ValidationError):
-            add_comment_to_feedback(feedback=self.feedback, comment="<p>orphan</p>", reply_to="not-a-comment")
+            add_comment_to_feedback(
+                feedback=self.feedback,
+                comment="<p>orphan</p>",
+                project=self.project,
+                reply_to="not-a-comment",
+            )
 
     def test_edit_own_comment(self):
         name, _ = self.add_comment("<p>original</p>")
@@ -258,43 +289,29 @@ class TestFeedbackComments(IntegrationTestCase):
         with self.assertRaises(frappe.DoesNotExistError):
             update_comment_in_feedback(comment_name=foreign.name, comment="<p>hijack</p>")
         with self.assertRaises(frappe.ValidationError):
-            add_comment_to_feedback(feedback=self.feedback, comment="<p>reply</p>", reply_to=foreign.name)
+            add_comment_to_feedback(
+                feedback=self.feedback,
+                comment="<p>reply</p>",
+                project=self.project,
+                reply_to=foreign.name,
+            )
 
     def test_mention_creates_only_nextpms_notification(self):
-        from erpnext import get_default_company
-
         from next_pms.next_projects.api.feedback import notify_feedback_nextpms_mentions
 
-        frappe.set_user("Administrator")
-        customer = frappe.db.get_value("Customer Feedback", self.feedback, "customer")
-        project = (
-            frappe.get_doc(
-                {
-                    "doctype": "Project",
-                    "project_name": "Feedback Mention Project",
-                    "company": get_default_company(),
-                    "customer": customer,
-                    "custom_billing_type": "Non-Billable",
-                }
-            )
-            .insert(ignore_permissions=True)
-            .name
-        )
-
         frappe.set_user(self.author_user)
-        mention_html = (
-            f'<p><span class="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span> ping</p>'
-        )
-        notify_feedback_nextpms_mentions(content=mention_html, feedback=self.feedback, project=project)
+        mention_html = f'<p><span class="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span> ping</p>'
+        log_filters = {
+            "for_user": OTHER_USER,
+            "document_name": self.feedback,
+            "type": "Mention",
+        }
+        logs_before = frappe.db.count("Notification Log", log_filters)
+        notify_feedback_nextpms_mentions(content=mention_html, feedback=self.feedback, project=self.project)
 
-        expected_path = f"/next-pms/projects/{project}?tab=feedback"
+        expected_path = f"/next-pms/projects/{self.project}?tab=feedback"
 
-        self.assertFalse(
-            frappe.db.exists(
-                "Notification Log",
-                {"for_user": OTHER_USER, "document_name": self.feedback, "type": "Mention"},
-            )
-        )
+        self.assertEqual(frappe.db.count("Notification Log", log_filters), logs_before)
 
         nextpms = frappe.get_all(
             "NextPMS Notifications",
@@ -304,4 +321,4 @@ class TestFeedbackComments(IntegrationTestCase):
         self.assertEqual(len(nextpms), 1)
         self.assertEqual(nextpms[0].url, expected_path)
         self.assertEqual(nextpms[0].title, "You got a Feedback mention")
-        self.assertIn("Feedback Mention Project", nextpms[0].label)
+        self.assertIn("Feedback Comment Project", nextpms[0].label)

--- a/next_pms/tests/next_projects/api/test_feedback_comments.py
+++ b/next_pms/tests/next_projects/api/test_feedback_comments.py
@@ -154,6 +154,18 @@ class TestFeedbackComments(IntegrationTestCase):
         self.assertFalse(root["deleted"])
         self.assertEqual(root["replies"], [])
 
+    def test_add_comment_with_mention(self):
+        mention = (
+            f'<span class="mention" data-type="mention" data-id="{OTHER_USER}" '
+            'data-label="Other">@Other</span>'
+        )
+        name, tree = self.add_comment(f"<p>{mention} ping</p>")
+        comment = find_comment(tree, name)
+
+        self.assertIsNotNone(comment)
+        self.assertNotIn('data-type="mention"', comment["comment"])
+        self.assertIn(f'data-id="{OTHER_USER}"', comment["comment"])
+
     def test_add_blank_comment_raises(self):
         frappe.set_user(self.author_user)
         with self.assertRaises(frappe.ValidationError):
@@ -247,3 +259,49 @@ class TestFeedbackComments(IntegrationTestCase):
             update_comment_in_feedback(comment_name=foreign.name, comment="<p>hijack</p>")
         with self.assertRaises(frappe.ValidationError):
             add_comment_to_feedback(feedback=self.feedback, comment="<p>reply</p>", reply_to=foreign.name)
+
+    def test_mention_creates_only_nextpms_notification(self):
+        from erpnext import get_default_company
+
+        from next_pms.next_projects.api.feedback import notify_feedback_nextpms_mentions
+
+        frappe.set_user("Administrator")
+        customer = frappe.db.get_value("Customer Feedback", self.feedback, "customer")
+        project = (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": "Feedback Mention Project",
+                    "company": get_default_company(),
+                    "customer": customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+        frappe.set_user(self.author_user)
+        mention_html = (
+            f'<p><span class="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span> ping</p>'
+        )
+        notify_feedback_nextpms_mentions(content=mention_html, feedback=self.feedback, project=project)
+
+        expected_path = f"/next-pms/projects/{project}?tab=feedback"
+
+        self.assertFalse(
+            frappe.db.exists(
+                "Notification Log",
+                {"for_user": OTHER_USER, "document_name": self.feedback, "type": "Mention"},
+            )
+        )
+
+        nextpms = frappe.get_all(
+            "NextPMS Notifications",
+            filters={"user": OTHER_USER, "linked_document": self.feedback},
+            fields=["url", "title", "label"],
+        )
+        self.assertEqual(len(nextpms), 1)
+        self.assertEqual(nextpms[0].url, expected_path)
+        self.assertEqual(nextpms[0].title, "You got a Feedback mention")
+        self.assertIn("Feedback Mention Project", nextpms[0].label)

--- a/next_pms/tests/timesheet/api/test_project_status_update.py
+++ b/next_pms/tests/timesheet/api/test_project_status_update.py
@@ -2,6 +2,7 @@ import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
 
+from next_pms.next_pms.notifications import send_mention_notifications
 from next_pms.timesheet.api.project_status_update import (
     add_comment_to_project_status_update,
     create_project_status_update,
@@ -356,6 +357,49 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
             delete_project_status_update(name=created["name"])
 
         self.assertTrue(frappe.db.exists("Project Status Update", created["name"]))
+
+    def test_mention_notifies_user_and_links_to_notes_page(self):
+        frappe.set_user(AUTHOR_USER)
+        created = self._make_update(title="Weekly note")
+        mention_html = (
+            f'<p><span class="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span> ping</p>'
+        )
+        expected_path = f"/next-pms/projects/{self.project}?tab=notes&note={created['name']}"
+        send_mention_notifications(
+            content=mention_html,
+            title="You got a Notes mention",
+            label=(
+                f"{frappe.utils.get_fullname(AUTHOR_USER)} mentioned you in "
+                "Weekly note from Comment Thread Project project"
+            ),
+            linked_doctype="Project Status Update",
+            linked_document=created["name"],
+            url_path=expected_path,
+        )
+        expected_url = frappe.utils.get_url(expected_path)
+
+        logs = frappe.get_all(
+            "Notification Log",
+            filters={"for_user": OTHER_USER, "document_name": created["name"], "type": "Mention"},
+            fields=["link", "subject", "email_header"],
+        )
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0].link, expected_url)
+        self.assertEqual(logs[0].email_header, "You got a Notes mention")
+        self.assertIn("Weekly note", logs[0].subject)
+        self.assertIn("Comment Thread Project", logs[0].subject)
+
+        nextpms = frappe.get_all(
+            "NextPMS Notifications",
+            filters={"user": OTHER_USER, "linked_document": created["name"]},
+            fields=["url", "title", "label"],
+        )
+        self.assertEqual(len(nextpms), 1)
+        self.assertEqual(nextpms[0].url, expected_path)
+        self.assertEqual(nextpms[0].title, "You got a Notes mention")
+        self.assertEqual(nextpms[0].label, logs[0].subject)
+        self.assertIn("Weekly note", nextpms[0].label)
+        self.assertIn("Comment Thread Project", nextpms[0].label)
 
     def _assert_direct_crud_forbidden(self, user):
         # Acting as `user` through the permission-checked ORM (the Desk path),

--- a/next_pms/tests/timesheet/api/test_project_status_update.py
+++ b/next_pms/tests/timesheet/api/test_project_status_update.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
@@ -361,21 +363,20 @@ class TestProjectStatusUpdateComments(IntegrationTestCase):
     def test_mention_notifies_user_and_links_to_notes_page(self):
         frappe.set_user(AUTHOR_USER)
         created = self._make_update(title="Weekly note")
-        mention_html = (
-            f'<p><span class="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span> ping</p>'
-        )
+        mention_html = f'<p><span class="mention" data-id="{OTHER_USER}" data-label="Other">@Other</span> ping</p>'
         expected_path = f"/next-pms/projects/{self.project}?tab=notes&note={created['name']}"
-        send_mention_notifications(
-            content=mention_html,
-            title="You got a Notes mention",
-            label=(
-                f"{frappe.utils.get_fullname(AUTHOR_USER)} mentioned you in "
-                "Weekly note from Comment Thread Project project"
-            ),
-            linked_doctype="Project Status Update",
-            linked_document=created["name"],
-            url_path=expected_path,
-        )
+        with patch("frappe.sendmail"):
+            send_mention_notifications(
+                content=mention_html,
+                title="You got a Notes mention",
+                label=(
+                    f"{frappe.utils.get_fullname(AUTHOR_USER)} mentioned you in "
+                    "Weekly note from Comment Thread Project project"
+                ),
+                linked_doctype="Project Status Update",
+                linked_document=created["name"],
+                url_path=expected_path,
+            )
         expected_url = frappe.utils.get_url(expected_path)
 
         logs = frappe.get_all(

--- a/next_pms/timesheet/api/project_status_update.py
+++ b/next_pms/timesheet/api/project_status_update.py
@@ -2,12 +2,12 @@ from typing import Any
 
 import frappe
 from frappe import _, enqueue, only_for
-from frappe.desk.notifications import extract_mentions
 from frappe.types import DF
 from frappe.utils import cint, now_datetime
 from frappe.utils.user import get_user_fullname
 
 from next_pms.api.utils import error_logger
+from next_pms.next_pms.notifications import send_mention_notifications
 
 ROLES = {
     "Projects Manager",
@@ -248,16 +248,7 @@ def add_comment_to_project_status_update(name: str, comment: str, reply_to: str 
 
     doc.save(ignore_permissions=True)
 
-    enqueue(
-        notify_mentions,
-        content=comment,
-        comment_name=doc.comments[-1].name,
-        project_status_update=name,
-        context_type="comment",
-        queue="short",
-        enqueue_after_commit=True,
-        job_name=f"Mention Notifications for Comment {doc.comments[-1].name}",
-    )
+    enqueue_note_mentions(comment, doc)
 
     return get_project_status_update_details(doc.name)
 
@@ -309,17 +300,6 @@ def update_comment_in_project_status_update(
     target_row.edited = 1
     target_row.modified_at = now_datetime()
     doc.save(ignore_permissions=True)
-
-    enqueue(
-        notify_mentions,
-        content=comment,
-        comment_name=target_row.name,
-        project_status_update=name,
-        context_type="comment_update",
-        enqueue_after_commit=True,
-        queue="short",
-        job_name=f"Mention Notifications for Comment Update {target_row.name}",
-    )
 
     return get_project_status_update_details(doc.name)
 
@@ -524,79 +504,22 @@ def get_project_status_update_details(name: str) -> dict[str, Any]:
     }
 
 
-def notify_mentions(
-    content: str,
-    comment_name: str = None,
-    project_status_update: str = None,
-    context_type: str = "comment",
-) -> dict[str, Any]:
-    """
-    Send notifications to mentioned users in project status updates or comments
-
-    Args:
-        content (str): The content containing mentions (HTML format)
-        project_status_update (str, optional): Project Status Update document name
-        context_type (str, optional): Type of context (project_status_update, comment, etc.)
-
-    Returns:
-        Dict[str, Any]: Notification results
-    """
-
-    mentioned_users = extract_mentions(content)
-
-    if not mentioned_users:
-        return {"message": "No mentions found"}
-
-    current_user = frappe.session.user
-    current_user_name = get_user_fullname(current_user)
-
-    doc_name = project_status_update
-    doc_type = "Project Status Update" if project_status_update else "Project"
-    project_name = None
-
-    if project_status_update and frappe.db.exists("Project Status Update", project_status_update):
-        status_update_doc = frappe.get_doc("Project Status Update", project_status_update)
-        project_name = status_update_doc.project
-        update_title = status_update_doc.title
-        notification_context = f"project status update '{update_title}'"
-    else:
-        return {"message": "No project status update found"}
-
-    for user_email in mentioned_users:
-        if user_email == current_user:
-            continue
-
-        if not frappe.db.exists("User", user_email):
-            continue
-
-        project_url = frappe.utils.get_url(f"/next-pms/project/{project_name}?tab=Project+Updates&cid={comment_name}")
-        notification_doc = frappe.get_doc(
-            {
-                "doctype": "Notification Log",
-                "subject": f"You were mentioned in {notification_context}",
-                "for_user": user_email,
-                "type": "Mention",
-                "document_type": doc_type,
-                "document_name": doc_name,
-                "from_user": current_user,
-                "email_content": frappe.render_template(  # nosemgrep - trusted template file
-                    "next_pms/timesheet/templates/project_status_update/mention_notification.html",
-                    {
-                        "current_user_name": current_user_name,
-                        "notification_context": notification_context,
-                        "content": content,
-                        "project_url": project_url,
-                    },
-                ),
-                "read": 0,
-            }
-        )
-
-        notification_doc.insert(ignore_permissions=True)
-
-    return {
-        "message": f"Notifications sent successfully to {len(mentioned_users)} users",
-    }
+def enqueue_note_mentions(content: str, doc) -> None:
+    project_title = frappe.db.get_value("Project", doc.project, "project_name") or doc.project
+    enqueue(
+        send_mention_notifications,
+        content=content,
+        title=_("You got a Notes mention"),
+        label=_("{0} mentioned you in {1} note from {2} project").format(
+            get_user_fullname(frappe.session.user), doc.title, project_title
+        ),
+        linked_doctype="Project Status Update",
+        linked_document=doc.name,
+        url_path=f"/next-pms/projects/{doc.project}?tab=notes&note={doc.name}",
+        queue="short",
+        enqueue_after_commit=True,
+        job_name=f"Mention Notifications for {doc.name}",
+    )
 
 
 def send_publish_notifications(project: str, title: str, name: str):

--- a/next_pms/timesheet/templates/project_status_update/mention_notification.html
+++ b/next_pms/timesheet/templates/project_status_update/mention_notification.html
@@ -1,5 +1,0 @@
-<p>{{ current_user_name }} mentioned you in {{ notification_context }}:</p>
-<div style="padding: 15px; border-left: 4px solid #007bff; margin: 10px 0;">
-    {{ content }}
-</div>
-<p>You can view the full update in the <a href="{{ project_url }}" target="_blank" rel="noopener noreferrer">Next PMS</a>.</p>


### PR DESCRIPTION
## Description

backend notifications when you @ a user in notes and feedback pages.

## Relevant Technical Choices

1. edited the frontend 
- to add the @ symbol for frontend notification icon (mentions)
- pass project param for proper url generation
- edit the emp call to use emp.user for user id
2. added the wiring in backend to send notification to - desk ui notification, email, nextpms ui notifications

## Testing Instructions

1. the notification should get triggered when a user is @ 
2. the nextpms ui notification should be clickable and take you to the right page

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1985