### PR TITLE
Fix: hide controls for making edits to project and allocation

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/project/allocationsProjectTable.tsx
@@ -46,8 +46,7 @@ export const AllocationsProjectTable = () => {
   const guardAction = useGuardedAction();
 
   const roles = useUser(({ state }) => state.roles);
-  const canManageAllocations =
-    roles.includes("Projects Manager") || roles.includes("Projects User");
+  const canManageAllocations = roles.includes("Projects Manager");
 
   const {
     openAddAllocationDialog,

--- a/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/allocationsTeamTable.tsx
@@ -44,8 +44,7 @@ export const AllocationsTeamTable = () => {
   const guardAction = useGuardedAction();
 
   const roles = useUser(({ state }) => state.roles);
-  const canManageAllocations =
-    roles.includes("Projects Manager") || roles.includes("Projects User");
+  const canManageAllocations = roles.includes("Projects Manager");
 
   const {
     openAddAllocationDialog,

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarContent.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/calendarContent.tsx
@@ -7,6 +7,7 @@ import { AddSm } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
+import { useUser } from "@/providers/user";
 import { CalendarGrid } from "./calendarGrid";
 import { CalendarToolbar } from "./calendarToolbar";
 import { useCalendar } from "./context";
@@ -19,6 +20,9 @@ import { TouchpointsTable } from "./touchpointsTable";
 import type { TableTab } from "./types";
 
 export function CalendarContent() {
+  const roles = useUser(({ state }) => state.roles);
+  const canCreate = roles.includes("Projects Manager");
+
   const projectId = useCalendar((c) => c.state.projectId);
   const activeView = useCalendar((c) => c.state.activeView);
   const tableTab = useCalendar((c) => c.state.tableTab);
@@ -63,18 +67,20 @@ export function CalendarContent() {
             ]}
           />
 
-          <Button
-            variant="solid"
-            label="Create"
-            iconLeft={() => <AddSm className="size-3.5" />}
-            onClick={() => {
-              if (tableTab === "milestones") {
-                setCreateMilestoneOpen(true);
-              } else {
-                setCreateTouchpointOpen(true);
-              }
-            }}
-          />
+          {canCreate && (
+            <Button
+              variant="solid"
+              label="Create"
+              iconLeft={() => <AddSm className="size-3.5" />}
+              onClick={() => {
+                if (tableTab === "milestones") {
+                  setCreateMilestoneOpen(true);
+                } else {
+                  setCreateTouchpointOpen(true);
+                }
+              }}
+            />
+          )}
         </div>
 
         {/* Table */}

--- a/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/notes/subHeader.tsx
@@ -10,12 +10,16 @@ import { AddSm, SmallDown } from "@rtcamp/frappe-ui-react/icons";
  * Internal dependencies.
  */
 import { ROUTES } from "@/lib/constant";
+import { useUser } from "@/providers/user";
 import { CREATE_OPTIONS } from "./constants";
 import { useNotes } from "./context";
 import { TemplateDialog } from "./templateDialog";
 import { useProjectDetail } from "../../context";
 
 export function NotesSubHeader() {
+  const roles = useUser(({ state }) => state.roles);
+  const canCreate = roles.includes("Projects Manager");
+
   const navigate = useNavigate();
   const projectId = useProjectDetail((s) => s.projectId);
   const [isTemplateDialogOpen, setIsTemplateDialogOpen] = useState(false);
@@ -33,29 +37,31 @@ export function NotesSubHeader() {
     <div className="flex flex-col gap-4">
       <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
         <h2 className="text-xl font-semibold text-ink-gray-7">Notes</h2>
-        <Dropdown
-          placement="right"
-          button={{
-            variant: "solid",
-            size: "sm",
-            iconLeft: AddSm,
-            iconRight: SmallDown,
-            label: "Create",
-          }}
-          options={[
-            {
-              label: "New from template",
-              key: CREATE_OPTIONS.newFromTemplate,
-              onClick: () => setIsTemplateDialogOpen(true),
-            },
-            {
-              label: "New blank note",
-              key: CREATE_OPTIONS.newBlankNote,
-              onClick: () =>
-                navigate(`${ROUTES.project}/${projectId}/notes/new`),
-            },
-          ]}
-        />
+        {canCreate && (
+          <Dropdown
+            placement="right"
+            button={{
+              variant: "solid",
+              size: "sm",
+              iconLeft: AddSm,
+              iconRight: SmallDown,
+              label: "Create",
+            }}
+            options={[
+              {
+                label: "New from template",
+                key: CREATE_OPTIONS.newFromTemplate,
+                onClick: () => setIsTemplateDialogOpen(true),
+              },
+              {
+                label: "New blank note",
+                key: CREATE_OPTIONS.newBlankNote,
+                onClick: () =>
+                  navigate(`${ROUTES.project}/${projectId}/notes/new`),
+              },
+            ]}
+          />
+        )}
       </div>
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-1 gap-2">

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
@@ -17,6 +17,7 @@ import { FrappeError, useFrappeUpdateDoc } from "frappe-react-sdk";
  * Internal dependencies.
  */
 import { mergeClassNames, parseFrappeErrorMsg } from "@/lib/utils";
+import { useUser } from "@/providers/user";
 import { useProjectDetail } from "../../context";
 import { OverviewSection } from "./components/overviewSection";
 import { overviewSchema, type OverviewFormValues } from "./schema";
@@ -96,6 +97,9 @@ function OverviewForm() {
     [project],
   );
 
+  const roles = useUser(({ state }) => state.roles);
+  const canEdit = roles.includes("Projects Manager");
+
   const [isEditing, setIsEditing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const toast = useToasts();
@@ -142,43 +146,46 @@ function OverviewForm() {
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-ink-gray-8">Overview</h1>
-        {isEditing ? (
-          <div className="flex items-center gap-2">
+        {canEdit &&
+          (isEditing ? (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="subtle"
+                onClick={() => {
+                  resetForm();
+                  setIsEditing(false);
+                }}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <form.Subscribe
+                selector={(state) =>
+                  [state.isDirty, state.isSubmitting] as const
+                }
+              >
+                {([isDirty, isSubmitting]) => (
+                  <Button
+                    variant="solid"
+                    onClick={() => {
+                      void form.handleSubmit();
+                    }}
+                    disabled={!isDirty || isSubmitting || submitting}
+                  >
+                    Save
+                  </Button>
+                )}
+              </form.Subscribe>
+            </div>
+          ) : (
             <Button
-              variant="subtle"
-              onClick={() => {
-                resetForm();
-                setIsEditing(false);
-              }}
-              disabled={submitting}
+              variant="solid"
+              iconLeft={() => <EditAlt size={16} />}
+              onClick={() => setIsEditing(true)}
             >
-              Cancel
+              Edit
             </Button>
-            <form.Subscribe
-              selector={(state) => [state.isDirty, state.isSubmitting] as const}
-            >
-              {([isDirty, isSubmitting]) => (
-                <Button
-                  variant="solid"
-                  onClick={() => {
-                    void form.handleSubmit();
-                  }}
-                  disabled={!isDirty || isSubmitting || submitting}
-                >
-                  Save
-                </Button>
-              )}
-            </form.Subscribe>
-          </div>
-        ) : (
-          <Button
-            variant="solid"
-            iconLeft={() => <EditAlt size={16} />}
-            onClick={() => setIsEditing(true)}
-          >
-            Edit
-          </Button>
-        )}
+          ))}
       </div>
 
       <form.Field name="summary">

--- a/frontend/packages/app/src/pages/project-details/tabs/risks/header.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/risks/header.tsx
@@ -7,22 +7,28 @@ import { AddSm } from "@rtcamp/frappe-ui-react/icons";
 /**
  * Internal dependencies.
  */
+import { useUser } from "@/providers/user";
 import { useRisks } from "./context";
 import { RisksToolbar } from "./toolbar/toolbar";
 
 export function RisksHeader() {
+  const roles = useUser(({ state }) => state.roles);
+  const canCreate = roles.includes("Projects Manager");
+
   const openCreateRisk = useRisks((c) => c.actions.openCreateRisk);
 
   return (
     <>
       <div className="flex items-center justify-between mb-3.5">
         <h1 className="text-xl font-semibold text-ink-gray-8">Risks</h1>
-        <Button
-          variant="solid"
-          label="Create"
-          iconLeft={() => <AddSm />}
-          onClick={openCreateRisk}
-        />
+        {canCreate && (
+          <Button
+            variant="solid"
+            label="Create"
+            iconLeft={() => <AddSm />}
+            onClick={openCreateRisk}
+          />
+        )}
       </div>
 
       <RisksToolbar />


### PR DESCRIPTION
## Description

- Hide allocations edit controls from project user in project allocations.
- Hide allocations edit controls from project user in team allocations.
- Project overview tab - hide edit controls from anyone without Project Manager role.
- Project calendar tab - hide milestone creation controls from anyone without Project Manager role.
- Project notes tab - hide notes ( Project status update ) creation controls from anyone without Project Manager role.
- Project risks tab - hide risk creation controls from anyone without Project Manager role.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially Fixes #1774