### PR TITLE
feat: add budget burn widget

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/budgetBurn.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/budgetBurn.tsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies.
+ */
+import { ProgressBar } from "@next-pms/design-system/components";
+import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import { currencyFormat } from "@/lib/utils";
+import { useProjectDetail } from "@/pages/project-details/context";
+import { useTracking } from "../context";
+import { LegendItem } from "./legendItem";
+
+export function BudgetBurnCell() {
+  const projectId = useProjectDetail((state) => state.projectId);
+  const currency = useProjectDetail((state) => state.project?.custom_currency);
+  const budgetBurn = useTracking((state) => state.tracking.budget_burn);
+
+  if (!budgetBurn) {
+    return null;
+  }
+
+  const { actual, forecasted, total_budget: totalBudget } = budgetBurn;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-base text-ink-gray-8 font-medium">
+          Budget burn (to date)
+        </span>
+        <a
+          href={`/desk/timesheet?parent_project=${projectId}`}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="flex items-center gap-2 text-base text-ink-gray-6 hover:text-ink-gray-8"
+        >
+          All Timesheets
+          <ArrowUpRight aria-hidden className="size-4" />
+        </a>
+      </div>
+      <ProgressBar
+        value={actual}
+        secondaryValue={actual + forecasted}
+        maxValue={totalBudget}
+        indicatorClassName="bg-surface-green-5"
+        secondaryIndicatorClassName="bg-surface-green-3"
+      />
+      <div className="flex flex-col gap-2 text-base text-ink-gray-7">
+        <LegendItem
+          className="bg-surface-green-5"
+          label="Actual budget burn"
+          value={currencyFormat(currency).format(actual)}
+          labelClassName="text-ink-gray-6"
+          valueClassName="shrink-0 font-medium"
+        />
+        <LegendItem
+          className="bg-surface-green-3"
+          label="Forecasted budget burn"
+          value={currencyFormat(currency).format(forecasted)}
+          labelClassName="text-ink-gray-6"
+          valueClassName="shrink-0 font-medium"
+        />
+        <LegendItem
+          className="bg-surface-gray-3"
+          label="Total project budget"
+          value={currencyFormat(currency).format(totalBudget)}
+          labelClassName="text-ink-gray-6"
+          valueClassName="shrink-0 font-medium"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/budgetBurn.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/budgetBurn.tsx
@@ -2,7 +2,6 @@
  * External dependencies.
  */
 import { ProgressBar } from "@next-pms/design-system/components";
-import { ArrowUpRight } from "@rtcamp/frappe-ui-react/icons";
 
 /**
  * Internal dependencies.
@@ -13,32 +12,17 @@ import { useTracking } from "../context";
 import { LegendItem } from "./legendItem";
 
 export function BudgetBurnCell() {
-  const projectId = useProjectDetail((state) => state.projectId);
   const currency = useProjectDetail((state) => state.project?.custom_currency);
   const budgetBurn = useTracking((state) => state.tracking.budget_burn);
-
-  if (!budgetBurn) {
-    return null;
-  }
-
-  const { actual, forecasted, total_budget: totalBudget } = budgetBurn;
+  const actual = budgetBurn?.actual ?? 0;
+  const forecasted = budgetBurn?.forecasted ?? 0;
+  const totalBudget = budgetBurn?.total_budget ?? 0;
 
   return (
     <div className="flex flex-1 flex-col gap-4 rounded-xl border border-outline-gray-1 bg-surface-cards p-3">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-base text-ink-gray-8 font-medium">
-          Budget burn (to date)
-        </span>
-        <a
-          href={`/desk/timesheet?parent_project=${projectId}`}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="flex items-center gap-2 text-base text-ink-gray-6 hover:text-ink-gray-8"
-        >
-          All Timesheets
-          <ArrowUpRight aria-hidden className="size-4" />
-        </a>
-      </div>
+      <span className="text-base text-ink-gray-8 font-medium">
+        Budget burn (to date)
+      </span>
       <ProgressBar
         value={actual}
         secondaryValue={actual + forecasted}

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/context.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/context.ts
@@ -58,6 +58,7 @@ export const DEFAULT_TRACKING: Tracking = {
     invoiced_but_not_paid: 0,
     total_project_amount: 0,
   },
+  budget_burn: null,
   contracts: null,
   project_rates: null,
   lifetime_values: null,

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
@@ -3,6 +3,7 @@
  */
 import { ROUTES } from "@/lib/constant";
 import { currencyFormat, formatPercentage } from "@/lib/utils";
+import { BudgetBurnCell } from "./components/budgetBurn";
 import { ContractsTable } from "./components/contractsTable";
 import { CostBurnCell } from "./components/costBurn";
 import { HoursUsageCell } from "./components/hoursUsage";
@@ -29,36 +30,46 @@ function TrackingContent() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex gap-3">
-        <KnowledgePoint title="Company" value={tracking.company} />
-        <KnowledgePoint
-          title="Total project value"
-          value={currencyFormat(currency).format(
-            tracking.total_project_value ?? 0,
-          )}
-          href={`${ROUTES.desk}/sales-order?status=${encodeURIComponent(
-            JSON.stringify(["!=", "Cancelled"]),
-          )}&project=${encodeURIComponent(projectId)}`}
-        />
-        <KnowledgePoint
-          title="Projected profit"
-          value={currencyFormat(currency).format(tracking.project_profit ?? 0)}
-        />
-        <KnowledgePoint
-          title="Projected profit margin"
-          value={formatPercentage(tracking.projected_profit_margin ?? 0)}
-        />
-      </div>
-
-      <div className="flex gap-3">
-        <HoursUsageCell />
+      <div className="flex gap-3 *:basis-1/2!">
+        <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
+          <div className="flex gap-3">
+            <KnowledgePoint title="Company" value={tracking.company} />
+            <KnowledgePoint
+              title="Total project value"
+              value={currencyFormat(currency).format(
+                tracking.total_project_value ?? 0,
+              )}
+              href={`${ROUTES.desk}/sales-order?status=${encodeURIComponent(
+                JSON.stringify(["!=", "Cancelled"]),
+              )}&project=${encodeURIComponent(projectId)}`}
+            />
+          </div>
+          <div className="flex gap-3">
+            <KnowledgePoint
+              title="Projected profit"
+              value={currencyFormat(currency).format(
+                tracking.project_profit ?? 0,
+              )}
+            />
+            <KnowledgePoint
+              title="Projected profit margin"
+              value={formatPercentage(tracking.projected_profit_margin ?? 0)}
+            />
+          </div>
+        </div>
         <TaskCompletionCell />
       </div>
 
       <div className="flex gap-3">
+        <HoursUsageCell />
         <InvoiceBurnCell />
+      </div>
+
+      <div className="flex gap-3">
+        <BudgetBurnCell />
         <CostBurnCell />
       </div>
+
       <div className="flex gap-3">
         <KnowledgePoint
           title="Lifetime value to date"

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/types.ts
@@ -55,6 +55,12 @@ export type TrackingInvoiceBurn = {
   total_project_amount: number | null;
 };
 
+export type TrackingBudgetBurn = {
+  actual: number;
+  forecasted: number;
+  total_budget: number;
+};
+
 export type TrackingContract = {
   name: string;
   start_date: string;
@@ -88,6 +94,7 @@ export type TrackingMessage = {
   hours_remaining: number | null;
   tasks: TrackingTasks;
   invoice_burn: TrackingInvoiceBurn;
+  budget_burn: TrackingBudgetBurn | null;
   contracts: TrackingContract[] | null;
   project_rates: [ProjectFlatRate, ...ProjectRate[]] | null;
   lifetime_values: TrackingLifetimeValues | null;


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds a new Budget Burn widget to the tracking page.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
- Navigate to a billable project and open the "Tracking" tab to view the newly added Budget Burn widget.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

<img width="1150" height="615" alt="Screenshot 2026-08-14 at 6 23 22 PM" src="https://github.com/user-attachments/assets/1b4bed1a-98aa-4ee5-840c-ab8bc9876eda" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1937 