### PR TITLE
feat(project): add tag composite filter

### DIFF
--- a/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
+++ b/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
@@ -271,6 +271,16 @@ export function ProjectFilters() {
                 { label: "Not Equals", value: "!=" },
               ],
             },
+            {
+              name: "tag",
+              label: "Tags",
+              type: "link",
+              link: { doctype: "Tag" },
+              operators: [
+                { label: "Equals", value: "=" },
+                { label: "Not Equals", value: "!=" },
+              ],
+            },
           ]}
           externalFilterCount={externalFilterCount}
           onClearAll={resetFilters}

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -22,7 +22,12 @@ from next_pms.next_projects.api.constant import (
     TASK_TRACKING_OPEN_STATUSES,
     TASK_TRACKING_TOTAL_STATUSES,
 )
-from next_pms.next_projects.api.utils import build_person_data, get_employee_image_map, get_user_image_map
+from next_pms.next_projects.api.utils import (
+    build_person_data,
+    get_employee_image_map,
+    get_user_image_map,
+    resolve_tag_filters,
+)
 from next_pms.project_currency.billing_rate import get_billing_rate_context, resolve_billing_rate
 from next_pms.timesheet.api import get_count
 from next_pms.utils.employee import (
@@ -585,7 +590,7 @@ def get_projects_view(
         filters = json.loads(filters)
 
     # Build filters
-    project_filters = list(filters) if filters else []
+    project_filters = resolve_tag_filters(list(filters) if filters else [])
 
     # Build or_filters for search
     or_filters = {}

--- a/next_pms/next_projects/api/utils.py
+++ b/next_pms/next_projects/api/utils.py
@@ -3,6 +3,11 @@
 
 import frappe
 
+# Composite-filter field name the projects view accepts for tags, and the
+# operators it resolves against Tag Link.
+TAG_FILTER_FIELD = "tag"
+TAG_FILTER_OPERATORS = ("=", "!=", "like", "not like")
+
 
 def get_user_image_map(users: list[str]) -> dict[str, str | None]:
     """Fetch user_image for multiple users in a single query."""
@@ -84,3 +89,38 @@ def build_person_data(
         "full_name": full_name or "",
         "image": image,
     }
+
+
+def resolve_tag_filters(filters: list) -> list:
+    """Rewrite `tag` conditions in a Project filter list into conditions on `name`.
+
+    A tag is not a Project column: ERPNext keeps the project-tag mapping in the Tag
+    Link doctype, so a tag condition is resolved there first and re-expressed as the
+    set of project names carrying that tag. Every other condition passes through
+    untouched.
+    """
+    resolved = []
+
+    for condition in filters:
+        if not (isinstance(condition, list | tuple) and len(condition) == 3 and condition[0] == TAG_FILTER_FIELD):
+            resolved.append(condition)
+            continue
+
+        _, operator, value = condition
+        if operator not in TAG_FILTER_OPERATORS:
+            frappe.throw(frappe._("Unsupported operator {0} for the tag filter.").format(operator))
+
+        is_like = operator in ("like", "not like")
+        tagged_projects = frappe.get_all(
+            "Tag Link",
+            filters={
+                "document_type": "Project",
+                "tag": ["like", f"%{value}%"] if is_like else ["=", value],
+            },
+            pluck="document_name",
+            distinct=True,
+        )
+        # An empty list keeps the semantics: `in ()` matches nothing, `not in ()` matches all.
+        resolved.append(["name", "in" if operator in ("=", "like") else "not in", tagged_projects])
+
+    return resolved

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -1,7 +1,9 @@
+import json
 from datetime import date
 
 import frappe
 from erpnext import get_default_company
+from frappe.desk.doctype.tag.tag import add_tag
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, flt, today
 
@@ -17,6 +19,7 @@ from next_pms.next_projects.api.project import (
     get_project_tracking,
     get_projects_view,
 )
+from next_pms.next_projects.api.utils import resolve_tag_filters
 from next_pms.project_currency.billing_rate import (
     BILLING_RATE_COST_MULTIPLIER,
     get_billing_rate_context,
@@ -31,6 +34,7 @@ BURN_FIXTURE_PREFIX = "BurnAccrued"
 FORECAST_FIXTURE_PREFIX = "CostForecast"
 ADJUSTED_FIXTURE_PREFIX = "CostAdjusted"
 BUDGET_FIXTURE_PREFIX = "BudgetForecast"
+TAG_FIXTURE_PREFIX = "TagFilter"
 
 # 2026-05-04 is a Monday, so 05-08 is Friday and 05-09/05-10 are the weekend.
 MONDAY = date(2026, 5, 4)
@@ -1033,3 +1037,95 @@ class TestBudgetForecasted(IntegrationTestCase):
         burn = get_project_sidebar(self.projects["FLAT"])["burn"]
         self.assertAlmostEqual(burn["budget_forecasted"], self.HOURS * self.FLAT_RATE)
         self.assertAlmostEqual(burn["cost_forecasted"], ALLOCATION_COST)
+
+
+class TestGetProjectsViewTagFilter(IntegrationTestCase):
+    """The projects list/kanban composite filter supports a `tag` condition,
+    resolved against the Tag Link doctype that ERPNext already maintains for the
+    tags shown on the Project form.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        # suffix -> tags assigned through the ERPNext tagging API
+        fixture_tags = {
+            "A": [f"{TAG_FIXTURE_PREFIX} Alpha", f"{TAG_FIXTURE_PREFIX} Beta"],
+            "B": [f"{TAG_FIXTURE_PREFIX} Beta"],
+            "C": [],
+        }
+        cls.projects = {}
+        for suffix, tags in fixture_tags.items():
+            name = (
+                frappe.get_doc(
+                    {
+                        "doctype": "Project",
+                        "project_name": f"{TAG_FIXTURE_PREFIX} {suffix}",
+                        "company": cls.company,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+            for tag in tags:
+                add_tag(tag, "Project", name)
+            cls.projects[suffix] = name
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    def matched(self, filters, view="list"):
+        result = get_projects_view(view=view, search=TAG_FIXTURE_PREFIX, filters=filters, limit=50)
+        by_name = {name: suffix for suffix, name in self.projects.items()}
+        return {by_name[row["name"]] for row in result["data"]}, result["total_count"]
+
+    def test_no_filter_returns_every_fixture(self):
+        self.assertEqual(self.matched([]), ({"A", "B", "C"}, 3))
+
+    def test_equals_returns_only_the_tagged_projects(self):
+        self.assertEqual(self.matched([["tag", "=", f"{TAG_FIXTURE_PREFIX} Beta"]]), ({"A", "B"}, 2))
+        self.assertEqual(self.matched([["tag", "=", f"{TAG_FIXTURE_PREFIX} Alpha"]]), ({"A"}, 1))
+
+    def test_not_equals_excludes_the_tagged_projects(self):
+        self.assertEqual(self.matched([["tag", "!=", f"{TAG_FIXTURE_PREFIX} Beta"]]), ({"C"}, 1))
+
+    def test_unknown_tag_matches_nothing(self):
+        self.assertEqual(self.matched([["tag", "=", f"{TAG_FIXTURE_PREFIX} Missing"]]), (set(), 0))
+        self.assertEqual(self.matched([["tag", "!=", f"{TAG_FIXTURE_PREFIX} Missing"]]), ({"A", "B", "C"}, 3))
+
+    def test_tag_conditions_combine_with_each_other(self):
+        filters = [
+            ["tag", "=", f"{TAG_FIXTURE_PREFIX} Alpha"],
+            ["tag", "=", f"{TAG_FIXTURE_PREFIX} Beta"],
+        ]
+        self.assertEqual(self.matched(filters), ({"A"}, 1))
+
+    def test_tag_condition_combines_with_project_fields(self):
+        frappe.db.set_value("Project", self.projects["A"], "status", "Completed", update_modified=False)
+        self.addCleanup(frappe.db.set_value, "Project", self.projects["A"], "status", "Open", update_modified=False)
+        filters = [["tag", "=", f"{TAG_FIXTURE_PREFIX} Beta"], ["status", "=", "Open"]]
+        self.assertEqual(self.matched(filters), ({"B"}, 1))
+
+    def test_kanban_view_applies_the_same_filter(self):
+        result = get_projects_view(
+            view="kanban",
+            search=TAG_FIXTURE_PREFIX,
+            filters=[["tag", "=", f"{TAG_FIXTURE_PREFIX} Alpha"]],
+            limit=50,
+        )
+        self.assertEqual(result["total_count"], 1)
+
+    def test_json_encoded_filters_are_accepted(self):
+        filters = json.dumps([["tag", "=", f"{TAG_FIXTURE_PREFIX} Alpha"]])
+        self.assertEqual(self.matched(filters), ({"A"}, 1))
+
+    def test_non_tag_conditions_pass_through_untouched(self):
+        self.assertEqual(
+            resolve_tag_filters([["status", "=", "Open"], ["project_name", "like", "%x%"]]),
+            [["status", "=", "Open"], ["project_name", "like", "%x%"]],
+        )
+
+    def test_unsupported_operator_is_rejected(self):
+        self.assertRaises(frappe.ValidationError, resolve_tag_filters, [["tag", "in", ["Alpha"]]])


### PR DESCRIPTION
## Description

* Added a new `"tag"` filter option to the `ProjectFilters` component in the frontend, allowing users to filter projects by tags.
* Implemented the `resolve_tag_filters` utility function in the backend to translate `tag` filter conditions into filters on project names using the `Tag Link` doctype. 
* Updated the `get_projects_view` API to process filters through `resolve_tag_filters`, enabling tag-based filtering in both list and kanban views. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast


https://github.com/user-attachments/assets/2ed426c4-f606-428f-af15-d894d7598d37




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2027