### PR TITLE
fix: Half Day Leave showing incorrect information on team allocation page

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/type.ts
+++ b/frontend/packages/app/src/pages/allocations/team/type.ts
@@ -15,11 +15,11 @@ export interface Employee {
 
 export interface Leave {
   employee: string;
-  employee_name: string;
   from_date: string;
   to_date: string;
   half_day: number;
   half_day_date: string | null;
+  custom_first_halfsecond_half: string | null;
   total_leave_days: number;
   name: string;
 }

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -1,4 +1,8 @@
-import type { Member, Project } from "@next-pms/design-system/components";
+import type {
+  LeaveAllocation,
+  Member,
+  Project,
+} from "@next-pms/design-system/components";
 import { parseISO } from "date-fns";
 import {
   calculateAllocationHourlyRate,
@@ -68,6 +72,25 @@ export function normalizeAllocationTypeSelection(
 }
 
 /**
+ * Reads the half a half-day leave covers. The field is a site customization, so
+ * it can be absent even when half_day is set.
+ */
+function parseLeaveHalfDayPortion(
+  half: string | null,
+): LeaveAllocation["halfDayPortion"] {
+  const normalized = half?.trim().toLowerCase();
+
+  if (normalized === "first half") {
+    return "first";
+  }
+  if (normalized === "second half") {
+    return "second";
+  }
+
+  return undefined;
+}
+
+/**
  * Converts a TeamAllocationResponse from the API into a Member[] array
  * suitable for the GanttGrid component.
  *
@@ -98,16 +121,21 @@ export function mapTeamAllocationToMembers(
     >
   >();
 
-  const leavesByEmployee = new Map<
-    string,
-    { startDate: Date; endDate: Date }[]
-  >();
+  const leavesByEmployee = new Map<string, LeaveAllocation[]>();
 
   for (const leave of leaveList) {
     const employeeLeaves = leavesByEmployee.get(leave.employee) ?? [];
     employeeLeaves.push({
       startDate: parseISO(leave.from_date),
       endDate: parseISO(leave.to_date),
+      ...(leave.half_day && leave.half_day_date
+        ? {
+            halfDayDate: parseISO(leave.half_day_date),
+            halfDayPortion: parseLeaveHalfDayPortion(
+              leave.custom_first_halfsecond_half,
+            ),
+          }
+        : {}),
     });
     leavesByEmployee.set(leave.employee, employeeLeaves);
   }

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
@@ -14,6 +14,7 @@ import { GanttBar } from "./ganttBar";
 import { allocationBarToEntry } from "./utils/allocationBarToEntry";
 import { getCapacityStatus } from "./utils/getCapacityStatus";
 import { getOverlappingAllocations } from "./utils/getOverlappingAllocations";
+import { getTimeoffLabel } from "./utils/getTimeoffLabel";
 import { withPendingDeleteEntry } from "./utils/withPendingDeleteEntry";
 
 interface GanttMemberSummaryBarProps {
@@ -68,7 +69,11 @@ export function GanttMemberSummaryBar({
   if (summary.type === "timeoff") {
     const leaveDays =
       differenceInCalendarDays(summary.endDate, summary.startDate) + 1;
-    const leaveLabel = `${leaveDays} ${leaveDays === 1 ? "day" : "days"} off`;
+    const leaveLabel = getTimeoffLabel(
+      summary.startDate,
+      summary.endDate,
+      summary.timeoff,
+    );
 
     return (
       <GanttBar

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -1,10 +1,29 @@
+/**
+ * External dependencies.
+ */
 import { addDays, eachDayOfInterval, isSameDay, startOfDay } from "date-fns";
+
+/**
+ * Internal dependencies.
+ */
 import type {
   Allocation,
   LeaveAllocation,
   MemberBarAllocation,
   Project,
+  TimeoffPortion,
 } from "../../types";
+
+/**
+ * Returns the portion of a leave that applies to a given day.
+ */
+function getLeaveDayPortion(leave: LeaveAllocation, day: Date): TimeoffPortion {
+  if (!leave.halfDayDate || !isSameDay(leave.halfDayDate, day)) {
+    return "full";
+  }
+
+  return leave.halfDayPortion ?? "half";
+}
 
 /**
  * Builds merged day-level allocation summary segments from a flat allocation
@@ -21,7 +40,7 @@ export function getAllocationSummary(
   const dayHours = new Map<number, number>();
   const dayHasNonBillable = new Map<number, boolean>();
   const dayHasTentative = new Map<number, boolean>();
-  const dayIsTimeoff = new Map<number, boolean>();
+  const dayTimeoff = new Map<number, TimeoffPortion>();
   const dayKeys = new Set<number>();
 
   for (const alloc of allocations) {
@@ -48,7 +67,10 @@ export function getAllocationSummary(
     })) {
       const key = startOfDay(day).getTime();
       dayKeys.add(key);
-      dayIsTimeoff.set(key, true);
+      const portion = getLeaveDayPortion(leave, day);
+      if (portion === "full" || !dayTimeoff.has(key)) {
+        dayTimeoff.set(key, portion);
+      }
     }
   }
 
@@ -57,15 +79,24 @@ export function getAllocationSummary(
     .sort((a, b) => a - b)
     .map((ts) => ({
       date: new Date(ts),
-      hours: dayIsTimeoff.get(ts) ? 0 : (dayHours.get(ts) ?? 0),
+      hours: dayTimeoff.has(ts) ? 0 : (dayHours.get(ts) ?? 0),
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
-      type: (dayIsTimeoff.get(ts) ? "timeoff" : "default") as
-        "default" | "timeoff",
+      type: (dayTimeoff.has(ts) ? "timeoff" : "default") as
+        | "default"
+        | "timeoff",
+      timeoff: dayTimeoff.get(ts),
     }));
 
   const merged: MemberBarAllocation[] = [];
-  for (const { date, hours, billable, tentative, type } of sortedDays) {
+  for (const {
+    date,
+    hours,
+    billable,
+    tentative,
+    type,
+    timeoff,
+  } of sortedDays) {
     const last = merged[merged.length - 1];
     if (
       last &&
@@ -73,6 +104,7 @@ export function getAllocationSummary(
       last.billable === billable &&
       last.tentative === tentative &&
       last.type === type &&
+      last.timeoff === timeoff &&
       isSameDay(addDays(last.endDate, 1), date)
     ) {
       last.endDate = date;
@@ -84,6 +116,7 @@ export function getAllocationSummary(
         billable,
         tentative,
         type,
+        timeoff,
       });
     }
   }

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -83,8 +83,7 @@ export function getAllocationSummary(
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
       type: (dayTimeoff.has(ts) ? "timeoff" : "default") as
-        | "default"
-        | "timeoff",
+        "default" | "timeoff",
       timeoff: dayTimeoff.get(ts),
     }));
 

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getTimeoffLabel.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getTimeoffLabel.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies.
+ */
+import { differenceInCalendarDays } from "date-fns";
+
+/**
+ * Internal dependencies.
+ */
+import type { TimeoffPortion } from "../../types";
+
+/**
+ * Builds the label for a time-off bar. Half days are named by the half they
+ * cover, matching the wording used on the team timesheet.
+ */
+export function getTimeoffLabel(
+  startDate: Date,
+  endDate: Date,
+  portion: TimeoffPortion = "full",
+): string {
+  if (portion === "first") {
+    return "First half off";
+  }
+  if (portion === "second") {
+    return "Second half off";
+  }
+  if (portion === "half") {
+    return "Half day off";
+  }
+
+  const days = differenceInCalendarDays(endDate, startDate) + 1;
+
+  return `${days} ${days === 1 ? "day" : "days"} off`;
+}

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -47,8 +47,12 @@ export interface Allocation {
   includeWeekends?: boolean;
 }
 
+export type TimeoffPortion = "full" | "first" | "second" | "half";
+
 export interface MemberBarAllocation extends Allocation {
   type?: "default" | "timeoff" | "free";
+  /** How much of the day is off, for `timeoff` segments. */
+  timeoff?: TimeoffPortion;
 }
 
 export interface LeaveAllocation {
@@ -56,6 +60,10 @@ export interface LeaveAllocation {
   startDate: Date;
   /** Last day of leave (inclusive). */
   endDate: Date;
+  /** The single day inside the range taken as a half day, when the leave has one. */
+  halfDayDate?: Date;
+  /** Which half of the half-day is taken off, when the leave has one. */
+  halfDayPortion?: "first" | "second";
 }
 
 export interface Project {

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -126,6 +126,13 @@ def get_resource_management_team_view_data(
                     "employee": "HR-EMP-00001",
                     "from_date": datetime.date(2026, 5, 20),
                     "to_date": datetime.date(2026, 5, 22),
+                    "half_day": 1,
+                    "half_day_date": datetime.date(2026, 5, 22),
+                    "custom_first_halfsecond_half": "Second Half",
+                    "total_leave_days": 2.5,
+                    "leave_type": "Casual Leave",
+                    "is_lwp": 0,
+                    "includes_holidays": True,
                     "name": "HR-LAP-00001",
                 },
             ],
@@ -504,23 +511,10 @@ def _get_resource_management_team_view_data(
         resource_allocation_map[resource_allocation.employee].append(resource_allocation)
 
     if not need_hours_summary:
-        all_leave_data = frappe.get_all(
-            "Leave Application",
-            filters={
-                "employee": ["in", [employee.name for employee in employees]],
-                "docstatus": ["in", [0, 1]],
-                "status": ["in", ["Approved", "Open"]],
-            },
-            fields=[
-                "employee",
-                "employee_name",
-                "from_date",
-                "to_date",
-                "half_day",
-                "half_day_date",
-                "total_leave_days",
-                "name",
-            ],
+        all_leave_data = get_employee_leaves(
+            employee=tuple(employee.name for employee in employees),
+            start_date=dates[0].get("start_date"),
+            end_date=dates[-1].get("end_date"),
         )
         res["employees"] = employees
         res["leaves"] = all_leave_data

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -3,8 +3,10 @@ import json
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
+from frappe.utils import getdate
 
 from next_pms.resource_management.api.team import get_resource_management_team_view_data
+from next_pms.resource_management.api.utils.query import get_employee_leaves
 from next_pms.timesheet.api.app import has_bu_field
 
 
@@ -15,6 +17,15 @@ def _business_unit_available():
     so fixtures and assertions that touch it must be skipped there.
     """
     return bool(has_bu_field())
+
+
+def _first_half_field_available():
+    """True only when the `custom_first_halfsecond_half` customization is installed.
+
+    The field is a site customization, so `get_employee_leaves` guards on it and reports
+    None where it is missing — the key is always in the payload, only its value varies.
+    """
+    return frappe.db.has_column("Leave Application", "custom_first_halfsecond_half")
 
 
 EMPLOYEE_TAGS = {
@@ -169,6 +180,10 @@ TEAM_WINDOW_START = "2026-06-15"
 
 FILTER_WRITE_USER = "tv.write@example.com"
 FILTER_READ_ONLY_USER = "tv.readonly@example.com"
+
+TEAM_LEAVE_TYPE = "TV Leave Without Pay"
+TEAM_HALF_DAY_DATE = "2026-06-17"
+TEAM_HALF_DAY_PORTION = "First Half"
 
 
 class _TeamViewBase(IntegrationTestCase):
@@ -658,3 +673,70 @@ class TestTeamViewHoursSummaryShape(_TeamViewBase):
         entry = next(row for row in result["data"] if row["name"] == self.employee)
         self.assertIn("all_dates_data", entry)
         self.assertIn("all_week_data", entry)
+
+
+class TestTeamViewFlatGridLeaves(_TeamViewBase):
+    """The `leaves` payload the flat grid renders time-off bars from.
+
+    The grid draws one bar per leave across from_date..to_date and splits out the
+    half day, so the window scoping and the half_day_date / custom_first_halfsecond_half
+    pair are contract, not incidental fields on the row.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
+        cls.employee = cls._make_employee("Tvl Employee")
+        cls.only = json.dumps([cls.employee])
+
+        # is_lwp so the applications below need no Leave Allocation to be valid.
+        if not frappe.db.exists("Leave Type", TEAM_LEAVE_TYPE):
+            frappe.get_doc({"doctype": "Leave Type", "leave_type_name": TEAM_LEAVE_TYPE, "is_lwp": 1}).insert(
+                ignore_permissions=True
+            )
+
+        # In-window half day ([2026-06-15, 2026-06-28]) and one leave entirely after it.
+        cls.in_window_leave = cls._make_leave(TEAM_HALF_DAY_DATE, TEAM_HALF_DAY_DATE, half_day_date=TEAM_HALF_DAY_DATE)
+        cls.out_of_window_leave = cls._make_leave("2026-07-01", "2026-07-05")
+
+        get_employee_leaves.clear_cache()
+        frappe.clear_cache()
+
+    @classmethod
+    def _make_leave(cls, from_date, to_date, half_day_date=None):
+        leave = frappe.get_doc(
+            {
+                "doctype": "Leave Application",
+                "employee": cls.employee,
+                "leave_type": TEAM_LEAVE_TYPE,
+                "from_date": from_date,
+                "to_date": to_date,
+                "half_day": 1 if half_day_date else 0,
+                "half_day_date": half_day_date,
+                "description": "team view flat grid leave fixture",
+                "leave_approver": "Administrator",
+                "status": "Open",
+            }
+        )
+        if half_day_date and _first_half_field_available():
+            leave.custom_first_halfsecond_half = TEAM_HALF_DAY_PORTION
+        return leave.insert(ignore_permissions=True).name
+
+    def _leaves(self):
+        return self._call(employee_id=self.only, need_hours_summary=False)["leaves"]
+
+    def test_excludes_out_of_window_leaves(self):
+        leave_names = {leave["name"] for leave in self._leaves()}
+        self.assertIn(self.in_window_leave, leave_names)
+        self.assertNotIn(self.out_of_window_leave, leave_names)
+
+    def test_half_day_leave_carries_the_day_and_the_half_it_covers(self):
+        leave = next(row for row in self._leaves() if row["name"] == self.in_window_leave)
+
+        self.assertTrue(leave["half_day"])
+        self.assertEqual(getdate(leave["half_day_date"]), getdate(TEAM_HALF_DAY_DATE))
+        self.assertIn("custom_first_halfsecond_half", leave)
+        if _first_half_field_available():
+            self.assertEqual(leave["custom_first_halfsecond_half"], TEAM_HALF_DAY_PORTION)

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -7,6 +7,7 @@ from frappe.utils import getdate
 
 from next_pms.resource_management.api.team import get_resource_management_team_view_data
 from next_pms.resource_management.api.utils.query import get_employee_leaves
+from next_pms.tests.utils import assign_empty_holiday_list
 from next_pms.timesheet.api.app import has_bu_field
 
 
@@ -690,6 +691,11 @@ class TestTeamViewFlatGridLeaves(_TeamViewBase):
         cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
         cls.employee = cls._make_employee("Tvl Employee")
         cls.only = json.dumps([cls.employee])
+
+        # HRMS subtracts holidays from every leave whose type does not include them, and throws
+        # outright when the employee resolves to no holiday list. An empty list satisfies that
+        # lookup without letting site holidays move the day counts below.
+        assign_empty_holiday_list(cls.employee)
 
         # is_lwp so the applications below need no Leave Allocation to be valid.
         if not frappe.db.exists("Leave Type", TEAM_LEAVE_TYPE):


### PR DESCRIPTION


## Description

<!-- What do we want to achieve with this PR? -->
This PR adds support for displaying half-day leaves in the Team Allocation page summary bars. Instead of only showing "X days off", it now shows "First half off" or "Second half off" for half-day leaves.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* The flat-grid branch of `_get_resource_management_team_view_data` previously fetched leave applications directly, which did not include `custom_first_halfsecond_half` and was not scoped to the requested date range. It now uses the shared `get_employee_leaves(...)` function used by the Team Timesheet, allowing the frontend to identify which half of the day is off while only fetching leaves for the requested weeks. This also keeps leave-related logic in one place and removes the unused `employee_name` from the response.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
1. Single-day half-day leave: Create an approved/open Leave Application with "Half Day" enabled and select "First Half". On the Team Allocation page, navigate to that week and hover over the time-off pill in the member's summary row. Verify the tooltip shows "First half off" instead of "1 day off". Repeat with "Second Half" and verify it shows "Second half off".
2. Half-day at the start of a multi-day leave: Create a leave from Monday to Wednesday with Monday as the half-day. Verify there are two pills: "First half off" or "Second half off" for Monday, followed by "2 days off".


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="894" height="429" alt="Screenshot 2026-08-14 at 10 41 34 PM" src="https://github.com/user-attachments/assets/d763700d-c404-4975-82f1-ac02c7ee5b14" />
<img width="894" height="429" alt="Screenshot 2026-08-14 at 10 41 51 PM" src="https://github.com/user-attachments/assets/88cc2f7b-3e05-49f2-bdf1-1204143fdc31" />
<img width="894" height="429" alt="Screenshot 2026-08-14 at 10 42 06 PM" src="https://github.com/user-attachments/assets/84c7acea-ecd6-44ac-9e32-5f76e6b893d8" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2035