### PR TITLE
fix(timesheet): show not-allowed cursor on disabled timesheet cells

### DIFF
--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -101,8 +101,8 @@ export const MemberRow: React.FC<MemberRowProps> = ({
                 "w-14.25 relative group flex justify-center items-center",
                 !isCellDisabled &&
                   "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
-                "disabled:cursor-default! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent! disabled:text-ink-gray-8!",
-                isCellDisabled && "cursor-default!",
+                "disabled:cursor-not-allowed! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent! disabled:text-ink-gray-8!",
+                isCellDisabled && "cursor-not-allowed!",
                 "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                 "text-base text-ink-gray-8",
               )}

--- a/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/project/projectRow.tsx
@@ -86,8 +86,8 @@ export const ProjectRow: React.FC<ProjectRowProps> = ({
                 "w-14.25 relative group flex justify-center items-center",
                 !isCellDisabled &&
                   "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
-                "disabled:cursor-default! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent!",
-                isCellDisabled && "cursor-default!",
+                "disabled:cursor-not-allowed! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent!",
+                isCellDisabled && "cursor-not-allowed!",
                 "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                 "text-base text-ink-gray-6",
                 highlightTimeEntries &&

--- a/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/task/taskRow.tsx
@@ -208,7 +208,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
                   className={cn(
                     "w-14.25 relative group flex justify-center items-center lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                     "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
-                    "aria-disabled:cursor-default! aria-disabled:text-ink-gray-5 aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent aria-disabled:active:bg-transparent",
+                    "aria-disabled:cursor-not-allowed! aria-disabled:text-ink-gray-5 aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent aria-disabled:active:bg-transparent",
                     timeEntryTextClassName,
                   )}
                   aria-disabled={timeEntry.disabled}

--- a/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/total/totalRow.tsx
@@ -114,8 +114,8 @@ export const TotalRow: React.FC<TotalRowProps> = ({
                 "w-14.25 relative group flex justify-center items-center",
                 !isCellDisabled &&
                   "enabled:hover:bg-surface-gray-2 enabled:focus:bg-surface-gray-2 enabled:active:bg-surface-gray-3",
-                "disabled:cursor-default! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent! disabled:text-ink-gray-8!",
-                isCellDisabled && "cursor-default!",
+                "disabled:cursor-not-allowed! disabled:opacity-100! disabled:bg-transparent! disabled:hover:bg-transparent! disabled:focus:bg-transparent! disabled:active:bg-transparent! disabled:text-ink-gray-8!",
+                isCellDisabled && "cursor-not-allowed!",
                 "lining-nums tabular-nums [&_span]:overflow-visible [&_span]:whitespace-normal",
                 "text-base font-medium text-ink-gray-8",
               )}


### PR DESCRIPTION
## Description
Follow-up to #2040 (backdate restriction). Disabled day cells across the timesheet grid — project, member, task, and total rows — still showed the default cursor on hover, giving no visual signal that the date can't be edited.

Swaps cursor-default → cursor-not-allowed on the disabled cell states in the four shared row components (projectRow, memberRow, taskRow, totalRow).

## Screenshot/Screencast
<img width="3306" height="884" alt="image" src="https://github.com/user-attachments/assets/04851d78-28f1-4909-92e2-f26457ce5319" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #883