### PR TITLE
chore: fix duplicate build of submodule

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run dev:app",
     "dev:app": "npm run dev -w @next-pms/app",
     "build:app": "npm run build -w @next-pms/app",
-    "build:frappe-ui-react": "npm run corepack-enable && cd ../frappe-ui-react && pnpm install && pnpm build",
+    "build:frappe-ui-react": "npm run corepack-enable && cd ../frappe-ui-react && pnpm install --frozen-lockfile && pnpm build",
     "build": "npm install && npm run build:frappe-ui-react && npm run build:app",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "dev": "cd frontend && npm run dev",
-    "build": "git submodule update --init --recursive && npx pnpm --dir frappe-ui-react install --frozen-lockfile && npx pnpm --dir frappe-ui-react build && npm --prefix frontend install && npm --prefix frontend run build",
+    "build": "git submodule update --init --recursive && npm --prefix frontend run build",
     "e2e:tests": "npx playwright test --config=tests/e2e/playwright.config.js",
     "lint:precommit": "eslint --fix --config eslint.config.js",
     "allure:report": "allure generate allure-results --clean -o allure-report-for-count-extraction",


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

Drops the pnpm --dir call from the root build script and lets it delegate to the frontend build, which already installs and builds frappe-ui-react with corepack pinned to 10.13.1. This fixes the pnpm version mismatch error and stops the submodule from being built twice. The --frozen-lockfile flag moves into build:frappe-ui-react so lockfile strictness is kept, which means a dep change in frappe-ui-react without a regenerated lockfile now fails instead of silently resolving.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2062