### PR TITLE
feat: add timesheet processing icon

### DIFF
--- a/frontend/packages/app/src/components/filters/approvalStatusFilter.tsx
+++ b/frontend/packages/app/src/components/filters/approvalStatusFilter.tsx
@@ -4,6 +4,8 @@ import {
 } from "@next-pms/design-system/components";
 import { MultiSelect } from "@rtcamp/frappe-ui-react";
 
+const NON_FILTERABLE_STATUSES: ApprovalStatusType[] = ["none", "processing"];
+
 type ApprovalStatusFilterProps = {
   value?: ApprovalStatusType[];
   onChange: (value: ApprovalStatusType[]) => void;
@@ -18,7 +20,8 @@ const ApprovalStatusFilter: React.FC<ApprovalStatusFilterProps> = ({
   const options = Object.entries(ApprovalStatusDisplayLabelMap)
     .filter(
       ([key]) =>
-        key !== "none" && !excludeOptions.includes(key as ApprovalStatusType),
+        !NON_FILTERABLE_STATUSES.includes(key as ApprovalStatusType) &&
+        !excludeOptions.includes(key as ApprovalStatusType),
     )
     .map(([key, label]) => ({ label, value: key }));
 

--- a/frontend/packages/app/src/pages/dashboard/widget/timesheet-summary/statusIcon.tsx
+++ b/frontend/packages/app/src/pages/dashboard/widget/timesheet-summary/statusIcon.tsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies.
  */
+import { mergeClassNames as cn } from "@next-pms/design-system";
+import { Spinner } from "@next-pms/design-system/components";
 import { CloseCircle, Hourglass, Success } from "@rtcamp/frappe-ui-react/icons";
 
 /**
@@ -12,6 +14,7 @@ const ICON = {
   approved: { Icon: Success, className: "text-ink-green-4" },
   pending: { Icon: Hourglass, className: "text-ink-amber-3" },
   rejected: { Icon: CloseCircle, className: "text-ink-red-4" },
+  processing: { Icon: Spinner, className: "text-ink-amber-3" },
 } as const;
 
 const STATE_BY_STATUS: Record<WeeklyApprovalStatus, keyof typeof ICON> = {
@@ -21,10 +24,10 @@ const STATE_BY_STATUS: Record<WeeklyApprovalStatus, keyof typeof ICON> = {
   "Not Submitted": "pending",
   "Approval Pending": "pending",
   "Partially Approved": "pending",
-  "Processing Timesheet": "pending",
+  "Processing Timesheet": "processing",
 };
 
 export function StatusIcon({ status }: { status: WeeklyApprovalStatus }) {
   const { Icon, className } = ICON[STATE_BY_STATUS[status]];
-  return <Icon className={`size-4 shrink-0 ${className}`} />;
+  return <Icon size={16} className={cn("size-4 shrink-0", className)} />;
 }

--- a/frontend/packages/design-system/src/components/approval-status/constants.ts
+++ b/frontend/packages/design-system/src/components/approval-status/constants.ts
@@ -13,6 +13,7 @@ import { cva } from "class-variance-authority";
  * Internal dependencies.
  */
 import type { ApprovalStatusLabelType } from "./types";
+import Spinner from "../spinner";
 
 export const approvalStatusIcon: Record<
   ApprovalStatusLabelType,
@@ -25,7 +26,7 @@ export const approvalStatusIcon: Record<
   Approved: Success,
   Rejected: CloseCircle,
   "Approval Pending": Hourglass,
-  "Processing Timesheet": Hourglass,
+  "Processing Timesheet": Spinner,
   "Not Submitted": Overdue,
   "Partially Approved": Success,
   "Partially Rejected": CloseCircle,

--- a/frontend/packages/design-system/src/components/spinner/index.tsx
+++ b/frontend/packages/design-system/src/components/spinner/index.tsx
@@ -9,12 +9,19 @@ import { mergeClassNames } from "../../utils";
 
 export type SpinnerProp = {
   isFull?: boolean;
+  size?: number;
   className?: string;
 };
-const Spinner = ({ isFull = false, className }: SpinnerProp) => {
+const Spinner = ({ isFull = false, size = 24, className }: SpinnerProp) => {
   return (
-    <div className={mergeClassNames("flex justify-center items-center", isFull && "h-screen", className)}>
-      <LoaderCircle size={64} className="w-6 h-6 animate-spin" />
+    <div
+      className={mergeClassNames(
+        "flex justify-center items-center",
+        isFull && "h-screen",
+        className,
+      )}
+    >
+      <LoaderCircle size={size} className="animate-spin" />
     </div>
   );
 };

--- a/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/constants.ts
@@ -14,12 +14,14 @@ import { cva } from "class-variance-authority";
  * Internal dependencies.
  */
 import { TaskStatusType } from "@/components/task-status";
+import Spinner from "../../spinner";
 
 export type ApprovalStatusType =
   | "not-submitted"
   | "approved"
   | "rejected"
   | "approval-pending"
+  | "processing"
   | "partially-approved"
   | "partially-rejected"
   | "none";
@@ -39,6 +41,7 @@ export type ApprovalStatusDisplayLabelType =
   | "Approved"
   | "Rejected"
   | "Approval pending"
+  | "Processing timesheet"
   | "None"
   | "Partially approved"
   | "Partially rejected";
@@ -51,6 +54,7 @@ export const ApprovalStatusLabelMap: Record<
   approved: "Approved",
   rejected: "Rejected",
   "approval-pending": "Approval Pending",
+  processing: "Processing Timesheet",
   "partially-approved": "Partially Approved",
   "partially-rejected": "Partially Rejected",
   none: "None",
@@ -64,6 +68,7 @@ export const ApprovalStatusDisplayLabelMap: Record<
   approved: "Approved",
   rejected: "Rejected",
   "approval-pending": "Approval pending",
+  processing: "Processing timesheet",
   "partially-approved": "Partially approved",
   "partially-rejected": "Partially rejected",
   none: "None",
@@ -79,7 +84,7 @@ export const ApprovalStatusMap: Record<
   "Approval Pending": "approval-pending",
   "Partially Approved": "partially-approved",
   "Partially Rejected": "partially-rejected",
-  "Processing Timesheet": "approval-pending",
+  "Processing Timesheet": "processing",
   None: "none",
 };
 
@@ -88,6 +93,7 @@ export const approvalStatusCanSubmitMap: Record<ApprovalStatusType, boolean> = {
   approved: false,
   rejected: true,
   "approval-pending": false,
+  processing: false,
   "partially-approved": true,
   "partially-rejected": true,
   none: false,
@@ -145,6 +151,7 @@ export const approvalStatusTheme: Record<
   approved: "green",
   rejected: "red",
   "approval-pending": "orange",
+  processing: "orange",
   "partially-approved": "green",
   "partially-rejected": "red",
   none: "gray",
@@ -172,6 +179,10 @@ export const approvalStatusIcon: Record<
   "approval-pending": {
     variant: "ghost",
     icon: Hourglass,
+  },
+  processing: {
+    variant: "ghost",
+    icon: Spinner,
   },
   "partially-approved": {
     variant: "ghost",

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/constants.ts
@@ -27,6 +27,7 @@ export const buttonVariants = cva("", {
       approved: "text-ink-green-4",
       rejected: "text-ink-red-4",
       "approval-pending": "text-ink-white",
+      processing: "text-ink-amber-4",
       "partially-approved": "text-ink-green-4",
       "partially-rejected": "text-ink-red-4",
       none: "",

--- a/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
+++ b/frontend/packages/design-system/src/components/timesheet/rows/member/memberRow.tsx
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import React from "react";
-import { Badge, Button, Avatar } from "@rtcamp/frappe-ui-react";
+import { Badge, Button, Avatar, Tooltip } from "@rtcamp/frappe-ui-react";
 import { AddMd, SmallDown } from "@rtcamp/frappe-ui-react/icons";
 
 /**
@@ -156,25 +156,27 @@ export const MemberRow: React.FC<MemberRowProps> = ({
 
       <div className="flex items-center justify-end w-12 h-7 whitespace-nowrap shrink-0">
         {!hideAction && !isStatusNone && memberStatusIcon[status]?.icon ? (
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onButtonClick?.();
-            }}
-            className={cn(
-              buttonVariants({
-                status,
-                variant: memberStatusIcon[status]?.variant,
-              }),
-            )}
-            variant={memberStatusIcon[status]?.variant}
-            size="sm"
-            icon={() => {
-              const IconComponent = memberStatusIcon[status]?.icon;
-              return IconComponent ? <IconComponent size={16} /> : null;
-            }}
-            title={ApprovalStatusDisplayLabelMap[status]}
-          />
+          <Tooltip text={ApprovalStatusDisplayLabelMap[status]}>
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onButtonClick?.();
+              }}
+              className={cn(
+                buttonVariants({
+                  status,
+                  variant: memberStatusIcon[status]?.variant,
+                }),
+              )}
+              variant={memberStatusIcon[status]?.variant}
+              size="sm"
+              icon={() => {
+                const IconComponent = memberStatusIcon[status]?.icon;
+                return IconComponent ? <IconComponent size={16} /> : null;
+              }}
+              aria-label={ApprovalStatusDisplayLabelMap[status]}
+            />
+          </Tooltip>
         ) : null}
       </div>
     </div>

--- a/frontend/packages/design-system/src/components/timesheet/rows/week/constants.ts
+++ b/frontend/packages/design-system/src/components/timesheet/rows/week/constants.ts
@@ -10,6 +10,7 @@ export const buttonVariants = cva("", {
       approved: "text-ink-green-4",
       rejected: "text-ink-red-4",
       "approval-pending": "text-ink-amber-4",
+      processing: "text-ink-amber-4",
       "partially-approved": "text-ink-green-4",
       "partially-rejected": "text-ink-red-4",
       none: "",


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds a spinner icon when a timesheet is in the processing state instead of showing the same icon as the Approval Pending state, which could mislead users.


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
To test the processing state, run the following command to stop the long worker:

`fm shell <sitename> --service schedule --user root -c "supervisorctl stop frappe-bench-frappe-long-worker"`

Approve a timesheet from the Team Timesheet page and verify that the row shows the processing spinner.

After testing, restart the long worker using:

`fm shell <sitename> --service schedule --user root -c "supervisorctl start frappe-bench-frappe-long-worker"`

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1624" height="531" alt="Screenshot 2026-08-19 at 8 22 33 PM" src="https://github.com/user-attachments/assets/a0bedb22-6c57-4d09-b9cb-9db4c42e2c0a" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2056