### PR TITLE
feat: add currency conversion in monetary fields before sorting

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -101,6 +101,10 @@ export const isWeekendEntryAllowed = (): boolean => {
   return window.frappe?.boot?.allow_weekend_entries ?? false;
 };
 
+export const getDefaultCurrency = (): string => {
+  return window.frappe?.boot?.sysdefaults?.currency ?? "INR";
+};
+
 export function parseFrappeErrorMsg(error: FrappeError) {
   const messages = getErrorMessages(error);
   let message = "";

--- a/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
+++ b/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
@@ -133,14 +133,18 @@ export function ProjectFilters() {
                 field: "burn_rate_per_week",
                 label: "Burn rate/week",
                 disabled: !currency,
-                tooltipText: "Select a currency to enable this sort",
+                tooltipText: !currency
+                  ? "Select a currency to enable this sort"
+                  : undefined,
               },
               { field: "cost_burn_percent", label: "Cost burn" },
               {
                 field: "total_budget",
                 label: "Total budget",
                 disabled: !currency,
-                tooltipText: "Select a currency to enable this sort",
+                tooltipText: !currency
+                  ? "Select a currency to enable this sort"
+                  : undefined,
               },
               { field: "profit_margin", label: "Profit margin" },
               { field: "expected_start_date", label: "Start date" },

--- a/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
+++ b/frontend/packages/app/src/pages/projects/components/project-filters/index.tsx
@@ -16,6 +16,7 @@ import {
  */
 import { FilterLinkValue } from "@/components/filters/FilterLinkValue";
 import { useDebounce } from "@/hooks/useDebounce";
+import { getDefaultCurrency } from "@/lib/utils";
 import { useUser } from "@/providers/user";
 import { useProjectFilters } from "./useProjectFilters";
 import { PHASE_OPTIONS, RAG_OPTIONS, STATUS_OPTIONS } from "../../constants";
@@ -36,6 +37,13 @@ export function ProjectFilters() {
     setCurrency,
   } = useProjectFilters();
   const currencies = useUser((s) => s.state.currencies);
+
+  const didInitCurrency = useRef(false);
+  useEffect(() => {
+    if (didInitCurrency.current) return;
+    didInitCurrency.current = true;
+    if (!currency) setCurrency(getDefaultCurrency());
+  }, [currency, setCurrency]);
 
   const externalFilterCount =
     (search !== "" ? 1 : 0) +
@@ -121,7 +129,19 @@ export function ProjectFilters() {
             fields={[
               { field: "project_name", label: "Project name" },
               { field: "custom_project_phase", label: "Phase" },
+              {
+                field: "burn_rate_per_week",
+                label: "Burn rate/week",
+                disabled: !currency,
+                tooltipText: "Select a currency to enable this sort",
+              },
               { field: "cost_burn_percent", label: "Cost burn" },
+              {
+                field: "total_budget",
+                label: "Total budget",
+                disabled: !currency,
+                tooltipText: "Select a currency to enable this sort",
+              },
               { field: "profit_margin", label: "Profit margin" },
               { field: "expected_start_date", label: "Start date" },
               { field: "custom_next_milestone", label: "Next milestone" },

--- a/frontend/packages/app/src/pages/projects/components/project-filters/useProjectFilters.ts
+++ b/frontend/packages/app/src/pages/projects/components/project-filters/useProjectFilters.ts
@@ -10,6 +10,7 @@ import type { FilterCondition } from "@rtcamp/frappe-ui-react";
  * Internal dependencies.
  */
 import { parseJSONArrayParam } from "@/lib/utils";
+import { MONETARY_SORT_FIELDS } from "../../constants";
 import type {
   Phase,
   ProjectListFilters,
@@ -91,8 +92,24 @@ export function useProjectFilters() {
     [setParam],
   );
   const setCurrency = useCallback(
-    (v: string) => setParam("currency", v),
-    [setParam],
+    (v: string) => {
+      setSearchParams(
+        (prev) => {
+          if (v) {
+            prev.set("currency", v);
+          } else {
+            prev.delete("currency");
+            if (MONETARY_SORT_FIELDS.includes(prev.get("sortField") ?? "")) {
+              prev.delete("sortField");
+              prev.delete("sortOrder");
+            }
+          }
+          return prev;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
   const setAdvanced = useCallback(
     (v: FilterCondition[]) =>

--- a/frontend/packages/app/src/pages/projects/constants.ts
+++ b/frontend/packages/app/src/pages/projects/constants.ts
@@ -53,6 +53,8 @@ export const RAG_STATUS = ["red", "amber", "green"] as const;
 
 export const PROJECT_LIST_PAGE_SIZE = 20;
 
+export const MONETARY_SORT_FIELDS = ["burn_rate_per_week", "total_budget"];
+
 export const RAG_OPTIONS = [
   { label: "Red", value: "red" },
   { label: "Amber", value: "amber" },

--- a/frontend/packages/app/src/pages/projects/list/columns.ts
+++ b/frontend/packages/app/src/pages/projects/list/columns.ts
@@ -17,6 +17,7 @@ export const PROJECT_LIST_COLUMNS: ProjectListColumn[] = [
     key: "burn_rate_per_week",
     label: "Burn rate/week",
     width: "130px",
+    sortField: "burn_rate_per_week",
   },
   {
     key: "cost_burn_percent",
@@ -28,6 +29,7 @@ export const PROJECT_LIST_COLUMNS: ProjectListColumn[] = [
     key: "total_budget",
     label: "Total budget",
     width: "130px",
+    sortField: "total_budget",
   },
   {
     key: "profit_margin",

--- a/frontend/packages/app/src/pages/projects/list/view.tsx
+++ b/frontend/packages/app/src/pages/projects/list/view.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { mergeClassNames as cn } from "@next-pms/design-system";
 import { LoadingOverlay, Spinner } from "@next-pms/design-system/components";
 import {
   ListHeader,
@@ -83,11 +84,12 @@ function ProjectList() {
                 <button
                   type="button"
                   aria-disabled={isDisabled}
-                  className={`flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none ${
+                  className={cn(
+                    "flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none",
                     isDisabled
                       ? "cursor-not-allowed text-ink-gray-5"
-                      : "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
-                  }`}
+                      : "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3",
+                  )}
                   onClick={() => handleHeaderClick(column.sortField!)}
                 >
                   <span className="truncate">{column.label}</span>

--- a/frontend/packages/app/src/pages/projects/list/view.tsx
+++ b/frontend/packages/app/src/pages/projects/list/view.tsx
@@ -7,6 +7,7 @@ import {
   ListRow,
   ListRows,
   ListView,
+  Tooltip,
 } from "@rtcamp/frappe-ui-react";
 import { ArrowDown, ArrowUp } from "@rtcamp/frappe-ui-react/icons";
 
@@ -67,6 +68,34 @@ function ProjectList() {
       >
         {PROJECT_LIST_COLUMNS.map((column) => {
           const isSorted = sort.field === column.sortField;
+          const isDisabled =
+            !currency && MONETARY_SORT_FIELDS.includes(column.sortField ?? "");
+
+          const headerControl = column.sortField ? (
+            <button
+              type="button"
+              aria-disabled={isDisabled}
+              className={`flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none ${
+                isDisabled
+                  ? "cursor-not-allowed text-ink-gray-5"
+                  : "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
+              }`}
+              onClick={() => handleHeaderClick(column.sortField!)}
+            >
+              <span className="truncate">{column.label}</span>
+              {isSorted &&
+                (sort.order === "asc" ? (
+                  <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
+                ) : (
+                  <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
+                ))}
+            </button>
+          ) : (
+            <div className="flex h-7 items-center gap-1 py-1.5">
+              <span className="truncate">{column.label}</span>
+            </div>
+          );
+
           return (
             <ListHeaderItem
               key={column.key}
@@ -82,24 +111,12 @@ function ProjectList() {
               }
               item={column}
             >
-              {column.sortField ? (
-                <button
-                  type="button"
-                  className="flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
-                  onClick={() => handleHeaderClick(column.sortField!)}
-                >
-                  <span className="truncate">{column.label}</span>
-                  {isSorted &&
-                    (sort.order === "asc" ? (
-                      <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
-                    ) : (
-                      <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
-                    ))}
-                </button>
+              {isDisabled ? (
+                <Tooltip text="Select a currency to enable this sort">
+                  {headerControl}
+                </Tooltip>
               ) : (
-                <div className="flex h-7 items-center gap-1 py-1.5">
-                  <span className="truncate">{column.label}</span>
-                </div>
+                headerControl
               )}
             </ListHeaderItem>
           );

--- a/frontend/packages/app/src/pages/projects/list/view.tsx
+++ b/frontend/packages/app/src/pages/projects/list/view.tsx
@@ -18,16 +18,20 @@ import { ProjectListCell } from "./cells";
 import { PROJECT_LIST_COLUMNS } from "./columns";
 import { useProjectList } from "./context";
 import { useProjectFilters } from "../components/project-filters/useProjectFilters";
-import { PROJECT_LIST_PAGE_SIZE } from "../constants";
+import { MONETARY_SORT_FIELDS, PROJECT_LIST_PAGE_SIZE } from "../constants";
 
 function ProjectList() {
   const data = useProjectList((c) => c.state.data);
   const isLoading = useProjectList((c) => c.state.isLoading);
   const hasMore = useProjectList((c) => c.state.hasMore);
   const loadMore = useProjectList((c) => c.actions.loadMore);
-  const { sort, setSort } = useProjectFilters();
+  const { sort, setSort, filters } = useProjectFilters();
+  const currency = filters.currency;
 
   const handleHeaderClick = (sortField: string) => {
+    if (!currency && MONETARY_SORT_FIELDS.includes(sortField)) {
+      return;
+    }
     if (sort.field === sortField) {
       setSort({
         field: sortField,

--- a/frontend/packages/app/src/types/index.ts
+++ b/frontend/packages/app/src/types/index.ts
@@ -76,6 +76,9 @@ declare global {
           can_create: string[];
         };
         currencies?: string[];
+        sysdefaults?: {
+          currency?: string;
+        };
         has_business_unit?: boolean;
         has_industry?: boolean;
         has_repository_connections?: boolean;

--- a/frontend/packages/design-system/src/components/sort-button/index.tsx
+++ b/frontend/packages/design-system/src/components/sort-button/index.tsx
@@ -11,6 +11,8 @@ export type SortOrder = "asc" | "desc";
 export interface SortField {
   field: string;
   label: string;
+  disabled?: boolean;
+  tooltipText?: string;
 }
 
 export interface SortState {

--- a/frontend/packages/design-system/src/components/sort-selector/index.tsx
+++ b/frontend/packages/design-system/src/components/sort-selector/index.tsx
@@ -3,6 +3,7 @@
  */
 import { useState } from "react";
 import { Popover } from "@base-ui/react";
+import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { ArrowDown, ArrowUp, Sort } from "@rtcamp/frappe-ui-react/icons";
 
 /**
@@ -56,14 +57,22 @@ export function SortSelector({
         <Popover.Positioner side="bottom" align="end" sideOffset={4}>
           <Popover.Popup className="min-w-44 rounded-lg border border-outline-gray-2 bg-surface-white py-1 shadow-lg z-50">
             <div className="flex flex-col px-1">
-              {fields.map(({ field, label }) => {
+              {fields.map(({ field, label, disabled, tooltipText }) => {
                 const isSelected = sort?.field === field;
-                return (
+                const button = (
                   <button
                     key={field}
                     type="button"
-                    className="flex w-full items-center justify-between gap-3 rounded px-3 py-1.5 text-sm text-ink-gray-8 hover:bg-surface-gray-2"
-                    onClick={() => handleFieldClick(field)}
+                    aria-disabled={disabled}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 rounded px-3 py-1.5 text-sm",
+                      disabled
+                        ? "cursor-not-allowed text-ink-gray-5"
+                        : "text-ink-gray-8 hover:bg-surface-gray-2",
+                    )}
+                    onClick={() => {
+                      if (!disabled) handleFieldClick(field);
+                    }}
                   >
                     <span>{label}</span>
                     {isSelected &&
@@ -74,6 +83,16 @@ export function SortSelector({
                       ))}
                   </button>
                 );
+
+                if (tooltipText) {
+                  return (
+                    <Tooltip key={field} text={tooltipText}>
+                      {button}
+                    </Tooltip>
+                  );
+                }
+
+                return button;
               })}
             </div>
             {isActive && (

--- a/next_pms/next_projects/api/constant.py
+++ b/next_pms/next_projects/api/constant.py
@@ -40,10 +40,17 @@ COMPUTED_SORT_FIELDS = (
     "contract_end_date",
 )
 
+# Computed sort fields whose values are monetary and must be converted to the selected currency before sorting.
+MONETARY_SORT_FIELDS = (
+    "burn_rate_per_week",
+    "total_budget",
+)
+
 # Minimal Project columns needed to compute the values in COMPUTED_SORT_FIELDS
 SORT_KEY_FIELDS = [
     "name",
     "custom_billing_type",
+    "custom_currency",
     "total_sales_amount",
     "estimated_costing",
     "total_costing_amount",

--- a/next_pms/next_projects/api/project.py
+++ b/next_pms/next_projects/api/project.py
@@ -17,6 +17,7 @@ from next_pms.next_projects.api.constant import (
     COMPUTED_SORT_FIELDS,
     KANBAN_VIEW_FIELDS,
     LIST_VIEW_FIELDS,
+    MONETARY_SORT_FIELDS,
     SORT_KEY_FIELDS,
     TASK_TRACKING_COMPLETED_STATUS,
     TASK_TRACKING_OPEN_STATUSES,
@@ -400,6 +401,7 @@ def get_page_names_for_computed_sort(
     or_filters: dict | None,
     start: int,
     limit: int,
+    currency: str | None = None,
 ) -> tuple[list[str], int]:
     """
     Sort-key pagination for computed fields: fetch only the component columns for
@@ -417,7 +419,25 @@ def get_page_names_for_computed_sort(
 
     cost_forecasted_map = get_cost_forecasted_map([row.name for row in rows]) if sort_field == "profit_margin" else {}
 
-    valued = [(get_computed_sort_value(sort_field, row, cost_forecasted_map), row.name) for row in rows]
+    # Monetary sort fields are converted to `currency` before sorting, mirroring `_apply_currency_conversion`, so the order matches the displayed values.
+    convert = bool(currency) and sort_field in MONETARY_SORT_FIELDS
+    rates = {}
+    if convert:
+        conversion_date = getdate(today())
+        for row in rows:
+            from_currency = row.get("custom_currency")
+            if from_currency and from_currency != currency and from_currency not in rates:
+                rates[from_currency] = get_exchange_rate(from_currency, currency, conversion_date) or 1.0
+
+    valued = []
+    for row in rows:
+        value = get_computed_sort_value(sort_field, row, cost_forecasted_map)
+        if convert and value is not None:
+            from_currency = row.get("custom_currency")
+            if from_currency and from_currency != currency:
+                value = flt(value) * rates.get(from_currency, 1.0)
+        valued.append((value, row.name))
+
     ranked = [entry for entry in valued if entry[0] is not None]
     ranked.sort(key=lambda entry: entry[0], reverse=sort_direction == "desc")
 
@@ -613,6 +633,7 @@ def get_projects_view(
             or_filters if or_filters else None,
             cint(start),
             cint(limit),
+            currency,
         )
         projects = []
         if page_names:

--- a/next_pms/tests/next_projects/api/test_project.py
+++ b/next_pms/tests/next_projects/api/test_project.py
@@ -35,6 +35,7 @@ FORECAST_FIXTURE_PREFIX = "CostForecast"
 ADJUSTED_FIXTURE_PREFIX = "CostAdjusted"
 BUDGET_FIXTURE_PREFIX = "BudgetForecast"
 TAG_FIXTURE_PREFIX = "TagFilter"
+CURRENCY_FIXTURE_PREFIX = "CurrSort"
 
 # 2026-05-04 is a Monday, so 05-08 is Friday and 05-09/05-10 are the weekend.
 MONDAY = date(2026, 5, 4)
@@ -187,6 +188,100 @@ class TestGetProjectsViewComputedSort(IntegrationTestCase):
         result = self.call("cost_burn_percent desc", view="kanban")
         self.assertEqual(result["total_count"], 4)
         self.assertIn("columns", result)
+
+
+class TestGetProjectsViewMonetarySortConversion(IntegrationTestCase):
+    """Monetary sort fields are converted to the selected currency before
+    ranking, so the order matches the displayed values.
+
+    Two projects use different currencies with an exchange rate that reverses
+    their raw numeric order: USD 100 vs INR 5000. Raw order is [INR, USD];
+    converted to INR the USD project becomes 8500, flipping the order to
+    [USD, INR].
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        for code in ("INR", "USD"):
+            if not frappe.db.exists("Currency", code):
+                frappe.get_doc({"doctype": "Currency", "currency_name": code, "enabled": 1}).insert(
+                    ignore_permissions=True
+                )
+
+        frappe.get_doc(
+            {
+                "doctype": "Currency Exchange",
+                "from_currency": "USD",
+                "to_currency": "INR",
+                "exchange_rate": 85,
+                "date": today(),
+            }
+        ).insert(ignore_permissions=True)
+
+        # suffix -> (currency, total_sales_amount)
+        # total_budget = total_sales_amount for Fixed Cost projects.
+        fixture_rows = {
+            "USD": ("USD", 100),
+            "INR": ("INR", 5000),
+        }
+        cls.projects = {}
+        for suffix, (currency, sales) in fixture_rows.items():
+            name = (
+                frappe.get_doc(
+                    {
+                        "doctype": "Project",
+                        "project_name": f"{CURRENCY_FIXTURE_PREFIX} {suffix}",
+                        "company": cls.company,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+            )
+            frappe.db.set_value(
+                "Project",
+                name,
+                {
+                    "custom_billing_type": "Fixed Cost",
+                    "total_sales_amount": sales,
+                    "custom_currency": currency,
+                },
+                update_modified=False,
+            )
+            cls.projects[suffix] = name
+
+        frappe.set_user("Administrator")
+        frappe.clear_cache()
+
+    def fixture_order(self, result):
+        by_name = {name: suffix for suffix, name in self.projects.items()}
+        return [by_name[row["name"]] for row in result["data"]]
+
+    def test_total_budget_sort_converts_to_selected_currency(self):
+        raw = get_projects_view(
+            view="list",
+            search=CURRENCY_FIXTURE_PREFIX,
+            start=0,
+            limit=20,
+            order_by="total_budget desc",
+        )
+        self.assertEqual(self.fixture_order(raw), ["INR", "USD"])
+
+        converted = get_projects_view(
+            view="list",
+            search=CURRENCY_FIXTURE_PREFIX,
+            start=0,
+            limit=20,
+            order_by="total_budget desc",
+            currency="INR",
+        )
+        self.assertEqual(self.fixture_order(converted), ["USD", "INR"])
+
+        budget_by_name = {row["name"]: row["total_budget"] for row in converted["data"]}
+        self.assertEqual(budget_by_name[self.projects["USD"]], 8500)
+        self.assertEqual(budget_by_name[self.projects["INR"]], 5000)
 
 
 class TestBudgetBurnAccrued(IntegrationTestCase):


### PR DESCRIPTION
## Description

- Adds currency conversion in monetary fields to a common currency before sorting, so that sorting is done properly and not mixed


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Required for: https://github.com/rtCamp/next-pms/pull/2071
Part of: #2033 