### PR TITLE
feat(resource-allocation): show leave and holidays on the project allocation view

### DIFF
--- a/frontend/packages/app/src/pages/allocations/project/type.ts
+++ b/frontend/packages/app/src/pages/allocations/project/type.ts
@@ -47,6 +47,13 @@ export interface ProjectDateData {
   }>;
 }
 
+export interface EmployeeLeaveDay {
+  is_on_leave: boolean;
+  is_holiday: boolean;
+  total_leave_hours: number;
+  holiday_name?: string;
+}
+
 export interface ProjectResourceAllocation extends AllocationApiRecord {
   employee: string;
   employee_name: string;
@@ -69,7 +76,8 @@ export interface ProjectRecord {
   all_week_data: ProjectWeekData[];
   all_dates_data: Record<string, ProjectDateData>;
   project_allocations:
-    Record<string, ProjectResourceAllocation> | ProjectResourceAllocation[];
+    | Record<string, ProjectResourceAllocation>
+    | ProjectResourceAllocation[];
 }
 
 export interface ProjectAllocationResponse {
@@ -77,6 +85,7 @@ export interface ProjectAllocationResponse {
   data: ProjectRecord[];
   customer: Record<string, Customer>;
   employees: Record<string, ProjectEmployee>;
+  employee_leaves?: Record<string, Record<string, EmployeeLeaveDay>>;
   total_count: number;
   has_more: boolean;
   permissions: Permissions;

--- a/frontend/packages/app/src/pages/allocations/project/type.ts
+++ b/frontend/packages/app/src/pages/allocations/project/type.ts
@@ -75,9 +75,7 @@ export interface ProjectRecord {
   remaining_hours?: number;
   all_week_data: ProjectWeekData[];
   all_dates_data: Record<string, ProjectDateData>;
-  project_allocations:
-    | Record<string, ProjectResourceAllocation>
-    | ProjectResourceAllocation[];
+  project_allocations: Record<string, ProjectResourceAllocation> | ProjectResourceAllocation[];
 }
 
 export interface ProjectAllocationResponse {

--- a/frontend/packages/app/src/pages/allocations/project/type.ts
+++ b/frontend/packages/app/src/pages/allocations/project/type.ts
@@ -75,7 +75,8 @@ export interface ProjectRecord {
   remaining_hours?: number;
   all_week_data: ProjectWeekData[];
   all_dates_data: Record<string, ProjectDateData>;
-  project_allocations: Record<string, ProjectResourceAllocation> | ProjectResourceAllocation[];
+  project_allocations:
+    Record<string, ProjectResourceAllocation> | ProjectResourceAllocation[];
 }
 
 export interface ProjectAllocationResponse {

--- a/frontend/packages/app/src/pages/allocations/project/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/project/utils.ts
@@ -2,11 +2,12 @@
  * External dependencies.
  */
 import type {
+  LeaveAllocation,
   ProjectGroup,
   ProjectMember,
 } from "@next-pms/design-system/components";
 import { formatDateRange } from "@next-pms/design-system/date";
-import { parseISO } from "date-fns";
+import { addDays, isSameDay, parseISO } from "date-fns";
 
 /**
  * Internal dependencies.
@@ -19,6 +20,7 @@ import {
 } from "../utils";
 import type {
   Customer,
+  EmployeeLeaveDay,
   ManagerNameMap,
   ProjectAllocationResponse,
   ProjectEmployee,
@@ -117,12 +119,81 @@ function getProjectDateRange(projectAllocations: ProjectResourceAllocation[]) {
 }
 
 /**
+ * Builds each employee's leave/holiday days into merged LeaveAllocation ranges.
+ *
+ * A day whose leave hours fall short of the employee's full daily capacity is kept as its
+ * own single-day range with a half-day marker, rather than merged into a neighbouring
+ * full-day run, since the API gives no way to tell which side of a run the half applies to.
+ * A holiday is always its own single-day range labelled with the holiday's name, never
+ * merged with a neighbouring day, so a run of leave days butting up against a named holiday
+ * doesn't drop the name into an "N days off" range.
+ */
+function buildEmployeeLeaveAllocations(
+  employeeLeaves: Record<string, Record<string, EmployeeLeaveDay>> | undefined,
+  employees: Record<string, ProjectEmployee>,
+): Map<string, LeaveAllocation[]> {
+  const leavesByEmployee = new Map<string, LeaveAllocation[]>();
+
+  for (const [employeeId, leaveDays] of Object.entries(employeeLeaves ?? {})) {
+    const employee = employees[employeeId];
+    const capacityHoursPerDay = getAllocationCapacityHoursPerDay(
+      employee?.custom_working_hours,
+      employee?.custom_work_schedule,
+    );
+
+    const sortedDates = Object.keys(leaveDays)
+      .filter((date) => leaveDays[date].is_on_leave)
+      .sort();
+
+    const ranges: LeaveAllocation[] = [];
+    for (const dateStr of sortedDates) {
+      const date = parseISO(dateStr);
+      const { total_leave_hours, is_holiday, holiday_name } =
+        leaveDays[dateStr];
+      const isHalfDay =
+        capacityHoursPerDay !== undefined &&
+        total_leave_hours > 0 &&
+        total_leave_hours < capacityHoursPerDay;
+      const label = is_holiday ? holiday_name || "Holiday" : undefined;
+
+      const last = ranges[ranges.length - 1];
+      const canExtendLast =
+        !isHalfDay &&
+        !label &&
+        last &&
+        !last.halfDayDate &&
+        !last.label &&
+        isSameDay(addDays(last.endDate, 1), date);
+
+      if (canExtendLast) {
+        last.endDate = date;
+        continue;
+      }
+
+      ranges.push({
+        startDate: date,
+        endDate: date,
+        ...(isHalfDay ? { halfDayDate: date } : {}),
+        ...(label ? { label } : {}),
+      });
+    }
+
+    if (ranges.length > 0) {
+      leavesByEmployee.set(employeeId, ranges);
+    }
+  }
+
+  return leavesByEmployee;
+}
+
+/**
  * Groups project allocations by employee for the project Gantt rows.
  */
 function getProjectMembers(
   projectAllocations: ProjectResourceAllocation[],
   customerLookup: Record<string, Customer>,
   employees: Record<string, ProjectEmployee>,
+  leavesByEmployee: Map<string, LeaveAllocation[]>,
   managerNameMap?: ManagerNameMap,
 ): ProjectMember[] {
   const membersById = new Map<string, ProjectMember>();
@@ -171,6 +242,7 @@ function getProjectMembers(
         : undefined,
       image: employee?.image ?? undefined,
       allocations: mappedAllocations,
+      leaves: leavesByEmployee.get(memberId),
     });
   }
 
@@ -184,6 +256,7 @@ function mapProjectRecord(
   project: ProjectRecord,
   customerLookup: Record<string, Customer>,
   employees: Record<string, ProjectEmployee>,
+  leavesByEmployee: Map<string, LeaveAllocation[]>,
   managerNameMap?: ManagerNameMap,
 ): ProjectGroup {
   const projectAllocations = getAllocationList(project.project_allocations);
@@ -192,6 +265,7 @@ function mapProjectRecord(
     projectAllocations,
     customerLookup,
     employees,
+    leavesByEmployee,
     managerNameMap,
   );
 
@@ -215,8 +289,18 @@ export function mapProjectAllocationToProjects(
   managerNameMap?: ManagerNameMap,
 ): ProjectGroup[] {
   const employees = response.employees ?? {};
+  const leavesByEmployee = buildEmployeeLeaveAllocations(
+    response.employee_leaves,
+    employees,
+  );
 
   return response.data.map((project) =>
-    mapProjectRecord(project, response.customer, employees, managerNameMap),
+    mapProjectRecord(
+      project,
+      response.customer,
+      employees,
+      leavesByEmployee,
+      managerNameMap,
+    ),
   );
 }

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -174,7 +174,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
                 strokeWidth={1.5}
               />
               {showInlineLabel && label ? (
-                <span className="text-[13px] font-medium tracking-[0.02em] truncate">
+                <span className="min-w-0 flex-1 overflow-hidden text-[13px] font-medium tracking-[0.02em] truncate">
                   {label}
                 </span>
               ) : null}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/memberSummaryBar.tsx
@@ -2,7 +2,6 @@
  * External dependencies.
  */
 import { Popover } from "@base-ui/react/popover";
-import { differenceInCalendarDays } from "date-fns";
 
 /**
  * Internal dependencies.
@@ -11,10 +10,10 @@ import { useGanttStore } from "../ganttStore";
 import type { MemberSummaryBar } from "../ganttStore";
 import { GanttAllocationPopover } from "./allocationPopover";
 import { GanttBar } from "./ganttBar";
+import { GanttTimeoffBar } from "./timeoffBar";
 import { allocationBarToEntry } from "./utils/allocationBarToEntry";
 import { getCapacityStatus } from "./utils/getCapacityStatus";
 import { getOverlappingAllocations } from "./utils/getOverlappingAllocations";
-import { getTimeoffLabel } from "./utils/getTimeoffLabel";
 import { withPendingDeleteEntry } from "./utils/withPendingDeleteEntry";
 
 interface GanttMemberSummaryBarProps {
@@ -67,19 +66,12 @@ export function GanttMemberSummaryBar({
   }
 
   if (summary.type === "timeoff") {
-    const leaveDays =
-      differenceInCalendarDays(summary.endDate, summary.startDate) + 1;
-    const leaveLabel = getTimeoffLabel(
-      summary.startDate,
-      summary.endDate,
-      summary.timeoff,
-    );
-
     return (
-      <GanttBar
-        variant="timeoff"
-        label={leaveLabel}
-        showInlineLabel={leaveDays > 1}
+      <GanttTimeoffBar
+        startDate={summary.startDate}
+        endDate={summary.endDate}
+        timeoff={summary.timeoff}
+        label={summary.label}
         left={left}
         width={width}
       />

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/timeoffBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/timeoffBar.tsx
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies.
+ */
+import { CELL_WIDTH } from "../constants";
+import type { TimeoffPortion } from "../types";
+import { GanttBar } from "./ganttBar";
+import { getTimeoffLabel } from "./utils/getTimeoffLabel";
+
+interface GanttTimeoffBarProps {
+  startDate: Date;
+  endDate: Date;
+  timeoff?: TimeoffPortion;
+  /** Literal text to show instead of the generated "N days off" wording, e.g. a holiday's name. */
+  label?: string;
+  left: number;
+  width: number;
+}
+
+export function GanttTimeoffBar({
+  startDate,
+  endDate,
+  timeoff,
+  label,
+  left,
+  width,
+}: GanttTimeoffBarProps) {
+  const resolvedLabel = label ?? getTimeoffLabel(startDate, endDate, timeoff);
+
+  return (
+    <GanttBar
+      variant="timeoff"
+      label={resolvedLabel}
+      // A single narrow day-column has room for the icon only; rendering the label
+      // span anyway would still reserve its flex gap and shift the icon off-centre.
+      showInlineLabel={width > CELL_WIDTH}
+      left={left}
+      width={width}
+    />
+  );
+}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -86,9 +86,7 @@ export function getAllocationSummary(
       hours: dayTimeoff.has(ts) ? 0 : (dayHours.get(ts) ?? 0),
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
-      type: (dayTimeoff.has(ts) ? "timeoff" : "default") as
-        | "default"
-        | "timeoff",
+      type: (dayTimeoff.has(ts) ? "timeoff" : "default") as "default" | "timeoff",
       timeoff: dayTimeoff.get(ts),
       label: dayLabel.get(ts),
     }));

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -41,6 +41,7 @@ export function getAllocationSummary(
   const dayHasNonBillable = new Map<number, boolean>();
   const dayHasTentative = new Map<number, boolean>();
   const dayTimeoff = new Map<number, TimeoffPortion>();
+  const dayLabel = new Map<number, string>();
   const dayKeys = new Set<number>();
 
   for (const alloc of allocations) {
@@ -71,6 +72,9 @@ export function getAllocationSummary(
       if (portion === "full" || !dayTimeoff.has(key)) {
         dayTimeoff.set(key, portion);
       }
+      if (leave.label) {
+        dayLabel.set(key, leave.label);
+      }
     }
   }
 
@@ -83,8 +87,10 @@ export function getAllocationSummary(
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
       type: (dayTimeoff.has(ts) ? "timeoff" : "default") as
-        "default" | "timeoff",
+        | "default"
+        | "timeoff",
       timeoff: dayTimeoff.get(ts),
+      label: dayLabel.get(ts),
     }));
 
   const merged: MemberBarAllocation[] = [];
@@ -95,6 +101,7 @@ export function getAllocationSummary(
     tentative,
     type,
     timeoff,
+    label,
   } of sortedDays) {
     const last = merged[merged.length - 1];
     if (
@@ -104,6 +111,7 @@ export function getAllocationSummary(
       last.tentative === tentative &&
       last.type === type &&
       last.timeoff === timeoff &&
+      last.label === label &&
       isSameDay(addDays(last.endDate, 1), date)
     ) {
       last.endDate = date;
@@ -116,6 +124,7 @@ export function getAllocationSummary(
         tentative,
         type,
         timeoff,
+        label,
       });
     }
   }

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/utils/getMemberAllocation.ts
@@ -86,7 +86,8 @@ export function getAllocationSummary(
       hours: dayTimeoff.has(ts) ? 0 : (dayHours.get(ts) ?? 0),
       billable: !dayHasNonBillable.get(ts),
       tentative: Boolean(dayHasTentative.get(ts)),
-      type: (dayTimeoff.has(ts) ? "timeoff" : "default") as "default" | "timeoff",
+      type: (dayTimeoff.has(ts) ? "timeoff" : "default") as
+        "default" | "timeoff",
       timeoff: dayTimeoff.get(ts),
       label: dayLabel.get(ts),
     }));

--- a/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/ganttMemberRow.tsx
@@ -12,6 +12,7 @@ import {
   RowAllocationOverlay,
   type RowAllocationOverlayHandle,
 } from "./gantt-bar/rowAllocationOverlay";
+import { GanttTimeoffBar } from "./gantt-bar/timeoffBar";
 import { GanttMemberItem } from "./ganttMemberItem";
 import { GanttRowOverlayCell } from "./ganttRowOverlayCell";
 import { useGanttStore } from "./ganttStore";
@@ -106,10 +107,25 @@ export const GanttMemberRow: React.FC<GanttMemberRowProps> = ({
               resizable={canEditAllocations}
             />
           ))}
+        {isExpanded &&
+          member.leaveBars?.map((bar) => (
+            <GanttTimeoffBar
+              key={`${bar.startDate.getTime()}-${bar.endDate.getTime()}`}
+              startDate={bar.startDate}
+              endDate={bar.endDate}
+              timeoff={bar.timeoff}
+              label={bar.label}
+              left={bar.barOffset + headerWidth}
+              width={bar.width}
+            />
+          ))}
         <RowAllocationOverlay
           ref={overlayRef}
           enabled={canManageAllocations && isExpanded}
-          allocations={member.allocations ?? []}
+          allocations={[
+            ...(member.allocations ?? []),
+            ...(member.leaveBars ?? []),
+          ]}
           createDraftBar={(left) => ({
             rowKey: memberRowKey,
             left,

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,4 +1,5 @@
-export type DeleteAllocationMode = "only_this" | "this_and_future" | "all_in_series";
+export type DeleteAllocationMode =
+  "only_this" | "this_and_future" | "all_in_series";
 
 export interface Allocation {
   /** Unique identifier for the allocation. */

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,7 +1,4 @@
-export type DeleteAllocationMode =
-  | "only_this"
-  | "this_and_future"
-  | "all_in_series";
+export type DeleteAllocationMode = "only_this" | "this_and_future" | "all_in_series";
 
 export interface Allocation {
   /** Unique identifier for the allocation. */

--- a/frontend/packages/design-system/src/components/gantt-view/types.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/types.ts
@@ -1,5 +1,7 @@
 export type DeleteAllocationMode =
-  "only_this" | "this_and_future" | "all_in_series";
+  | "only_this"
+  | "this_and_future"
+  | "all_in_series";
 
 export interface Allocation {
   /** Unique identifier for the allocation. */
@@ -53,6 +55,8 @@ export interface MemberBarAllocation extends Allocation {
   type?: "default" | "timeoff" | "free";
   /** How much of the day is off, for `timeoff` segments. */
   timeoff?: TimeoffPortion;
+  /** Literal text to show instead of the generated "N days off" wording, e.g. a holiday's name. */
+  label?: string;
 }
 
 export interface LeaveAllocation {
@@ -64,6 +68,8 @@ export interface LeaveAllocation {
   halfDayDate?: Date;
   /** Which half of the half-day is taken off, when the leave has one. */
   halfDayPortion?: "first" | "second";
+  /** Literal text to show instead of the generated "N days off" wording, e.g. a holiday's name. */
+  label?: string;
 }
 
 export interface Project {

--- a/frontend/packages/design-system/src/components/gantt-view/utils.ts
+++ b/frontend/packages/design-system/src/components/gantt-view/utils.ts
@@ -7,6 +7,7 @@ import { addDays, eachDayOfInterval, isSameDay, startOfDay } from "date-fns";
  * Internal dependencies.
  */
 import {
+  getAllocationSummary,
   getCoveredDayKeys,
   getFreeCapacitySegments,
   getMemberAllocation,
@@ -59,6 +60,7 @@ export type ProjectMemberAllocationBar = ProjectAllocationBar;
 
 export interface ProjectMember extends SourceProjectMember {
   allocations: ProjectMemberAllocationBar[];
+  leaveBars: MemberSummaryBar[];
 }
 
 export interface ProjectGroup extends SourceProjectGroup {
@@ -369,20 +371,32 @@ export const prepareProjectBars = (
     );
 
     const members: ProjectGroup["members"] = (project.members ?? []).map(
-      (member) => ({
-        ...member,
-        allocations: prepareAllocationBars(
-          member.allocations ?? [],
-          weekStart,
-          columnCount,
-          showWeekend,
-          columnWidth,
-        ).map((allocation) => ({
-          ...allocation,
-          projectName: project.name,
-          customerName: project.client,
-        })),
-      }),
+      (member) => {
+        const rawAllocations = member.allocations ?? [];
+        const leaveSegments = getAllocationSummary([], member.leaves ?? []);
+
+        return {
+          ...member,
+          allocations: prepareAllocationBars(
+            rawAllocations,
+            weekStart,
+            columnCount,
+            showWeekend,
+            columnWidth,
+          ).map((allocation) => ({
+            ...allocation,
+            projectName: project.name,
+            customerName: project.client,
+          })),
+          leaveBars: prepareMemberSummaryBars(
+            leaveSegments,
+            weekStart,
+            columnCount,
+            showWeekend,
+            columnWidth,
+          ),
+        };
+      },
     );
 
     const projectSummaryBars = prepareProjectSummaryBars(

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -15,6 +15,11 @@ from next_pms.resource_management.api.utils.helpers import (
     override_hours_by_date,
     resource_api_permissions_check,
 )
+from next_pms.resource_management.api.utils.leave_calendar import (
+    build_leave_map,
+    get_daily_working_hours,
+    get_leave_calendars,
+)
 from next_pms.resource_management.api.utils.query import (
     attach_extra_entries,
     get_allocation_list_for_employee_for_given_range,
@@ -119,6 +124,11 @@ def get_resource_management_project_view_data(
             - employees (dict): employee metadata keyed by employee id for the
               employees appearing in the allocations. Blank custom_working_hours /
               custom_work_schedule are filled from HR Settings / "Per Day" before returning.
+            - employee_leaves (dict): the days those employees are away, keyed by employee
+              id and then by date, each carrying is_on_leave, is_holiday and
+              total_leave_hours. Sparse - employees and dates without leave are absent.
+              Leave already reduces the allocated hours reported above; this is what says
+              why they were reduced.
             - total_count (int): total number of projects matching the filters,
               independent of page_length.
             - has_more (bool): whether more projects exist beyond this page.
@@ -270,6 +280,7 @@ def _get_resource_management_project_view_data(
         "reports_to",
         "custom_work_schedule",
         "custom_working_hours",
+        "company",
         *privileged_emp_fields,
     ]
     emp_ids = set()
@@ -298,6 +309,16 @@ def _get_resource_management_project_view_data(
     )
     apply_working_hours_fallback(employees.values())
 
+    leaves_map, holidays_map = get_leave_calendars(
+        employees.values(), weeks[0].get("start_date"), weeks[-1].get("end_date")
+    )
+    employee_leaves = build_leave_map(
+        employees.values(),
+        [date for week in weeks for date in week.get("dates")],
+        leaves_map,
+        holidays_map,
+    )
+
     remaining_hours_map = get_remaining_allocation_hours_by_project(
         [project.name for project in projects],
         getdate(today),
@@ -313,6 +334,7 @@ def _get_resource_management_project_view_data(
             total_allocated_hours_for_given_week = 0
 
             for date in week.get("dates"):
+                date_key = date.strftime(DATE_FORMAT)
                 total_allocated_hours_for_given_date = 0
                 project_resource_allocation_for_given_date = []
 
@@ -328,6 +350,7 @@ def _get_resource_management_project_view_data(
                             {
                                 "name": resource_allocation.name,
                                 "date": date,
+                                "is_on_leave": date_key in employee_leaves.get(resource_allocation.employee, {}),
                             }
                         )
 
@@ -335,14 +358,14 @@ def _get_resource_management_project_view_data(
 
                 if permissions["write"]:
                     date_data = {
-                        "date": date.strftime(DATE_FORMAT),
+                        "date": date_key,
                         "total_allocated_hours": total_allocated_hours_for_given_date,
                         "project_resource_allocation_for_given_date": project_resource_allocation_for_given_date,
                         "total_worked_hours": get_allocation_worked_hours_for_given_projects(project.name, date, date),
                     }
                 else:
                     date_data = {
-                        "date": date.strftime(DATE_FORMAT),
+                        "date": date_key,
                         "total_allocated_hours": total_allocated_hours_for_given_date,
                         "project_resource_allocation_for_given_date": project_resource_allocation_for_given_date,
                     }
@@ -381,6 +404,7 @@ def _get_resource_management_project_view_data(
     res["data"] = data
     res["customer"] = customer
     res["employees"] = employees
+    res["employee_leaves"] = employee_leaves
     res["total_count"] = total_count
     res["has_more"] = int(start) + int(page_length) < total_count
     res["permissions"] = permissions
@@ -390,7 +414,13 @@ def _get_resource_management_project_view_data(
 
 @frappe.whitelist(methods=["GET"])
 def get_employees_resrouce_data_for_given_project(project: str, start_date: str, end_date: str, is_billable: int = -1):
-    """Returns the data required for resource management employee view based on the filters provided for a given project"""
+    """Returns the data required for resource management employee view based on the filters provided for a given project.
+
+    Each employee carries all_dates_data (per-date allocated hours, plus is_on_leave and
+    total_leave_hours), all_leave_data (hours away, keyed by date, for the days they are),
+    employee_daily_working_hours and their allocations. A day the employee is fully away is
+    reported even when nothing is allocated or worked on it.
+    """
     permissions = resource_api_permissions_check()
     return _get_employees_resrouce_data_for_given_project(
         json.dumps(permissions),
@@ -473,6 +503,7 @@ def _get_employees_resrouce_data_for_given_project(
         "reports_to",
         "custom_work_schedule",
         "custom_working_hours",
+        "company",
         *privileged_emp_fields,
     ]
 
@@ -484,6 +515,16 @@ def _get_employees_resrouce_data_for_given_project(
     }
     apply_working_hours_fallback(all_employees.values())
 
+    working_dates = []
+    current_date = start_date
+    while current_date <= end_date:
+        if current_date.weekday() < 5:
+            working_dates.append(current_date)
+        current_date = add_days(current_date, 1)
+
+    leaves_map, holidays_map = get_leave_calendars(all_employees.values(), start_date, end_date)
+    employee_leaves = build_leave_map(all_employees.values(), working_dates, leaves_map, holidays_map)
+
     for emp_id in resource_allocation_map:
         employee_resource_allocation = resource_allocation_map.get(emp_id, [])
 
@@ -491,14 +532,12 @@ def _get_employees_resrouce_data_for_given_project(
         if not employee:
             continue
 
-        current_date = start_date
+        employee_dates_off = employee_leaves.get(emp_id, {})
+        all_dates_data, all_leave_data = {}, {}
 
-        all_dates_data = {}
-
-        while current_date <= end_date:
-            if current_date.weekday() in [5, 6]:
-                current_date = add_days(current_date, 1)
-                continue
+        for current_date in working_dates:
+            date_key = current_date.strftime(DATE_FORMAT)
+            leave_info = employee_dates_off.get(date_key)
 
             total_allocated_hours_for_employee = 0
             employee_resource_allocation_for_given_date = []
@@ -520,26 +559,35 @@ def _get_employees_resrouce_data_for_given_project(
                     )
 
             total_worked_hours_for_employee = get_allocation_worked_hours_for_given_employee(
-                project, employee.name, current_date.strftime(DATE_FORMAT), current_date.strftime(DATE_FORMAT)
+                project, employee.name, date_key, date_key
             )
 
-            if total_allocated_hours_for_employee > 0 or total_worked_hours_for_employee > 0:
-                if permissions["write"]:
-                    all_dates_data[current_date.strftime(DATE_FORMAT)] = {
-                        "date": current_date.strftime(DATE_FORMAT),
-                        "total_allocated_hours": total_allocated_hours_for_employee,
-                        "total_worked_hours": total_worked_hours_for_employee,
-                        "employee_resource_allocation_for_given_date": employee_resource_allocation_for_given_date,
-                    }
-                else:
-                    all_dates_data[current_date.strftime(DATE_FORMAT)] = {
-                        "date": current_date.strftime(DATE_FORMAT),
-                        "total_allocated_hours": total_allocated_hours_for_employee,
-                        "employee_resource_allocation_for_given_date": employee_resource_allocation_for_given_date,
-                    }
+            if leave_info:
+                all_leave_data[date_key] = leave_info["total_leave_hours"]
 
-            current_date = add_days(current_date, 1)
-        data.append({**employee, "all_dates_data": all_dates_data, "allocations": employee_resource_allocation})
+            if total_allocated_hours_for_employee > 0 or total_worked_hours_for_employee > 0 or leave_info:
+                date_data = {
+                    "date": date_key,
+                    "total_allocated_hours": total_allocated_hours_for_employee,
+                    "employee_resource_allocation_for_given_date": employee_resource_allocation_for_given_date,
+                    "is_on_leave": bool(leave_info),
+                    "total_leave_hours": leave_info["total_leave_hours"] if leave_info else 0.0,
+                }
+
+                if permissions["write"]:
+                    date_data["total_worked_hours"] = total_worked_hours_for_employee
+
+                all_dates_data[date_key] = date_data
+
+        data.append(
+            {
+                **employee,
+                "all_dates_data": all_dates_data,
+                "all_leave_data": all_leave_data,
+                "allocations": employee_resource_allocation,
+                "employee_daily_working_hours": get_daily_working_hours(employee),
+            }
+        )
 
     res["data"] = data
     res["customer"] = customer

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -126,7 +126,8 @@ def get_resource_management_project_view_data(
               custom_work_schedule are filled from HR Settings / "Per Day" before returning.
             - employee_leaves (dict): the days those employees are away, keyed by employee
               id and then by date, each carrying is_on_leave, is_holiday and
-              total_leave_hours. Sparse - employees and dates without leave are absent.
+              total_leave_hours, plus holiday_name when is_holiday is true. Sparse -
+              employees and dates without leave are absent.
               Leave already reduces the allocated hours reported above; this is what says
               why they were reduced.
             - total_count (int): total number of projects matching the filters,

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -1,9 +1,8 @@
 import json
 
 import frappe
-from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 from frappe.core.doctype.recorder.recorder import redis_cache
-from frappe.utils import DATE_FORMAT, getdate
+from frappe.utils import DATE_FORMAT
 
 from next_pms.resource_management.api.utils.helpers import (
     _parse_multi_select_filter,
@@ -18,10 +17,10 @@ from next_pms.resource_management.api.utils.helpers import (
     override_hours_by_date,
     resource_api_permissions_check,
 )
+from next_pms.resource_management.api.utils.leave_calendar import get_leave_calendars
 from next_pms.resource_management.api.utils.query import (
     attach_extra_entries,
     get_allocation_list_for_employee_for_given_range,
-    get_employee_leaves,
 )
 from next_pms.timesheet.api import filter_employees
 from next_pms.timesheet.api.employee import apply_working_hours_fallback, get_employee_working_hours
@@ -442,7 +441,7 @@ def _get_resource_management_team_view_data(
         status=["Active"],
         ids=ids,
         ignore_permissions=True,
-        extra_fields=["custom_work_schedule", "custom_working_hours", "reports_to", *privileged_fields],
+        extra_fields=["custom_work_schedule", "custom_working_hours", "reports_to", "company", *privileged_fields],
         extra_conditions=extra_conditions,
     )
 
@@ -543,33 +542,7 @@ def _get_resource_management_team_view_data(
     for t in all_timesheets:
         timesheet_map.setdefault(t.employee, []).append(t)
 
-    # Batch leaves — get_employee_leaves accepts a tuple of employee IDs
-    all_leaves = get_employee_leaves(
-        employee=tuple(employee_ids),
-        start_date=range_start,
-        end_date=range_end,
-    )
-    leaves_map = {}
-    for leave in all_leaves:
-        leaves_map.setdefault(leave.employee, []).append(leave)
-
-    # Batch holidays — fetch once per unique holiday list instead of once per employee
-    holiday_list_per_employee = {
-        emp.name: get_holiday_list_for_employee(emp.name, raise_exception=False) for emp in employees
-    }
-    unique_holiday_lists = {hl for hl in holiday_list_per_employee.values() if hl}
-    holidays_by_list = {
-        hl: frappe.get_all(
-            "Holiday",
-            filters={
-                "parent": hl,
-                "holiday_date": ["between", (getdate(range_start), getdate(range_end))],
-            },
-            fields=["holiday_date", "description", "weekly_off"],
-        )
-        for hl in unique_holiday_lists
-    }
-    holidays_map = {emp.name: holidays_by_list.get(holiday_list_per_employee.get(emp.name), []) for emp in employees}
+    leaves_map, holidays_map = get_leave_calendars(employees, range_start, range_end)
 
     for employee in employees:
         employee_resource_allocation = resource_allocation_map.get(employee.name, [])

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -21,6 +21,7 @@ from next_pms.resource_management.api.utils.leave_calendar import get_leave_cale
 from next_pms.resource_management.api.utils.query import (
     attach_extra_entries,
     get_allocation_list_for_employee_for_given_range,
+    get_employee_leaves,
 )
 from next_pms.timesheet.api import filter_employees
 from next_pms.timesheet.api.employee import apply_working_hours_fallback, get_employee_working_hours

--- a/next_pms/resource_management/api/utils/leave_calendar.py
+++ b/next_pms/resource_management/api/utils/leave_calendar.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+import datetime
+from collections.abc import Iterable
+
+import frappe
+from frappe.utils import DATE_FORMAT, flt, getdate
+
+from next_pms.resource_management.api.utils.helpers import is_on_leave
+from next_pms.resource_management.api.utils.query import get_employee_leaves
+from next_pms.timesheet.api.utils import resolve_holiday_lists
+
+
+def get_leave_calendars(employees: Iterable[dict], start_date, end_date) -> tuple[dict, dict]:
+    """Return the leaves and holidays of a whole page of employees in three queries.
+
+    Batched on every axis that would otherwise scale with the employee count: one leave
+    query for all employees, one assignment query to resolve their holiday lists (hrms
+    overrides `get_holiday_list_for_employee` to read Holiday List Assignment, uncached,
+    once per employee), and one Holiday query covering every list involved.
+
+    Args:
+        employees: Employee rows carrying at least `name` and `company`; `company` is what
+            lets an employee fall back to their company's holiday list.
+        start_date: Range start, inclusive.
+        end_date: Range end, inclusive.
+
+    Returns:
+        tuple[dict, dict]: leaves and holidays, each keyed by employee id and shaped the way
+        :func:`is_on_leave` expects them.
+    """
+    employee_meta = {employee["name"]: employee for employee in employees}
+    if not employee_meta:
+        return {}, {}
+
+    leaves_map = {}
+    for leave in get_employee_leaves(
+        employee=tuple(employee_meta),
+        start_date=str(getdate(start_date)),
+        end_date=str(getdate(end_date)),
+    ):
+        leaves_map.setdefault(leave.employee, []).append(leave)
+
+    holiday_list_by_employee = resolve_holiday_lists(employee_meta, list(employee_meta))
+    holiday_lists = {holiday_list for holiday_list in holiday_list_by_employee.values() if holiday_list}
+
+    holidays_by_list = {}
+    if holiday_lists:
+        for holiday in frappe.get_all(
+            "Holiday",
+            filters={
+                "parent": ["in", list(holiday_lists)],
+                "holiday_date": ["between", (getdate(start_date), getdate(end_date))],
+            },
+            fields=["parent", "holiday_date", "weekly_off"],
+        ):
+            holidays_by_list.setdefault(holiday.parent, []).append(holiday)
+
+    holidays_map = {
+        employee: holidays_by_list.get(holiday_list_by_employee.get(employee), []) for employee in employee_meta
+    }
+
+    return leaves_map, holidays_map
+
+
+def get_daily_working_hours(employee: dict) -> float:
+    """The employee's normal hours for a single day.
+
+    Expects `apply_working_hours_fallback` to have filled the blanks; anything other than a
+    "Per Day" schedule is spread over a five-day week, as the team view does.
+    """
+    working_hours = flt(employee.get("custom_working_hours"))
+
+    if employee.get("custom_work_schedule") == "Per Day":
+        return working_hours
+
+    return working_hours / 5
+
+
+def build_leave_map(employees: Iterable[dict], dates: Iterable[datetime.date], leaves_map: dict, holidays_map: dict):
+    """Map each employee to the days they are away, over the dates a view already renders.
+
+    Sparse by design: an employee with nothing booked off in the window is absent from the
+    result, as is every date they are fully available, so the payload carries no filler for
+    the common case.
+
+    `total_leave_hours` is the part of a normal day the employee is away — a full day off for
+    leave or a holiday, half of one for a half-day leave.
+    """
+    leave_map = {}
+
+    for employee in employees:
+        leaves = leaves_map.get(employee["name"], [])
+        holidays = holidays_map.get(employee["name"], [])
+
+        if not leaves and not holidays:
+            continue
+
+        daily_working_hours = get_daily_working_hours(employee)
+        holiday_dates = {holiday.holiday_date for holiday in holidays}
+        dates_off = {}
+
+        for date in dates:
+            leave_object = is_on_leave(date, daily_working_hours, leaves, holidays)
+
+            if not leave_object.get("on_leave"):
+                continue
+
+            dates_off[date.strftime(DATE_FORMAT)] = {
+                "is_on_leave": True,
+                "is_holiday": date in holiday_dates,
+                "total_leave_hours": flt(daily_working_hours - leave_object.get("leave_work_hours"), 2),
+            }
+
+        if dates_off:
+            leave_map[employee["name"]] = dates_off
+
+    return leave_map

--- a/next_pms/resource_management/api/utils/leave_calendar.py
+++ b/next_pms/resource_management/api/utils/leave_calendar.py
@@ -5,7 +5,7 @@ import datetime
 from collections.abc import Iterable
 
 import frappe
-from frappe.utils import DATE_FORMAT, flt, getdate
+from frappe.utils import DATE_FORMAT, flt, getdate, strip_html_tags
 
 from next_pms.resource_management.api.utils.helpers import is_on_leave
 from next_pms.resource_management.api.utils.query import get_employee_leaves
@@ -53,7 +53,7 @@ def get_leave_calendars(employees: Iterable[dict], start_date, end_date) -> tupl
                 "parent": ["in", list(holiday_lists)],
                 "holiday_date": ["between", (getdate(start_date), getdate(end_date))],
             },
-            fields=["parent", "holiday_date", "weekly_off"],
+            fields=["parent", "holiday_date", "weekly_off", "description"],
         ):
             holidays_by_list.setdefault(holiday.parent, []).append(holiday)
 
@@ -98,7 +98,9 @@ def build_leave_map(employees: Iterable[dict], dates: Iterable[datetime.date], l
             continue
 
         daily_working_hours = get_daily_working_hours(employee)
-        holiday_dates = {holiday.holiday_date for holiday in holidays}
+        holiday_names_by_date = {
+            holiday.holiday_date: strip_html_tags(holiday.description or "").strip() for holiday in holidays
+        }
         dates_off = {}
 
         for date in dates:
@@ -107,10 +109,13 @@ def build_leave_map(employees: Iterable[dict], dates: Iterable[datetime.date], l
             if not leave_object.get("on_leave"):
                 continue
 
+            is_holiday = date in holiday_names_by_date
+            holiday_name = holiday_names_by_date.get(date)
             dates_off[date.strftime(DATE_FORMAT)] = {
                 "is_on_leave": True,
-                "is_holiday": date in holiday_dates,
+                "is_holiday": is_holiday,
                 "total_leave_hours": flt(daily_working_hours - leave_object.get("leave_work_hours"), 2),
+                **({"holiday_name": holiday_name} if holiday_name else {}),
             }
 
         if dates_off:

--- a/next_pms/tests/resource_management/api/test_project.py
+++ b/next_pms/tests/resource_management/api/test_project.py
@@ -1,8 +1,19 @@
+import json
+
 import frappe
 from erpnext import get_default_company
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, getdate
 
-from next_pms.resource_management.api.project import get_employees_resrouce_data_for_given_project
+from next_pms.resource_management.api.project import (
+    _get_employees_resrouce_data_for_given_project,
+    _get_resource_management_project_view_data,
+    get_employees_resrouce_data_for_given_project,
+    get_resource_management_project_view_data,
+)
+from next_pms.resource_management.api.utils.leave_calendar import get_leave_calendars
+from next_pms.resource_management.api.utils.query import get_employee_leaves
+from next_pms.tests.utils import assign_empty_holiday_list
 
 WRITE_USER = "priya.sharma@example.com"
 READ_ONLY_USER = "arjun.mehta@example.com"
@@ -12,6 +23,22 @@ END_DATE = "2026-06-19"
 
 # Employee fields the endpoint only returns to write-permitted callers.
 PRIVILEGED_FIELDS = ("ctc", "salary_currency")
+
+# The leave fixtures below sit inside the first week of the same window, so the
+# project view's two-week window runs [2026-06-15, 2026-06-26].
+WORKING_DAY = "2026-06-16"
+FULL_LEAVE = "2026-06-17"
+HALF_LEAVE = "2026-06-18"
+# Second week — the employee is away but holds no allocation.
+PUBLIC_HOLIDAY = "2026-06-23"
+LEAVE_VIEW_END = "2026-06-26"
+
+LEAVE_HOLIDAY_LIST = "Project View Leave Holiday List"
+LEAVE_TYPE = "Project View Leave LWP"
+LEAVE_CUSTOMER = "Project View Leave Customer"
+LEAVE_PROJECT = "Project View Leave Project"
+
+DAILY_HOURS = 8.0
 
 
 class TestEmployeeResourceDataCacheIsolation(IntegrationTestCase):
@@ -194,3 +221,346 @@ class TestEmployeeResourceDataCacheIsolation(IntegrationTestCase):
         entry = self._employee_entry(write_result)
         for field in PRIVILEGED_FIELDS:
             self.assertIn(field, entry)
+
+
+class TestProjectLeaveReporting(IntegrationTestCase):
+    """The project view has to say which days its people are away.
+
+    Leave already removes the hours (`leave_sync`), so without this the payload reports a
+    day that dropped to zero with nothing to explain it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.holiday_list = cls._make_holiday_list()
+        cls._make_leave_type()
+
+        cls.employee_away = cls._make_employee("Project View Away")
+        cls._assign_holiday_list(cls.employee_away)
+
+        cls.employee_present = cls._make_employee("Project View Present")
+        assign_empty_holiday_list(cls.employee_present)
+
+        cls.customer = cls._make_customer()
+        cls.project = cls._make_project()
+
+        # Leave first: an allocation derives its day overrides on save, so this is the order
+        # that exercises the same path the UI does.
+        cls._apply_leave(cls.employee_away, FULL_LEAVE, FULL_LEAVE)
+        cls._apply_leave(cls.employee_away, HALF_LEAVE, HALF_LEAVE, half_day=True)
+
+        for employee in (cls.employee_away, cls.employee_present):
+            cls._allocate(employee)
+
+        frappe.db.commit()
+        cls._clear_caches()
+
+    @classmethod
+    def tearDownClass(cls):
+        for doctype, filters in (
+            ("Resource Allocation", {"project": cls.project}),
+            ("Leave Application", {"employee": ["in", [cls.employee_away, cls.employee_present]]}),
+        ):
+            for name in frappe.get_all(doctype, filters=filters, pluck="name"):
+                frappe.delete_doc(doctype, name, force=1, ignore_permissions=True)
+        frappe.db.commit()
+        cls._clear_caches()
+        super().tearDownClass()
+
+    @staticmethod
+    def _clear_caches():
+        get_employee_leaves.clear_cache()
+        _get_resource_management_project_view_data.clear_cache()
+        _get_employees_resrouce_data_for_given_project.clear_cache()
+
+    # --- fixtures ---------------------------------------------------------
+
+    @classmethod
+    def _make_holiday_list(cls):
+        frappe.delete_doc_if_exists("Holiday List", LEAVE_HOLIDAY_LIST, force=1)
+        holidays = [{"holiday_date": PUBLIC_HOLIDAY, "description": "Company Day"}]
+
+        date = getdate("2026-01-01")
+        while date <= getdate("2026-12-31"):
+            if date.weekday() >= 5:
+                holidays.append({"holiday_date": date, "description": date.strftime("%A"), "weekly_off": 1})
+            date = add_days(date, 1)
+
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Holiday List",
+                    "holiday_list_name": LEAVE_HOLIDAY_LIST,
+                    "from_date": "2026-01-01",
+                    "to_date": "2026-12-31",
+                    "holidays": holidays,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_leave_type(cls):
+        if frappe.db.exists("Leave Type", LEAVE_TYPE):
+            return LEAVE_TYPE
+
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Leave Type",
+                    "leave_type_name": LEAVE_TYPE,
+                    "is_lwp": 1,
+                    "include_holiday": 1,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_employee(cls, first_name):
+        existing = frappe.db.get_value("Employee", {"employee_name": first_name})
+        if existing:
+            return existing
+
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Employee",
+                    "naming_series": "EMP-",
+                    "first_name": first_name,
+                    "company": cls.company,
+                    "gender": "Female",
+                    "date_of_birth": "1990-05-08",
+                    "date_of_joining": "2013-01-01",
+                    "status": "Active",
+                    "employment_type": "Intern",
+                    "leave_approver": "Administrator",
+                    "custom_working_hours": DAILY_HOURS,
+                    "custom_work_schedule": "Per Day",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _assign_holiday_list(cls, employee):
+        """HRMS resolves holidays through Holiday List Assignment; the `holiday_list` field
+        on Employee alone leaves them on the company default."""
+        frappe.db.set_value("Employee", employee, "holiday_list", cls.holiday_list)
+
+        if frappe.db.exists(
+            "Holiday List Assignment",
+            {"assigned_to": employee, "holiday_list": cls.holiday_list, "docstatus": 1},
+        ):
+            return
+
+        frappe.get_doc(
+            {
+                "doctype": "Holiday List Assignment",
+                "applicable_for": "Employee",
+                "assigned_to": employee,
+                "holiday_list": cls.holiday_list,
+                "from_date": "2026-01-01",
+            }
+        ).insert(ignore_permissions=True).submit()
+
+    @classmethod
+    def _make_customer(cls):
+        existing = frappe.db.get_value("Customer", {"customer_name": LEAVE_CUSTOMER}, "name")
+        if existing:
+            return existing
+
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Customer",
+                    "customer_name": LEAVE_CUSTOMER,
+                    "customer_type": "Company",
+                    "default_currency": frappe.get_cached_value("Company", cls.company, "default_currency"),
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _make_project(cls):
+        existing = frappe.db.get_value("Project", {"project_name": LEAVE_PROJECT})
+        if existing:
+            return existing
+
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Project",
+                    "project_name": LEAVE_PROJECT,
+                    "company": cls.company,
+                    "customer": cls.customer,
+                    "custom_billing_type": "Non-Billable",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    @classmethod
+    def _apply_leave(cls, employee, from_date, to_date, half_day=False):
+        get_employee_leaves.clear_cache()
+        frappe.get_doc(
+            {
+                "doctype": "Leave Application",
+                "employee": employee,
+                "leave_type": LEAVE_TYPE,
+                "from_date": from_date,
+                "to_date": to_date,
+                "half_day": 1 if half_day else 0,
+                "half_day_date": from_date if half_day else None,
+                "description": "project view leave test",
+                "leave_approver": "Administrator",
+                "status": "Approved",
+            }
+        ).insert(ignore_permissions=True)
+
+    @classmethod
+    def _allocate(cls, employee):
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "Resource Allocation",
+                    "employee": employee,
+                    "project": cls.project,
+                    "customer": cls.customer,
+                    "allocation_start_date": START_DATE,
+                    "allocation_end_date": END_DATE,
+                    "hours_allocated_per_day": DAILY_HOURS,
+                    "include_weekends": 0,
+                    "status": "Confirmed",
+                }
+            )
+            .insert(ignore_permissions=True)
+            .name
+        )
+
+    # --- callers ----------------------------------------------------------
+
+    def _project_view(self):
+        frappe.set_user("Administrator")
+        return get_resource_management_project_view_data(
+            date=START_DATE, max_week=2, project_id=json.dumps([self.project])
+        )
+
+    def _employee_view(self):
+        frappe.set_user("Administrator")
+        return get_employees_resrouce_data_for_given_project(
+            project=self.project, start_date=START_DATE, end_date=LEAVE_VIEW_END
+        )
+
+    def _leave_days(self, employee):
+        return self._project_view()["employee_leaves"].get(employee, {})
+
+    def _allocation_entries(self, date):
+        entry = next(row for row in self._project_view()["data"] if row["name"] == self.project)
+        return entry["all_dates_data"][date]["project_resource_allocation_for_given_date"]
+
+    def _employee_row(self, employee):
+        return next(row for row in self._employee_view()["data"] if row["name"] == employee)
+
+    # --- the project view --------------------------------------------------
+
+    def test_full_day_leave_is_reported(self):
+        self.assertEqual(
+            self._leave_days(self.employee_away)[FULL_LEAVE],
+            {"is_on_leave": True, "is_holiday": False, "total_leave_hours": DAILY_HOURS},
+        )
+
+    def test_half_day_leave_reports_half_the_day(self):
+        self.assertEqual(
+            self._leave_days(self.employee_away)[HALF_LEAVE],
+            {"is_on_leave": True, "is_holiday": False, "total_leave_hours": DAILY_HOURS / 2},
+        )
+
+    def test_public_holiday_is_reported_without_a_leave_application(self):
+        self.assertEqual(
+            self._leave_days(self.employee_away)[PUBLIC_HOLIDAY],
+            {"is_on_leave": True, "is_holiday": True, "total_leave_hours": DAILY_HOURS},
+        )
+
+    def test_only_the_days_off_are_reported(self):
+        self.assertEqual(set(self._leave_days(self.employee_away)), {FULL_LEAVE, HALF_LEAVE, PUBLIC_HOLIDAY})
+
+    def test_employee_without_leave_is_absent(self):
+        self.assertNotIn(self.employee_present, self._project_view()["employee_leaves"])
+
+    def test_leave_explains_the_hours_it_removed(self):
+        entry = next(row for row in self._project_view()["data"] if row["name"] == self.project)
+
+        # Only the present employee's 8 hours survive the full day of leave.
+        self.assertEqual(entry["all_dates_data"][FULL_LEAVE]["total_allocated_hours"], DAILY_HOURS)
+        self.assertEqual(entry["all_dates_data"][HALF_LEAVE]["total_allocated_hours"], DAILY_HOURS * 1.5)
+        self.assertEqual(entry["all_dates_data"][WORKING_DAY]["total_allocated_hours"], DAILY_HOURS * 2)
+
+    def test_allocation_of_the_day_carries_the_leave_flag(self):
+        by_employee = {
+            frappe.db.get_value("Resource Allocation", row["name"], "employee"): row
+            for row in self._allocation_entries(FULL_LEAVE)
+        }
+
+        self.assertTrue(by_employee[self.employee_away]["is_on_leave"])
+        self.assertFalse(by_employee[self.employee_present]["is_on_leave"])
+
+    def test_day_off_outside_every_allocation_is_still_reported(self):
+        """The holiday falls in week two, where nobody is allocated — the per-date breakdown
+        has nothing to hang it on, so the leave payload is the only place it can surface."""
+        entry = next(row for row in self._project_view()["data"] if row["name"] == self.project)
+
+        self.assertNotIn(PUBLIC_HOLIDAY, entry["all_dates_data"])
+        self.assertIn(PUBLIC_HOLIDAY, self._leave_days(self.employee_away))
+
+    # --- the per-project employee view -------------------------------------
+
+    def test_employee_view_reports_hours_away_per_day(self):
+        self.assertEqual(
+            self._employee_row(self.employee_away)["all_leave_data"],
+            {FULL_LEAVE: DAILY_HOURS, HALF_LEAVE: DAILY_HOURS / 2, PUBLIC_HOLIDAY: DAILY_HOURS},
+        )
+        self.assertEqual(self._employee_row(self.employee_present)["all_leave_data"], {})
+
+    def test_employee_view_flags_the_day(self):
+        dates = self._employee_row(self.employee_away)["all_dates_data"]
+
+        self.assertTrue(dates[FULL_LEAVE]["is_on_leave"])
+        self.assertEqual(dates[FULL_LEAVE]["total_leave_hours"], DAILY_HOURS)
+        self.assertEqual(dates[FULL_LEAVE]["total_allocated_hours"], 0)
+
+        self.assertFalse(dates[WORKING_DAY]["is_on_leave"])
+        self.assertEqual(dates[WORKING_DAY]["total_leave_hours"], 0.0)
+
+    def test_employee_view_keeps_a_day_that_holds_nothing_but_leave(self):
+        holiday = self._employee_row(self.employee_away)["all_dates_data"][PUBLIC_HOLIDAY]
+
+        self.assertTrue(holiday["is_on_leave"])
+        self.assertEqual(holiday["total_allocated_hours"], 0)
+        self.assertEqual(holiday["employee_resource_allocation_for_given_date"], [])
+
+    def test_employee_view_reports_the_daily_norm_the_leave_hours_are_measured_against(self):
+        self.assertEqual(self._employee_row(self.employee_away)["employee_daily_working_hours"], DAILY_HOURS)
+
+    # --- cost --------------------------------------------------------------
+
+    def test_leave_calendar_cost_does_not_grow_with_the_page(self):
+        """One leave query, one holiday-list-assignment query, one holiday query — whether the
+        page holds two employees or fifty."""
+        employees = frappe.get_all("Employee", filters={"status": "Active"}, fields=["name", "company"], limit=50)
+        self.assertGreater(len(employees), 2, "need more than a couple of employees for this to mean anything")
+
+        # Warm the doctype metas so the assertion below counts the work, not the first touch.
+        get_leave_calendars([{"name": self.employee_away, "company": self.company}], START_DATE, LEAVE_VIEW_END)
+
+        get_employee_leaves.clear_cache()
+        with self.assertQueryCount(3):
+            get_leave_calendars(employees, START_DATE, LEAVE_VIEW_END)

--- a/next_pms/tests/resource_management/api/test_project.py
+++ b/next_pms/tests/resource_management/api/test_project.py
@@ -487,7 +487,12 @@ class TestProjectLeaveReporting(IntegrationTestCase):
     def test_public_holiday_is_reported_without_a_leave_application(self):
         self.assertEqual(
             self._leave_days(self.employee_away)[PUBLIC_HOLIDAY],
-            {"is_on_leave": True, "is_holiday": True, "total_leave_hours": DAILY_HOURS},
+            {
+                "is_on_leave": True,
+                "is_holiday": True,
+                "total_leave_hours": DAILY_HOURS,
+                "holiday_name": "Company Day",
+            },
         )
 
     def test_only_the_days_off_are_reported(self):


### PR DESCRIPTION
## Description
- Map the project allocation API's `employee_leaves` into a leave/holiday bar on each employee's expanded row within a project, mirroring the Team page's own leave indicator
- Holidays show their real name (e.g. "Diwali") instead of a generic "1 day off" label - `Holiday.description` is now fetched and HTML-stripped on the backend
- Fixes a pre-existing bug that broke the Team allocations page entirely (`get_employee_leaves` import was dropped in 697c8a4c)
- Fixes an off-center icon on narrow single-day timeoff bars, caused by a label span reserving its flex gap even when rendering nothing visible

## Screenshot/Screencast

https://github.com/user-attachments/assets/6bac0d62-50f1-4528-8a23-6843fc96ef32

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1965