### PR TITLE
fix: add loading indicator to task, project, and timesheet pages on filter change

### DIFF
--- a/frontend/packages/app/src/pages/projects/list/context.ts
+++ b/frontend/packages/app/src/pages/projects/list/context.ts
@@ -13,6 +13,8 @@ export interface ProjectListContextProps {
     data: ProjectListItem[];
     hasMore: boolean;
     isLoading: boolean;
+    isInitialLoad: boolean;
+    isFilterRequest: boolean;
     error: unknown;
   };
   actions: {
@@ -27,6 +29,8 @@ export const ProjectListContext = createContext<ProjectListContextProps>({
     data: [],
     hasMore: false,
     isLoading: false,
+    isInitialLoad: false,
+    isFilterRequest: false,
     error: null,
   },
   actions: {

--- a/frontend/packages/app/src/pages/projects/list/provider.tsx
+++ b/frontend/packages/app/src/pages/projects/list/provider.tsx
@@ -63,7 +63,7 @@ export function ProjectListProvider({ children }: PropsWithChildren) {
         revalidateOnFocus: false,
         revalidateAll: false,
         revalidateFirstPage: false,
-        keepPreviousData: false,
+        keepPreviousData: true,
       },
     );
 
@@ -80,6 +80,8 @@ export function ProjectListProvider({ children }: PropsWithChildren) {
   const hasMore = lastPage ? Boolean(lastPage.message?.has_more) : true;
   const isNextPageLoading =
     !isLoading && isValidating && typeof data?.[size - 1] === "undefined";
+  const isInitialLoad = isLoading && (data?.length ?? 0) === 0;
+  const isFilterRequest = isLoading && (data?.length ?? 0) > 0;
 
   const loadMore = useCallback(() => {
     if (isLoading || isNextPageLoading || !hasMore) return;
@@ -92,13 +94,23 @@ export function ProjectListProvider({ children }: PropsWithChildren) {
         data: projects,
         hasMore,
         isLoading,
+        isInitialLoad,
+        isFilterRequest,
         error,
       },
       actions: {
         loadMore,
       },
     }),
-    [projects, hasMore, isLoading, error, loadMore],
+    [
+      projects,
+      hasMore,
+      isLoading,
+      isInitialLoad,
+      isFilterRequest,
+      error,
+      loadMore,
+    ],
   );
 
   return (

--- a/frontend/packages/app/src/pages/projects/list/provider.tsx
+++ b/frontend/packages/app/src/pages/projects/list/provider.tsx
@@ -3,11 +3,16 @@
  */
 import { useCallback, useMemo, type PropsWithChildren } from "react";
 import { type PaginationKey, usePagination } from "@next-pms/hooks";
+import { useToasts } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
-import { useFrappeDocTypeEventListener } from "frappe-react-sdk";
+import {
+  type FrappeError,
+  useFrappeDocTypeEventListener,
+} from "frappe-react-sdk";
+import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useProjectFilters } from "../components/project-filters/useProjectFilters";
 import { PROJECT_LIST_PAGE_SIZE, PROJECTS_VIEW_METHOD } from "../constants";
 import { ProjectListContext, type ProjectListContextProps } from "./context";
@@ -15,6 +20,7 @@ import { buildListFrappeFilters } from "../utils";
 import type { ResponseProjectList } from "./types";
 
 export function ProjectListProvider({ children }: PropsWithChildren) {
+  const toast = useToasts();
   const { filters, sort } = useProjectFilters();
   const frappeFilters = useMemo(
     () => buildListFrappeFilters(filters),
@@ -64,6 +70,11 @@ export function ProjectListProvider({ children }: PropsWithChildren) {
         revalidateAll: false,
         revalidateFirstPage: false,
         keepPreviousData: true,
+        onError: (err) => {
+          toast.error(parseFrappeErrorMsg(err as FrappeError), {
+            id: "project-list-fetch-error",
+          });
+        },
       },
     );
 

--- a/frontend/packages/app/src/pages/projects/list/view.tsx
+++ b/frontend/packages/app/src/pages/projects/list/view.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { LoadingOverlay, Spinner } from "@next-pms/design-system/components";
 import {
   ListHeader,
   ListHeaderItem,
@@ -23,6 +24,8 @@ import { PROJECT_LIST_PAGE_SIZE } from "../constants";
 function ProjectList() {
   const data = useProjectList((c) => c.state.data);
   const isLoading = useProjectList((c) => c.state.isLoading);
+  const isInitialLoad = useProjectList((c) => c.state.isInitialLoad);
+  const isFilterRequest = useProjectList((c) => c.state.isFilterRequest);
   const hasMore = useProjectList((c) => c.state.hasMore);
   const loadMore = useProjectList((c) => c.actions.loadMore);
   const { sort, setSort } = useProjectFilters();
@@ -39,101 +42,107 @@ function ProjectList() {
   };
 
   return (
-    <ListView
-      role="table"
-      aria-label="Projects"
-      className="px-5 py-0 scrollbar-thin"
-      columns={PROJECT_LIST_COLUMNS}
-      rows={data}
-      rowKey="name"
-      options={{
-        options: {
-          selectable: false,
-          showTooltip: true,
-          resizeColumn: false,
-        },
-        slots: {
-          cell: ProjectListCell,
-        },
-      }}
-    >
-      <ListHeader
-        role="row"
-        className="mb-0 rounded-none bg-transparent border-b border-outline-gray-1 p-2 gap-2"
-      >
-        {PROJECT_LIST_COLUMNS.map((column) => {
-          const isSorted = sort.field === column.sortField;
-          return (
-            <ListHeaderItem
-              key={column.key}
-              role="columnheader"
-              aria-sort={
-                column.sortField
-                  ? isSorted
-                    ? sort.order === "asc"
-                      ? "ascending"
-                      : "descending"
-                    : "none"
-                  : undefined
-              }
-              item={column}
-            >
-              {column.sortField ? (
-                <button
-                  type="button"
-                  className="flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
-                  onClick={() => handleHeaderClick(column.sortField!)}
-                >
-                  <span className="truncate">{column.label}</span>
-                  {isSorted &&
-                    (sort.order === "asc" ? (
-                      <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
-                    ) : (
-                      <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
-                    ))}
-                </button>
-              ) : (
-                <div className="flex h-7 items-center gap-1 py-1.5">
-                  <span className="truncate">{column.label}</span>
-                </div>
-              )}
-            </ListHeaderItem>
-          );
-        })}
-      </ListHeader>
-      <ListRows role="rowgroup">
-        {data.length === 0 ? (
-          <div role="row">
-            <p
-              role="cell"
-              className="py-6 text-center text-base text-ink-gray-5"
-            >
-              No projects found.
-            </p>
-          </div>
-        ) : (
-          <InfiniteScroll
-            role="presentation"
-            isLoading={isLoading}
-            hasMore={hasMore}
-            verticalLodMore={loadMore}
-            count={PROJECT_LIST_PAGE_SIZE}
+    <LoadingOverlay active={isFilterRequest}>
+      {isInitialLoad ? (
+        <Spinner isFull />
+      ) : (
+        <ListView
+          role="table"
+          aria-label="Projects"
+          className="px-5 py-0 scrollbar-thin"
+          columns={PROJECT_LIST_COLUMNS}
+          rows={data}
+          rowKey="name"
+          options={{
+            options: {
+              selectable: false,
+              showTooltip: true,
+              resizeColumn: false,
+            },
+            slots: {
+              cell: ProjectListCell,
+            },
+          }}
+        >
+          <ListHeader
+            role="row"
+            className="mb-0 rounded-none bg-transparent border-b border-outline-gray-1 p-2 gap-2"
           >
-            {data.map((row) => (
-              <ListRow key={row.name} role="row" row={row}>
-                {PROJECT_LIST_COLUMNS.map((column) => {
-                  return (
-                    <div key={column.key} role="cell" className="min-w-0">
-                      <ProjectListCell row={row} column={column} />
+            {PROJECT_LIST_COLUMNS.map((column) => {
+              const isSorted = sort.field === column.sortField;
+              return (
+                <ListHeaderItem
+                  key={column.key}
+                  role="columnheader"
+                  aria-sort={
+                    column.sortField
+                      ? isSorted
+                        ? sort.order === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                      : undefined
+                  }
+                  item={column}
+                >
+                  {column.sortField ? (
+                    <button
+                      type="button"
+                      className="flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
+                      onClick={() => handleHeaderClick(column.sortField!)}
+                    >
+                      <span className="truncate">{column.label}</span>
+                      {isSorted &&
+                        (sort.order === "asc" ? (
+                          <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
+                        ) : (
+                          <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
+                        ))}
+                    </button>
+                  ) : (
+                    <div className="flex h-7 items-center gap-1 py-1.5">
+                      <span className="truncate">{column.label}</span>
                     </div>
-                  );
-                })}
-              </ListRow>
-            ))}
-          </InfiniteScroll>
-        )}
-      </ListRows>
-    </ListView>
+                  )}
+                </ListHeaderItem>
+              );
+            })}
+          </ListHeader>
+          <ListRows role="rowgroup">
+            {!isFilterRequest && data.length === 0 ? (
+              <div role="row">
+                <p
+                  role="cell"
+                  className="py-6 text-center text-base text-ink-gray-5"
+                >
+                  No projects found.
+                </p>
+              </div>
+            ) : (
+              <InfiniteScroll
+                role="presentation"
+                isLoading={isLoading}
+                hasMore={hasMore}
+                verticalLodMore={loadMore}
+                count={PROJECT_LIST_PAGE_SIZE}
+              >
+                {data.map((row) => (
+                  <ListRow key={row.name} role="row" row={row}>
+                    {PROJECT_LIST_COLUMNS.map((column) => {
+                      return (
+                        <div key={column.key} role="cell" className="min-w-0">
+                          <ProjectListCell row={row} column={column} />
+                        </div>
+                      );
+                    })}
+                  </ListRow>
+                ))}
+              </InfiniteScroll>
+            )}
+          </ListRows>
+        </ListView>
+      )}
+    </LoadingOverlay>
   );
 }
 

--- a/frontend/packages/app/src/pages/tasks/list/context.ts
+++ b/frontend/packages/app/src/pages/tasks/list/context.ts
@@ -14,6 +14,8 @@ export interface TaskListContextProps {
     data: TaskListItem[];
     hasMore: boolean;
     isLoading: boolean;
+    isInitialLoad: boolean;
+    isFilterRequest: boolean;
     error: unknown;
     addTaskOpen: boolean;
     addTaskPrefill: AddTaskPrefill | null;
@@ -37,6 +39,8 @@ export const TaskListContext = createContext<TaskListContextProps>({
     data: [],
     hasMore: false,
     isLoading: false,
+    isInitialLoad: false,
+    isFilterRequest: false,
     error: null,
     addTaskOpen: false,
     addTaskPrefill: null,

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -110,7 +110,7 @@ export function TaskListProvider({ children }: PropsWithChildren) {
         revalidateOnFocus: false,
         revalidateAll: false,
         revalidateFirstPage: false,
-        keepPreviousData: false,
+        keepPreviousData: true,
       },
     );
 
@@ -123,6 +123,8 @@ export function TaskListProvider({ children }: PropsWithChildren) {
   const hasMore = lastPage ? Boolean(lastPage.message?.has_more) : true;
   const isNextPageLoading =
     !isLoading && isValidating && typeof data?.[size - 1] === "undefined";
+  const isInitialLoad = isLoading && (data?.length ?? 0) === 0;
+  const isFilterRequest = isLoading && (data?.length ?? 0) > 0;
 
   const loadMore = useCallback(() => {
     if (isLoading || isNextPageLoading || !hasMore) return;
@@ -152,6 +154,8 @@ export function TaskListProvider({ children }: PropsWithChildren) {
         data: tasks,
         hasMore,
         isLoading,
+        isInitialLoad,
+        isFilterRequest,
         error,
         addTaskOpen,
         addTaskPrefill,
@@ -170,6 +174,8 @@ export function TaskListProvider({ children }: PropsWithChildren) {
       tasks,
       hasMore,
       isLoading,
+      isInitialLoad,
+      isFilterRequest,
       error,
       addTaskOpen,
       addTaskPrefill,

--- a/frontend/packages/app/src/pages/tasks/list/provider.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/provider.tsx
@@ -111,6 +111,11 @@ export function TaskListProvider({ children }: PropsWithChildren) {
         revalidateAll: false,
         revalidateFirstPage: false,
         keepPreviousData: true,
+        onError: (err) => {
+          toast.error(parseFrappeErrorMsg(err as FrappeError), {
+            id: "task-list-fetch-error",
+          });
+        },
       },
     );
 

--- a/frontend/packages/app/src/pages/tasks/list/view.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/view.tsx
@@ -3,7 +3,11 @@
  */
 import { useCallback, useState } from "react";
 import { getTodayDate } from "@next-pms/design-system";
-import { DeleteActionDialog } from "@next-pms/design-system/components";
+import {
+  DeleteActionDialog,
+  LoadingOverlay,
+  Spinner,
+} from "@next-pms/design-system/components";
 import {
   ListHeader,
   ListHeaderItem,
@@ -35,6 +39,8 @@ const SORT_FIELD_BY_COLUMN = new Map(
 function TaskList() {
   const data = useTaskList((c) => c.state.data);
   const isLoading = useTaskList((c) => c.state.isLoading);
+  const isInitialLoad = useTaskList((c) => c.state.isInitialLoad);
+  const isFilterRequest = useTaskList((c) => c.state.isFilterRequest);
   const hasMore = useTaskList((c) => c.state.hasMore);
   const loadMore = useTaskList((c) => c.actions.loadMore);
   const deleteTask = useTaskList((c) => c.actions.deleteTask);
@@ -68,109 +74,115 @@ function TaskList() {
 
   return (
     <>
-      <ListView
-        role="table"
-        aria-label="Tasks"
-        className="px-5 py-0 scrollbar-thin"
-        columns={TASK_LIST_COLUMNS}
-        rows={data}
-        rowKey="name"
-        options={{
-          options: {
-            selectable: false,
-            showTooltip: true,
-            resizeColumn: false,
-          },
-          slots: {
-            cell: TaskListCell,
-          },
-        }}
-      >
-        <ListHeader
-          role="row"
-          className="mb-0 rounded-none bg-transparent border-b border-outline-gray-1 p-2 gap-2"
-        >
-          {TASK_LIST_COLUMNS.map((column) => {
-            const sortField = SORT_FIELD_BY_COLUMN.get(column.key);
-            const isSorted = Boolean(sortField) && sort.field === sortField;
-            return (
-              <ListHeaderItem
-                key={column.key}
-                role="columnheader"
-                aria-sort={
-                  sortField
-                    ? isSorted
-                      ? sort.order === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                    : undefined
-                }
-                item={column}
-              >
-                {sortField ? (
-                  <button
-                    type="button"
-                    className="flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
-                    onClick={() => handleHeaderClick(sortField)}
-                  >
-                    <span className="truncate">{column.label}</span>
-                    {isSorted &&
-                      (sort.order === "asc" ? (
-                        <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
-                      ) : (
-                        <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
-                      ))}
-                  </button>
-                ) : (
-                  <div className="flex h-7 items-center gap-1 py-1.5">
-                    <span className="truncate">{column.label}</span>
-                  </div>
-                )}
-              </ListHeaderItem>
-            );
-          })}
-        </ListHeader>
-        <ListRows role="rowgroup">
-          {data.length === 0 ? (
-            <div role="row">
-              <p
-                role="cell"
-                className="py-6 text-center text-base text-ink-gray-5"
-              >
-                No tasks found.
-              </p>
-            </div>
-          ) : (
-            <InfiniteScroll
-              role="presentation"
-              isLoading={isLoading}
-              hasMore={hasMore}
-              verticalLodMore={loadMore}
-              count={TASK_LIST_PAGE_SIZE}
+      <LoadingOverlay active={isFilterRequest}>
+        {isInitialLoad ? (
+          <Spinner isFull />
+        ) : (
+          <ListView
+            role="table"
+            aria-label="Tasks"
+            className="px-5 py-0 scrollbar-thin"
+            columns={TASK_LIST_COLUMNS}
+            rows={data}
+            rowKey="name"
+            options={{
+              options: {
+                selectable: false,
+                showTooltip: true,
+                resizeColumn: false,
+              },
+              slots: {
+                cell: TaskListCell,
+              },
+            }}
+          >
+            <ListHeader
+              role="row"
+              className="mb-0 rounded-none bg-transparent border-b border-outline-gray-1 p-2 gap-2"
             >
-              {data.map((row) => (
-                <ListRow key={row.name} role="row" row={row}>
-                  {TASK_LIST_COLUMNS.map((column) => (
-                    <div key={column.key} role="cell" className="min-w-0">
-                      <TaskListCell
-                        row={row}
-                        column={column}
-                        onOpenTask={setOpenTask}
-                        onAddTime={handleAddTime}
-                        onEditTask={openEditTaskModal}
-                        onDeleteTask={setDeleteTaskName}
-                        userId={userId}
-                        roles={roles}
-                      />
-                    </div>
+              {TASK_LIST_COLUMNS.map((column) => {
+                const sortField = SORT_FIELD_BY_COLUMN.get(column.key);
+                const isSorted = Boolean(sortField) && sort.field === sortField;
+                return (
+                  <ListHeaderItem
+                    key={column.key}
+                    role="columnheader"
+                    aria-sort={
+                      sortField
+                        ? isSorted
+                          ? sort.order === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                        : undefined
+                    }
+                    item={column}
+                  >
+                    {sortField ? (
+                      <button
+                        type="button"
+                        className="flex h-7 min-w-0 items-center gap-1 rounded-sm py-1.5 select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-3"
+                        onClick={() => handleHeaderClick(sortField)}
+                      >
+                        <span className="truncate">{column.label}</span>
+                        {isSorted &&
+                          (sort.order === "asc" ? (
+                            <ArrowUp className="size-3.5 shrink-0 text-ink-gray-7" />
+                          ) : (
+                            <ArrowDown className="size-3.5 shrink-0 text-ink-gray-7" />
+                          ))}
+                      </button>
+                    ) : (
+                      <div className="flex h-7 items-center gap-1 py-1.5">
+                        <span className="truncate">{column.label}</span>
+                      </div>
+                    )}
+                  </ListHeaderItem>
+                );
+              })}
+            </ListHeader>
+            <ListRows role="rowgroup">
+              {!isFilterRequest && data.length === 0 ? (
+                <div role="row">
+                  <p
+                    role="cell"
+                    className="py-6 text-center text-base text-ink-gray-5"
+                  >
+                    No tasks found.
+                  </p>
+                </div>
+              ) : (
+                <InfiniteScroll
+                  role="presentation"
+                  isLoading={isLoading}
+                  hasMore={hasMore}
+                  verticalLodMore={loadMore}
+                  count={TASK_LIST_PAGE_SIZE}
+                >
+                  {data.map((row) => (
+                    <ListRow key={row.name} role="row" row={row}>
+                      {TASK_LIST_COLUMNS.map((column) => (
+                        <div key={column.key} role="cell" className="min-w-0">
+                          <TaskListCell
+                            row={row}
+                            column={column}
+                            onOpenTask={setOpenTask}
+                            onAddTime={handleAddTime}
+                            onEditTask={openEditTaskModal}
+                            onDeleteTask={setDeleteTaskName}
+                            userId={userId}
+                            roles={roles}
+                          />
+                        </div>
+                      ))}
+                    </ListRow>
                   ))}
-                </ListRow>
-              ))}
-            </InfiniteScroll>
-          )}
-        </ListRows>
-      </ListView>
+                </InfiniteScroll>
+              )}
+            </ListRows>
+          </ListView>
+        )}
+      </LoadingOverlay>
       {openTask &&
         (showTeamTaskLog ? (
           <TeamTaskLog

--- a/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/personal/personalTimesheetTable.tsx
@@ -3,7 +3,11 @@
  */
 import { Fragment, useState } from "react";
 import { mergeClassNames as cn } from "@next-pms/design-system";
-import { Spinner, Typography } from "@next-pms/design-system/components";
+import {
+  LoadingOverlay,
+  Spinner,
+  Typography,
+} from "@next-pms/design-system/components";
 
 /**
  * Internal dependencies.
@@ -72,100 +76,84 @@ const PersonalTimesheetGrid = () => {
             />
           )}
 
-          {Object.keys(timesheetData?.data).length == 0 ? (
-            <Typography
-              className={cn("flex items-center justify-center", {
-                "opacity-50 transition-opacity duration-150":
-                  isFilteredDataLoading,
-              })}
-            >
-              No data found
-            </Typography>
-          ) : (
-            <InfiniteScroll
-              isLoading={isLoadingPersonalData}
-              hasMore={!isFilterRequest && hasMoreWeeks}
-              verticalLodMore={loadData}
-              className={cn(
-                "relative w-full h-[calc(100%-var(--spacing)*7)] opacity-100",
-                {
-                  "opacity-50 transition-opacity duration-150":
-                    isFilteredDataLoading,
-                },
-              )}
-              count={NUMBER_OF_WEEKS_TO_FETCH}
-              enableScrollArea
-            >
-              <div className="min-w-225">
-                {Object.entries(timesheetData.data).map(
-                  ([key, value], index) => {
-                    return (
-                      <Fragment key={`${value.start_date}-${value.end_date}`}>
-                        {index === 0 ? (
-                          <div className="sticky top-0 z-20 bg-surface-white">
-                            <HeaderRow
+          <LoadingOverlay active={isFilteredDataLoading}>
+            {Object.keys(timesheetData?.data).length == 0 ? (
+              <Typography className="flex items-center justify-center">
+                No data found
+              </Typography>
+            ) : (
+              <InfiniteScroll
+                isLoading={isLoadingPersonalData}
+                hasMore={!isFilterRequest && hasMoreWeeks}
+                verticalLodMore={loadData}
+                className="w-full h-full"
+                count={NUMBER_OF_WEEKS_TO_FETCH}
+                enableScrollArea
+              >
+                <div className="min-w-225">
+                  {Object.entries(timesheetData.data).map(
+                    ([key, value], index) => {
+                      return (
+                        <Fragment key={`${value.start_date}-${value.end_date}`}>
+                          {index === 0 ? (
+                            <div className="sticky top-0 z-20 bg-surface-white">
+                              <HeaderRow
+                                dates={value.dates}
+                                showHeading={true}
+                                breadcrumbs={{
+                                  items: [
+                                    { label: "Week", interactive: false },
+                                    { label: "Project", interactive: false },
+                                    { label: "Task", interactive: false },
+                                  ],
+                                  highlightLastItem: false,
+                                  size: "sm",
+                                  crumbClassName:
+                                    "first:pl-0 px-0.5 py-0 last:pr-0 font-[420]",
+                                  className: "pl-[8px]",
+                                }}
+                              />
+                            </div>
+                          ) : null}
+                          <div
+                            className={cn(
+                              "animate-fade-in",
+                              index === 0 && "mt-4",
+                            )}
+                          >
+                            <PersonalTimesheetRow
+                              label={value.label ?? key}
+                              employee={employeeId}
+                              workingHour={timesheetData.working_hour}
+                              workingFrequency={
+                                timesheetData.working_frequency as WorkingFrequency
+                              }
                               dates={value.dates}
-                              showHeading={true}
-                              breadcrumbs={{
-                                items: [
-                                  { label: "Week", interactive: false },
-                                  { label: "Project", interactive: false },
-                                  { label: "Task", interactive: false },
-                                ],
-                                highlightLastItem: false,
-                                size: "sm",
-                                crumbClassName:
-                                  "first:pl-0 px-0.5 py-0 last:pr-0 font-[420]",
-                                className: "pl-[8px]",
-                              }}
+                              holidays={timesheetData.holidays}
+                              leaves={timesheetData.leaves}
+                              tasks={value.tasks}
+                              collapsed={index >= 6}
+                              disabled={value.status === "Approved"}
+                              setSelectedTask={setSelectedTask}
+                              onButtonClick={() =>
+                                handleApproval(
+                                  value.start_date,
+                                  value.end_date,
+                                  value.total_hours,
+                                )
+                              }
+                              status={value.status}
+                              hideTotalRow={hasTaskFilter}
                             />
                           </div>
-                        ) : null}
-                        <div
-                          className={cn(
-                            "animate-fade-in",
-                            index === 0 && "mt-4",
-                          )}
-                        >
-                          <PersonalTimesheetRow
-                            label={value.label ?? key}
-                            employee={employeeId}
-                            workingHour={timesheetData.working_hour}
-                            workingFrequency={
-                              timesheetData.working_frequency as WorkingFrequency
-                            }
-                            dates={value.dates}
-                            holidays={timesheetData.holidays}
-                            leaves={timesheetData.leaves}
-                            tasks={value.tasks}
-                            collapsed={index >= 6}
-                            disabled={value.status === "Approved"}
-                            setSelectedTask={setSelectedTask}
-                            onButtonClick={() =>
-                              handleApproval(
-                                value.start_date,
-                                value.end_date,
-                                value.total_hours,
-                              )
-                            }
-                            status={value.status}
-                            hideTotalRow={hasTaskFilter}
-                          />
-                        </div>
-                      </Fragment>
-                    );
-                  },
-                )}
-              </div>
-            </InfiniteScroll>
-          )}
-
-          {isFilteredDataLoading ? (
-            <Spinner
-              isFull
-              className="absolute top-0 left-0 w-full h-full cursor-wait"
-            />
-          ) : null}
+                        </Fragment>
+                      );
+                    },
+                  )}
+                </div>
+              </InfiniteScroll>
+            )}
+          </LoadingOverlay>
         </>
       )}
     </>
@@ -174,7 +162,7 @@ const PersonalTimesheetGrid = () => {
 
 export const PersonalTimesheetTable = () => {
   return (
-    <div className="w-full flex-1 min-h-0 py-3.5 px-5 relative">
+    <div className="w-full flex-1 min-h-0 flex flex-col py-3.5 px-5 relative">
       <SubHeader />
       <PersonalTimesheetGrid />
     </div>

--- a/frontend/packages/app/src/pages/timesheet/personal/usePersonalTimesheetData.ts
+++ b/frontend/packages/app/src/pages/timesheet/personal/usePersonalTimesheetData.ts
@@ -216,10 +216,10 @@ export function usePersonalTimesheetData({
       revalidateFirstPage: false,
       keepPreviousData: true,
       persistSize: false,
-      shouldRetryOnError: false,
-      errorRetryCount: 0,
       onError: (err) => {
-        toast.error(parseFrappeErrorMsg(err as FrappeError));
+        toast.error(parseFrappeErrorMsg(err as FrappeError), {
+          id: "personal-timesheet-fetch-error",
+        });
       },
     },
   );

--- a/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/project/projectTimesheetTable.tsx
@@ -3,7 +3,11 @@
  */
 import { Fragment } from "react";
 import { mergeClassNames as cn } from "@next-pms/design-system";
-import { Spinner, Typography } from "@next-pms/design-system/components";
+import {
+  LoadingOverlay,
+  Spinner,
+  Typography,
+} from "@next-pms/design-system/components";
 
 /**
  * Internal dependencies.
@@ -32,75 +36,72 @@ const ProjectTimesheetGrid = () => {
     <>
       {isLoadingProjectData && weekGroups.length === 0 ? (
         <Spinner isFull />
-      ) : weekGroups.length === 0 ? (
-        <Typography className="flex items-center justify-center">
-          No data found
-        </Typography>
       ) : (
-        <InfiniteScroll
-          isLoading={isLoadingProjectData}
-          hasMore={hasMore}
-          verticalLodMore={loadData}
-          className={cn("w-full h-[calc(100%-var(--spacing)*7)] opacity-100", {
-            "opacity-50 transition-opacity duration-150": isFilteredDataLoading,
-          })}
-          count={NUMBER_OF_WEEKS_TO_FETCH}
-          enableScrollArea
-        >
-          <div className="min-w-225">
-            {weekGroups.map((week, index) => {
-              return (
-                <Fragment key={`${week.start_date}-${week.end_date}`}>
-                  {index === 0 ? (
-                    <div className="sticky top-0 z-20 bg-surface-white">
-                      <HeaderRow
-                        dates={week.dates}
-                        showHeading={true}
-                        breadcrumbs={{
-                          items: [
-                            { label: "Week", interactive: false },
-                            { label: "Project", interactive: false },
-                            { label: "Member", interactive: false },
-                            { label: "Task", interactive: false },
-                          ],
-                          highlightLastItem: false,
-                          size: "sm",
-                          crumbClassName:
-                            "first:pl-0 last:pr-0 px-0.5 py-0 font-[420]",
-                          className: "pl-[8px]",
-                        }}
-                      />
-                    </div>
-                  ) : null}
+        <LoadingOverlay active={isFilteredDataLoading}>
+          {weekGroups.length === 0 ? (
+            <Typography className="flex items-center justify-center">
+              No data found
+            </Typography>
+          ) : (
+            <InfiniteScroll
+              isLoading={isLoadingProjectData}
+              hasMore={hasMore}
+              verticalLodMore={loadData}
+              className="w-full h-full"
+              count={NUMBER_OF_WEEKS_TO_FETCH}
+              enableScrollArea
+            >
+              <div className="min-w-225">
+                {weekGroups.map((week, index) => {
+                  return (
+                    <Fragment key={`${week.start_date}-${week.end_date}`}>
+                      {index === 0 ? (
+                        <div className="sticky top-0 z-20 bg-surface-white">
+                          <HeaderRow
+                            dates={week.dates}
+                            showHeading={true}
+                            breadcrumbs={{
+                              items: [
+                                { label: "Week", interactive: false },
+                                { label: "Project", interactive: false },
+                                { label: "Member", interactive: false },
+                                { label: "Task", interactive: false },
+                              ],
+                              highlightLastItem: false,
+                              size: "sm",
+                              crumbClassName:
+                                "first:pl-0 last:pr-0 px-0.5 py-0 font-[420]",
+                              className: "pl-[8px]",
+                            }}
+                          />
+                        </div>
+                      ) : null}
 
-                  <div className={cn("animate-fade-in", index === 0 && "mt-4")}>
-                    <ProjectTimesheetRow
-                      label={week.label}
-                      dates={week.dates}
-                      collapsed={index >= 6}
-                      projects={week.projects}
-                    />
-                  </div>
-                </Fragment>
-              );
-            })}
-          </div>
-        </InfiniteScroll>
+                      <div
+                        className={cn("animate-fade-in", index === 0 && "mt-4")}
+                      >
+                        <ProjectTimesheetRow
+                          label={week.label}
+                          dates={week.dates}
+                          collapsed={index >= 6}
+                          projects={week.projects}
+                        />
+                      </div>
+                    </Fragment>
+                  );
+                })}
+              </div>
+            </InfiniteScroll>
+          )}
+        </LoadingOverlay>
       )}
-
-      {isFilteredDataLoading ? (
-        <Spinner
-          isFull
-          className="absolute top-0 left-0 w-full h-full cursor-wait"
-        />
-      ) : null}
     </>
   );
 };
 
 export const ProjectTimesheetTable = () => {
   return (
-    <div className="w-full flex-1 min-h-0 py-3.5 px-5 relative">
+    <div className="w-full flex-1 min-h-0 flex flex-col py-3.5 px-5 relative">
       <SubHeader />
       <ProjectTimesheetGrid />
     </div>

--- a/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/teamTimesheetTable.tsx
@@ -3,7 +3,11 @@
  */
 import { Fragment, useState } from "react";
 import { mergeClassNames as cn } from "@next-pms/design-system";
-import { Spinner, Typography } from "@next-pms/design-system/components";
+import {
+  LoadingOverlay,
+  Spinner,
+  Typography,
+} from "@next-pms/design-system/components";
 
 /**
  * Internal dependencies.
@@ -70,75 +74,72 @@ const TeamTimesheetGrid = () => {
 
       {isLoadingWeeks && weeks.length === 0 ? (
         <Spinner isFull />
-      ) : weeks.length === 0 ? (
-        <Typography className="flex justify-center items-center">
-          No data
-        </Typography>
       ) : (
-        <InfiniteScroll
-          isLoading={isNextPageLoading}
-          hasMore={hasMoreWeeks}
-          verticalLodMore={loadMoreWeeks}
-          className={cn("w-full h-[calc(100%-var(--spacing)*7)] opacity-100", {
-            "opacity-50 transition-opacity duration-150": isFilteredDataLoading,
-          })}
-          scrollResetKey={activeFilterKey}
-          enableScrollArea
-        >
-          <div className="min-w-225">
-            {weeks.map((week, index) => (
-              <Fragment key={`${resolvedFilterKey}:${week.key}`}>
-                {index === 0 ? (
-                  <div className="sticky top-0 z-20 bg-surface-white">
-                    <HeaderRow
-                      dates={week.dates}
-                      showHeading={true}
-                      breadcrumbs={{
-                        items: [
-                          { label: "Week", interactive: false },
-                          { label: "Member", interactive: false },
-                          { label: "Project", interactive: false },
-                          { label: "Task", interactive: false },
-                        ],
-                        highlightLastItem: false,
-                        size: "sm",
-                        crumbClassName:
-                          "first:pl-0 last:pr-0 px-0.5 py-0 font-[420]",
-                        className: "pl-[8px]",
-                      }}
-                    />
-                  </div>
-                ) : null}
+        <LoadingOverlay active={isFilteredDataLoading}>
+          {weeks.length === 0 ? (
+            <Typography className="flex justify-center items-center">
+              No data
+            </Typography>
+          ) : (
+            <InfiniteScroll
+              isLoading={isNextPageLoading}
+              hasMore={hasMoreWeeks}
+              verticalLodMore={loadMoreWeeks}
+              className="w-full h-full"
+              scrollResetKey={activeFilterKey}
+              enableScrollArea
+            >
+              <div className="min-w-225">
+                {weeks.map((week, index) => (
+                  <Fragment key={`${resolvedFilterKey}:${week.key}`}>
+                    {index === 0 ? (
+                      <div className="sticky top-0 z-20 bg-surface-white">
+                        <HeaderRow
+                          dates={week.dates}
+                          showHeading={true}
+                          breadcrumbs={{
+                            items: [
+                              { label: "Week", interactive: false },
+                              { label: "Member", interactive: false },
+                              { label: "Project", interactive: false },
+                              { label: "Task", interactive: false },
+                            ],
+                            highlightLastItem: false,
+                            size: "sm",
+                            crumbClassName:
+                              "first:pl-0 last:pr-0 px-0.5 py-0 font-[420]",
+                            className: "pl-[8px]",
+                          }}
+                        />
+                      </div>
+                    ) : null}
 
-                <div className={cn("animate-fade-in", index === 0 && "mt-4")}>
-                  <TeamTimesheetWeek
-                    week={week}
-                    defaultExpanded={index === 0}
-                    setSelectedTask={setSelectedTask}
-                    openWeeklyApproval={(employee, date) =>
-                      setWeeklyApproval({ employee, startDate: date })
-                    }
-                  />
-                </div>
-              </Fragment>
-            ))}
-          </div>
-        </InfiniteScroll>
+                    <div
+                      className={cn("animate-fade-in", index === 0 && "mt-4")}
+                    >
+                      <TeamTimesheetWeek
+                        week={week}
+                        defaultExpanded={index === 0}
+                        setSelectedTask={setSelectedTask}
+                        openWeeklyApproval={(employee, date) =>
+                          setWeeklyApproval({ employee, startDate: date })
+                        }
+                      />
+                    </div>
+                  </Fragment>
+                ))}
+              </div>
+            </InfiniteScroll>
+          )}
+        </LoadingOverlay>
       )}
-
-      {isFilteredDataLoading ? (
-        <Spinner
-          isFull
-          className="absolute top-0 left-0 w-full h-full cursor-wait"
-        />
-      ) : null}
     </>
   );
 };
 
 export const TeamTimesheetTable = () => {
   return (
-    <div className="w-full flex-1 min-h-0 py-3.5 px-5 relative">
+    <div className="w-full flex-1 min-h-0 flex flex-col py-3.5 px-5 relative">
       <SubHeader />
       <TeamTimesheetGrid />
     </div>

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetWeeks.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamTimesheetWeeks.ts
@@ -95,10 +95,10 @@ export function useTeamTimesheetWeeks({
       revalidateFirstPage: false,
       keepPreviousData: true,
       persistSize: false,
-      shouldRetryOnError: false,
-      errorRetryCount: 0,
       onError: (err) => {
-        toast.error(parseFrappeErrorMsg(err as FrappeError));
+        toast.error(parseFrappeErrorMsg(err as FrappeError), {
+          id: "team-timesheet-weeks-fetch-error",
+        });
       },
     },
   );

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamWeekMembers.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamWeekMembers.ts
@@ -100,10 +100,10 @@ export function useTeamWeekMembers({
       revalidateFirstPage: false,
       keepPreviousData: true,
       persistSize: false,
-      shouldRetryOnError: false,
-      errorRetryCount: 0,
       onError: (err) => {
-        toast.error(parseFrappeErrorMsg(err as FrappeError));
+        toast.error(parseFrappeErrorMsg(err as FrappeError), {
+          id: "team-timesheet-members-fetch-error",
+        });
       },
     },
   );

--- a/frontend/packages/design-system/src/components/index.ts
+++ b/frontend/packages/design-system/src/components/index.ts
@@ -4,6 +4,10 @@
 export { type CheckedState } from "@radix-ui/react-checkbox";
 export { default as Input, type InputProps } from "./input";
 export { default as Spinner, type SpinnerProp } from "./spinner";
+export {
+  default as LoadingOverlay,
+  type LoadingOverlayProps,
+} from "./loading-overlay";
 export { default as Typography, type TypographyProps } from "./typography";
 export {
   TaskStatus,

--- a/frontend/packages/design-system/src/components/loading-overlay/index.tsx
+++ b/frontend/packages/design-system/src/components/loading-overlay/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import type { PropsWithChildren } from "react";
+
+/**
+ * Internal dependencies
+ */
+import { mergeClassNames } from "../../utils";
+import Spinner from "../spinner";
+
+export type LoadingOverlayProps = PropsWithChildren<{
+  active: boolean;
+  className?: string;
+}>;
+
+const LoadingOverlay = ({
+  active,
+  className,
+  children,
+}: LoadingOverlayProps) => {
+  return (
+    <div
+      className={mergeClassNames(
+        "relative flex min-h-0 flex-1 flex-col",
+        className,
+      )}
+    >
+      <div
+        className={mergeClassNames(
+          "flex min-h-0 flex-1 flex-col",
+          active && "opacity-50 transition-opacity duration-150",
+        )}
+      >
+        {children}
+      </div>
+      {active && (
+        <Spinner
+          isFull
+          className="absolute top-0 left-0 h-full w-full cursor-wait"
+        />
+      )}
+    </div>
+  );
+};
+
+export default LoadingOverlay;


### PR DESCRIPTION
## Description
- Add loading indicator on Task and project list pages during initial load and filter change.
- Refactor Timesheet (Personal/Project/Team) pages to use the new loading overlay component - unifying the loading behaviour across the pages.
- Surface a "Network Error" toast when a filtered/sorted refetch fails on Task list, Project list, and Personal/Team Timesheet, instead of silently leaving stale data displayed as if it matched the new filter. Toasts use a fixed id per hook so SWR's automatic retries refresh one toast in place rather than stacking duplicates.

## Screenshot/Screencast
<img width="2600" height="1696" alt="image" src="https://github.com/user-attachments/assets/7b21281c-3115-4a62-a303-3662d5b495b6" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #2064