### PR TITLE
feat: only show tooltip when content is truncated

### DIFF
--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/eventPill.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/eventPill.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useRef } from "react";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { Sparkle, Zap } from "@rtcamp/frappe-ui-react/icons";
 
@@ -13,10 +14,11 @@ import type { ProjectTimelineItem } from "./types";
 type EventPillProps = { item: ProjectTimelineItem; truncate?: boolean };
 
 export function EventPill({ item, truncate = false }: EventPillProps) {
+  const titleRef = useRef<HTMLSpanElement>(null);
   const isMilestone = item.type === "Milestone";
 
   return (
-    <Tooltip text={item.title}>
+    <Tooltip text={item.title} showWhen="truncated" truncationRef={titleRef}>
       <div
         className={mergeClassNames(
           "flex gap-1 rounded p-1 text-xs w-full cursor-pointer",
@@ -32,6 +34,7 @@ export function EventPill({ item, truncate = false }: EventPillProps) {
           <Zap className="size-3 shrink-0" />
         )}
         <span
+          ref={titleRef}
           className={mergeClassNames(
             "min-w-0 leading-tight",
             truncate ? "truncate" : "wrap-break-word",

--- a/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/calendar/ganttBar.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useRef } from "react";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { Sparkle, Zap } from "@rtcamp/frappe-ui-react/icons";
 
@@ -20,6 +21,7 @@ type GanttBarProps = {
 };
 
 export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
+  const titleRef = useRef<HTMLSpanElement>(null);
   if (item.type === "Milestone") {
     if (pos.width <= MIN_BAR_WIDTH) {
       return (
@@ -35,14 +37,14 @@ export function GanttBar({ item, pos, totalWidth }: GanttBarProps) {
     }
 
     return (
-      <Tooltip text={item.title}>
+      <Tooltip text={item.title} showWhen="truncated" truncationRef={titleRef}>
         <div
           className="absolute top-1/2 -translate-y-1/2 z-1 flex items-center gap-1.5 px-2.5 rounded-md overflow-hidden mx-0.5 bg-surface-blue-2 text-blue-700"
           style={{ left: pos.left, width: pos.width, height: 32 }}
-          title={item.title}
         >
           <Sparkle className="size-3.5 shrink-0" />
           <span
+            ref={titleRef}
             className={`truncate text-sm${item.isComplete ? " line-through opacity-60" : ""}`}
           >
             {item.title}

--- a/frontend/packages/app/src/pages/project-details/tabs/rag-stats/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/rag-stats/index.tsx
@@ -48,7 +48,7 @@ function renderCell(column: ColumnDef, row: RagTrigger | RagHistory) {
   switch (column.key) {
     case "type":
       return (
-        <Tooltip text={row.type_label}>
+        <Tooltip text={row.type_label} showWhen="truncated">
           <span className="truncate">{row.type_label}</span>
         </Tooltip>
       );

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/knowledgePoint.tsx
@@ -25,7 +25,7 @@ export function KnowledgePoint({ title, value, href }: KnowledgePointProps) {
           {title}
         </span>
       </div>
-      <Tooltip text={value}>
+      <Tooltip text={value} showWhen="truncated">
         <span className="truncate text-xl font-medium text-ink-gray-8">
           {value}
         </span>

--- a/frontend/packages/app/src/pages/projects/list/cells/employeeCell.tsx
+++ b/frontend/packages/app/src/pages/projects/list/cells/employeeCell.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useRef } from "react";
 import { Avatar, Tooltip } from "@rtcamp/frappe-ui-react";
 
 /**
@@ -10,6 +11,7 @@ import type { Employee } from "../types";
 import { TextCell } from "./textCell";
 
 export function EmployeeCell({ employee }: { employee: Employee | null }) {
+  const nameRef = useRef<HTMLSpanElement>(null);
   if (!employee) {
     return <TextCell text="N/A" />;
   }
@@ -36,7 +38,11 @@ export function EmployeeCell({ employee }: { employee: Employee | null }) {
     );
   }
   return (
-    <Tooltip text={employee.full_name || ""}>
+    <Tooltip
+      text={employee.full_name || ""}
+      showWhen="truncated"
+      truncationRef={nameRef}
+    >
       <div className="flex gap-2 w-fit">
         {employee.image && (
           <Avatar
@@ -46,7 +52,7 @@ export function EmployeeCell({ employee }: { employee: Employee | null }) {
             label={employee.full_name || ""}
           />
         )}
-        <span className="truncate text-ink-gray-6 text-base">
+        <span ref={nameRef} className="truncate text-ink-gray-6 text-base">
           {employee.full_name}
         </span>
       </div>

--- a/frontend/packages/app/src/pages/projects/list/cells/projectNameCell.tsx
+++ b/frontend/packages/app/src/pages/projects/list/cells/projectNameCell.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useRef } from "react";
 import { Link } from "react-router";
 import { mergeClassNames } from "@next-pms/design-system";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
@@ -24,9 +25,10 @@ export function ProjectNameCell({
   riskLevel?: string;
 }) {
   const risk = pickAllowed<RagStatus>(riskLevel, RAG_STATUS);
+  const nameRef = useRef<HTMLSpanElement>(null);
 
   return (
-    <Tooltip text={name}>
+    <Tooltip text={name} showWhen="truncated" truncationRef={nameRef}>
       <Link
         to={`${ROUTES.project}/${id}`}
         className={mergeClassNames(
@@ -36,7 +38,9 @@ export function ProjectNameCell({
         )}
       >
         {risk && <Dot risk={risk} />}
-        <span className="ml-2 truncate">{name}</span>
+        <span ref={nameRef} className="ml-2 truncate">
+          {name}
+        </span>
       </Link>
     </Tooltip>
   );

--- a/frontend/packages/app/src/pages/tasks/list/cells/subjectCell.tsx
+++ b/frontend/packages/app/src/pages/tasks/list/cells/subjectCell.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useRef } from "react";
 import { mergeClassNames } from "@next-pms/design-system";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
 
@@ -13,10 +14,11 @@ export function SubjectCell({
   subject: string;
   onOpenTask?: (taskName: string) => void;
 }) {
+  const subjectRef = useRef<HTMLSpanElement>(null);
   const handleOpen = () => onOpenTask?.(name);
 
   return (
-    <Tooltip text={subject}>
+    <Tooltip text={subject} showWhen="truncated" truncationRef={subjectRef}>
       {/* A native <button> can't be used here: ListRow already wraps every
           cell in a <button>, and nested buttons are invalid HTML / trigger
           a React DOM-nesting warning. */}
@@ -43,7 +45,9 @@ export function SubjectCell({
           "focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 transition-colors",
         )}
       >
-        <span className="ml-2 truncate">{subject}</span>
+        <span ref={subjectRef} className="ml-2 truncate">
+          {subject}
+        </span>
       </div>
     </Tooltip>
   );


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR updates `Tooltip` component usage across the project to use the newly added prop that shows the tooltip only when the content is actually truncated, removing unnecessary tooltips.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Depends on https://github.com/rtCamp/frappe-ui-react/pull/336

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Navigate to a project's "Tracking" page.
2. Check the Company and Total Project Value cards.
3. When the text is not truncated, hover over it and verify that no tooltip is shown.
4. Use DevTools to resize the page until the text becomes truncated.
5. Hover over the truncated text and verify that the tooltip is now shown.



## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/d1c544ae-3d68-4006-bfa2-a2ef5e9d5289



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2052