### PR TITLE
fix(timesheet): resolve team work filters per week, not per lookback window 

### DIFF
--- a/next_pms/tests/timesheet/api/test_team_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_team_timesheet_data.py
@@ -547,6 +547,14 @@ class TestTeamTimesheetFilteredWeekMembership(_TeamTimesheetDataBase):
     def _alpha_task_filter(self):
         return json.dumps([["Task", "project", "=", self.project_alpha]])
 
+    def _detail_task_filter(self):
+        """The payload the Team Timesheets UI emits for its Task filter."""
+        return json.dumps([["Timesheet Detail", "task", "=", self.task_alpha]])
+
+    def _detail_project_filter(self):
+        """The payload the Team Timesheets UI emits for its Project filter."""
+        return json.dumps([["Timesheet Detail", "project", "=", self.project_alpha]])
+
     def test_week_without_matching_entries_drops_the_member(self):
         res = self._call(reports_to=self.mgr, filters=self._alpha_task_filter(), start_date=W2_MON)
 
@@ -575,6 +583,36 @@ class TestTeamTimesheetFilteredWeekMembership(_TeamTimesheetDataBase):
 
         self.assertEqual(res["members"], [])
         self.assertEqual(res["total_count"], 0)
+
+    def test_ui_task_filter_is_resolved_per_week(self):
+        # Issue #2011 as reported: a Timesheet Detail task filter with no Task condition,
+        # which resolves without the task scan.
+        kept = self._call(reports_to=self.mgr, filters=self._detail_task_filter(), start_date=W1_MON)
+        dropped = self._call(reports_to=self.mgr, filters=self._detail_task_filter(), start_date=W2_MON)
+
+        self.assertIn(self.r1, self._members_by_employee(kept))
+        self.assertEqual(dropped["members"], [])
+        self.assertEqual(dropped["total_count"], 0)
+
+    def test_ui_project_filter_is_resolved_per_week(self):
+        kept = self._call(reports_to=self.mgr, filters=self._detail_project_filter(), start_date=W1_MON)
+        dropped = self._call(reports_to=self.mgr, filters=self._detail_project_filter(), start_date=W2_MON)
+
+        self.assertIn(self.r1, self._members_by_employee(kept))
+        self.assertEqual(dropped["members"], [])
+        self.assertEqual(dropped["total_count"], 0)
+
+    def test_weeks_endpoint_drops_the_non_matching_week_for_ui_filters(self):
+        for label, filters in (
+            ("task", self._detail_task_filter()),
+            ("project", self._detail_project_filter()),
+        ):
+            with self.subTest(filter=label):
+                res = self._weeks(reports_to=self.mgr, max_week=2, filters=filters)
+
+                starts = [week["start_date"] for week in res["weeks"]]
+                self.assertIn(frappe.utils.getdate(W1_MON), starts)
+                self.assertNotIn(frappe.utils.getdate(W2_MON), starts)
 
     def test_unfiltered_week_still_lists_the_member(self):
         res = self._call(reports_to=self.mgr, start_date=W2_MON)

--- a/next_pms/tests/timesheet/api/test_team_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_team_timesheet_data.py
@@ -527,6 +527,61 @@ class TestTeamTimesheetDataFilters(_TeamTimesheetDataBase):
         self.assertNotIn(self.r3, self._members_by_employee(res))
 
 
+class TestTeamTimesheetFilteredWeekMembership(_TeamTimesheetDataBase):
+    """Issue #2011 — a work filter qualifies a *week*, not the whole lookback window.
+
+    Filtered requests widen the window to FILTER_LOOKBACK_WEEKS to resolve the employee pool,
+    so a member matching in one week used to be listed in every other week they had merely
+    logged something in — rendering as an empty row under the filter.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+        # R1 logs alpha work in W1 (base fixture) and beta work in W2: a candidate for an
+        # alpha filter across the window, with nothing matching it in W2.
+        cls._save(cls.r1, W2_MON, cls.task_beta, 5, "r1 w2 beta")
+        frappe.clear_cache()
+
+    def _alpha_task_filter(self):
+        return json.dumps([["Task", "project", "=", self.project_alpha]])
+
+    def test_week_without_matching_entries_drops_the_member(self):
+        res = self._call(reports_to=self.mgr, filters=self._alpha_task_filter(), start_date=W2_MON)
+
+        self.assertEqual(res["members"], [])
+        self.assertEqual(res["total_count"], 0)
+
+    def test_week_with_matching_entries_keeps_the_member(self):
+        res = self._call(reports_to=self.mgr, filters=self._alpha_task_filter(), start_date=W1_MON)
+
+        self.assertIn(self.r1, self._members_by_employee(res))
+
+    def test_weeks_endpoint_drops_the_non_matching_week(self):
+        res = self._weeks(reports_to=self.mgr, max_week=2, filters=self._alpha_task_filter())
+
+        starts = [week["start_date"] for week in res["weeks"]]
+        self.assertIn(frappe.utils.getdate(W1_MON), starts)
+        self.assertNotIn(frappe.utils.getdate(W2_MON), starts)
+
+    def test_timesheet_level_filter_is_resolved_per_week(self):
+        # parent_project lives on Timesheet, so it was never applied to the per-week query.
+        res = self._call(
+            reports_to=self.mgr,
+            filters=json.dumps([["Timesheet", "parent_project", "=", self.project_alpha]]),
+            start_date=W2_MON,
+        )
+
+        self.assertEqual(res["members"], [])
+        self.assertEqual(res["total_count"], 0)
+
+    def test_unfiltered_week_still_lists_the_member(self):
+        res = self._call(reports_to=self.mgr, start_date=W2_MON)
+
+        self.assertIn(self.r1, self._members_by_employee(res))
+
+
 LEFT_EMP_NAME = "Meera Joshi"
 BU_ALPHA_NAME = "Ttf BU Alpha"
 BU_BETA_NAME = "Ttf BU Beta"

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -311,7 +311,9 @@ def get_team_timesheet_weeks(
 
     Feeds first paint: the page can render its week rows and pending-approval badges
     before any member data is fetched, and `get_team_timesheet_data` then fills one week
-    at a time. Touches no Timesheet Detail rows.
+    at a time. Builds no member payload, so an unfiltered call reads Timesheet rows only;
+    a Task or Timesheet Detail filter does reach the detail rows, since qualifying a week
+    against it cannot be answered from the Timesheet table alone.
     """
     only_for(["Timesheet Manager", "Timesheet User", "Projects Manager"], message=True)
 

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -14,6 +14,7 @@ from next_pms.timesheet.utils.constant import (
     ALLOWED_TIMESHET_DETAIL_FIELDS,
     FILTER_LOOKBACK_WEEKS,
     NOT_SUBMITTED_STATUS,
+    WORK_FILTER_DOCTYPES,
 )
 
 from . import filter_employees
@@ -400,12 +401,20 @@ def build_aggregate_dates(date: str, max_week: int, has_filters: bool):
     return dates, max_lookback
 
 
-def get_matching_timesheet_employee_ids(
+def get_matching_timesheets(
     dates: list,
     parsed_filters: dict,
     approval_status: list[str] | None = None,
     require_project_tasks: bool = False,
+    employee_ids: list[str] | None = None,
 ):
+    """Timesheets in the range that satisfy the filters, detail and task conditions included.
+
+    Returns the rows rather than the employees behind them because the same join answers
+    two different questions: *who* can match at all (the employee pool) and *which weeks*
+    of theirs match (per-week membership). Collapsing to employees here is what let a
+    match in one week qualify every other week the employee logged anything in.
+    """
     if not dates:
         return []
 
@@ -416,9 +425,11 @@ def get_matching_timesheet_employee_ids(
     }
     if approval_status:
         base_ts_filters["custom_weekly_approval_status"] = ["in", approval_status]
+    if employee_ids is not None:
+        base_ts_filters["employee"] = ["in", employee_ids]
 
     ts_filters = build_filters(base_ts_filters, parsed_filters.get("Timesheet", []))
-    timesheets = get_all("Timesheet", filters=ts_filters, fields=["name", "employee"])
+    timesheets = get_all("Timesheet", filters=ts_filters, fields=["name", "employee", "start_date"])
     if not timesheets:
         return []
 
@@ -426,7 +437,7 @@ def get_matching_timesheet_employee_ids(
         require_project_tasks or parsed_filters.get("Task") or parsed_filters.get("Timesheet Detail")
     )
     if not requires_detail_scan:
-        return list({timesheet.employee for timesheet in timesheets})
+        return timesheets
 
     timesheet_by_name = {timesheet.name: timesheet for timesheet in timesheets}
     detail_filters = build_filters(
@@ -437,27 +448,40 @@ def get_matching_timesheet_employee_ids(
         return []
 
     requires_task_scan = bool(require_project_tasks or parsed_filters.get("Task"))
-    if not requires_task_scan:
+    if requires_task_scan:
+        task_ids = list({detail.task for detail in details if detail.task})
+        if not task_ids:
+            return []
+
+        task_filters = build_filters({"name": ["in", task_ids]}, parsed_filters.get("Task", []))
+        tasks = get_all("Task", filters=task_filters, fields=["name", "project"])
+        if require_project_tasks:
+            tasks = [task for task in tasks if task.get("project")]
+
+        valid_task_ids = {task.name for task in tasks}
+        if not valid_task_ids:
+            return []
+
+        matched_parent_names = {detail.parent for detail in details if detail.task in valid_task_ids}
+    else:
         matched_parent_names = {detail.parent for detail in details}
-        return list(
-            {timesheet_by_name[parent].employee for parent in matched_parent_names if parent in timesheet_by_name}
-        )
 
-    task_ids = list({detail.task for detail in details if detail.task})
-    if not task_ids:
-        return []
+    return [timesheet_by_name[parent] for parent in matched_parent_names if parent in timesheet_by_name]
 
-    task_filters = build_filters({"name": ["in", task_ids]}, parsed_filters.get("Task", []))
-    tasks = get_all("Task", filters=task_filters, fields=["name", "project"])
-    if require_project_tasks:
-        tasks = [task for task in tasks if task.get("project")]
 
-    valid_task_ids = {task.name for task in tasks}
-    if not valid_task_ids:
-        return []
-
-    matched_parent_names = {detail.parent for detail in details if detail.task in valid_task_ids}
-    return list({timesheet_by_name[parent].employee for parent in matched_parent_names if parent in timesheet_by_name})
+def get_matching_timesheet_employee_ids(
+    dates: list,
+    parsed_filters: dict,
+    approval_status: list[str] | None = None,
+    require_project_tasks: bool = False,
+):
+    timesheets = get_matching_timesheets(
+        dates=dates,
+        parsed_filters=parsed_filters,
+        approval_status=approval_status,
+        require_project_tasks=require_project_tasks,
+    )
+    return list({timesheet.employee for timesheet in timesheets})
 
 
 def sanitize_employee_conditions(employee_conditions: list | None) -> list:
@@ -557,6 +581,15 @@ class TeamEmployeeScope:
         return self.candidate_employee_ids == []
 
     @property
+    def has_work_filters(self) -> bool:
+        """True when a filter describes logged work rather than who the employee is.
+
+        Employee-level conditions narrow the pool once; work filters have to be answered
+        again for every week, since a member matching one week says nothing about another.
+        """
+        return any(self.parsed_filters.get(doctype) for doctype in WORK_FILTER_DOCTYPES)
+
+    @property
     def skip_empty_weeks(self) -> bool:
         """Empty weeks are dropped for filters that describe *work*, not for member search.
 
@@ -627,9 +660,10 @@ def get_team_week_participation(scope: TeamEmployeeScope, weeks: list) -> dict:
     `get_first_day_of_week` so the week boundary matches the rest of the app rather
     than a hand-rolled SQL date expression that would ignore System Settings.
 
-    Returns `{week_start: {"members": set, "pending": set}}`. Sets rather than counts
-    because API 2 intersects them with its own employee page, and a count cannot be
-    intersected.
+    Returns `{week_start: {"members": set, "matched": set, "pending": set, "status_matched": set}}`.
+    Sets rather than counts because API 2 intersects them with its own employee page, and a
+    count cannot be intersected. `members` is raw participation; `matched` is the subset whose
+    timesheets *in that week* satisfy the work filters.
     """
     if not weeks:
         return {}
@@ -645,23 +679,43 @@ def get_team_week_participation(scope: TeamEmployeeScope, weeks: list) -> dict:
     rows = get_all(
         "Timesheet",
         filters=timesheet_filters,
-        fields=["employee", "start_date", "custom_weekly_approval_status"],
+        fields=["name", "employee", "start_date", "custom_weekly_approval_status"],
         distinct=True,
         # Unordered on purpose: the result is folded into sets, and the default
         # `creation` sort costs a filesort over the whole match set.
         order_by=None,
     )
 
+    # A work filter is resolved per week, not once for the whole lookback window:
+    # `candidate_employee_ids` only says the employee matched *somewhere* in it, so reading
+    # that as membership listed them in every week they merely logged something in.
+    matched_names = None
+    if scope.has_work_filters:
+        matched_names = {
+            timesheet.name
+            for timesheet in get_matching_timesheets(
+                dates=weeks,
+                parsed_filters=scope.parsed_filters,
+                employee_ids=scope.candidate_employee_ids,
+            )
+        }
+
     status_filter = set(scope.status_filter or [])
     participation = {
-        week["start_date"]: {"members": set(), "pending": set(), "status_matched": set()} for week in weeks
+        week["start_date"]: {"members": set(), "matched": set(), "pending": set(), "status_matched": set()}
+        for week in weeks
     }
     for row in rows:
         week_start = get_first_day_of_week(row.start_date)
         bucket = participation.get(week_start)
         if bucket is None:
             continue
+        # `members` stays raw participation - "Not Submitted" is the absence of a row, so it
+        # has to be derived from every week the employee did or did not log time in.
         bucket["members"].add(row.employee)
+        if matched_names is not None and row.name not in matched_names:
+            continue
+        bucket["matched"].add(row.employee)
         if row.custom_weekly_approval_status == "Approval Pending":
             bucket["pending"].add(row.employee)
         # Read the status the same way the payload derives it for display, so a row whose
@@ -706,9 +760,11 @@ def resolve_team_members(scope: TeamEmployeeScope, weeks: list) -> dict:
     members_by_week = {}
     pending_by_week = {}
     for week in weeks:
-        bucket = participation.get(week["start_date"], {"members": set(), "pending": set(), "status_matched": set()})
-        # Membership is per-week participation only for filters that describe work.
-        # For a member-name search an employee belongs to every week whether or not they
+        bucket = participation.get(
+            week["start_date"], {"members": set(), "matched": set(), "pending": set(), "status_matched": set()}
+        )
+        # Membership is per-week filter-matching participation only for filters that describe
+        # work. For a member-name search an employee belongs to every week whether or not they
         # logged time - the point of searching a person is to see their empty weeks too.
         # A status filter is stricter still: the week's approval status must match, so it
         # keys off the status-matched set rather than plain participation.
@@ -720,7 +776,7 @@ def resolve_team_members(scope: TeamEmployeeScope, weeks: list) -> dict:
             if NOT_SUBMITTED_STATUS in scope.status_filter:
                 week_members = week_members | (eligible_ids - bucket["members"])
         elif scope.skip_empty_weeks:
-            week_members = bucket["members"]
+            week_members = bucket["matched"]
         else:
             week_members = eligible_ids
         members_by_week[week["start_date"]] = week_members & eligible_ids

--- a/next_pms/timesheet/utils/constant.py
+++ b/next_pms/timesheet/utils/constant.py
@@ -51,6 +51,10 @@ ALLOWED_FILTER_FIELDS = {
     "Employee": {"status", "custom_business_unit"},
 }
 
+# Filter doctypes that describe logged work rather than who the employee is. Work filters
+# qualify a week, so they are re-checked per week; Employee conditions narrow the pool once.
+WORK_FILTER_DOCTYPES = ("Timesheet", "Timesheet Detail", "Task")
+
 FILTER_LOOKBACK_WEEKS = 12
 
 # Default members per page, matching TEAM_MEMBER_PAGE_LENGTH in the frontend.


### PR DESCRIPTION

## Description

This pull request refines how timesheet filters are applied to weekly team data, ensuring that work-related filters (such as task or project filters) are evaluated per week rather than across the entire lookback window. This prevents employees from appearing in weeks where they have no matching entries, fixing an issue where empty rows were shown for filtered weeks. The changes also clarify the distinction between employee-level and work-level filters and adjust the API and internal logic accordingly.

**Work filter handling and weekly membership:**
* Introduced the `WORK_FILTER_DOCTYPES` constant to distinguish filters that describe logged work from those that describe employee attributes, ensuring work filters are applied per week (`next_pms/timesheet/utils/constant.py`).
* Refactored `get_matching_timesheet_employee_ids` into `get_matching_timesheets` to return timesheet rows rather than just employee IDs, allowing for accurate per-week matching (`next_pms/timesheet/api/utils.py`). [[1]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L403-R417) [[2]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21R428-R440) [[3]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L440-R451) [[4]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L460-R484)
* Updated the participation and membership resolution logic so that only employees with matching work in a given week are included for that week, preventing empty rows for non-matching weeks (`next_pms/timesheet/api/utils.py`). [[1]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L630-R666) [[2]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L648-R718) [[3]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L709-R767) [[4]](diffhunk://#diff-71963aea71107db75319dc18bc92b2d15203fd12c2979c2836c3ddb514fdce21L723-R779)

**Filter and API enhancements:**
* Added the `has_work_filters` property to the scope class to identify when work filters are present and require per-week evaluation (`next_pms/timesheet/api/utils.py`).
* Updated test coverage to ensure that filtered weeks correctly exclude or include members based on per-week matching, and that unfiltered requests continue to work as before (`next_pms/tests/timesheet/api/test_team_timesheet_data.py`).

These changes collectively ensure that timesheet API endpoints return accurate weekly membership lists under filtered queries, improving both correctness and user experience.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2011 