### PR TITLE
fix: Hide non-existent project fields and expose availability flags

### DIFF
--- a/frontend/packages/app/src/lib/utils.ts
+++ b/frontend/packages/app/src/lib/utils.ts
@@ -101,6 +101,14 @@ export const isWeekendEntryAllowed = (): boolean => {
   return window.frappe?.boot?.allow_weekend_entries ?? false;
 };
 
+export const hasProjectField = (fieldname: string): boolean => {
+  return window.frappe?.boot?.optional_project_fields?.[fieldname] ?? false;
+};
+
+export const hasTodoCustomFields = (): boolean => {
+  return window.frappe?.boot?.has_todo_custom_fields ?? false;
+};
+
 export const getDefaultCurrency = (): string => {
   return window.frappe?.boot?.sysdefaults?.currency ?? "INR";
 };

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/constants.ts
@@ -3,9 +3,3 @@ export const SOURCING_FIELDS = [
   "custom_territory",
   "custom_previous_cms",
 ] as const;
-
-export const MARKETING_FIELDS = [
-  "custom_restricted_under_nda",
-  "custom_permission_for_case_study",
-  "custom_permission_for_testimonial",
-] as const;

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/constants.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/constants.ts
@@ -1,0 +1,11 @@
+export const SOURCING_FIELDS = [
+  "custom_source",
+  "custom_territory",
+  "custom_previous_cms",
+] as const;
+
+export const MARKETING_FIELDS = [
+  "custom_restricted_under_nda",
+  "custom_permission_for_case_study",
+  "custom_permission_for_testimonial",
+] as const;

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/index.tsx
@@ -16,9 +16,14 @@ import { FrappeError, useFrappeUpdateDoc } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
-import { mergeClassNames, parseFrappeErrorMsg } from "@/lib/utils";
+import {
+  hasProjectField,
+  mergeClassNames,
+  parseFrappeErrorMsg,
+} from "@/lib/utils";
 import { useProjectDetail } from "../../context";
 import { OverviewSection } from "./components/overviewSection";
+import { SOURCING_FIELDS } from "./constants";
 import { overviewSchema, type OverviewFormValues } from "./schema";
 import { Communication } from "./sections/communication";
 import { Marketing } from "./sections/marketing";
@@ -34,6 +39,27 @@ const toBoolStr = (value: 0 | 1 | undefined) => {
   }
   return value === 1 ? "1" : "0";
 };
+
+const OPTIONAL_FIELD_READERS: Record<
+  string,
+  (value: OverviewFormValues) => string | 0 | 1
+> = {
+  custom_source: (value) => value.source,
+  custom_territory: (value) => value.primaryLocation,
+  custom_previous_cms: (value) => value.previousCms,
+  custom_restricted_under_nda: (value) => Number(value.ndaSigned) as 0 | 1,
+  custom_permission_for_case_study: (value) =>
+    Number(value.caseStudyApproved) as 0 | 1,
+  custom_permission_for_testimonial: (value) =>
+    Number(value.testimonialApproval) as 0 | 1,
+};
+
+const optionalFieldValues = (value: OverviewFormValues) =>
+  Object.fromEntries(
+    Object.entries(OPTIONAL_FIELD_READERS)
+      .filter(([fieldname]) => hasProjectField(fieldname))
+      .map(([fieldname, read]) => [fieldname, read(value)]),
+  );
 
 const useOverviewForm = (
   defaultValues: OverviewFormValues,
@@ -111,17 +137,10 @@ function OverviewForm() {
         custom_host: value.host,
         custom_complexity: value.complexity,
         custom_key_account: value.keyAccount,
-        custom_source: value.source,
-        custom_territory: value.primaryLocation,
-        custom_previous_cms: value.previousCms,
         custom_client_point_of_contact: value.pointOfContact,
         custom_time_report_frequency: value.timeReportFrequency,
-        custom_restricted_under_nda: Number(value.ndaSigned) as 0 | 1,
-        custom_permission_for_case_study: Number(value.caseStudyApproved) as
-          0 | 1,
-        custom_permission_for_testimonial: Number(value.testimonialApproval) as
-          0 | 1,
         custom_testimonial_contact: value.testimonialContact,
+        ...optionalFieldValues(value),
       });
       mutate();
       form.reset(value);
@@ -233,7 +252,9 @@ function OverviewForm() {
       </form.Field>
 
       <Specifics form={form} isEditing={isEditing} submitting={submitting} />
-      <Sourcing form={form} isEditing={isEditing} submitting={submitting} />
+      {SOURCING_FIELDS.some(hasProjectField) && (
+        <Sourcing form={form} isEditing={isEditing} submitting={submitting} />
+      )}
       <Communication
         form={form}
         isEditing={isEditing}

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/sections/marketing.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/sections/marketing.tsx
@@ -14,6 +14,7 @@ import {
  * Internal dependencies.
  */
 import { useCustomerContactLookup } from "@/hooks/useCustomerContactLookup";
+import { hasProjectField } from "@/lib/utils";
 import { useProjectDetail } from "../../../context";
 import { EditableField } from "../components/editableField";
 import { OverviewSection } from "../components/overviewSection";
@@ -48,59 +49,65 @@ export function Marketing({ form, isEditing, submitting }: MarketingProps) {
   return (
     <OverviewSection title="Marketing">
       <div className="flex w-220 max-w-full flex-wrap gap-4">
-        <form.Field name="ndaSigned">
-          {(field) => (
-            <EditableField
-              icon={<PreviewOff className="size-[18px]" />}
-              label="NDA signed"
-              value={toYesNo(field.state.value)}
-              isEditing={isEditing}
-            >
-              <Select
-                value={field.state.value}
-                onChange={(v) => field.handleChange(v || "0")}
-                options={YES_NO_OPTIONS}
-                disabled={submitting}
-              />
-            </EditableField>
-          )}
-        </form.Field>
+        {hasProjectField("custom_restricted_under_nda") && (
+          <form.Field name="ndaSigned">
+            {(field) => (
+              <EditableField
+                icon={<PreviewOff className="size-[18px]" />}
+                label="NDA signed"
+                value={toYesNo(field.state.value)}
+                isEditing={isEditing}
+              >
+                <Select
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v || "0")}
+                  options={YES_NO_OPTIONS}
+                  disabled={submitting}
+                />
+              </EditableField>
+            )}
+          </form.Field>
+        )}
 
-        <form.Field name="caseStudyApproved">
-          {(field) => (
-            <EditableField
-              icon={<Article className="size-[18px]" />}
-              label="Case study approved"
-              value={toYesNo(field.state.value)}
-              isEditing={isEditing}
-            >
-              <Select
-                value={field.state.value}
-                onChange={(v) => field.handleChange(v || "0")}
-                options={YES_NO_OPTIONS}
-                disabled={submitting}
-              />
-            </EditableField>
-          )}
-        </form.Field>
+        {hasProjectField("custom_permission_for_case_study") && (
+          <form.Field name="caseStudyApproved">
+            {(field) => (
+              <EditableField
+                icon={<Article className="size-[18px]" />}
+                label="Case study approved"
+                value={toYesNo(field.state.value)}
+                isEditing={isEditing}
+              >
+                <Select
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v || "0")}
+                  options={YES_NO_OPTIONS}
+                  disabled={submitting}
+                />
+              </EditableField>
+            )}
+          </form.Field>
+        )}
 
-        <form.Field name="testimonialApproval">
-          {(field) => (
-            <EditableField
-              icon={<Quote className="size-[18px]" />}
-              label="Testimonial approval"
-              value={toYesNo(field.state.value)}
-              isEditing={isEditing}
-            >
-              <Select
-                value={field.state.value}
-                onChange={(v) => field.handleChange(v || "0")}
-                options={YES_NO_OPTIONS}
-                disabled={submitting}
-              />
-            </EditableField>
-          )}
-        </form.Field>
+        {hasProjectField("custom_permission_for_testimonial") && (
+          <form.Field name="testimonialApproval">
+            {(field) => (
+              <EditableField
+                icon={<Quote className="size-[18px]" />}
+                label="Testimonial approval"
+                value={toYesNo(field.state.value)}
+                isEditing={isEditing}
+              >
+                <Select
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v || "0")}
+                  options={YES_NO_OPTIONS}
+                  disabled={submitting}
+                />
+              </EditableField>
+            )}
+          </form.Field>
+        )}
 
         <form.Field name="testimonialContact">
           {(field) => (

--- a/frontend/packages/app/src/pages/project-details/tabs/overview/sections/sourcing.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/overview/sections/sourcing.tsx
@@ -10,6 +10,7 @@ import { Location, SearchAlt, Tag1 } from "@rtcamp/frappe-ui-react/icons";
  */
 import { useTerritoryLookup } from "@/hooks/useTerritoryLookup";
 import { useUtmSourceLookup } from "@/hooks/useUtmSourceLookup";
+import { hasProjectField } from "@/lib/utils";
 import { EditableField } from "../components/editableField";
 import { OverviewSection } from "../components/overviewSection";
 import type { OverviewFormApi } from "../index";
@@ -26,84 +27,90 @@ export function Sourcing({ form, isEditing, submitting }: SourcingProps) {
   const [sourceSearch, setSourceSearch] = useState("");
   const { options: sourceOptions, isLoading: isSourceLoading } =
     useUtmSourceLookup({
-      shouldFetch: isEditing,
+      shouldFetch: isEditing && hasProjectField("custom_source"),
       query: sourceSearch,
     });
 
   const [territorySearch, setTerritorySearch] = useState("");
   const { options: territoryOptions, isLoading: isTerritoryLoading } =
     useTerritoryLookup({
-      shouldFetch: isEditing,
+      shouldFetch: isEditing && hasProjectField("custom_territory"),
       query: territorySearch,
     });
 
   return (
     <OverviewSection title="Sourcing">
       <div className="flex w-[880px] max-w-full flex-wrap gap-4">
-        <form.Field name="source">
-          {(field) => (
-            <EditableField
-              icon={<SearchAlt className="size-[18px]" />}
-              label="Source"
-              value={field.state.value || EMPTY}
-              isEditing={isEditing}
-            >
-              <Combobox
-                loading={isSourceLoading}
-                options={sourceOptions}
-                popupClassName="w-max min-w-(--anchor-width) max-w-[300px]"
-                placeholder="Select source"
-                searchValue={sourceSearch}
-                onSearchChange={setSourceSearch}
-                value={field.state.value || null}
-                onChange={(v) => field.handleChange(v ?? "")}
-                disabled={submitting}
-                openOnFocus
-              />
-            </EditableField>
-          )}
-        </form.Field>
+        {hasProjectField("custom_source") && (
+          <form.Field name="source">
+            {(field) => (
+              <EditableField
+                icon={<SearchAlt className="size-[18px]" />}
+                label="Source"
+                value={field.state.value || EMPTY}
+                isEditing={isEditing}
+              >
+                <Combobox
+                  loading={isSourceLoading}
+                  options={sourceOptions}
+                  popupClassName="w-max min-w-(--anchor-width) max-w-[300px]"
+                  placeholder="Select source"
+                  searchValue={sourceSearch}
+                  onSearchChange={setSourceSearch}
+                  value={field.state.value || null}
+                  onChange={(v) => field.handleChange(v ?? "")}
+                  disabled={submitting}
+                  openOnFocus
+                />
+              </EditableField>
+            )}
+          </form.Field>
+        )}
 
-        <form.Field name="primaryLocation">
-          {(field) => (
-            <EditableField
-              icon={<Location className="size-[18px]" />}
-              label="Primary location"
-              value={field.state.value || EMPTY}
-              isEditing={isEditing}
-            >
-              <Combobox
-                loading={isTerritoryLoading}
-                options={territoryOptions}
-                popupClassName="w-max min-w-(--anchor-width) max-w-[300px]"
-                placeholder="Select primary location"
-                searchValue={territorySearch}
-                onSearchChange={setTerritorySearch}
-                value={field.state.value || null}
-                onChange={(v) => field.handleChange(v ?? "")}
-                disabled={submitting}
-                openOnFocus
-              />
-            </EditableField>
-          )}
-        </form.Field>
+        {hasProjectField("custom_territory") && (
+          <form.Field name="primaryLocation">
+            {(field) => (
+              <EditableField
+                icon={<Location className="size-[18px]" />}
+                label="Primary location"
+                value={field.state.value || EMPTY}
+                isEditing={isEditing}
+              >
+                <Combobox
+                  loading={isTerritoryLoading}
+                  options={territoryOptions}
+                  popupClassName="w-max min-w-(--anchor-width) max-w-[300px]"
+                  placeholder="Select primary location"
+                  searchValue={territorySearch}
+                  onSearchChange={setTerritorySearch}
+                  value={field.state.value || null}
+                  onChange={(v) => field.handleChange(v ?? "")}
+                  disabled={submitting}
+                  openOnFocus
+                />
+              </EditableField>
+            )}
+          </form.Field>
+        )}
 
-        <form.Field name="previousCms">
-          {(field) => (
-            <EditableField
-              icon={<Tag1 className="size-[18px]" />}
-              label="Previous CMS"
-              value={field.state.value || EMPTY}
-              isEditing={isEditing}
-            >
-              <TextInput
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                disabled={submitting}
-              />
-            </EditableField>
-          )}
-        </form.Field>
+        {hasProjectField("custom_previous_cms") && (
+          <form.Field name="previousCms">
+            {(field) => (
+              <EditableField
+                icon={<Tag1 className="size-[18px]" />}
+                label="Previous CMS"
+                value={field.state.value || EMPTY}
+                isEditing={isEditing}
+              >
+                <TextInput
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  disabled={submitting}
+                />
+              </EditableField>
+            )}
+          </form.Field>
+        )}
       </div>
     </OverviewSection>
   );

--- a/frontend/packages/app/src/pages/project-details/tabs/to-do/provider/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/to-do/provider/index.tsx
@@ -13,12 +13,21 @@ import {
 /**
  * Internal dependencies.
  */
-import { parseFrappeErrorMsg } from "@/lib/utils";
+import { hasTodoCustomFields, parseFrappeErrorMsg } from "@/lib/utils";
 import { useProjectDetail } from "@/pages/project-details/context";
 import { TodosContext, type TodosContextProps } from "./context";
 import type { TodoStatus } from "../create-todo/schema";
 import type { CreateTodoInput, TodoDoc } from "../types";
 import { useTodosData } from "../useTodosData";
+
+const customFieldValues = (input: CreateTodoInput) =>
+  hasTodoCustomFields()
+    ? {
+        custom_title: input.title,
+        custom_from_time: input.startAt,
+        custom_to_time: input.endAt,
+      }
+    : {};
 
 export function TodosProvider({ children }: PropsWithChildren) {
   const projectId = useProjectDetail((s) => s.projectId);
@@ -34,15 +43,13 @@ export function TodosProvider({ children }: PropsWithChildren) {
       setPending(true);
       try {
         const doc = (await createDoc("ToDo", {
-          custom_title: input.title,
           description: input.description,
           status: input.status,
           allocated_to: input.assignee,
-          custom_from_time: input.startAt,
-          custom_to_time: input.endAt,
           priority: input.priority,
           reference_type: "Project",
           reference_name: projectId,
+          ...customFieldValues(input),
         })) as TodoDoc;
         toast.success("To-do created");
         await mutate();
@@ -62,13 +69,11 @@ export function TodosProvider({ children }: PropsWithChildren) {
       setPending(true);
       try {
         const doc = (await updateDoc("ToDo", name, {
-          custom_title: input.title,
           description: input.description,
           status: input.status,
           allocated_to: input.assignee,
-          custom_from_time: input.startAt,
-          custom_to_time: input.endAt,
           priority: input.priority,
+          ...customFieldValues(input),
         })) as TodoDoc;
         toast.success("To-do updated");
         await mutate();

--- a/frontend/packages/app/src/pages/project-details/tabs/to-do/todoRow.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/to-do/todoRow.tsx
@@ -18,6 +18,7 @@ import { format, parseISO } from "date-fns";
 /**
  * Internal dependencies.
  */
+import { extractTextFromHTML, hasTodoCustomFields } from "@/lib/utils";
 import type { TodoPriority, TodoStatus } from "./create-todo/schema";
 import { useTodos } from "./provider/context";
 import type { Todo } from "./types";
@@ -75,7 +76,9 @@ export function TodoRow({ todo, onEdit }: TodoRowProps) {
     <div className="flex items-center gap-4 border-b border-outline-gray-2 py-4">
       <div className="min-w-0 flex-1">
         <h3 className="truncate text-base font-medium text-ink-gray-8">
-          {todo.custom_title || "Untitled"}
+          {todo.custom_title ||
+            extractTextFromHTML(todo.description) ||
+            "Untitled"}
         </h3>
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-ink-gray-5">
           <a
@@ -90,16 +93,20 @@ export function TodoRow({ todo, onEdit }: TodoRowProps) {
             />
             <span className="truncate">{todo.allocated_to_full_name}</span>
           </a>
-          <span aria-hidden>·</span>
-          <span className="flex items-center gap-1.5">
-            <Calendar className="size-3.5" />
-            {formatDateTime(todo.custom_from_time)}
-          </span>
-          <span aria-hidden>·</span>
-          <span className="flex items-center gap-1.5">
-            <Calendar className="size-3.5" />
-            {formatDateTime(todo.custom_to_time)}
-          </span>
+          {hasTodoCustomFields() && (
+            <>
+              <span aria-hidden>·</span>
+              <span className="flex items-center gap-1.5">
+                <Calendar className="size-3.5" />
+                {formatDateTime(todo.custom_from_time)}
+              </span>
+              <span aria-hidden>·</span>
+              <span className="flex items-center gap-1.5">
+                <Calendar className="size-3.5" />
+                {formatDateTime(todo.custom_to_time)}
+              </span>
+            </>
+          )}
           <span aria-hidden>·</span>
           <span className="flex items-center gap-1.5">
             <span

--- a/frontend/packages/app/src/pages/project-details/tabs/to-do/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/to-do/types.ts
@@ -14,9 +14,9 @@ export interface TodoDoc {
   allocated_to: string;
   assigned_by: string;
   assigned_by_full_name: string;
-  custom_from_time: string;
-  custom_title: string;
-  custom_to_time: string;
+  custom_from_time?: string;
+  custom_title?: string;
+  custom_to_time?: string;
   date: string;
   description: string;
   priority: TodoPriority;

--- a/frontend/packages/app/src/pages/project-details/tabs/to-do/useTodosData.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/to-do/useTodosData.ts
@@ -7,7 +7,7 @@ import { useFrappeGetDocList } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
-import { hashString } from "@/lib/utils";
+import { hasTodoCustomFields, hashString } from "@/lib/utils";
 import { useProjectDetail } from "@/pages/project-details/context";
 import type { Todo, TodoDoc, TodoUserDetails } from "./types";
 
@@ -23,27 +23,32 @@ export function useTodosData() {
     [projectId],
   );
 
+  const fields = useMemo(
+    () => [
+      "name",
+      "allocated_to",
+      "assigned_by",
+      "assigned_by_full_name",
+      ...(hasTodoCustomFields()
+        ? ["custom_from_time", "custom_title", "custom_to_time"]
+        : []),
+      "date",
+      "description",
+      "priority",
+      "reference_name",
+      "reference_type",
+      "status",
+      "owner",
+      "creation",
+      "modified",
+    ],
+    [],
+  );
+
   const { data, isLoading, error, mutate } = useFrappeGetDocList<TodoDoc>(
     "ToDo",
     {
-      fields: [
-        "name",
-        "allocated_to",
-        "assigned_by",
-        "assigned_by_full_name",
-        "custom_from_time",
-        "custom_title",
-        "custom_to_time",
-        "date",
-        "description",
-        "priority",
-        "reference_name",
-        "reference_type",
-        "status",
-        "owner",
-        "creation",
-        "modified",
-      ],
+      fields,
       filters: filters as never,
       orderBy: { field: "creation", order: "desc" },
       limit: 500,

--- a/frontend/packages/app/src/types/index.ts
+++ b/frontend/packages/app/src/types/index.ts
@@ -86,6 +86,7 @@ declare global {
         show_rag_trigger_page?: boolean;
         desk_theme?: string;
         has_todo_custom_fields?: boolean;
+        optional_project_fields?: Record<string, boolean>;
         is_calendar_setup: boolean;
         global_filters: GlobalFilters;
         allow_weekend_entries?: boolean;

--- a/next_pms/www/next-pms/index.py
+++ b/next_pms/www/next-pms/index.py
@@ -44,6 +44,7 @@ def get_context(context):
     boot["has_customer_feedback"] = is_customer_feedback_available()
     boot["show_rag_trigger_page"] = show_rag_trigger_page()
     boot["has_todo_custom_fields"] = has_todo_custom_fields()
+    boot["optional_project_fields"] = optional_project_fields()
     boot["is_calendar_setup"] = is_google_calendar_enabled()
     boot["global_filters"] = get_global_filters()
     boot["allow_weekend_entries"] = bool(
@@ -89,6 +90,7 @@ def get_boot():
     boot["has_customer_feedback"] = is_customer_feedback_available()
     boot["show_rag_trigger_page"] = show_rag_trigger_page()
     boot["has_todo_custom_fields"] = has_todo_custom_fields()
+    boot["optional_project_fields"] = optional_project_fields()
     boot["is_calendar_setup"] = is_google_calendar_enabled()
     boot["app_name"] = "Next PMS"
     boot["global_filters"] = get_global_filters()
@@ -117,6 +119,27 @@ def has_todo_custom_fields():
     """
     meta = frappe.get_meta("ToDo")
     return all(meta.has_field(fieldname) for fieldname in ("custom_title", "custom_from_time", "custom_to_time"))
+
+
+OPTIONAL_PROJECT_FIELDS = (
+    "custom_source",
+    "custom_territory",
+    "custom_previous_cms",
+    "custom_restricted_under_nda",
+    "custom_permission_for_case_study",
+    "custom_permission_for_testimonial",
+)
+
+
+def optional_project_fields():
+    """Availability map for Project custom fields that Next PMS renders but does not ship.
+
+    They come from other apps installed alongside Next PMS, so the frontend must check
+    each one before binding an editor to it - writes to a field that has no column are
+    silently discarded by the REST layer.
+    """
+    meta = frappe.get_meta("Project")
+    return {fieldname: bool(meta.has_field(fieldname)) for fieldname in OPTIONAL_PROJECT_FIELDS}
 
 
 def get_global_filters():


### PR DESCRIPTION
## Description

- Added utility functions `hasProjectField` and `hasTodoCustomFields` in `utils.ts` to check for the presence of optional fields based on backend-provided configuration (`window.frappe.boot`). 
- Updated the Project Overview form (`overview/index.tsx`) to dynamically include or exclude optional project fields (like sourcing and marketing fields) in both the UI and form submission payloads, using the new utility functions and a central mapping of field readers. 
- The Sourcing and Marketing sections now conditionally render their respective fields only if enabled for the current project, improving the user experience and preventing unnecessary fields from appearing. 
- To-Do creation, update, and data fetching now include custom fields (`custom_title`, `custom_from_time`, `custom_to_time`) only if they are enabled for the current installation, as determined by the backend. 
- The To-Do row component (`todoRow.tsx`) conditionally displays these custom fields, and provides a fallback to extracting text from the description if a custom title is not present.
- The backend now exposes `optional_project_fields` and `has_todo_custom_fields` in the boot context, enabling the frontend to adapt dynamically to the available fields.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**Without Other Apps** 
<img width="910" height="582" alt="image" src="https://github.com/user-attachments/assets/df3fc0bf-f005-48a9-bed9-7c2f32c1d284" />

<img width="542" height="415" alt="image" src="https://github.com/user-attachments/assets/7dd0f855-42e0-4852-b3c7-47ce7ee801ab" />


**With other Apps** 
<img width="1069" height="637" alt="image" src="https://github.com/user-attachments/assets/dd7a72b4-46f8-40fa-9b5d-46e31e049773" />
<img width="553" height="518" alt="image" src="https://github.com/user-attachments/assets/025c075d-4814-4c95-81e7-aacdad1ff23f" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #281 