### PR TITLE
feat(resource-management): show public holidays on the team allocation page

### DIFF
--- a/frontend/packages/app/src/pages/allocations/team/type.ts
+++ b/frontend/packages/app/src/pages/allocations/team/type.ts
@@ -24,6 +24,12 @@ export interface Leave {
   name: string;
 }
 
+export interface Holiday {
+  employee: string;
+  holiday_date: string;
+  description: string;
+}
+
 export interface ResourceAllocation {
   name: string;
   employee: string;
@@ -60,6 +66,7 @@ export interface Permissions {
 export interface TeamAllocationResponse {
   employees: Employee[];
   leaves: Leave[];
+  holidays: Holiday[];
   resource_allocations: ResourceAllocation[];
   customer: Record<string, Customer>;
   total_count: number;

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -13,6 +13,7 @@ import {
 import { teamAllocationStatusOptionValues } from "./constants";
 import type {
   AllocationTypeSelection,
+  Holiday,
   ManagerNameMap,
   TeamAllocationResponse,
 } from "./type";
@@ -91,6 +92,30 @@ function parseLeaveHalfDayPortion(
 }
 
 /**
+ * Groups each employee's public holidays into single-day LeaveAllocation ranges, one per
+ * holiday, labelled with the holiday's name so they render distinctly from approved leave
+ * (which falls back to the generic "N days off" wording when no label is set).
+ */
+function buildEmployeeHolidayAllocations(
+  holidayList: Holiday[],
+): Map<string, LeaveAllocation[]> {
+  const holidaysByEmployee = new Map<string, LeaveAllocation[]>();
+
+  for (const holiday of holidayList) {
+    const date = parseISO(holiday.holiday_date);
+    const employeeHolidays = holidaysByEmployee.get(holiday.employee) ?? [];
+    employeeHolidays.push({
+      startDate: date,
+      endDate: date,
+      label: holiday.description.trim() || "Holiday",
+    });
+    holidaysByEmployee.set(holiday.employee, employeeHolidays);
+  }
+
+  return holidaysByEmployee;
+}
+
+/**
  * Converts a TeamAllocationResponse from the API into a Member[] array
  * suitable for the GanttGrid component.
  *
@@ -101,11 +126,13 @@ export function mapTeamAllocationToMembers(
   response: TeamAllocationResponse,
   managerNameMap?: ManagerNameMap,
 ): Member[] {
-  const { employees, resource_allocations, customer, leaves } = response;
+  const { employees, resource_allocations, customer, leaves, holidays } =
+    response;
 
   const employeeList = employees ?? [];
   const allocationList = resource_allocations ?? [];
   const leaveList = leaves ?? [];
+  const holidaysByEmployee = buildEmployeeHolidayAllocations(holidays ?? []);
 
   // Group allocations by employee, then by project
   const allocationsByEmployee = new Map<
@@ -178,7 +205,10 @@ export function mapTeamAllocationToMembers(
         )
       : [];
 
-    const memberLeaves = leavesByEmployee.get(employee.name) ?? [];
+    const memberLeaves = [
+      ...(leavesByEmployee.get(employee.name) ?? []),
+      ...(holidaysByEmployee.get(employee.name) ?? []),
+    ];
 
     return {
       id: employee.name,

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/ganttBar.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import React from "react";
+import React, { type ComponentType, type SVGProps } from "react";
 import { Tooltip } from "@rtcamp/frappe-ui-react";
 import { TimeOff } from "@rtcamp/frappe-ui-react/icons";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -79,6 +79,7 @@ interface GanttBarProps
   renderLabel?: (state: GanttBarRenderState) => React.ReactNode;
   renderFloatingLabel?: (state: GanttBarRenderState) => React.ReactNode;
   showInlineLabel?: boolean;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
   trailingLabel?: React.ReactNode;
   trailingLabelVariant?: GanttBarTrailingLabelVariant;
   /**
@@ -110,6 +111,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
       showInlineLabel = true,
       trailingLabel,
       trailingLabelVariant,
+      icon: Icon = TimeOff,
       passive = false,
       onClick,
       style,
@@ -168,7 +170,7 @@ export const GanttBar = React.forwardRef<HTMLDivElement, GanttBarProps>(
         {isTimeoff ? (
           <Tooltip text={label}>
             <div className="absolute inset-0 px-2.5 py-2 w-full flex items-center justify-center gap-1.5">
-              <TimeOff
+              <Icon
                 className="shrink-0 size-4 text-ink-gray-5"
                 size={16}
                 strokeWidth={1.5}

--- a/frontend/packages/design-system/src/components/gantt-view/gantt-bar/timeoffBar.tsx
+++ b/frontend/packages/design-system/src/components/gantt-view/gantt-bar/timeoffBar.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies.
+ */
+import { Holiday } from "@rtcamp/frappe-ui-react/icons";
+
+/**
  * Internal dependencies.
  */
 import { CELL_WIDTH } from "../constants";
@@ -25,13 +30,13 @@ export function GanttTimeoffBar({
   width,
 }: GanttTimeoffBarProps) {
   const resolvedLabel = label ?? getTimeoffLabel(startDate, endDate, timeoff);
+  const isHoliday = label !== undefined;
 
   return (
     <GanttBar
       variant="timeoff"
       label={resolvedLabel}
-      // A single narrow day-column has room for the icon only; rendering the label
-      // span anyway would still reserve its flex gap and shift the icon off-centre.
+      icon={isHoliday ? Holiday : undefined}
       showInlineLabel={width > CELL_WIDTH}
       left={left}
       width={width}

--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -305,8 +305,8 @@ doc_events = {
             "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
         ],
     },
-    # Reassigning an employee to a different Holiday List changes which holidays the
-    # resource views resolve for them, so the cached payloads must be dropped too.
+    # An employee's holidays resolve through their Holiday List Assignment, so reassigning
+    # one changes the holidays the cached resource payloads were built from.
     "Holiday List Assignment": {
         "on_submit": [
             "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",

--- a/next_pms/hooks.py
+++ b/next_pms/hooks.py
@@ -298,6 +298,28 @@ doc_events = {
     },
     "Holiday List": {
         "validate": "next_pms.timesheet.doc_events.holiday_list.validate",
+        "on_update": [
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
+        "on_trash": [
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
+    },
+    # Reassigning an employee to a different Holiday List changes which holidays the
+    # resource views resolve for them, so the cached payloads must be dropped too.
+    "Holiday List Assignment": {
+        "on_submit": [
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
+        "on_update_after_submit": [
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
+        "on_cancel": [
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
+        "on_trash": [
+            "next_pms.resource_management.doctype.resource_allocation.resource_allocation.clear_cache",
+        ],
     },
 }
 #

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -190,7 +190,6 @@ def get_resource_management_team_view_data(
                             "is_on_leave": False,
                             "total_leave_hours": 0.0,
                             "is_holiday": False,
-                            "holiday_name": "Independence Day",  # only present when is_holiday is True
                             "employee_resource_allocation_for_given_date": [
                                 {
                                     "name": "RA-00001",
@@ -200,6 +199,21 @@ def get_resource_management_team_view_data(
                                 },
                             ],
                         },
+                        # a holiday zeroes the day's working hours, so it always lands in
+                        # the sparse map even with no allocation; `holiday_name` is
+                        # emitted only on such a day
+                        "2026-05-25": {
+                            "date": "2026-05-25",
+                            "total_allocated_hours": 0.0,
+                            "total_working_hours": 0.0,
+                            "total_worked_hours": 0.0,  # write permission only
+                            "total_allocation_count": 0,
+                            "is_on_leave": True,
+                            "total_leave_hours": 8.0,
+                            "is_holiday": True,
+                            "holiday_name": "Independence Day",
+                            "employee_resource_allocation_for_given_date": [],
+                        },
                     },
                     "all_week_data": {
                         "This Week": {
@@ -208,7 +222,7 @@ def get_resource_management_team_view_data(
                             "total_worked_hours": 32.0,  # write permission only
                         },
                     },
-                    "all_leave_data": {"2026-05-20": 8.0},
+                    "all_leave_data": {"2026-05-20": 8.0, "2026-05-25": 8.0},
                     "employee_allocations": [],
                 },
             ],

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -135,9 +135,7 @@ def get_resource_management_team_view_data(
                     "name": "HR-LAP-00001",
                 },
             ],
-            # every employee's holidays for the window, independent of allocation or
-            # leave — an employee with nothing else booked still gets their holidays
-            "holidays": [
+            "holidays": [  # independent of allocation — an unallocated employee still gets these
                 {
                     "employee": "HR-EMP-00001",
                     "holiday_date": datetime.date(2026, 5, 25),
@@ -199,9 +197,7 @@ def get_resource_management_team_view_data(
                                 },
                             ],
                         },
-                        # a holiday zeroes the day's working hours, so it always lands in
-                        # the sparse map even with no allocation; `holiday_name` is
-                        # emitted only on such a day
+                        # a holiday zeroes the day's working hours, so it lands here with no allocation
                         "2026-05-25": {
                             "date": "2026-05-25",
                             "total_allocated_hours": 0.0,
@@ -540,9 +536,7 @@ def _get_resource_management_team_view_data(
     if not need_hours_summary:
         leaves_map, holidays_map = get_leave_calendars(employees, dates[0].get("start_date"), dates[-1].get("end_date"))
         all_leave_data = [leave for employee_leaves in leaves_map.values() for leave in employee_leaves]
-        # Holidays apply to every employee regardless of allocation, so they are
-        # collected independently of leaves — a weekly_off entry marks the routine
-        # weekend, not a named holiday, so it is dropped here.
+        # weekly_off rows mark the routine weekend, not a named holiday.
         all_holiday_data = [
             {
                 "employee": employee_name,

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -2,7 +2,7 @@ import json
 
 import frappe
 from frappe.core.doctype.recorder.recorder import redis_cache
-from frappe.utils import DATE_FORMAT
+from frappe.utils import DATE_FORMAT, strip_html_tags
 
 from next_pms.resource_management.api.utils.helpers import (
     _parse_multi_select_filter,
@@ -21,7 +21,6 @@ from next_pms.resource_management.api.utils.leave_calendar import get_leave_cale
 from next_pms.resource_management.api.utils.query import (
     attach_extra_entries,
     get_allocation_list_for_employee_for_given_range,
-    get_employee_leaves,
 )
 from next_pms.timesheet.api import filter_employees
 from next_pms.timesheet.api.employee import apply_working_hours_fallback, get_employee_working_hours
@@ -136,6 +135,15 @@ def get_resource_management_team_view_data(
                     "name": "HR-LAP-00001",
                 },
             ],
+            # every employee's holidays for the window, independent of allocation or
+            # leave — an employee with nothing else booked still gets their holidays
+            "holidays": [
+                {
+                    "employee": "HR-EMP-00001",
+                    "holiday_date": datetime.date(2026, 5, 25),
+                    "description": "Independence Day",
+                },
+            ],
             "resource_allocations": [
                 {
                     "name": "RA-00001",
@@ -181,6 +189,8 @@ def get_resource_management_team_view_data(
                             "total_allocation_count": 2,
                             "is_on_leave": False,
                             "total_leave_hours": 0.0,
+                            "is_holiday": False,
+                            "holiday_name": "Independence Day",  # only present when is_holiday is True
                             "employee_resource_allocation_for_given_date": [
                                 {
                                     "name": "RA-00001",
@@ -349,6 +359,7 @@ def _get_resource_management_team_view_data(
                     res["employees"] = []
                     res["resource_allocations"] = []
                     res["leaves"] = []
+                    res["holidays"] = []
                     res["customer"] = {}
                     res["total_count"] = 0
                     res["has_more"] = False
@@ -423,6 +434,7 @@ def _get_resource_management_team_view_data(
                     res["employees"] = []
                     res["resource_allocations"] = []
                     res["leaves"] = []
+                    res["holidays"] = []
                 res["customer"] = customer
                 res["total_count"] = 0
                 res["has_more"] = False
@@ -453,6 +465,7 @@ def _get_resource_management_team_view_data(
             res["employees"] = []
             res["resource_allocations"] = []
             res["leaves"] = []
+            res["holidays"] = []
         res["customer"] = customer
         res["total_count"] = total_count
         res["has_more"] = False
@@ -511,13 +524,24 @@ def _get_resource_management_team_view_data(
         resource_allocation_map[resource_allocation.employee].append(resource_allocation)
 
     if not need_hours_summary:
-        all_leave_data = get_employee_leaves(
-            employee=tuple(employee.name for employee in employees),
-            start_date=dates[0].get("start_date"),
-            end_date=dates[-1].get("end_date"),
-        )
+        leaves_map, holidays_map = get_leave_calendars(employees, dates[0].get("start_date"), dates[-1].get("end_date"))
+        all_leave_data = [leave for employee_leaves in leaves_map.values() for leave in employee_leaves]
+        # Holidays apply to every employee regardless of allocation, so they are
+        # collected independently of leaves — a weekly_off entry marks the routine
+        # weekend, not a named holiday, so it is dropped here.
+        all_holiday_data = [
+            {
+                "employee": employee_name,
+                "holiday_date": holiday.holiday_date,
+                "description": strip_html_tags(holiday.description or "").strip(),
+            }
+            for employee_name, holidays in holidays_map.items()
+            for holiday in holidays
+            if not holiday.get("weekly_off")
+        ]
         res["employees"] = employees
         res["leaves"] = all_leave_data
+        res["holidays"] = all_holiday_data
         res["resource_allocations"] = resource_allocation_data
         res["customer"] = customer
         res["total_count"] = total_count
@@ -560,6 +584,9 @@ def _get_resource_management_team_view_data(
         timesheet_data = timesheet_map.get(employee.name, [])
         leaves = leaves_map.get(employee.name, [])
         holidays = holidays_map.get(employee.name, [])
+        holiday_names_by_date = {
+            holiday.holiday_date: strip_html_tags(holiday.description or "").strip() for holiday in holidays
+        }
 
         all_dates_data, all_week_data, all_leave_data = {}, {}, {}
         max_allocation_count_for_single_date = 0
@@ -583,6 +610,9 @@ def _get_resource_management_team_view_data(
                 employee_resource_allocation_for_given_date = []
 
                 leave_object = is_on_leave(date, daily_working_hours, leaves, holidays)
+
+                is_holiday = date in holiday_names_by_date
+                holiday_name = holiday_names_by_date.get(date)
 
                 if leave_object.get("on_leave") and not leave_object.get("leave_work_hours"):
                     # If employee is on leave and not working on that day then total working hours will be 0
@@ -634,6 +664,8 @@ def _get_resource_management_team_view_data(
                         "is_on_leave": leave_object.get("on_leave"),
                         "total_leave_hours": daily_working_hours - total_working_hours_for_given_date,
                         "total_allocation_count": total_allocation_count,
+                        "is_holiday": is_holiday,
+                        **({"holiday_name": holiday_name} if holiday_name else {}),
                     }
 
                 else:
@@ -645,6 +677,8 @@ def _get_resource_management_team_view_data(
                         "is_on_leave": leave_object.get("on_leave"),
                         "total_leave_hours": daily_working_hours - total_working_hours_for_given_date,
                         "total_allocation_count": total_allocation_count,
+                        "is_holiday": is_holiday,
+                        **({"holiday_name": holiday_name} if holiday_name else {}),
                     }
 
                 if date_data["total_allocation_count"] > 0 or date_data["is_on_leave"]:

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -692,7 +692,6 @@ class TestTeamViewFlatGridHolidays(_TeamViewBase):
         super().setUpClass()
         cls.company = get_default_company()
         cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
-        # No allocations at all — proves holidays surface independent of allocation status.
         cls.employee = cls._make_employee("Tvh Holiday Employee")
         cls.only = json.dumps([cls.employee])
 
@@ -730,8 +729,6 @@ class TestTeamViewFlatGridHolidays(_TeamViewBase):
         return self._call(employee_id=self.only, need_hours_summary=False)["holidays"]
 
     def test_unallocated_employee_still_gets_holidays(self):
-        # #2003: an employee with no resource allocation in the window must still surface
-        # their holidays, so the FE can mark holiday cells even on otherwise-empty days.
         result = self._call(employee_id=self.only, need_hours_summary=False)
         self.assertEqual(result["resource_allocations"], [])
         holiday_dates = {getdate(holiday["holiday_date"]) for holiday in result["holidays"]}
@@ -742,8 +739,7 @@ class TestTeamViewFlatGridHolidays(_TeamViewBase):
         self.assertNotIn(getdate(self.OUT_OF_WINDOW_HOLIDAY_DATE), holiday_dates)
 
     def test_excludes_weekly_off_placeholders(self):
-        # weekly_off entries (Saturday/Sunday) are routine, not named holidays, and must be
-        # dropped so the FE doesn't mark every weekend as a "holiday".
+        # weekly_off rows mark the routine weekend, so keeping them would flag every weekend.
         for holiday in self._holidays():
             self.assertNotEqual(holiday["description"], "Saturday")
 
@@ -755,9 +751,8 @@ class TestTeamViewFlatGridHolidays(_TeamViewBase):
         self.assertEqual(holiday["description"], "Testing holiday")
 
     def test_editing_the_holiday_list_invalidates_the_cached_payload(self):
-        # #2003 AC: "the calendar shall accurately reflect updates when holidays are added,
-        # modified, or removed". The team view is @redis_cache()d, so a Holiday List save
-        # has to drop that cache or the page keeps serving the pre-edit holidays.
+        # The view is @redis_cache()d, so a save that misses the invalidation would keep
+        # serving the pre-edit holidays.
         added_date = "2026-06-18"
         # The redis cache outlives the per-test rollback, so drop it for the next test.
         self.addCleanup(frappe.clear_cache)

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -710,6 +710,7 @@ class TestTeamViewFlatGridHolidays(_TeamViewBase):
             }
         )
         holiday_list.insert(ignore_permissions=True)
+        cls.holiday_list = holiday_list.name
         frappe.db.set_value("Employee", cls.employee, "holiday_list", holiday_list.name)
         # hrms resolves an employee's holiday list from Holiday List Assignment, not the
         # Employee.holiday_list field directly — mirrors assign_empty_holiday_list.
@@ -752,6 +753,21 @@ class TestTeamViewFlatGridHolidays(_TeamViewBase):
         )
         self.assertEqual(holiday["employee"], self.employee)
         self.assertEqual(holiday["description"], "Testing holiday")
+
+    def test_editing_the_holiday_list_invalidates_the_cached_payload(self):
+        # #2003 AC: "the calendar shall accurately reflect updates when holidays are added,
+        # modified, or removed". The team view is @redis_cache()d, so a Holiday List save
+        # has to drop that cache or the page keeps serving the pre-edit holidays.
+        added_date = "2026-06-18"
+        # The redis cache outlives the per-test rollback, so drop it for the next test.
+        self.addCleanup(frappe.clear_cache)
+        self.assertNotIn(getdate(added_date), {getdate(row["holiday_date"]) for row in self._holidays()})
+
+        holiday_list = frappe.get_doc("Holiday List", self.holiday_list)
+        holiday_list.append("holidays", {"holiday_date": added_date, "description": "Added later", "weekly_off": 0})
+        holiday_list.save(ignore_permissions=True)
+
+        self.assertIn(getdate(added_date), {getdate(row["holiday_date"]) for row in self._holidays()})
 
 
 class TestTeamViewFlatGridLeaves(_TeamViewBase):

--- a/next_pms/tests/resource_management/api/test_team.py
+++ b/next_pms/tests/resource_management/api/test_team.py
@@ -676,6 +676,84 @@ class TestTeamViewHoursSummaryShape(_TeamViewBase):
         self.assertIn("all_week_data", entry)
 
 
+class TestTeamViewFlatGridHolidays(_TeamViewBase):
+    """The `holidays` payload the flat grid uses to mark holiday cells.
+
+    Holidays are company/holiday-list wide, not tied to an allocation, so an employee with
+    zero resource allocations in the window must still surface their holidays — unlike
+    `leaves`/`resource_allocations`, which are naturally empty for an unallocated employee.
+    """
+
+    TEAM_HOLIDAY_DATE = "2026-06-17"  # A Wednesday inside the [2026-06-15, 2026-06-28] window.
+    OUT_OF_WINDOW_HOLIDAY_DATE = "2026-07-02"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.write_user = cls._make_user(FILTER_WRITE_USER, projects_user=True)
+        # No allocations at all — proves holidays surface independent of allocation status.
+        cls.employee = cls._make_employee("Tvh Holiday Employee")
+        cls.only = json.dumps([cls.employee])
+
+        holiday_list = frappe.get_doc(
+            {
+                "doctype": "Holiday List",
+                "holiday_list_name": "TV Holiday Grid List",
+                "from_date": "2026-01-01",
+                "to_date": "2026-12-31",
+                "holidays": [
+                    {"holiday_date": cls.TEAM_HOLIDAY_DATE, "description": "Testing holiday", "weekly_off": 0},
+                    {"holiday_date": cls.OUT_OF_WINDOW_HOLIDAY_DATE, "description": "Out of window", "weekly_off": 0},
+                    {"holiday_date": "2026-06-20", "description": "Saturday", "weekly_off": 1},
+                ],
+            }
+        )
+        holiday_list.insert(ignore_permissions=True)
+        frappe.db.set_value("Employee", cls.employee, "holiday_list", holiday_list.name)
+        # hrms resolves an employee's holiday list from Holiday List Assignment, not the
+        # Employee.holiday_list field directly — mirrors assign_empty_holiday_list.
+        frappe.get_doc(
+            {
+                "doctype": "Holiday List Assignment",
+                "applicable_for": "Employee",
+                "assigned_to": cls.employee,
+                "holiday_list": holiday_list.name,
+                "from_date": "2026-01-01",
+            }
+        ).insert(ignore_permissions=True).submit()
+
+        frappe.clear_cache()
+
+    def _holidays(self):
+        return self._call(employee_id=self.only, need_hours_summary=False)["holidays"]
+
+    def test_unallocated_employee_still_gets_holidays(self):
+        # #2003: an employee with no resource allocation in the window must still surface
+        # their holidays, so the FE can mark holiday cells even on otherwise-empty days.
+        result = self._call(employee_id=self.only, need_hours_summary=False)
+        self.assertEqual(result["resource_allocations"], [])
+        holiday_dates = {getdate(holiday["holiday_date"]) for holiday in result["holidays"]}
+        self.assertIn(getdate(self.TEAM_HOLIDAY_DATE), holiday_dates)
+
+    def test_excludes_out_of_window_holidays(self):
+        holiday_dates = {getdate(holiday["holiday_date"]) for holiday in self._holidays()}
+        self.assertNotIn(getdate(self.OUT_OF_WINDOW_HOLIDAY_DATE), holiday_dates)
+
+    def test_excludes_weekly_off_placeholders(self):
+        # weekly_off entries (Saturday/Sunday) are routine, not named holidays, and must be
+        # dropped so the FE doesn't mark every weekend as a "holiday".
+        for holiday in self._holidays():
+            self.assertNotEqual(holiday["description"], "Saturday")
+
+    def test_holiday_carries_employee_and_description(self):
+        holiday = next(
+            row for row in self._holidays() if getdate(row["holiday_date"]) == getdate(self.TEAM_HOLIDAY_DATE)
+        )
+        self.assertEqual(holiday["employee"], self.employee)
+        self.assertEqual(holiday["description"], "Testing holiday")
+
+
 class TestTeamViewFlatGridLeaves(_TeamViewBase):
     """The `leaves` payload the flat grid renders time-off bars from.
 


### PR DESCRIPTION
## Description
- Displays public holidays on the Team Allocation calendar, matching what #2069 already does on the Project allocation page.
- Both team and project page now use a visually distinct icon for holidays.


## Screenshot/Screencast
<img width="3130" height="1844" alt="image" src="https://github.com/user-attachments/assets/c32273f2-4206-4c49-99d3-34d48376f300" />

<img width="2256" height="1654" alt="image" src="https://github.com/user-attachments/assets/cd475cc2-d56b-4a17-9ffd-41ec518ca1a6" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #2003