### PR TITLE
fix: stop broadcasting member-week detail to the site room

### DIFF
--- a/frontend/packages/app/src/pages/timesheet/team/context.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/context.ts
@@ -15,7 +15,7 @@ import type {
   TeamWeekSummary,
 } from "./types";
 
-export type MemberRefreshHandler = (member: TeamMemberPayload) => void;
+export type MemberRefreshHandler = (member: TeamMemberPayload | null) => void;
 
 export interface TeamTimesheetContextProps {
   state: {

--- a/frontend/packages/app/src/pages/timesheet/team/provider.tsx
+++ b/frontend/packages/app/src/pages/timesheet/team/provider.tsx
@@ -164,10 +164,10 @@ export const TeamTimesheetProvider: FC<PropsWithChildren> = ({ children }) => {
       );
       if (!week) return;
 
-      const handler = refreshRegistry.current.get(week.start_date);
-      if (handler && info.message) {
-        handler(info.message);
-      }
+      // A site-wide update arrives without `message` - the detailed member-week is
+      // routed only to the user who wrote the timesheet - so pass null and let the
+      // week refetch through the role-checked endpoint.
+      refreshRegistry.current.get(week.start_date)?.(info.message ?? null);
       void refreshWeeks();
     },
     [refreshWeeks],

--- a/frontend/packages/app/src/pages/timesheet/team/useTeamWeekMembers.ts
+++ b/frontend/packages/app/src/pages/timesheet/team/useTeamWeekMembers.ts
@@ -30,7 +30,7 @@ type UseTeamWeekMembersResult = {
   isLoadingMembers: boolean;
   isNextPageLoading: boolean;
   loadMore: () => void;
-  refreshMember: (member: TeamMemberPayload) => void;
+  refreshMember: (member: TeamMemberPayload | null) => void;
 };
 
 const QUERY_SIGNATURE_PREFIX = "team-week-members:";
@@ -130,8 +130,15 @@ export function useTeamWeekMembers({
   }, [hasMore, isLoading, isNextPageLoading, setSize]);
 
   const refreshMember = useCallback(
-    (member: TeamMemberPayload) => {
+    (member: TeamMemberPayload | null) => {
       if (!paginatedData?.length) {
+        return;
+      }
+
+      // No member means the update arrived as an invalidation, so the week has to be
+      // refetched through get_team_timesheet_data, which enforces the viewing roles.
+      if (!member) {
+        void mutate();
         return;
       }
 

--- a/next_pms/tests/timesheet/api/test_team_timesheet_data.py
+++ b/next_pms/tests/timesheet/api/test_team_timesheet_data.py
@@ -854,13 +854,13 @@ class TestTeamTimesheetMemberWeek(_TeamTimesheetDataBase):
         frappe.set_user(WRITE_USER)
         self.assertIsNone(get_team_timesheet_member_week(employee="EMP-does-not-exist", start_date=W1_MON))
 
-    def test_publisher_payload_carries_member_employee_and_start_date(self):
-        """Regression guard for D2: the published shape was never asserted, and the
-        page silently discarded every realtime update for it."""
+    def _capture_timesheet_info(self):
+        """Run the publisher with publish_realtime stubbed, returning its timesheet_info
+        calls as (message, kwargs) pairs."""
         published = []
 
         def capture(event, message, **kwargs):
-            published.append((event, message))
+            published.append((event, message, kwargs))
 
         frappe.set_user(WRITE_USER)
         original = frappe.publish_realtime
@@ -877,13 +877,44 @@ class TestTeamTimesheetMemberWeek(_TeamTimesheetDataBase):
         finally:
             frappe.publish_realtime = original
 
-        info = [message for event, message in published if event == "timesheet_info"]
+        return [(message, kwargs) for event, message, kwargs in published if event == "timesheet_info"]
+
+    def test_publisher_payload_carries_member_employee_and_start_date(self):
+        """Regression guard for D2: the published shape was never asserted, and the
+        page silently discarded every realtime update for it."""
+        info = self._capture_timesheet_info()
         self.assertTrue(info, "no timesheet_info event published")
-        for payload in info:
-            self.assertEqual(sorted(payload), ["employee", "message", "start_date"])
+        for payload, _kwargs in info:
             self.assertEqual(payload["employee"], self.r1)
+            self.assertEqual(payload["start_date"], W1_MON)
+
+    def test_site_room_broadcast_carries_no_member_detail(self):
+        """The site room is every logged-in System User - joined on socket connect with no
+        role check - so it must get an invalidation only. Shipping the member-week there
+        hands another employee's tasks, hours and leave to clients that would fail
+        get_team_timesheet_data's only_for."""
+        info = self._capture_timesheet_info()
+
+        broadcasts = [payload for payload, kwargs in info if kwargs.get("room")]
+        self.assertTrue(broadcasts, "no site-room timesheet_info event published")
+        for payload in broadcasts:
+            self.assertEqual(sorted(payload), ["employee", "start_date"])
+
+        targeted = [payload for payload, kwargs in info if kwargs.get("user")]
+        self.assertTrue(targeted, "no user-targeted timesheet_info event published")
+        for payload in targeted:
+            self.assertEqual(sorted(payload), ["employee", "message", "start_date"])
             self.assertIn("tasks", payload["message"])
             self.assertIn("status", payload["message"])
+
+    def test_is_not_exposed_over_http(self):
+        """The function takes `by_pass_access_check`, which skips only_for. Every other test
+        here calls it in-process, so all of them would still pass if @whitelist were
+        restored - this asserts the boundary itself, through the gate frappe.handler uses."""
+        method = frappe.get_attr("next_pms.timesheet.api.team.get_team_timesheet_member_week")
+        self.assertNotIn(method, frappe.whitelisted)
+        with self.assertRaises(frappe.PermissionError):
+            frappe.is_whitelisted(method)
 
 
 class TestTeamTimesheetDataBackdateRestriction(_TeamTimesheetDataBase):

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -371,13 +371,19 @@ def get_team_timesheet_weeks(
     }
 
 
-@whitelist(methods=["GET", "POST"])
 @error_logger
 def get_team_timesheet_member_week(employee: str, start_date: str, by_pass_access_check: bool = False):
     """One member's row for one week - the unit the realtime publisher swaps in.
 
     Returns exactly one element of `get_team_timesheet_data`'s `members`, so a realtime
     update replaces a single row instead of forcing a reload of the whole week.
+
+    Deliberately not whitelisted, mirroring `get_project_timesheet_member_week`.
+    `by_pass_access_check` exists for the publisher, which runs as whoever saved the
+    timesheet and so cannot be assumed to hold the viewing roles; exposing that switch
+    over HTTP let any logged-in user skip `only_for` and read another employee's tasks,
+    hours and leave. The page never calls this directly - it reads
+    `get_team_timesheet_data` - so there is nothing to expose.
     """
     if not by_pass_access_check:
         only_for(["Timesheet Manager", "Timesheet User", "Projects Manager"], message=True)

--- a/next_pms/timesheet/doc_events/timesheet.py
+++ b/next_pms/timesheet/doc_events/timesheet.py
@@ -414,13 +414,20 @@ def publish_timesheet_update(employee, start_date):
         start_date=get_date_str(start_date),
         by_pass_access_check=True,
     )
-    payload = {
-        "message": member,
-        "employee": employee,
-        "start_date": get_date_str(start_date),
-    }
-    publish_realtime("timesheet_info", payload, after_commit=True, room=get_site_room())
-    publish_realtime("timesheet_info", payload, after_commit=True, user=frappe.session.user)
+    # Same split as project_timesheet_info below: the member-week carries another
+    # employee's tasks, hours and leave, and the site room is every logged-in System User
+    # - joined automatically on socket connect, with no role check - so it gets an
+    # invalidation only. Authorized viewers reload the week through get_team_timesheet_data,
+    # which enforces only_for. The editor, authorized by having just written the timesheet,
+    # keeps the payload so their own row swaps in without a round trip.
+    member_invalidation = {"employee": employee, "start_date": get_date_str(start_date)}
+    publish_realtime("timesheet_info", member_invalidation, after_commit=True, room=get_site_room())
+    publish_realtime(
+        "timesheet_info",
+        {**member_invalidation, "message": member},
+        after_commit=True,
+        user=frappe.session.user,
+    )
 
     # The project timesheet groups by project, so it needs the employee's whole week keyed
     # by project - a single member-week would not tell it which project rows to update, nor


### PR DESCRIPTION
## Description

This pull request makes an important security-related change to the `get_team_timesheet_member_week` function in `next_pms/timesheet/api/team.py`. The function is no longer whitelisted for HTTP access, which prevents users from bypassing access controls and viewing other employees' timesheet data.

**Security and Access Control Improvements:**

* Removed the `@whitelist` decorator from `get_team_timesheet_member_week`, so it is no longer exposed as an HTTP endpoint. This prevents any logged-in user from using the `by_pass_access_check` parameter to read another employee's timesheet details, improving the security of sensitive employee data.
* Added a detailed docstring explaining the rationale for not exposing this function over HTTP and clarifying the intended usage and security considerations.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast


https://github.com/user-attachments/assets/f5ef44fb-e394-4eb7-afa4-bf095acac99b




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #2107 