### PR TITLE
feat: Add designation lookup endpoint with ranking and pagination tests

### DIFF
--- a/frontend/packages/app/src/hooks/useDesignationLookup.ts
+++ b/frontend/packages/app/src/hooks/useDesignationLookup.ts
@@ -41,13 +41,11 @@ export const useDesignationLookup = ({
     query,
     pageSize,
     revalidateOnFocus,
+    method: "next_pms.api.designation.get_designations",
     params: ({ query: searchQuery, pageSize }) => ({
-      doctype: "Designation",
-      fields: ["name"],
-      limit_page_length: pageSize,
-      or_filters: searchQuery
-        ? [["Designation", "name", "like", `%${searchQuery}%`]]
-        : undefined,
+      search: searchQuery || undefined,
+      page_length: pageSize,
+      start: 0,
     }),
     getItems: (message) => message ?? [],
     mapOption: (designation) => ({

--- a/frontend/packages/app/src/pages/allocations/team/subHeader.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/subHeader.tsx
@@ -108,7 +108,7 @@ export function SubHeader() {
 
   const { options: designationOptions, isLoading: isDesignationLookupLoading } =
     useDesignationLookup({
-      shouldFetch: true,
+      shouldFetch: showFilters,
       query: designationQuery,
     });
 

--- a/next_pms/api/designation.py
+++ b/next_pms/api/designation.py
@@ -1,0 +1,61 @@
+import frappe
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Count
+
+DEFAULT_PAGE_LENGTH = 20
+MAX_PAGE_LENGTH = 100
+
+
+def _escape_like(term: str) -> str:
+    """Neutralize LIKE wildcards so a `%` in the search box matches literally."""
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+@frappe.whitelist(methods=["GET"])
+def get_designations(search: str | None = None, page_length: int = DEFAULT_PAGE_LENGTH, start: int = 0) -> list[dict]:
+    """Return designations that at least one active employee is mapped to, most used first.
+
+    Drop-in replacement for the `frappe.client.get_list` call the Designation
+    dropdown on the allocations page makes, so it returns the same
+    `[{"name": ...}]` shape. The list is derived from Employee rather than the
+    Designation doctype, so a designation nobody is mapped to is never offered
+    as an option. The employee counts only order the result; they are not
+    returned. Ties are broken alphabetically to keep paging stable.
+
+    Args:
+        search: Case-insensitive substring matched against the designation name.
+            LIKE wildcards in the term are escaped. Blank or whitespace-only
+            disables the filter.
+        page_length: Rows to return in this page. Clamped to 1..100. Frappe's
+            whitelist layer coerces the incoming query-string value to int and
+            rejects anything non-numeric.
+        start: Zero-based offset of the first row to return. Negative values
+            are clamped to 0.
+
+    Returns:
+        list[dict]: {"name": <designation>} per row, ordered by active-employee
+            count descending then name ascending.
+    """
+    page_length = min(max(page_length, 1), MAX_PAGE_LENGTH)
+    start = max(start, 0)
+
+    search = (search or "").strip()
+
+    Employee = DocType("Employee")
+    query = (
+        frappe.qb.from_(Employee)
+        .where(Employee.status == "Active")
+        .where(Employee.designation.isnotnull())
+        .where(Employee.designation != "")
+        .select(Employee.designation.as_("name"))
+        .groupby(Employee.designation)
+        .orderby(Count("*"), order=frappe.qb.desc)
+        .orderby(Employee.designation)
+        .limit(page_length)
+        .offset(start)
+    )
+
+    if search:
+        query = query.where(Employee.designation.like(f"%{_escape_like(search)}%"))
+
+    return query.run(as_dict=True)

--- a/next_pms/api/designation.py
+++ b/next_pms/api/designation.py
@@ -36,6 +36,8 @@ def get_designations(search: str | None = None, page_length: int = DEFAULT_PAGE_
         list[dict]: {"name": <designation>} per row, ordered by active-employee
             count descending then name ascending.
     """
+    frappe.only_for(["Projects Manager", "Projects User", "Delivery Manager"], message=True)
+
     page_length = min(max(page_length, 1), MAX_PAGE_LENGTH)
     start = max(start, 0)
 

--- a/next_pms/tests/api/test_designation.py
+++ b/next_pms/tests/api/test_designation.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.api.designation import get_designations
+
+# Every fixture designation carries one of these prefixes so the assertions can scope
+# themselves with `search` and stay immune to whatever designations the site already has.
+PREFIX = "DsgTest"
+PCT_PREFIX = "DsgPct"
+UND_PREFIX = "DsgUnd"
+
+ALPHA = f"{PREFIX} Alpha"
+BETA = f"{PREFIX} Beta"
+GAMMA = f"{PREFIX} Gamma"
+DELTA = f"{PREFIX} Delta"
+EMPTY = f"{PREFIX} Empty"
+DEPARTED = f"{PREFIX} Departed"
+
+PCT_LITERAL = f"{PCT_PREFIX} 100% Bonus"
+PCT_DECOY = f"{PCT_PREFIX} 100X Bonus"
+UND_LITERAL = f"{UND_PREFIX} A_B"
+UND_DECOY = f"{UND_PREFIX} AXB"
+
+# Active-employee counts descending, name ascending — the order the endpoint must produce.
+EXPECTED_ORDER = [ALPHA, BETA, GAMMA, DELTA]
+
+
+class TestGetDesignations(IntegrationTestCase):
+    """Cover ranking, exclusion, search and pagination on next_pms.api.designation.
+
+    Fixtures are built once in setUpClass; IntegrationTestCase rolls the whole class's
+    DB writes back on class teardown, so nothing leaks into the site.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+
+        for designation in (
+            ALPHA,
+            BETA,
+            GAMMA,
+            DELTA,
+            EMPTY,
+            DEPARTED,
+            PCT_LITERAL,
+            PCT_DECOY,
+            UND_LITERAL,
+            UND_DECOY,
+        ):
+            cls._make_designation(designation)
+
+        for index in range(3):
+            cls._make_employee(f"DsgAlpha{index}", designation=ALPHA)
+        for index in range(2):
+            cls._make_employee(f"DsgBeta{index}", designation=BETA)
+        for index in range(2):
+            cls._make_employee(f"DsgGamma{index}", designation=GAMMA)
+        cls._make_employee("DsgDelta0", designation=DELTA)
+
+        cls._make_employee("DsgPctLiteral", designation=PCT_LITERAL)
+        cls._make_employee("DsgPctDecoy", designation=PCT_DECOY)
+        cls._make_employee("DsgUndLiteral", designation=UND_LITERAL)
+        cls._make_employee("DsgUndDecoy", designation=UND_DECOY)
+
+        # EMPTY gets no employee at all; DEPARTED only gets employees who are gone.
+        cls._make_employee("DsgDeparted0", designation=DEPARTED, status="Inactive")
+        cls._make_employee("DsgDeparted1", designation=DEPARTED, status="Left", relieving_date="2025-01-31")
+
+        cls._make_employee("DsgNoDesignation", designation=None)
+
+    @classmethod
+    def _make_designation(cls, designation_name):
+        if not frappe.db.exists("Designation", designation_name):
+            frappe.get_doc({"doctype": "Designation", "designation_name": designation_name}).insert(
+                ignore_permissions=True
+            )
+        return designation_name
+
+    @classmethod
+    def _make_employee(cls, employee_name, designation=None, status="Active", relieving_date=None):
+        employee = frappe.new_doc("Employee")
+        employee.update(
+            {
+                "naming_series": "EMP-",
+                "first_name": employee_name,
+                "company": cls.company,
+                "gender": "Female",
+                "date_of_birth": "1990-05-08",
+                "date_of_joining": "2013-01-01",
+                "status": status,
+                "employment_type": "Intern",
+                "leave_approver": "Administrator",
+                "designation": designation,
+                "relieving_date": relieving_date,
+            }
+        )
+        employee.insert(ignore_permissions=True)
+        return employee.name
+
+    def _names(self, **kwargs):
+        return [row["name"] for row in get_designations(**kwargs)]
+
+    def test_ranks_by_active_employee_count(self):
+        self.assertEqual(self._names(search=PREFIX, page_length=50), EXPECTED_ORDER)
+
+    def test_returns_only_the_name_key(self):
+        """The dropdown consumes the frappe.client.get_list shape — name and nothing else."""
+        rows = get_designations(search=PREFIX, page_length=50)
+        self.assertTrue(all(set(row) == {"name"} for row in rows))
+
+    def test_alphabetical_tiebreak_on_equal_counts(self):
+        names = self._names(search=PREFIX, page_length=50)
+        self.assertLess(names.index(BETA), names.index(GAMMA))
+
+    def test_designation_with_no_employees_is_excluded(self):
+        self.assertNotIn(EMPTY, self._names(search=PREFIX, page_length=50))
+
+    def test_inactive_employees_do_not_count(self):
+        self.assertNotIn(DEPARTED, self._names(search=PREFIX, page_length=50))
+
+    def test_blank_designation_is_not_returned(self):
+        self.assertTrue(all(row["name"] for row in get_designations(page_length=100)))
+
+    def test_search_filters_by_substring(self):
+        self.assertEqual(self._names(search="dsgtest alph"), [ALPHA])
+        self.assertEqual(self._names(search="GAMMA"), [GAMMA])
+
+    def test_blank_search_is_ignored(self):
+        self.assertEqual(self._names(search="   ", page_length=100), self._names(page_length=100))
+
+    def test_search_escapes_percent_wildcard(self):
+        self.assertEqual(sorted(self._names(search=PCT_PREFIX)), sorted([PCT_LITERAL, PCT_DECOY]))
+        self.assertEqual(self._names(search="100%"), [PCT_LITERAL])
+
+    def test_search_escapes_underscore_wildcard(self):
+        self.assertEqual(sorted(self._names(search=UND_PREFIX)), sorted([UND_LITERAL, UND_DECOY]))
+        self.assertEqual(self._names(search="A_B"), [UND_LITERAL])
+
+    def test_search_no_match_returns_empty_list(self):
+        self.assertEqual(get_designations(search=f"{PREFIX} Nonexistent"), [])
+
+    def test_pagination_pages_without_overlap(self):
+        self.assertEqual(self._names(search=PREFIX, page_length=2, start=0), EXPECTED_ORDER[:2])
+        self.assertEqual(self._names(search=PREFIX, page_length=2, start=2), EXPECTED_ORDER[2:])
+
+    def test_start_beyond_last_row_returns_empty_list(self):
+        self.assertEqual(get_designations(search=PREFIX, page_length=2, start=10), [])
+
+    def test_page_length_and_start_are_clamped(self):
+        self.assertEqual(self._names(search=PREFIX, page_length="2"), EXPECTED_ORDER[:2])
+        self.assertEqual(self._names(search=PREFIX, start="2", page_length=50), EXPECTED_ORDER[2:])
+        self.assertEqual(self._names(search=PREFIX, page_length=0), EXPECTED_ORDER[:1])
+        self.assertEqual(self._names(search=PREFIX, page_length=-5), EXPECTED_ORDER[:1])
+        self.assertEqual(self._names(search=PREFIX, page_length=1000), EXPECTED_ORDER)
+        self.assertEqual(self._names(search=PREFIX, start=-5, page_length=50), EXPECTED_ORDER)
+
+    def test_non_numeric_pagination_params_are_rejected(self):
+        """Frappe's whitelist layer coerces "2" but throws on junk, before the endpoint runs."""
+        with self.assertRaises(frappe.exceptions.FrappeTypeError):
+            get_designations(search=PREFIX, page_length="abc")


### PR DESCRIPTION
## Description


* Added `get_designations` function in `next_pms/api/designation.py` to return designations mapped to at least one active employee, ordered by usage and supporting pagination and search with wildcard escaping.
* Introduced `next_pms/tests/api/test_designation.py` with integration tests covering ranking, name-only return shape, alphabetical tiebreaks, exclusion of unused/inactive designations, search filtering (including literal `%` and `_`), pagination, and parameter clamping.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #2087