### PR TITLE
feat: update designation lookup hook to use dedicated endpoint

### DIFF
--- a/frontend/packages/app/src/hooks/useDesignationLookup.ts
+++ b/frontend/packages/app/src/hooks/useDesignationLookup.ts
@@ -41,13 +41,11 @@ export const useDesignationLookup = ({
     query,
     pageSize,
     revalidateOnFocus,
+    method: "next_pms.api.designation.get_designations",
     params: ({ query: searchQuery, pageSize }) => ({
-      doctype: "Designation",
-      fields: ["name"],
-      limit_page_length: pageSize,
-      or_filters: searchQuery
-        ? [["Designation", "name", "like", `%${searchQuery}%`]]
-        : undefined,
+      search: searchQuery || undefined,
+      page_length: pageSize,
+      start: 0,
     }),
     getItems: (message) => message ?? [],
     mapOption: (designation) => ({


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR updates the `DesignationLookup` hook to use the newly introduced endpoint in #2098, which orders designations based on the number of employees assigned to them and filters out designations that have no employees assigned.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Navigate to the "Team Allocation" page.
2. Open the "Select designation" filter.
3. Verify that designations with more employees assigned are ranked higher in the list.
4. Search for a designation that has no employees assigned.
5. Verify that the designation does not appear in the search results.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially fixes #2087