### PR TITLE
fix: reject reason scoped to task instead of timesheet

### DIFF
--- a/next_pms/install.py
+++ b/next_pms/install.py
@@ -23,13 +23,12 @@ def setup_timesheet_rejection_reason_field():
 
     create_custom_fields(
         {
-            "Timesheet": [
+            "Timesheet Detail": [
                 {
                     "fieldname": "custom_rejection_reason",
                     "fieldtype": "Text Editor",
                     "label": "Rejection Reason",
-                    "insert_after": "note",
-                    "depends_on": 'eval:doc.custom_approval_status=="Rejected"',
+                    "insert_after": "description",
                     "read_only": 1,
                     "no_copy": 1,
                     "module": "Timesheet",
@@ -49,7 +48,7 @@ def setup_timesheet_weekly_rejection_reason_field():
                     "fieldname": "custom_weekly_rejection_reason",
                     "fieldtype": "Text Editor",
                     "label": "Weekly Rejection Reason",
-                    "insert_after": "custom_rejection_reason",
+                    "insert_after": "note",
                     "depends_on": 'eval:doc.custom_weekly_approval_status=="Rejected"',
                     "read_only": 1,
                     "no_copy": 1,

--- a/next_pms/patches.txt
+++ b/next_pms/patches.txt
@@ -41,3 +41,4 @@ next_pms.next_pms.patches.setup_time_report_frequency
 next_pms.timesheet.patches.restore_stuck_processing_timesheets
 next_pms.next_pms.patches.backfill_risk_owner_and_initial_log
 next_pms.next_projects.patches.setup_todo_permissions
+next_pms.timesheet.patches.move_rejection_reason_to_timesheet_detail

--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -170,7 +170,6 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
                 "name",
                 "start_date",
                 "custom_approval_status",
-                "custom_rejection_reason",
                 "custom_weekly_approval_status",
                 "custom_weekly_rejection_reason",
                 "docstatus",
@@ -180,12 +179,29 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         self.assertEqual(len(by_date), 5, "expected exactly 5 daily timesheets for the test week")
         return by_date
 
+    def assert_day_row_reasons(self, by_date, date, reason):
+        """Every Timesheet Detail row of the day carries the same rejection reason."""
+        rows = frappe.get_all(
+            "Timesheet Detail",
+            filters={"parent": by_date[date].name},
+            pluck="custom_rejection_reason",
+        )
+        self.assertTrue(rows, f"expected at least one time entry for {date}")
+        for value in rows:
+            self.assertEqual(value or "", reason or "", f"unexpected row rejection reason on {date}")
+
     def assert_weekly_rejection_reason(self, by_date, expected_reasons):
         """Weekly reason is duplicated on every timesheet in the week."""
         expected = set(expected_reasons) if expected_reasons is not None else set()
         for date in WEEK_DATES:
             actual = {line for line in (by_date[date].custom_weekly_rejection_reason or "").split("\n") if line}
             self.assertEqual(actual, expected, f"unexpected weekly rejection reason on {date}")
+
+    def assert_original_row_keeps_reason_and_new_row_does_not(self, rows, original_description, new_description):
+        self.assertEqual(len(rows), 2, "expected the original row plus the post-reject row")
+        by_description = {row["description"]: row["custom_rejection_reason"] or "" for row in rows}
+        self.assertEqual(by_description[original_description], TUE_REASON)
+        self.assertEqual(by_description[new_description], "")
 
     def decide_timesheets(self, status, dates, note=""):
         drafts = frappe.get_all(
@@ -214,8 +230,9 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
 
     def assert_entries_carry_fields(self, entries_by_parent, by_date):
         def assert_day(date, status, reason):
-            # The approval fields come from the parent Timesheet, so every entry
-            # under that Timesheet must carry the same values.
+            # The approval status comes from the parent Timesheet and the rejection
+            # reason from each row; a day-level decision stamps every row alike, so
+            # all entries under one Timesheet carry the same values.
             entries = entries_by_parent[by_date[date].name]
             self.assertTrue(entries, f"expected at least one time entry for {date}")
             for entry in entries:
@@ -253,7 +270,7 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         by_date = self.get_timesheets_by_date()
         for date in WEEK_DATES:
             self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
-            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assert_day_row_reasons(by_date, date, None)
             self.assertEqual(by_date[date].docstatus, 0)
 
         # Step 2: reject Tuesday and Thursday, each with its own reason.
@@ -262,12 +279,12 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
 
         by_date = self.get_timesheets_by_date()
         self.assertEqual(by_date[TUE].custom_approval_status, "Rejected")
-        self.assertEqual(by_date[TUE].custom_rejection_reason, TUE_REASON)
+        self.assert_day_row_reasons(by_date, TUE, TUE_REASON)
         self.assertEqual(by_date[THU].custom_approval_status, "Rejected")
-        self.assertEqual(by_date[THU].custom_rejection_reason, THU_REASON)
+        self.assert_day_row_reasons(by_date, THU, THU_REASON)
         for date in (MON, WED, FRI):
             self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
-            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assert_day_row_reasons(by_date, date, None)
         # Partial reject must not populate the weekly reason.
         self.assertEqual(by_date[MON].custom_weekly_approval_status, "Partially Rejected")
         self.assert_weekly_rejection_reason(by_date, None)
@@ -281,8 +298,8 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
             self.assertEqual(by_date[date].docstatus, 0)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Approval Pending")
-        self.assertEqual(by_date[TUE].custom_rejection_reason, TUE_REASON)
-        self.assertEqual(by_date[THU].custom_rejection_reason, THU_REASON)
+        self.assert_day_row_reasons(by_date, TUE, TUE_REASON)
+        self.assert_day_row_reasons(by_date, THU, THU_REASON)
         self.assert_weekly_rejection_reason(by_date, None)
 
         # Step 4: manager approves the whole week; reasons are cleared on approval.
@@ -292,7 +309,7 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         for date in WEEK_DATES:
             self.assertEqual(by_date[date].custom_approval_status, "Approved")
             self.assertEqual(by_date[date].docstatus, 1)
-            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assert_day_row_reasons(by_date, date, None)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Approved")
         self.assert_weekly_rejection_reason(by_date, None)
 
@@ -302,7 +319,7 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         by_date = self.get_timesheets_by_date()
         for date in WEEK_DATES:
             self.assertEqual(by_date[date].custom_approval_status, "Rejected")
-            self.assertEqual(by_date[date].custom_rejection_reason, WEEK_REASON)
+            self.assert_day_row_reasons(by_date, date, WEEK_REASON)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Rejected")
         self.assert_weekly_rejection_reason(by_date, [WEEK_REASON])
 
@@ -313,7 +330,7 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         by_date = self.get_timesheets_by_date()
         for date, reason in DAY_REASONS.items():
             self.assertEqual(by_date[date].custom_approval_status, "Rejected")
-            self.assertEqual(by_date[date].custom_rejection_reason, reason)
+            self.assert_day_row_reasons(by_date, date, reason)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Rejected")
         self.assert_weekly_rejection_reason(by_date, DAY_REASONS.values())
 
@@ -329,7 +346,7 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         by_date = self.get_timesheets_by_date()
         for date in WEEK_DATES:
             self.assertEqual(by_date[date].custom_approval_status, "Approval Pending")
-            self.assertEqual(by_date[date].custom_rejection_reason, WEEK_REASON)
+            self.assert_day_row_reasons(by_date, date, WEEK_REASON)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Approval Pending")
         self.assert_weekly_rejection_reason(by_date, None)
 
@@ -337,6 +354,49 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         by_date = self.get_timesheets_by_date()
         for date in WEEK_DATES:
             self.assertEqual(by_date[date].custom_approval_status, "Approved")
-            self.assertEqual(by_date[date].custom_rejection_reason or "", "")
+            self.assert_day_row_reasons(by_date, date, None)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Approved")
         self.assert_weekly_rejection_reason(by_date, None)
+
+    def test_new_row_after_reject_does_not_inherit_rejection_reason(self):
+        # setUp already logged one row per day and submitted the week.
+        original_description = f"Work logged on {TUE}"
+        new_description = "Follow-up work after rejection"
+
+        self.decide_timesheets("Rejected", [TUE], note=TUE_REASON)
+        by_date = self.get_timesheets_by_date()
+        self.assertEqual(by_date[TUE].custom_approval_status, "Rejected")
+        self.assert_day_row_reasons(by_date, TUE, TUE_REASON)
+
+        save_timesheet(
+            date=TUE,
+            description=new_description,
+            task=self.task,
+            hours=1,
+            employee=self.employee,
+        )
+
+        rows = frappe.get_all(
+            "Timesheet Detail",
+            filters={"parent": by_date[TUE].name},
+            fields=["description", "custom_rejection_reason"],
+        )
+        self.assert_original_row_keeps_reason_and_new_row_does_not(rows, original_description, new_description)
+
+        by_date = self.get_timesheets_by_date()
+        self.assertEqual(by_date[TUE].custom_approval_status, "Rejected")
+
+        personal = get_timesheet_data(employee=self.employee, start_date=MON, max_week=1)
+        self.assert_original_row_keeps_reason_and_new_row_does_not(
+            self.collect_entries_by_parent(personal["data"])[by_date[TUE].name],
+            original_description,
+            new_description,
+        )
+
+        team = get_team_timesheet_data(start_date=MON, reports_to=self.manager)
+        member = next(m for m in team["members"] if m["employee"] == self.employee)
+        self.assert_original_row_keeps_reason_and_new_row_does_not(
+            self.collect_entries_by_parent({MON: {"tasks": member["tasks"]}})[by_date[TUE].name],
+            original_description,
+            new_description,
+        )

--- a/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
+++ b/next_pms/tests/timesheet/api/test_timesheet_rejection_reason.py
@@ -228,6 +228,24 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
                     entries_by_parent[entry["parent"]].append(entry)
         return entries_by_parent
 
+    def collect_personal_and_team_entries(self):
+        personal = get_timesheet_data(employee=self.employee, start_date=MON, max_week=1)
+        team = get_team_timesheet_data(start_date=MON, reports_to=self.manager)
+        member = next(m for m in team["members"] if m["employee"] == self.employee)
+        return (
+            self.collect_entries_by_parent(personal["data"]),
+            self.collect_entries_by_parent({MON: {"tasks": member["tasks"]}}),
+        )
+
+    def assert_entries_carry_weekly_rejection_reason(self, entries_by_parent, by_date, expected_reasons):
+        expected = set(expected_reasons) if expected_reasons else set()
+        for date in WEEK_DATES:
+            entries = entries_by_parent[by_date[date].name]
+            self.assertTrue(entries, f"expected at least one time entry for {date}")
+            for entry in entries:
+                actual = {line for line in (entry["custom_weekly_rejection_reason"] or "").split("\n") if line}
+                self.assertEqual(actual, expected, f"unexpected weekly rejection reason on {date} payload")
+
     def assert_entries_carry_fields(self, entries_by_parent, by_date):
         def assert_day(date, status, reason):
             # The approval status comes from the parent Timesheet and the rejection
@@ -238,6 +256,8 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             for entry in entries:
                 self.assertEqual(entry["custom_approval_status"], status)
                 self.assertEqual(entry["custom_rejection_reason"], reason)
+                # Partial reject must not surface a weekly reason on the payload.
+                self.assertFalse(entry["custom_weekly_rejection_reason"])
 
         # A rejected timesheet surfaces its rejection reason.
         assert_day(TUE, "Rejected", TUE_REASON)
@@ -255,15 +275,9 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
         # parent name we look each entry up by.
         by_date = self.get_timesheets_by_date()
 
-        # get_timesheet_data returns data[week]["tasks"][task]["data"][...]
-        personal = get_timesheet_data(employee=self.employee, start_date=MON, max_week=1)
-        self.assert_entries_carry_fields(self.collect_entries_by_parent(personal["data"]), by_date)
-
-        # get_team_timesheet_data is single-week now: the member row carries its tasks
-        # directly, instead of a timesheet_details map keyed by week.
-        team = get_team_timesheet_data(start_date=MON, reports_to=self.manager)
-        member = next(m for m in team["members"] if m["employee"] == self.employee)
-        self.assert_entries_carry_fields(self.collect_entries_by_parent({MON: {"tasks": member["tasks"]}}), by_date)
+        personal_entries, team_entries = self.collect_personal_and_team_entries()
+        self.assert_entries_carry_fields(personal_entries, by_date)
+        self.assert_entries_carry_fields(team_entries, by_date)
 
     def test_reject_resubmit_approve_lifecycle(self):
         # Step 1 (done in setUp): all 5 days pending, no rejection reason yet.
@@ -323,6 +337,10 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Rejected")
         self.assert_weekly_rejection_reason(by_date, [WEEK_REASON])
 
+        personal_entries, team_entries = self.collect_personal_and_team_entries()
+        self.assert_entries_carry_weekly_rejection_reason(personal_entries, by_date, [WEEK_REASON])
+        self.assert_entries_carry_weekly_rejection_reason(team_entries, by_date, [WEEK_REASON])
+
     def test_distinct_day_reasons_combined_when_week_rejected(self):
         for date, reason in DAY_REASONS.items():
             self.decide_timesheets("Rejected", [date], note=reason)
@@ -333,6 +351,10 @@ class TestTimesheetRejectionReason(IntegrationTestCase):
             self.assert_day_row_reasons(by_date, date, reason)
             self.assertEqual(by_date[date].custom_weekly_approval_status, "Rejected")
         self.assert_weekly_rejection_reason(by_date, DAY_REASONS.values())
+
+        personal_entries, team_entries = self.collect_personal_and_team_entries()
+        self.assert_entries_carry_weekly_rejection_reason(personal_entries, by_date, DAY_REASONS.values())
+        self.assert_entries_carry_weekly_rejection_reason(team_entries, by_date, DAY_REASONS.values())
 
     def test_weekly_rejection_reason_cleared_when_leaving_rejected(self):
         self.decide_timesheets("Rejected", WEEK_DATES, note=WEEK_REASON)

--- a/next_pms/timesheet/api/team.py
+++ b/next_pms/timesheet/api/team.py
@@ -569,7 +569,8 @@ def _approve_or_reject_timesheet(
         for timesheet in timesheets_to_process:
             doc = get_doc("Timesheet", timesheet.name)
             doc.custom_approval_status = status
-            doc.custom_rejection_reason = note if status == "Rejected" else None
+            for log in doc.time_logs:
+                log.custom_rejection_reason = note if status == "Rejected" else None
             doc.save(ignore_permissions=has_permission)
             if status == "Approved":
                 doc.submit()

--- a/next_pms/timesheet/api/timesheet.py
+++ b/next_pms/timesheet/api/timesheet.py
@@ -548,7 +548,7 @@ def get_timesheet(dates: list, employee: str, search: str | None = None, parsed_
     timesheets = frappe.get_all(
         "Timesheet",
         filters=ts_filters,
-        fields=["name", "custom_approval_status", "custom_rejection_reason", "custom_weekly_rejection_reason"],
+        fields=["name", "custom_approval_status", "custom_weekly_rejection_reason"],
         ignore_permissions=employee_has_higher_access(employee, ptype="read"),
     )
 
@@ -637,7 +637,6 @@ def get_timesheet(dates: list, employee: str, search: str | None = None, parsed_
         entry = {field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS}
         parent_ts = ts_parent_map.get(log.get("parent"))
         entry["custom_approval_status"] = parent_ts.get("custom_approval_status") if parent_ts else None
-        entry["custom_rejection_reason"] = parent_ts.get("custom_rejection_reason") if parent_ts else None
         entry["custom_weekly_rejection_reason"] = parent_ts.get("custom_weekly_rejection_reason") if parent_ts else None
         data[task_name]["data"].append(entry)
 

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -1225,6 +1225,7 @@ def build_chunk_context(employees: list, dates: list, parsed_filters: dict):
             "note",
             "custom_approval_status",
             "custom_weekly_approval_status",
+            "custom_weekly_rejection_reason",
         ],
     )
     ts_parent_map = {ts.name: ts for ts in all_timesheets}
@@ -1374,6 +1375,9 @@ def build_employee_week_details(
                 entry = {field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS}
                 parent_ts = ts_parent_map.get(ts_name)
                 entry["custom_approval_status"] = parent_ts.get("custom_approval_status") if parent_ts else None
+                entry["custom_weekly_rejection_reason"] = (
+                    parent_ts.get("custom_weekly_rejection_reason") if parent_ts else None
+                )
                 tasks[task_name]["data"].append(entry)
 
         week_status = context["week_status_map"].get((employee_name, date_info["start_date"]), "Not Submitted")

--- a/next_pms/timesheet/api/utils.py
+++ b/next_pms/timesheet/api/utils.py
@@ -146,7 +146,7 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
             "end_date": ["<=", end_date],
             "docstatus": ["<", 2],
         },
-        ["name", "custom_approval_status", "custom_rejection_reason", "start_date"],
+        ["name", "custom_approval_status", "start_date"],
     )
     if not current_week_timesheet:
         return
@@ -212,12 +212,21 @@ def update_weekly_status_of_timesheet(employee: str, date: str):
 
     weekly_rejection_reason = None
     if week_status == "Rejected":
+        rejected_ts_order = {
+            ts.name: (ts.start_date, ts.name)
+            for ts in sorted(current_week_timesheet, key=lambda ts: ts.start_date)
+            if ts.get("custom_approval_status") == "Rejected"
+        }
+        rejected_rows = frappe.get_all(
+            "Timesheet Detail",
+            filters={"parent": ["in", list(rejected_ts_order)]},
+            fields=["parent", "custom_rejection_reason", "idx"],
+        )
+        rejected_rows.sort(key=lambda row: (rejected_ts_order[row.parent], row.idx))
         reasons = []
         seen = set()
-        for ts in current_week_timesheet:
-            if ts.get("custom_approval_status") != "Rejected":
-                continue
-            reason = (ts.get("custom_rejection_reason") or "").strip()
+        for row in rejected_rows:
+            reason = (row.get("custom_rejection_reason") or "").strip()
             if reason and reason not in seen:
                 seen.add(reason)
                 reasons.append(reason)
@@ -1215,7 +1224,6 @@ def build_chunk_context(employees: list, dates: list, parsed_filters: dict):
             "total_hours",
             "note",
             "custom_approval_status",
-            "custom_rejection_reason",
             "custom_weekly_approval_status",
         ],
     )
@@ -1366,7 +1374,6 @@ def build_employee_week_details(
                 entry = {field: log.get(field) for field in ALLOWED_TIMESHET_DETAIL_FIELDS}
                 parent_ts = ts_parent_map.get(ts_name)
                 entry["custom_approval_status"] = parent_ts.get("custom_approval_status") if parent_ts else None
-                entry["custom_rejection_reason"] = parent_ts.get("custom_rejection_reason") if parent_ts else None
                 tasks[task_name]["data"].append(entry)
 
         week_status = context["week_status_map"].get((employee_name, date_info["start_date"]), "Not Submitted")

--- a/next_pms/timesheet/patches/move_rejection_reason_to_timesheet_detail.py
+++ b/next_pms/timesheet/patches/move_rejection_reason_to_timesheet_detail.py
@@ -11,22 +11,22 @@ def execute():
     weekly rejection reason field that used to sit after it.
     """
     setup_timesheet_rejection_reason_field()
-
-    timesheets = frappe.get_all(
-        "Timesheet",
-        filters={"custom_rejection_reason": ["is", "set"], "docstatus": ["!=", 2]},
-        fields=["name", "custom_rejection_reason"],
-    )
-    for timesheet in timesheets:
-        frappe.db.set_value(
-            "Timesheet Detail",
-            {"parent": timesheet.name},
-            "custom_rejection_reason",
-            timesheet.custom_rejection_reason,
-            update_modified=False,
-        )
-
     parent_field = frappe.db.get_value("Custom Field", {"dt": "Timesheet", "fieldname": "custom_rejection_reason"})
+    if parent_field and frappe.db.has_column("Timesheet", "custom_rejection_reason"):
+        timesheets = frappe.get_all(
+            "Timesheet",
+            filters={"custom_rejection_reason": ["is", "set"], "docstatus": ["!=", 2]},
+            fields=["name", "custom_rejection_reason"],
+        )
+        for timesheet in timesheets:
+            frappe.db.set_value(
+                "Timesheet Detail",
+                {"parent": timesheet.name},
+                "custom_rejection_reason",
+                timesheet.custom_rejection_reason,
+                update_modified=False,
+            )
+
     if parent_field:
         frappe.delete_doc("Custom Field", parent_field, force=True)
 

--- a/next_pms/timesheet/patches/move_rejection_reason_to_timesheet_detail.py
+++ b/next_pms/timesheet/patches/move_rejection_reason_to_timesheet_detail.py
@@ -1,0 +1,40 @@
+import frappe
+
+from next_pms.install import setup_timesheet_rejection_reason_field
+
+
+def execute():
+    """Move rejection reasons from Timesheet to its Timesheet Detail rows.
+
+    Creates the row-level custom field, stamps each parent's stored reason onto
+    all of its rows, deletes the parent-level custom field, and re-anchors the
+    weekly rejection reason field that used to sit after it.
+    """
+    setup_timesheet_rejection_reason_field()
+
+    timesheets = frappe.get_all(
+        "Timesheet",
+        filters={"custom_rejection_reason": ["is", "set"], "docstatus": ["!=", 2]},
+        fields=["name", "custom_rejection_reason"],
+    )
+    for timesheet in timesheets:
+        frappe.db.set_value(
+            "Timesheet Detail",
+            {"parent": timesheet.name},
+            "custom_rejection_reason",
+            timesheet.custom_rejection_reason,
+            update_modified=False,
+        )
+
+    parent_field = frappe.db.get_value("Custom Field", {"dt": "Timesheet", "fieldname": "custom_rejection_reason"})
+    if parent_field:
+        frappe.delete_doc("Custom Field", parent_field, force=True)
+
+    frappe.db.set_value(
+        "Custom Field",
+        {"dt": "Timesheet", "fieldname": "custom_weekly_rejection_reason"},
+        "insert_after",
+        "note",
+    )
+    frappe.clear_cache(doctype="Timesheet")
+    frappe.clear_cache(doctype="Timesheet Detail")

--- a/next_pms/timesheet/utils/constant.py
+++ b/next_pms/timesheet/utils/constant.py
@@ -76,6 +76,7 @@ ALLOWED_TIMESHET_DETAIL_FIELDS = [
     "from_time",
     "to_time",
     "description",
+    "custom_rejection_reason",
     "project",
     "task",
     "project_name",


### PR DESCRIPTION
## Description

rejection reason scoped to task instead of timesheet

## Relevant Technical Choices

1. patch to migrate existing reasons 
2. install hook updated

## Testing Instructions

1. make a time entry for a day with multiple task:project pair
2. reject the day 
3. add a new time entry for the day
4. you should not observe the rejection reason propagated for it 


1. reject the week with 5 different reasons (each day individually reject) - see all the rejection reasons in a newline (combined)

## Screenshot/Screencast

<img width="510" height="1300" alt="image" src="https://github.com/user-attachments/assets/4e1f9f07-debc-4de9-8740-062dbbf53bcd" />
<img width="528" height="1289" alt="image" src="https://github.com/user-attachments/assets/539cfdb6-2bf6-4e76-9d29-077e27b72690" />
<img width="2294" height="484" alt="image" src="https://github.com/user-attachments/assets/8808dbbf-89bf-4426-b820-1693dba2a76b" />


## Checklist

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #2022 