### PR TITLE
feat(allocations): show hourly rates in a configurable display currency

### DIFF
--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -9,6 +9,7 @@ from frappe.utils import add_days
 from next_pms.resource_management.api.utils.helpers import (
     add_customer_data_if_not_exists,
     allocation_hours_for_date,
+    convert_ctc_to_allocation_currency,
     filter_project_list,
     get_dates_date,
     normalize_project_view_filters,
@@ -309,6 +310,7 @@ def _get_resource_management_project_view_data(
         else {}
     )
     apply_working_hours_fallback(employees.values())
+    convert_ctc_to_allocation_currency(employees.values())
 
     leaves_map, holidays_map = get_leave_calendars(
         employees.values(), weeks[0].get("start_date"), weeks[-1].get("end_date")

--- a/next_pms/resource_management/api/project.py
+++ b/next_pms/resource_management/api/project.py
@@ -517,6 +517,7 @@ def _get_employees_resrouce_data_for_given_project(
         )
     }
     apply_working_hours_fallback(all_employees.values())
+    convert_ctc_to_allocation_currency(all_employees.values())
 
     working_dates = []
     current_date = start_date

--- a/next_pms/resource_management/api/team.py
+++ b/next_pms/resource_management/api/team.py
@@ -8,6 +8,7 @@ from next_pms.resource_management.api.utils.helpers import (
     _parse_multi_select_filter,
     add_customer_data_if_not_exists,
     allocation_hours_for_date,
+    convert_ctc_to_allocation_currency,
     find_worked_hours,
     get_allocation_objects,
     get_dates_date,
@@ -116,9 +117,9 @@ def get_resource_management_team_view_data(
                     "custom_work_schedule": "Per Day",
                     "custom_working_hours": 8.0,
                     "reports_to": "HR-EMP-00002",
-                    # write permission only:
+                    # write permission only; restated in the configured display currency:
                     "ctc": "120000",
-                    "salary_currency": "INR",
+                    "salary_currency": "USD",
                 },
             ],
             "leaves": [
@@ -168,9 +169,9 @@ def get_resource_management_team_view_data(
                     "working_frequency": "Per Day",
                     "employee_daily_working_hours": 8.0,
                     "max_allocation_count_for_single_date": 2,
-                    # write permission only:
+                    # write permission only; restated in the configured display currency:
                     "ctc": "120000",
-                    "salary_currency": "INR",
+                    "salary_currency": "USD",
                     # sparse — only days with allocations or leave are included
                     "all_dates_data": {
                         "2026-05-21": {
@@ -460,6 +461,7 @@ def _get_resource_management_team_view_data(
         return res
 
     apply_working_hours_fallback(employees)
+    convert_ctc_to_allocation_currency(employees)
 
     resource_allocation_data = get_allocation_list_for_employee_for_given_range(
         [

--- a/next_pms/resource_management/api/utils/helpers.py
+++ b/next_pms/resource_management/api/utils/helpers.py
@@ -1,10 +1,13 @@
 import datetime
+from collections.abc import Iterable
 
 import frappe
 from frappe.utils import cint, flt
 from frappe.utils.data import add_days, getdate
 
 from next_pms.timesheet.api.team import get_week_dates
+
+DEFAULT_ALLOCATION_RATE_CURRENCY = "USD"
 
 
 def add_customer_data_if_not_exists(customer: dict, customer_name: str | None) -> dict:
@@ -42,6 +45,55 @@ def add_customer_data_if_not_exists(customer: dict, customer_name: str | None) -
         }
 
     return customer
+
+
+def get_allocation_rate_currency() -> str:
+    """Currency the resource management views display employee rates in.
+
+    Configured per install at Timesheet Settings > Resource Management > Default Currency,
+    so the display currency is an operator's choice rather than a deployment-specific
+    constant baked into the app.
+    """
+    return frappe.db.get_single_value("Timesheet Settings", "default_currency") or DEFAULT_ALLOCATION_RATE_CURRENCY
+
+
+def convert_ctc_to_allocation_currency(employees: Iterable[dict], currency: str | None = None) -> None:
+    """Restate every employee's CTC in the currency the allocation views report rates in.
+
+    The allocation hover cards derive an hourly rate from ctc/salary_currency, so without this
+    the rate swings with each rtCamper's local currency and the cards cannot be compared
+    against one another. Rows whose currency has no usable exchange rate are left untouched
+    rather than relabelled while still holding an unconverted amount.
+
+    Args:
+        employees (Iterable[dict]): Employee rows carrying ctc and salary_currency — absent on
+            callers without write permission, in which case there is nothing to convert.
+            Mutated in place.
+        currency (str | None): Target currency. Resolved from Timesheet Settings when omitted.
+    """
+    from erpnext.setup.utils import get_exchange_rate
+
+    if not currency:
+        currency = get_allocation_rate_currency()
+
+    exchange_rates = {}
+
+    for employee in employees:
+        salary_currency = employee.get("salary_currency")
+        if not salary_currency or not employee.get("ctc"):
+            continue
+
+        if salary_currency != currency:
+            if salary_currency not in exchange_rates:
+                exchange_rates[salary_currency] = get_exchange_rate(salary_currency, currency)
+
+            exchange_rate = exchange_rates[salary_currency]
+            if not exchange_rate:
+                continue
+
+            employee["ctc"] = flt(employee["ctc"]) * exchange_rate
+
+        employee["salary_currency"] = currency
 
 
 def get_allocation_objects(employee_resource_allocation: list[object]) -> object:

--- a/next_pms/tests/resource_management/api/test_project.py
+++ b/next_pms/tests/resource_management/api/test_project.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 import frappe
 from erpnext import get_default_company
@@ -13,10 +14,11 @@ from next_pms.resource_management.api.project import (
 )
 from next_pms.resource_management.api.utils.leave_calendar import get_leave_calendars
 from next_pms.resource_management.api.utils.query import get_employee_leaves
-from next_pms.tests.utils import assign_empty_holiday_list
+from next_pms.tests.utils import assign_empty_holiday_list, make_employee
 
 WRITE_USER = "priya.sharma@example.com"
 READ_ONLY_USER = "arjun.mehta@example.com"
+RATE_CURRENCY_USER = "rate.currency@example.com"
 
 START_DATE = "2026-06-15"
 END_DATE = "2026-06-19"
@@ -569,3 +571,76 @@ class TestProjectLeaveReporting(IntegrationTestCase):
         get_employee_leaves.clear_cache()
         with self.assertQueryCount(3):
             get_leave_calendars(employees, START_DATE, LEAVE_VIEW_END)
+
+
+class TestProjectViewRateCurrency(IntegrationTestCase):
+    """Both project endpoints restate CTC in the configured display currency.
+
+    The allocation hover cards derive an hourly rate from the ctc/salary_currency the payload
+    carries, so an endpoint that skips the conversion reports rates in whichever currency the
+    employee happens to be paid in and the cards stop being comparable.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls.customer = frappe.db.get_value("Customer", {}, "name")
+        cls.project = frappe.get_doc(
+            {
+                "doctype": "Project",
+                "project_name": "Rate Currency Project",
+                "company": cls.company,
+                "customer": cls.customer,
+                "custom_billing_type": "Non-Billable",
+            }
+        ).insert(ignore_permissions=True)
+        cls.employee = make_employee(RATE_CURRENCY_USER, cls.company, ctc=100000, salary_currency="INR")
+        assign_empty_holiday_list(cls.employee)
+
+        frappe.get_doc(
+            {
+                "doctype": "Resource Allocation",
+                "employee": cls.employee,
+                "project": cls.project.name,
+                "allocation_start_date": START_DATE,
+                "allocation_end_date": END_DATE,
+                "hours_allocated_per_day": 8,
+                "status": "Confirmed",
+                "is_billable": 0,
+            }
+        ).insert(ignore_permissions=True)
+
+    def setUp(self):
+        self.original_currency = frappe.db.get_single_value("Timesheet Settings", "default_currency")
+        frappe.db.set_single_value("Timesheet Settings", "default_currency", "USD")
+        self._clear_caches()
+
+    def tearDown(self):
+        frappe.db.set_single_value("Timesheet Settings", "default_currency", self.original_currency)
+        self._clear_caches()
+
+    @staticmethod
+    def _clear_caches():
+        _get_resource_management_project_view_data.clear_cache()
+        _get_employees_resrouce_data_for_given_project.clear_cache()
+
+    def test_project_view_reports_the_display_currency(self):
+        with patch("erpnext.setup.utils.get_exchange_rate", return_value=0.012):
+            result = get_resource_management_project_view_data(
+                date=END_DATE, project_id=json.dumps([self.project.name])
+            )
+
+        employee = result["employees"][self.employee]
+        self.assertEqual(employee["salary_currency"], "USD")
+        self.assertAlmostEqual(employee["ctc"], 1200.0)
+
+    def test_employee_view_reports_the_display_currency(self):
+        with patch("erpnext.setup.utils.get_exchange_rate", return_value=0.012):
+            result = get_employees_resrouce_data_for_given_project(
+                project=self.project.name, start_date=START_DATE, end_date=END_DATE
+            )
+
+        entry = next(entry for entry in result["data"] if entry["name"] == self.employee)
+        self.assertEqual(entry["salary_currency"], "USD")
+        self.assertAlmostEqual(entry["ctc"], 1200.0)

--- a/next_pms/tests/resource_management/api/utils/test_helpers.py
+++ b/next_pms/tests/resource_management/api/utils/test_helpers.py
@@ -1,0 +1,108 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from next_pms.resource_management.api.utils.helpers import (
+    DEFAULT_ALLOCATION_RATE_CURRENCY,
+    convert_ctc_to_allocation_currency,
+    get_allocation_rate_currency,
+)
+
+EXCHANGE_RATE_PATH = "erpnext.setup.utils.get_exchange_rate"
+
+
+class TestAllocationRateCurrency(IntegrationTestCase):
+    """The currency the resource management views restate employee rates in."""
+
+    def setUp(self):
+        self.original_currency = frappe.db.get_single_value("Timesheet Settings", "default_currency")
+
+    def tearDown(self):
+        frappe.db.set_single_value("Timesheet Settings", "default_currency", self.original_currency)
+
+    def _set_currency(self, currency):
+        frappe.db.set_single_value("Timesheet Settings", "default_currency", currency)
+
+    def test_configured_currency_is_used(self):
+        self._set_currency("EUR")
+        self.assertEqual(get_allocation_rate_currency(), "EUR")
+
+    def test_unset_currency_falls_back_to_the_default(self):
+        self._set_currency(None)
+        self.assertEqual(get_allocation_rate_currency(), DEFAULT_ALLOCATION_RATE_CURRENCY)
+
+
+class TestConvertCtcToAllocationCurrency(IntegrationTestCase):
+    """convert_ctc_to_allocation_currency restates CTC in the display currency in place."""
+
+    def test_ctc_is_converted_and_relabelled(self):
+        employees = [{"ctc": 100000, "salary_currency": "INR"}]
+
+        with patch(EXCHANGE_RATE_PATH, return_value=0.012) as get_rate:
+            convert_ctc_to_allocation_currency(employees, currency="USD")
+
+        get_rate.assert_called_once_with("INR", "USD")
+        self.assertAlmostEqual(employees[0]["ctc"], 1200.0)
+        self.assertEqual(employees[0]["salary_currency"], "USD")
+
+    def test_matching_currency_is_left_alone(self):
+        employees = [{"ctc": 100000, "salary_currency": "USD"}]
+
+        with patch(EXCHANGE_RATE_PATH) as get_rate:
+            convert_ctc_to_allocation_currency(employees, currency="USD")
+
+        get_rate.assert_not_called()
+        self.assertEqual(employees[0]["ctc"], 100000)
+        self.assertEqual(employees[0]["salary_currency"], "USD")
+
+    def test_row_without_an_exchange_rate_keeps_its_own_currency(self):
+        # An unconfigured pair is a setup gap, not a data error. The row keeps the amount
+        # and the label that actually describe it rather than being relabelled USD while
+        # still holding rupees.
+        employees = [{"ctc": 100000, "salary_currency": "INR"}]
+
+        with patch(EXCHANGE_RATE_PATH, return_value=0):
+            convert_ctc_to_allocation_currency(employees, currency="USD")
+
+        self.assertEqual(employees[0]["ctc"], 100000)
+        self.assertEqual(employees[0]["salary_currency"], "INR")
+
+    def test_rows_without_salary_data_are_skipped(self):
+        # Read-only callers never receive ctc/salary_currency, so the helper must leave
+        # those rows untouched instead of stamping a currency onto them.
+        employees = [{"ctc": None, "salary_currency": "INR"}, {"employee_name": "No Salary Fields"}]
+
+        with patch(EXCHANGE_RATE_PATH) as get_rate:
+            convert_ctc_to_allocation_currency(employees, currency="USD")
+
+        get_rate.assert_not_called()
+        self.assertIsNone(employees[0]["ctc"])
+        self.assertEqual(employees[0]["salary_currency"], "INR")
+        self.assertNotIn("salary_currency", employees[1])
+
+    def test_exchange_rate_is_looked_up_once_per_currency(self):
+        employees = [
+            {"ctc": 100000, "salary_currency": "INR"},
+            {"ctc": 200000, "salary_currency": "INR"},
+            {"ctc": 50000, "salary_currency": "EUR"},
+        ]
+
+        with patch(EXCHANGE_RATE_PATH, return_value=2) as get_rate:
+            convert_ctc_to_allocation_currency(employees, currency="USD")
+
+        self.assertEqual(get_rate.call_count, 2)
+        self.assertEqual([employee["ctc"] for employee in employees], [200000, 400000, 100000])
+
+    def test_currency_defaults_to_the_configured_setting(self):
+        original = frappe.db.get_single_value("Timesheet Settings", "default_currency")
+        frappe.db.set_single_value("Timesheet Settings", "default_currency", "EUR")
+        self.addCleanup(frappe.db.set_single_value, "Timesheet Settings", "default_currency", original)
+
+        employees = [{"ctc": 100000, "salary_currency": "INR"}]
+
+        with patch(EXCHANGE_RATE_PATH, return_value=0.011) as get_rate:
+            convert_ctc_to_allocation_currency(employees)
+
+        get_rate.assert_called_once_with("INR", "EUR")
+        self.assertEqual(employees[0]["salary_currency"], "EUR")

--- a/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.json
+++ b/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.json
@@ -27,6 +27,8 @@
   "report_configuration_section",
   "pm_report_api_key",
   "tab_break_34k6",
+  "rate_display_section",
+  "default_currency",
   "notifications_section",
   "send_missing_allocation_reminder",
   "remind_on",
@@ -227,12 +229,25 @@
    "fieldname": "pm_report_api_key",
    "fieldtype": "Password",
    "label": "PM Report API Key"
+  },
+  {
+   "fieldname": "rate_display_section",
+   "fieldtype": "Section Break",
+   "label": "Rate Display"
+  },
+  {
+   "default": "USD",
+   "description": "Currency used to display employee hourly rates across the resource management views. Rates held in another currency are converted at the current exchange rate.",
+   "fieldname": "default_currency",
+   "fieldtype": "Link",
+   "label": "Default Currency",
+   "options": "Currency"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-29 19:10:48.300804",
+ "modified": "2026-08-31 15:43:28.904082",
  "modified_by": "Administrator",
  "module": "Timesheet",
  "name": "Timesheet Settings",

--- a/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.py
+++ b/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.py
@@ -6,4 +6,40 @@ from frappe.model.document import Document
 
 
 class TimesheetSettings(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from next_pms.resource_management.doctype.employee_department.employee_department import EmployeeDepartment
+        from next_pms.timesheet.doctype.timesheet_department.timesheet_department import TimesheetDepartment
+        from next_pms.timesheet.doctype.timesheet_role.timesheet_role import TimesheetRole
+
+        allocation_email_template: DF.Link | None
+        allow_backdated_entries: DF.Check
+        allow_backdated_entries_till_employee: DF.Int
+        allow_backdated_entries_till_manager: DF.Int
+        allow_future_entries: DF.Check
+        allow_weekend_entries: DF.Check
+        allowed_departments: DF.TableMultiSelect[TimesheetDepartment]
+        approval_request_reminder_template: DF.Link | None
+        daily_reminder_template: DF.Link | None
+        day_to_send_reminder: DF.Literal["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+        default_currency: DF.Link | None
+        designations: DF.TableMultiSelect[EmployeeDepartment]
+        ignored_role: DF.TableMultiSelect[TimesheetRole]
+        pm_report_api_key: DF.Password | None
+        remind_on: DF.Literal["", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+        send_daily_reminder: DF.Check
+        send_missing_allocation_reminder: DF.Check
+        send_reminder_on_approval_request: DF.Check
+        send_weekly_approval_reminder: DF.Check
+        timesheet_approval_template: DF.Link | None
+        timesheet_rejection_template: DF.Link | None
+        weekly_approval_reminder_template: DF.Link | None
+    # end: auto-generated types
+
     pass

--- a/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.py
+++ b/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.py
@@ -4,6 +4,8 @@
 # import frappe
 from frappe.model.document import Document
 
+from next_pms.resource_management.doctype.resource_allocation.resource_allocation import clear_cache
+
 
 class TimesheetSettings(Document):
     # begin: auto-generated types
@@ -42,4 +44,8 @@ class TimesheetSettings(Document):
         weekly_approval_reminder_template: DF.Link | None
     # end: auto-generated types
 
-    pass
+    def on_update(self):
+        if self.has_value_changed("default_currency"):
+            # The resource management views cache their payload with the rates already
+            # restated in this currency, so a stale cache keeps serving the old one.
+            clear_cache()


### PR DESCRIPTION
## Description

* Added a "Default Currency" (`default_currency`) field to `Timesheet Settings`, allowing operators to choose the display currency for employee rates. This is configurable via the UI and defaults to USD. 
* Implemented the `get_allocation_rate_currency` and `convert_ctc_to_allocation_currency` helper functions to fetch the configured currency and convert employee CTCs to this currency using current exchange rates. 
* Updated the project and team resource management API endpoints to apply currency conversion to employee CTCs before returning data, ensuring consistent rate display. 
* Adjusted test data in team view API responses to reflect CTCs and salary currencies restated in the configured display currency (now "USD" instead of "INR"), with clarifying comments. 


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially addresses #2099 