### PR TITLE
fix: N+1 in project threshold reminder

### DIFF
--- a/next_pms/project_currency/tasks/reminde_project_threshold.py
+++ b/next_pms/project_currency/tasks/reminde_project_threshold.py
@@ -13,94 +13,133 @@ def send_reminder_mail():
                 "custom_send_reminder_when_approaching_project_threshold_limit": 1,
                 "status": "Open",
             },
-            fields=["name"],
+            fields=[
+                "name",
+                "project_name",
+                "custom_billing_type",
+                "custom_reminder_threshold_percentage",
+                "custom_email_template",
+                "estimated_costing",
+                "total_billable_amount",
+            ],
         )
 
         need_to_send_reminder_project_list = filter_project_list(project_list)
 
-        for project in need_to_send_reminder_project_list:
-            send_reminder_mail_for_project(project)
+        if need_to_send_reminder_project_list:
+            send_reminder_mails(need_to_send_reminder_project_list)
     except Exception:
         generate_the_error_log(
             "send_reminder_project_threshold_mail_failed",
         )
 
 
-def send_reminder_mail_for_project(project: str):
-    if not project:
-        return frappe.throw(frappe._("Project not found"))
+def send_reminder_mails(projects: list):
+    project_names = [project.name for project in projects]
 
-    if not project.custom_email_template:
-        return
-
-    user_list = frappe.get_all(
+    doc_shares = frappe.get_all(
         "DocShare",
-        fields=["name", "user"],
-        filters=dict(share_doctype=project.doctype, share_name=project.name),
+        fields=["share_name", "user"],
+        filters={"share_doctype": "Project", "share_name": ["in", project_names]},
     )
+    shared_users_by_project = {}
+    for share in doc_shares:
+        shared_users_by_project.setdefault(share.share_name, []).append(share.user)
 
-    user_list = [user["user"] for user in user_list]
-
-    all_pms = [
-        d.parent
-        for d in frappe.get_all(
+    shared_users = list({share.user for share in doc_shares})
+    project_managers = set(
+        frappe.get_all(
             "Has Role",
             filters={
                 "role": "Projects Manager",
                 "parenttype": "User",
-                "parent": ["in", user_list],
+                "parent": ["in", shared_users],
             },
-            fields=["parent"],
+            pluck="parent",
         )
-    ]
+        if shared_users
+        else []
+    )
 
-    reminder_template = frappe.get_doc("Email Template", project.custom_email_template)
-
-    email_message = ""
-    if reminder_template.use_html:
-        email_message = reminder_template.response_html
-    else:
-        email_message = reminder_template.response
-
-    email_subject = reminder_template.subject
-    recipients = all_pms
-
-    args = {
-        "project": project,
+    template_names = list({project.custom_email_template for project in projects})
+    templates = {
+        template.name: template
+        for template in frappe.get_all(
+            "Email Template",
+            filters={"name": ["in", template_names]},
+            fields=["name", "use_html", "response_html", "response", "subject"],
+        )
     }
 
-    message = frappe.render_template(email_message, args)  # nosemgrep - trusted Email Template from DB
-    subject = frappe.render_template(email_subject, args)  # nosemgrep - trusted Email Template from DB
+    for project in projects:
+        reminder_template = templates.get(project.custom_email_template)
+        if not reminder_template:
+            continue
 
-    frappe.sendmail(recipients=recipients, subject=subject, message=message)
+        recipients = [user for user in shared_users_by_project.get(project.name, []) if user in project_managers]
+        if not recipients:
+            continue
+
+        if reminder_template.use_html:
+            email_message = reminder_template.response_html
+        else:
+            email_message = reminder_template.response
+
+        args = {
+            "project": project,
+        }
+
+        message = frappe.render_template(email_message, args)  # nosemgrep - trusted Email Template from DB
+        subject = frappe.render_template(reminder_template.subject, args)  # nosemgrep - trusted Email Template from DB
+
+        frappe.sendmail(recipients=recipients, subject=subject, message=message)
 
 
 def filter_project_list(project_list: list):
+    budget_rows = frappe.get_all(
+        "Project Budget",
+        filters={
+            "parenttype": "Project",
+            "parentfield": "custom_project_budget_hours",
+            "parent": ["in", [project.name for project in project_list]],
+        },
+        fields=["parent", "hours_purchased", "consumed_hours"],
+        order_by="parent asc, idx asc",
+    )
+    budget_rows_by_project = {}
+    for row in budget_rows:
+        budget_rows_by_project.setdefault(row.parent, []).append(row)
+
     need_to_send_reminder_project_list = []
-    for project_name in project_list:
-        project = frappe.get_doc("Project", project_name)
+    for project in project_list:
+        if not project.custom_email_template:
+            continue
 
         project_threshold = 0
 
         if project.custom_billing_type == "Retainer":
-            custom_project_budget_hours = project.custom_project_budget_hours
+            custom_project_budget_hours = budget_rows_by_project.get(project.name, [])
             if len(custom_project_budget_hours) == 0:
                 continue
 
             custom_project_budget_hours = custom_project_budget_hours[-1]
+            if not custom_project_budget_hours.hours_purchased:
+                continue
+
             project_threshold = (
                 custom_project_budget_hours.consumed_hours * 100
             ) / custom_project_budget_hours.hours_purchased
 
         elif project.custom_billing_type == "Time and Material":
-            project_threshold = (
-                custom_project_budget_hours.total_billable_amount * 100
-            ) / custom_project_budget_hours.estimated_costing
+            if not project.estimated_costing:
+                continue
+
+            project_threshold = (project.total_billable_amount * 100) / project.estimated_costing
 
         else:
             continue
 
-        if project.custom_reminder_threshold_percentage <= project_threshold and project.custom_email_template:
+        if project.custom_reminder_threshold_percentage <= project_threshold:
             need_to_send_reminder_project_list.append(project)
 
     return need_to_send_reminder_project_list

--- a/next_pms/tests/project_currency/test_project_threshold_reminder.py
+++ b/next_pms/tests/project_currency/test_project_threshold_reminder.py
@@ -1,0 +1,207 @@
+from unittest.mock import patch
+
+import frappe
+from erpnext import get_default_company
+from frappe.tests import IntegrationTestCase
+
+from next_pms.project_currency.tasks.reminde_project_threshold import send_reminder_mail
+
+PM_USER = "threshold-reminder-pm@example.com"
+NON_PM_USER = "threshold-reminder-member@example.com"
+TEMPLATE_NAME = "Project Threshold Reminder Test Template"
+PROJECT_PREFIX = "Threshold Reminder Test"
+
+
+class TestProjectThresholdReminder(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = get_default_company()
+        cls._cleanup_projects()
+        cls._make_email_template()
+        cls._make_user(PM_USER, with_pm_role=True)
+        cls._make_user(NON_PM_USER, with_pm_role=False)
+
+        cls.retainer_over = cls._make_retainer_project(
+            f"{PROJECT_PREFIX} Retainer Over", hours_purchased=100, consumed_hours=90
+        )
+        cls.retainer_under = cls._make_retainer_project(
+            f"{PROJECT_PREFIX} Retainer Under", hours_purchased=100, consumed_hours=10
+        )
+        cls.retainer_zero_hours = cls._make_retainer_project(
+            f"{PROJECT_PREFIX} Retainer Zero", hours_purchased=0, consumed_hours=0
+        )
+        cls.tnm_over = cls._make_project(f"{PROJECT_PREFIX} TnM Over", "Time and Material")
+        frappe.db.set_value("Project", cls.tnm_over, {"estimated_costing": 1000, "total_billable_amount": 900})
+
+        for project in (cls.retainer_over, cls.retainer_zero_hours, cls.tnm_over):
+            cls._share_project(project, PM_USER)
+        cls._share_project(cls.retainer_over, NON_PM_USER)
+        cls._share_project(cls.retainer_under, PM_USER)
+
+        cls.original_mute_emails = frappe.flags.mute_emails
+        frappe.flags.mute_emails = True
+        cls.enterClassContext(patch("frappe.utils.get_assets_json", return_value={}))
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.flags.mute_emails = cls.original_mute_emails
+        super().tearDownClass()
+
+    @classmethod
+    def _cleanup_projects(cls):
+        stale_projects = frappe.get_all(
+            "Project", filters={"project_name": ["like", f"{PROJECT_PREFIX}%"]}, pluck="name"
+        )
+        for name in stale_projects:
+            frappe.delete_doc("Project", name, force=True, ignore_permissions=True)
+
+    @classmethod
+    def _make_email_template(cls):
+        if frappe.db.exists("Email Template", TEMPLATE_NAME):
+            return
+        frappe.get_doc(
+            {
+                "doctype": "Email Template",
+                "__newname": TEMPLATE_NAME,
+                "subject": "Threshold reached for {{ project.name }}",
+                "use_html": 0,
+                "response": "Project {{ project.name }} - {{ project.project_name }} crossed the threshold.",
+            }
+        ).insert(ignore_permissions=True)
+
+    @classmethod
+    def _make_user(cls, email, with_pm_role):
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": email.split("@")[0],
+                    "send_welcome_email": 0,
+                }
+            ).insert(ignore_permissions=True)
+        user = frappe.get_doc("User", email)
+        if with_pm_role:
+            user.add_roles("Projects Manager")
+
+    @classmethod
+    def _make_project(cls, title, billing_type):
+        project = frappe.get_doc(
+            {
+                "doctype": "Project",
+                "project_name": title,
+                "company": cls.company,
+                "status": "Open",
+                "custom_billing_type": billing_type,
+                "custom_send_reminder_when_approaching_project_threshold_limit": 1,
+                "custom_reminder_threshold_percentage": 80,
+                "custom_email_template": TEMPLATE_NAME,
+            }
+        ).insert(ignore_permissions=True)
+        return project.name
+
+    @classmethod
+    def _make_retainer_project(cls, title, hours_purchased, consumed_hours):
+        project = frappe.get_doc(
+            {
+                "doctype": "Project",
+                "project_name": title,
+                "company": cls.company,
+                "status": "Open",
+                "custom_billing_type": "Retainer",
+                "custom_send_reminder_when_approaching_project_threshold_limit": 1,
+                "custom_reminder_threshold_percentage": 80,
+                "custom_email_template": TEMPLATE_NAME,
+                "custom_project_budget_hours": [
+                    {
+                        "start_date": "2026-01-01",
+                        "end_date": "2026-12-31",
+                        "hours_purchased": hours_purchased,
+                    }
+                ],
+            }
+        ).insert(ignore_permissions=True)
+        budget_row = project.custom_project_budget_hours[0]
+        frappe.db.set_value(
+            "Project Budget",
+            budget_row.name,
+            {"hours_purchased": hours_purchased, "consumed_hours": consumed_hours},
+        )
+        return project.name
+
+    @classmethod
+    def _share_project(cls, project, user):
+        frappe.share.add_docshare("Project", project, user, read=1, flags={"ignore_share_permission": True})
+
+    def setUp(self):
+        self._clear_test_email_queue()
+
+    def _clear_test_email_queue(self):
+        queue_names = frappe.get_all(
+            "Email Queue Recipient",
+            filters={"recipient": ["in", [PM_USER, NON_PM_USER]]},
+            pluck="parent",
+        )
+        if queue_names:
+            frappe.db.delete("Email Queue Recipient", {"parent": ["in", queue_names]})
+            frappe.db.delete("Email Queue", {"name": ["in", queue_names]})
+
+    def _queued_subjects_for(self, recipient):
+        queue_names = frappe.get_all("Email Queue Recipient", filters={"recipient": recipient}, pluck="parent")
+        if not queue_names:
+            return []
+        return frappe.get_all("Email Queue", filters={"name": ["in", queue_names]}, pluck="message")
+
+    def _error_log_count(self):
+        return frappe.db.count("Error Log", {"method": "send_reminder_project_threshold_mail_failed"})
+
+    def test_reminder_goes_to_project_managers_only(self):
+        errors_before = self._error_log_count()
+
+        send_reminder_mail()
+
+        self.assertEqual(self._error_log_count(), errors_before)
+
+        pm_messages = "\n".join(self._queued_subjects_for(PM_USER))
+        self.assertIn(self.retainer_over, pm_messages)
+        self.assertNotIn(self.retainer_under, pm_messages)
+        self.assertNotIn(self.retainer_zero_hours, pm_messages)
+
+        self.assertEqual(self._queued_subjects_for(NON_PM_USER), [])
+
+    def test_time_and_material_project_sends_reminder(self):
+        send_reminder_mail()
+
+        pm_messages = "\n".join(self._queued_subjects_for(PM_USER))
+        self.assertIn(self.tnm_over, pm_messages)
+
+    def test_query_count_does_not_scale_with_project_count(self):
+        baseline = self._count_queries()
+
+        extra_projects = [
+            self._make_retainer_project(f"{PROJECT_PREFIX} Extra {index}", hours_purchased=100, consumed_hours=10)
+            for index in range(3)
+        ]
+        try:
+            scaled = self._count_queries()
+        finally:
+            for name in extra_projects:
+                frappe.delete_doc("Project", name, force=True, ignore_permissions=True)
+
+        self.assertEqual(baseline, scaled)
+
+    def _count_queries(self):
+        send_reminder_mail()  # warm caches so both measured runs start equal
+        self._clear_test_email_queue()
+
+        counter = {"queries": 0}
+        original_sql = frappe.db.sql
+
+        def counting_sql(*args, **kwargs):
+            counter["queries"] += 1
+            return original_sql(*args, **kwargs)
+
+        with patch.object(frappe.db, "sql", side_effect=counting_sql):
+            send_reminder_mail()
+        return counter["queries"]


### PR DESCRIPTION
## Description

N+1 fix for project threshold reminder

## Relevant Technical Choices

batches the weekly project-threshold reminder job from ~6 queries/project down to 5 total, and fixes the T&M branch that crashed the whole job (undefined variable) plus div-by-zero on empty retainer budgets.

## Testing Instructions

behaviour unchanged for project threshold reminder

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [X] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes #767 