### PR TITLE
fix: remove duplicate Tailwind import causing Firefox focus-ring regression

### DIFF
--- a/frontend/packages/app/src/global.css
+++ b/frontend/packages/app/src/global.css
@@ -1,5 +1,4 @@
 @import "@rtcamp/frappe-ui-react/theme";
-@import "tailwindcss";
 @source "../../../node_modules/@rtcamp/frappe-ui-react/dist";
 @source "../../design-system/src";
 


### PR DESCRIPTION
## Description
- `global.css` imported `tailwindcss` directly on top of `@rtcamp/frappe-ui-react/theme`, which already imports it — Preflight was compiled twice into the same merged `base` layer.
- Firefox uniquely matches Tailwind Preflight's `:-moz-focusring { outline: auto; }` rule (Chrome ignores it), and the duplicate copy won the cascade tie, silently overriding the design system's gray `:focus-visible` ring with the native blue one.
- Removing the redundant import leaves a single Preflight, so the gray focus ring wins consistently in Firefox too.

## Screenshot/Screencast
<img width="1014" height="1068" alt="image" src="https://github.com/user-attachments/assets/f54d93b1-27db-4e49-993c-1fd4c16d7d8a" />

<img width="2326" height="628" alt="image" src="https://github.com/user-attachments/assets/4537d2cb-ca05-42c2-9791-a14c2a0fb41e" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #1662