### PR TITLE
fix: broken login redirect

### DIFF
--- a/frontend/packages/app/src/providers/user/index.ts
+++ b/frontend/packages/app/src/providers/user/index.ts
@@ -14,6 +14,8 @@ export interface UserContextProps {
   state: {
     /** Indicates whether user/auth data is still being resolved. */
     isLoading: boolean;
+    /** Indicates whether the app data is still being fetched. */
+    isAppDataLoading: boolean;
     /** Employee record ID linked to the current user. */
     employeeId: string;
     /** Whether the current user has a linked Employee record.
@@ -61,6 +63,7 @@ export interface UserContextProps {
 export const UserContext = createContext<UserContextProps>({
   state: {
     isLoading: false,
+    isAppDataLoading: false,
     employeeId: "",
     hasEmployee: null,
     employeeName: "",

--- a/frontend/packages/app/src/providers/user/provider.tsx
+++ b/frontend/packages/app/src/providers/user/provider.tsx
@@ -36,9 +36,6 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<
     UserContextProps["state"]["isSidebarCollapsed"]
   >(getLocalStorage("next-pms:isSidebarCollapsed", false));
-  const [roles, setRoles] = useState<UserContextProps["state"]["roles"]>(
-    window.frappe?.boot?.user?.roles || [],
-  );
   const [currencies, setCurrencies] = useState<
     UserContextProps["state"]["currencies"]
   >(window.frappe?.boot?.currencies || []);
@@ -63,12 +60,16 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
       : null,
   );
 
+  const isAppDataLoading = isAuthenticated && !appData && !appDataError;
+
+  const roles: UserContextProps["state"]["roles"] =
+    appData?.message?.roles ?? window.frappe?.boot?.user?.roles ?? [];
+
   useEffect(() => {
     if (!appData) {
       return;
     }
 
-    setRoles(appData?.message?.roles || []);
     setCurrencies(appData?.message?.currencies || []);
     setHasBuField(appData?.message?.has_business_unit || false);
     setHasIndustryField(appData?.message?.has_industry || false);
@@ -139,6 +140,7 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
       value={{
         state: {
           isLoading: isAuthLoading,
+          isAppDataLoading,
           employeeId,
           hasEmployee,
           employeeName,

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -308,12 +308,16 @@ const AuthenticatedRoute = () => {
     hasEmployee: state.hasEmployee,
   }));
 
-  if (isUserLoading || hasEmployee === null) {
+  if (isUserLoading) {
     return <Spinner isFull />;
   }
 
   if (!currentUser || currentUser === "Guest") {
     window.location.replace("/login?redirect-to=/next-pms/timesheet");
+    return <Spinner isFull />;
+  }
+
+  if (hasEmployee === null) {
     return <Spinner isFull />;
   }
 
@@ -325,12 +329,13 @@ const AuthenticatedRoute = () => {
 };
 
 const RoleProtectedRoute = ({ allowedRoles }: { allowedRoles: Role[] }) => {
-  const { isLoading, roles } = useUser(({ state }) => ({
+  const { isLoading, isAppDataLoading, roles } = useUser(({ state }) => ({
     isLoading: state.isLoading,
+    isAppDataLoading: state.isAppDataLoading,
     roles: state.roles,
   }));
 
-  if (isLoading) {
+  if (isLoading || isAppDataLoading) {
     return <Spinner isFull />;
   }
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes regressions introduced by the PR that added the "No Employee" route:

* Fixes an issue where logging out would leave the user stuck on the loading screen instead of redirecting to the login page.
* Fixes an issue in the development environment where roles were unavailable during the initial render due to being stored in `useState`, causing users to be incorrectly redirected to the 404 page. Roles are now synchronized immediately, preventing the incorrect redirect.



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/pull/2120#discussion_r3902618609 and https://github.com/rtCamp/next-pms/pull/2120#discussion_r3902618677