### PR TITLE
chore: fix "Projects Manager" role permissions 

### DIFF
--- a/frontend/packages/app/src/layout/sidebar/index.tsx
+++ b/frontend/packages/app/src/layout/sidebar/index.tsx
@@ -245,7 +245,11 @@ const Sidebar = () => {
     });
   }
 
-  if (roles.includes("Timesheet Manager") || roles.includes("Timesheet User")) {
+  if (
+    roles.includes("Timesheet Manager") ||
+    roles.includes("Timesheet User") ||
+    roles.includes("Projects Manager")
+  ) {
     searchItems.push({
       label: "Timesheet - Team",
       action: () =>

--- a/frontend/packages/app/src/route.tsx
+++ b/frontend/packages/app/src/route.tsx
@@ -83,7 +83,7 @@ export const routeConfig: Record<
   },
   "timesheet-project": {
     Component: ReactLazyPreload(() => import("./pages/timesheet/project")),
-    allowedRoles: ["Timesheet Manager", "Timesheet User"],
+    allowedRoles: ["Timesheet Manager", "Timesheet User", "Projects Manager"],
     title: "Project Timesheet",
   },
   "allocations-team": {


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR adds the missing "Projects Manager" permission on the frontend, allowing users with this role to access the Project Timesheet page and see Project / Team timesheet options in Global Search.


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. Grant an employee only the "Projects Manager" role.
2. Log in as that employee.
3. Verify that the user can access the "Project Timesheet" page.
4. Open Global Search.
5. Verify that the user can search for and access both "Project Timesheet" and "Team Timesheet".


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2126 