### PR TITLE
fix: remove trailing underscore from custom_account_manager in MANAGER_FIELDS

### DIFF
--- a/next_pms/next_projects/patches/share_projects_with_managers.py
+++ b/next_pms/next_projects/patches/share_projects_with_managers.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.share import add_docshare
 
-MANAGER_FIELDS = ["custom_project_manager", "custom_engineering_manager", "custom_account_manager_"]
+MANAGER_FIELDS = ["custom_project_manager", "custom_engineering_manager", "custom_account_manager"]
 
 
 def execute():


### PR DESCRIPTION
## Summary
Removes trailing underscore from `custom_account_manager_` → `custom_account_manager` in the MANAGER_FIELDS array in share_projects_with_managers.py.

## Root Cause
The trailing underscore in `"custom_account_manager_"` causes MySQLdb.OperationalError: Unknown column 'custom_account_manager_' during post_model_sync migration phase.

## Changes
1 file changed, 1 insertion(+), 1 deletion(-)

## References
- Fixes rtCamp/next-pms#2131 (Bug)
- Author: Jah-yee