### PR TITLE
feat: update tracking page layout to support current and projected

### DIFF
--- a/frontend/packages/app/src/pages/project-details/about/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/about/index.tsx
@@ -86,6 +86,13 @@ function AboutThisProjectContent({ className }: { className: string }) {
           }
         >
           <div className="grid grid-cols-[auto_1fr] items-center gap-x-3 gap-y-4.5 text-base text-ink-gray-5">
+            <span>Financial company</span>
+            <Tooltip text={sidebar.details.company ?? ""} showWhen="truncated">
+              <span className="truncate text-ink-gray-7">
+                {sidebar.details.company}
+              </span>
+            </Tooltip>
+
             <span>Project name</span>
             <div className="flex min-w-0 items-center gap-2">
               <Tooltip text={sidebar.details.project_name} showWhen="truncated">

--- a/frontend/packages/app/src/pages/project-details/about/sidebarContext.ts
+++ b/frontend/packages/app/src/pages/project-details/about/sidebarContext.ts
@@ -41,7 +41,13 @@ export interface SidebarContextProps {
 
 export const DEFAULT_SIDEBAR: ProjectSidebar = {
   summary: "",
-  details: { project_name: "", phase: "", status: "", customer: "" },
+  details: {
+    company: "",
+    project_name: "",
+    phase: "",
+    status: "",
+    customer: "",
+  },
   links: {
     slack: null,
     google_drive: null,

--- a/frontend/packages/app/src/pages/project-details/about/types.ts
+++ b/frontend/packages/app/src/pages/project-details/about/types.ts
@@ -8,7 +8,11 @@ import type { ComponentType, SVGProps } from "react";
  */
 
 export type ProjectLinkKey =
-  "website" | "files" | "github" | "people" | "support";
+  | "website"
+  | "files"
+  | "github"
+  | "people"
+  | "support";
 
 export type ProjectLink = {
   key: ProjectLinkKey;
@@ -75,6 +79,7 @@ export type ProjectAboutData = {
 export type ProjectSidebar = {
   summary: string | null;
   details: {
+    company: string | null;
     project_name: string;
     phase: string | null;
     status: string;

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/financialsBlock.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/financialsBlock.tsx
@@ -1,0 +1,131 @@
+/**
+ * External dependencies.
+ */
+import { useState } from "react";
+import { Dropdown, Tooltip } from "@rtcamp/frappe-ui-react";
+import { Check, DotHorizontal } from "@rtcamp/frappe-ui-react/icons";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  currencyFormat,
+  formatPercentage,
+  mergeClassNames as cn,
+} from "@/lib/utils";
+import { useProjectDetail } from "@/pages/project-details/context";
+import { useTracking } from "../context";
+
+type FinancialsBlockProps = {
+  showProjectValue: boolean;
+  layout?: "stacked" | "row";
+};
+
+export function FinancialsBlock({
+  showProjectValue,
+  layout = "stacked",
+}: FinancialsBlockProps) {
+  const currency = useProjectDetail((s) => s.project?.custom_currency);
+  const tracking = useTracking((state) => state.tracking);
+  const [mode, setMode] = useState<"projected" | "current">("projected");
+
+  const format = currencyFormat(currency);
+
+  const rows = [
+    ...(showProjectValue
+      ? [
+          {
+            key: "project-value",
+            label: "Total project value",
+            value: format.format(
+              (mode === "projected"
+                ? tracking.total_project_value
+                : tracking.current_project_value) ?? 0,
+            ),
+          },
+        ]
+      : []),
+    {
+      key: "profit",
+      label: mode === "projected" ? "Projected profit" : "Current profit",
+      value: format.format(
+        (mode === "projected"
+          ? tracking.project_profit
+          : tracking.current_profit) ?? 0,
+      ),
+    },
+    {
+      key: "margin",
+      label:
+        mode === "projected"
+          ? "Projected profit margin"
+          : "Current profit margin",
+      value: formatPercentage(
+        (mode === "projected"
+          ? tracking.projected_profit_margin
+          : tracking.current_profit_margin) ?? 0,
+      ),
+    },
+  ];
+
+  return (
+    <div className="relative flex flex-1 min-w-0 flex-col rounded-xl border border-outline-gray-1 bg-surface-cards">
+      <div className="absolute right-3 top-3">
+        <Dropdown
+          placement="center"
+          selectedKey={mode}
+          button={{
+            variant: "ghost",
+            icon: DotHorizontal,
+            "aria-label": "Switch financial figures",
+          }}
+          options={[
+            {
+              key: "current",
+              label: "Current",
+              icon:
+                mode === "current" ? (
+                  <Check className="order-last ml-auto size-4 shrink-0" />
+                ) : undefined,
+              onClick: () => setMode("current"),
+            },
+            {
+              key: "projected",
+              label: "Projected",
+              icon:
+                mode === "projected" ? (
+                  <Check className="order-last ml-auto size-4 shrink-0" />
+                ) : undefined,
+              onClick: () => setMode("projected"),
+            },
+          ]}
+        />
+      </div>
+      <div
+        className={cn(
+          "flex flex-1 divide-outline-gray-1",
+          layout === "row" ? "divide-x py-3" : "flex-col divide-y px-3",
+        )}
+      >
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            className={cn(
+              "flex min-w-0 flex-1 flex-col justify-center gap-2",
+              layout === "row" ? "px-3" : "py-3",
+            )}
+          >
+            <span className="truncate pr-6 text-base font-normal text-ink-gray-5">
+              {row.label}
+            </span>
+            <Tooltip text={row.value} showWhen="truncated">
+              <span className="truncate text-xl font-medium text-ink-gray-8">
+                {row.value}
+              </span>
+            </Tooltip>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/components/taskCompletion.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/components/taskCompletion.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies.
  */
+import { mergeClassNames as cn } from "@/lib/utils";
 import { useTracking } from "../context";
 
 // Full circle normalized to 200 units; the rotated dash keeps only the
@@ -8,7 +9,13 @@ import { useTracking } from "../context";
 const CIRCLE_PATH_LENGTH = 200;
 const SEMICIRCLE = CIRCLE_PATH_LENGTH / 2;
 
-export function TaskCompletionCell() {
+type TaskCompletionCellProps = {
+  layout?: "stacked" | "row";
+};
+
+export function TaskCompletionCell({
+  layout = "row",
+}: TaskCompletionCellProps) {
   const tasks = useTracking((state) => state.tracking.tasks);
   const totalIssuesCreated = tasks.total;
   const issuesOpen = tasks.open;
@@ -23,8 +30,18 @@ export function TaskCompletionCell() {
       <span className="text-base font-medium text-ink-gray-8">
         Task completion
       </span>
-      <div className="flex flex-col items-center gap-6 md:flex-row">
-        <div className="relative shrink-0 w-[167px]">
+      <div
+        className={cn(
+          "flex flex-1 flex-col items-center justify-center gap-5",
+          layout === "row" && "md:flex-row",
+        )}
+      >
+        <div
+          className={cn(
+            "relative shrink-0",
+            layout === "row" ? "w-41.75" : "w-55",
+          )}
+        >
           <svg
             viewBox="0 0 200 110"
             className="block w-full h-auto"
@@ -66,7 +83,12 @@ export function TaskCompletionCell() {
             <span className="text-xs text-ink-gray-6">completed</span>
           </div>
         </div>
-        <div className="flex max-md:w-full flex-1 flex-col gap-2 text-base text-ink-gray-6">
+        <div
+          className={cn(
+            "flex w-full max-w-60 flex-col gap-2 text-base text-ink-gray-6",
+            layout === "row" && "md:flex-1",
+          )}
+        >
           <div className="flex items-center justify-between gap-2">
             <span className="min-w-0 truncate">Total issues created</span>
             <span className="font-medium">{totalIssuesCreated}</span>

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/context.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/context.ts
@@ -38,12 +38,14 @@ export interface TrackingContextProps {
 }
 
 export const DEFAULT_TRACKING: Tracking = {
-  company: "",
   billing_type: "",
   currency: "INR",
   total_project_value: 0,
   project_profit: 0,
   projected_profit_margin: 0,
+  current_project_value: 0,
+  current_profit: 0,
+  current_profit_margin: 0,
   actual_cost_incurred: 0,
   forecasted_cost_to_completion: 0,
   expected_total_cost: 0,

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/index.tsx
@@ -2,10 +2,11 @@
  * Internal dependencies.
  */
 import { ROUTES } from "@/lib/constant";
-import { currencyFormat, formatPercentage } from "@/lib/utils";
+import { currencyFormat, mergeClassNames as cn } from "@/lib/utils";
 import { BudgetBurnCell } from "./components/budgetBurn";
 import { ContractsTable } from "./components/contractsTable";
 import { CostBurnCell } from "./components/costBurn";
+import { FinancialsBlock } from "./components/financialsBlock";
 import { HoursUsageCell } from "./components/hoursUsage";
 import { InvoiceBurnCell } from "./components/invoiceBurn";
 import { KnowledgePoint } from "./components/knowledgePoint";
@@ -28,36 +29,41 @@ function TrackingContent() {
   const currency = useProjectDetail((s) => s.project?.custom_currency);
   const tracking = useTracking((state) => state.tracking);
 
+  const salesOrderHref = `${ROUTES.desk}/sales-order?status=${encodeURIComponent(
+    JSON.stringify(["!=", "Cancelled"]),
+  )}&project=${encodeURIComponent(projectId)}`;
+
+  const isBillable = tracking.billing_type !== "Non-Billable";
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-3 lg:flex-row lg:*:basis-1/2!">
-        <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
-          <div className="flex flex-col gap-3 lg:flex-row">
-            <KnowledgePoint title="Company" value={tracking.company} />
-            <KnowledgePoint
-              title="Total project value"
-              value={currencyFormat(currency).format(
-                tracking.total_project_value ?? 0,
-              )}
-              href={`${ROUTES.desk}/sales-order?status=${encodeURIComponent(
-                JSON.stringify(["!=", "Cancelled"]),
-              )}&project=${encodeURIComponent(projectId)}`}
-            />
+      <div
+        className={cn(
+          "flex flex-col gap-3 lg:flex-row",
+          isBillable && "lg:*:basis-1/2!",
+        )}
+      >
+        {isBillable && (
+          <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
+            {tracking.billing_type === "Time and Material" ? (
+              <FinancialsBlock showProjectValue />
+            ) : (
+              <>
+                <div className="flex shrink-0">
+                  <KnowledgePoint
+                    title="Total project value"
+                    value={currencyFormat(currency).format(
+                      tracking.total_project_value ?? 0,
+                    )}
+                    href={salesOrderHref}
+                  />
+                </div>
+                <FinancialsBlock showProjectValue={false} />
+              </>
+            )}
           </div>
-          <div className="flex flex-col gap-3 lg:flex-row">
-            <KnowledgePoint
-              title="Projected profit"
-              value={currencyFormat(currency).format(
-                tracking.project_profit ?? 0,
-              )}
-            />
-            <KnowledgePoint
-              title="Projected profit margin"
-              value={formatPercentage(tracking.projected_profit_margin ?? 0)}
-            />
-          </div>
-        </div>
-        <TaskCompletionCell />
+        )}
+        <TaskCompletionCell layout={isBillable ? "stacked" : "row"} />
       </div>
 
       <div className="flex flex-col gap-3 lg:flex-row">

--- a/frontend/packages/app/src/pages/project-details/tabs/tracking/types.ts
+++ b/frontend/packages/app/src/pages/project-details/tabs/tracking/types.ts
@@ -79,12 +79,14 @@ export type TrackingLifetimeValues = {
 };
 
 export type TrackingMessage = {
-  company: string;
   billing_type: string;
   currency: string | null;
   total_project_value: number | null;
   project_profit: number | null;
   projected_profit_margin: number | null;
+  current_project_value: number | null;
+  current_profit: number | null;
+  current_profit_margin: number | null;
   actual_cost_incurred: number;
   forecasted_cost_to_completion: number;
   expected_total_cost: number;


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR updates the Tracking page to support the new layout defined in the issue. Based on the project type, related widgets are combined into a single widget, and their values change based on the option selected from the newly added dropdown.

Note: This is the first half of the frontend implementation. This PR adds the new data needed for the changes, while the widget customization will be added in a follow-up PR.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* Moves Company from the Tracking page to the Project Details section in the right rail and renames it to "Financial Company".
* Groups Profit and Profit Margin into a single widget for Fixed, Retainer, and Staff Augmentation engagements.
* Groups Project Value, Profit, and Profit Margin into a single widget for T&M engagements.
* Adds a dropdown to switch the grouped widgets between Projected and Current values.
* Projected values continue to use the existing calculations.
* Current values are calculated using logged time only, excluding forecasted time.


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/75b494c1-5398-4e56-8d5a-e221eb03da0e

Fixed Cost, Retainer:
<img width="1152" height="617" alt="Screenshot 2026-09-07 at 5 23 56 PM" src="https://github.com/user-attachments/assets/2befb7bf-0408-4492-927a-7985d836e770" />

T&M:
<img width="1152" height="617" alt="Screenshot 2026-09-07 at 5 24 21 PM" src="https://github.com/user-attachments/assets/efd2dbe5-fae5-48b7-8443-4c7c59724608" />

Non billable:
<img width="1152" height="617" alt="Screenshot 2026-09-07 at 5 25 06 PM" src="https://github.com/user-attachments/assets/c62bbf0b-241c-48f3-8e10-01b23b2e7475" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially Fixes #1828