### PR TITLE
feat: add system config tabs to settings modal and hook

### DIFF
--- a/frontend/packages/app/src/components/settings/constants.ts
+++ b/frontend/packages/app/src/components/settings/constants.ts
@@ -1,17 +1,49 @@
-import { Clock, User } from "lucide-react";
+import { Clock, User, Users } from "lucide-react";
 
-import type { SettingsPageConfig } from "./types";
+import type { SettingsSection } from "./types";
 
-export const USER_CONFIGURATION_PAGES: SettingsPageConfig[] = [
+export const SETTINGS_SECTIONS: SettingsSection[] = [
   {
-    id: "profile",
-    label: "Profile",
-    icon: User,
+    label: "User Configuration",
+    tabs: [
+      {
+        id: "profile",
+        label: "Profile",
+        icon: User,
+      },
+      {
+        id: "timesheets",
+        label: "Timesheets",
+        icon: Clock,
+        showSave: true,
+      },
+    ],
   },
   {
-    id: "timesheets",
-    label: "Timesheets",
-    icon: Clock,
-    showSave: true,
+    label: "System Configuration",
+    tabs: [
+      {
+        id: "system-timesheets",
+        label: "Timesheets",
+        icon: Clock,
+        showSave: true,
+      },
+      {
+        id: "system-resource-management",
+        label: "Resource Management",
+        icon: Users,
+        showSave: true,
+      },
+    ],
   },
 ];
+
+export const WEEK_DAYS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;

--- a/frontend/packages/app/src/components/settings/fields.tsx
+++ b/frontend/packages/app/src/components/settings/fields.tsx
@@ -1,0 +1,163 @@
+/**
+ * External dependencies.
+ */
+import { useMemo, useState } from "react";
+import {
+  Combobox,
+  FormLabel,
+  MultiSelect,
+  Select,
+} from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import { useDoctypeLinkLookup } from "@/hooks/useDoctypeLinkLookup";
+import { useUser } from "@/providers/user";
+import { WEEK_DAYS } from "./constants";
+
+type Option = { label: string; value: string };
+
+export function SettingsLinkField({
+  label,
+  doctype,
+  value,
+  onChange,
+  clearable = false,
+}: {
+  label: string;
+  doctype: string;
+  value?: string | null;
+  onChange: (value: string | null) => void;
+  clearable?: boolean;
+}) {
+  const [query, setQuery] = useState("");
+  const selectedOption = useMemo(
+    () => (value ? { label: value, value } : null),
+    [value],
+  );
+  const { options, isLoading } = useDoctypeLinkLookup({
+    doctype,
+    shouldFetch: true,
+    query,
+    selectedOption,
+  });
+
+  return (
+    <div>
+      <FormLabel size="md" className="text-ink-gray-8!">
+        {label}
+      </FormLabel>
+      <Combobox
+        options={options}
+        value={value ?? ""}
+        loading={isLoading}
+        searchValue={query}
+        onSearchChange={setQuery}
+        openOnFocus
+        clearable={clearable}
+        placeholder={`Select ${label}`}
+        onChange={(val) => onChange(val ?? null)}
+        className="mt-2"
+      />
+    </div>
+  );
+}
+
+export function SettingsCurrencyField({
+  value,
+  onChange,
+}: {
+  value?: string | null;
+  onChange: (value: string | null) => void;
+}) {
+  const currencies = useUser((s) => s.state.currencies);
+
+  return (
+    <div>
+      <FormLabel size="md" className="text-ink-gray-8!">
+        Default Currency
+      </FormLabel>
+      <Combobox
+        options={currencies}
+        value={value || null}
+        clearable
+        placeholder="Select Currency"
+        onChange={(val) => onChange(val ?? null)}
+        className="mt-2"
+      />
+    </div>
+  );
+}
+
+export function SettingsMultiSelectField({
+  label,
+  doctype,
+  value,
+  onChange,
+}: {
+  label: string;
+  doctype: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const selectedOptions = useMemo(
+    () => value.map((item) => ({ label: item, value: item })),
+    [value],
+  );
+  const { options, isLoading } = useDoctypeLinkLookup({
+    doctype,
+    shouldFetch: true,
+    query,
+    selectedOption: selectedOptions,
+  });
+
+  return (
+    <div>
+      <FormLabel size="md" className="text-ink-gray-8!">
+        {label}
+      </FormLabel>
+      <MultiSelect
+        options={options}
+        value={value}
+        loading={isLoading}
+        searchValue={query}
+        onSearchChange={setQuery}
+        placeholder={`Select ${label}`}
+        onChange={onChange}
+        triggerClassName="mt-2 w-full"
+        positionerClassName="z-100"
+      />
+    </div>
+  );
+}
+
+export function SettingsDaySelect({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value?: string;
+  onChange: (value: string) => void;
+}) {
+  const options = useMemo<Option[]>(
+    () => WEEK_DAYS.map((day) => ({ label: day, value: day })),
+    [],
+  );
+
+  return (
+    <div>
+      <FormLabel size="md" className="text-ink-gray-8!">
+        {label}
+      </FormLabel>
+      <Select
+        options={options}
+        value={value ?? ""}
+        onChange={(val) => onChange(val ?? "")}
+        className="mt-2"
+      />
+    </div>
+  );
+}

--- a/frontend/packages/app/src/components/settings/index.tsx
+++ b/frontend/packages/app/src/components/settings/index.tsx
@@ -10,13 +10,20 @@ import type { FrappeError } from "frappe-react-sdk";
 /**
  * Internal dependencies.
  */
-import { usePMSSettings } from "@/hooks/usePMSSettings";
+import { usePMSSettings, usePMSSystemSettings } from "@/hooks/usePMSSettings";
 import { parseFrappeErrorMsg } from "@/lib/utils";
 import { useUser } from "@/providers/user";
-import { USER_CONFIGURATION_PAGES } from "./constants";
+import { SETTINGS_SECTIONS } from "./constants";
 import { ProfilePage } from "./pages/profile";
+import { SystemResourceManagementPage } from "./pages/system-resource-management";
+import { SystemTimesheetsPage } from "./pages/system-timesheets";
 import { TimesheetsPage } from "./pages/timesheets";
-import type { SettingsModalProps, SettingsPage } from "./types";
+import type {
+  FieldUpdater,
+  SettingsModalProps,
+  SettingsPage,
+  SystemSettings,
+} from "./types";
 
 export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const toast = useToasts();
@@ -24,12 +31,18 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const [autoExpandWeeks, setAutoExpandWeeks] = useState("");
   const [useSystemAutoExpandWeeks, setUseSystemAutoExpandWeeks] =
     useState(true);
-  const { employeeName, userName, userId, image } = useUser(({ state }) => ({
-    employeeName: state.employeeName,
-    userName: state.userName,
-    userId: state.userId,
-    image: state.image,
-  }));
+  const [systemForm, setSystemForm] = useState<SystemSettings>({ name: "" });
+  const { employeeName, userName, userId, image, roles } = useUser(
+    ({ state }) => ({
+      employeeName: state.employeeName,
+      userName: state.userName,
+      userId: state.userId,
+      image: state.image,
+      roles: state.roles,
+    }),
+  );
+  const isSystemManager = roles.includes("System Manager");
+
   const {
     error: settingsError,
     isLoading,
@@ -38,9 +51,23 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     pmsSettings,
     updatePMSSettings,
   } = usePMSSettings(open);
-  const activePageConfig =
-    USER_CONFIGURATION_PAGES.find(({ id }) => id === activePage) ??
-    USER_CONFIGURATION_PAGES[0];
+  const {
+    error: systemError,
+    isLoading: isSystemLoading,
+    isSaving: isSystemSaving,
+    mutate: mutateSystem,
+    systemSettings,
+    updateSystemSettings,
+  } = usePMSSystemSettings(open && isSystemManager);
+
+  const sections = isSystemManager
+    ? SETTINGS_SECTIONS
+    : SETTINGS_SECTIONS.filter(({ tabs }) =>
+        tabs.some(({ id }) => !id.startsWith("system-")),
+      );
+  const activeTab = sections
+    .flatMap(({ tabs }) => tabs)
+    .find(({ id }) => id === activePage);
   const systemAutoExpandWeeks =
     pmsSettings?.system_auto_expand_weeks_by_default;
 
@@ -52,13 +79,18 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     setUseSystemAutoExpandWeeks(
       Boolean(pmsSettings?.use_system_auto_expand_weeks),
     );
-  }, [pmsSettings]);
+
+    if (systemSettings) {
+      setSystemForm(systemSettings);
+    }
+  }, [pmsSettings, systemSettings]);
 
   useEffect(() => {
-    if (settingsError) {
-      toast.error(parseFrappeErrorMsg(settingsError));
+    const error = settingsError ?? systemError;
+    if (error) {
+      toast.error(parseFrappeErrorMsg(error));
     }
-  }, [settingsError, toast]);
+  }, [settingsError, systemError, toast]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -91,6 +123,28 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     }
   };
 
+  const saveSystemSettings = async () => {
+    try {
+      await updateSystemSettings(systemForm);
+      await mutateSystem();
+      toast.success("Settings saved");
+    } catch (error) {
+      toast.error(parseFrappeErrorMsg(error as FrappeError));
+    }
+  };
+
+  const updateSystemField: FieldUpdater<SystemSettings> = (field, value) => {
+    setSystemForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const isSaveDisabled =
+    isLoading ||
+    isSystemLoading ||
+    isSaving ||
+    isSystemSaving ||
+    Boolean(settingsError) ||
+    Boolean(systemError);
+
   return (
     <Dialog
       open={open}
@@ -103,33 +157,38 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     >
       <div className="flex h-[min(860px,calc(100vh-8rem))] bg-surface-menu-bar">
         <aside className="flex w-56 shrink-0 flex-col overflow-y-auto border-r border-outline-gray-1 bg-surface-menu-bar p-2">
-          <p className="flex h-7 items-center px-2 text-base text-ink-gray-5">
-            User Configuration
-          </p>
-          <nav className="flex flex-col gap-0.5" aria-label="Settings sections">
-            {USER_CONFIGURATION_PAGES.map(({ id, label, icon: Icon }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setActivePage(id)}
-                aria-current={activePage === id ? "page" : undefined}
-                className={cn(
-                  "flex h-7 w-full items-center gap-2 rounded px-2 text-left text-base text-ink-gray-7",
-                  activePage === id
-                    ? "bg-surface-selected shadow-sm"
-                    : "hover:bg-surface-gray-2",
-                )}
-              >
-                <Icon size={16} className="shrink-0 text-ink-gray-6" />
+          {sections.map(({ label, tabs }) => (
+            <div key={label} className="flex flex-col">
+              <p className="flex h-7 items-center px-2 text-base text-ink-gray-5">
                 {label}
-              </button>
-            ))}
-          </nav>
+              </p>
+              <nav className="flex flex-col gap-0.5" aria-label={label}>
+                {tabs.map(({ id, label: tabLabel, icon: Icon }) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setActivePage(id)}
+                    aria-current={activePage === id ? "page" : undefined}
+                    className={cn(
+                      "flex h-7 w-full items-center gap-2 rounded px-2 text-left text-base text-ink-gray-7",
+                      activePage === id
+                        ? "bg-surface-selected shadow-sm"
+                        : "hover:bg-surface-gray-2",
+                    )}
+                  >
+                    <Icon size={16} className="shrink-0 text-ink-gray-6" />
+                    {tabLabel}
+                  </button>
+                ))}
+              </nav>
+            </div>
+          ))}
         </aside>
 
         <main className="flex flex-1 flex-col overflow-y-auto bg-surface-modal">
           <div className="px-[4.4rem] pt-10 pb-16">
-            {isLoading ? (
+            {isLoading ||
+            (activeTab?.id.startsWith("system-") && isSystemLoading) ? (
               <Spinner isFull />
             ) : activePage === "profile" ? (
               <ProfilePage
@@ -145,16 +204,30 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                 onAutoExpandWeeksChange={setAutoExpandWeeks}
                 onUseSystemAutoExpandWeeksChange={setUseSystemAutoExpandWeeks}
               />
+            ) : activePage === "system-timesheets" ? (
+              <SystemTimesheetsPage
+                form={systemForm}
+                updateField={updateSystemField}
+              />
+            ) : activePage === "system-resource-management" ? (
+              <SystemResourceManagementPage
+                form={systemForm}
+                updateField={updateSystemField}
+              />
             ) : null}
           </div>
-          {activePageConfig.showSave && (
+          {activeTab?.showSave && (
             <div className="mt-auto flex justify-end border-t border-outline-gray-1 px-8 py-5">
               <Button
                 variant="solid"
                 label="Save"
-                loading={isSaving}
-                disabled={isLoading || isSaving || Boolean(settingsError)}
-                onClick={saveSettings}
+                loading={isSaving || isSystemSaving}
+                disabled={isSaveDisabled}
+                onClick={
+                  activeTab.id.startsWith("system-")
+                    ? saveSystemSettings
+                    : saveSettings
+                }
               />
             </div>
           )}

--- a/frontend/packages/app/src/components/settings/index.tsx
+++ b/frontend/packages/app/src/components/settings/index.tsx
@@ -79,11 +79,13 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     setUseSystemAutoExpandWeeks(
       Boolean(pmsSettings?.use_system_auto_expand_weeks),
     );
+  }, [pmsSettings]);
 
+  useEffect(() => {
     if (systemSettings) {
       setSystemForm(systemSettings);
     }
-  }, [pmsSettings, systemSettings]);
+  }, [systemSettings]);
 
   useEffect(() => {
     const error = settingsError ?? systemError;
@@ -137,13 +139,10 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     setSystemForm((previous) => ({ ...previous, [field]: value }));
   };
 
-  const isSaveDisabled =
-    isLoading ||
-    isSystemLoading ||
-    isSaving ||
-    isSystemSaving ||
-    Boolean(settingsError) ||
-    Boolean(systemError);
+  const isSystemTab = activeTab?.id.startsWith("system-") ?? false;
+  const isSaveDisabled = isSystemTab
+    ? isSystemLoading || isSystemSaving || Boolean(systemError)
+    : isLoading || isSaving || Boolean(settingsError);
 
   return (
     <Dialog

--- a/frontend/packages/app/src/components/settings/index.tsx
+++ b/frontend/packages/app/src/components/settings/index.tsx
@@ -83,7 +83,9 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
 
   useEffect(() => {
     if (systemSettings) {
-      setSystemForm(systemSettings);
+      const { pm_report_api_key, ...form } = systemSettings;
+      void pm_report_api_key;
+      setSystemForm(form);
     }
   }, [systemSettings]);
 
@@ -207,6 +209,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
               <SystemTimesheetsPage
                 form={systemForm}
                 updateField={updateSystemField}
+                hasApiKey={Boolean(systemSettings?.pm_report_api_key)}
               />
             ) : activePage === "system-resource-management" ? (
               <SystemResourceManagementPage

--- a/frontend/packages/app/src/components/settings/pages/system-resource-management.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-resource-management.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies.
+ */
+import { Checkbox } from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import {
+  SettingsCurrencyField,
+  SettingsDaySelect,
+  SettingsLinkField,
+  SettingsMultiSelectField,
+} from "../fields";
+import type { SystemResourceManagementPageProps } from "../types";
+
+export function SystemResourceManagementPage({
+  form,
+  updateField,
+}: SystemResourceManagementPageProps) {
+  const sendReminder = Boolean(form.send_missing_allocation_reminder);
+
+  return (
+    <div className="max-w-3xl">
+      <div>
+        <h2 className="text-xl font-semibold text-ink-gray-8">
+          Resource Management
+        </h2>
+        <p className="mt-1 text-p-sm text-ink-gray-6">
+          Configure global resource management settings.
+        </p>
+      </div>
+
+      <section className="mt-10">
+        <h3 className="text-lg font-semibold text-ink-gray-8">Rate Display</h3>
+        <div className="mt-5 max-w-sm">
+          <SettingsCurrencyField
+            value={form.default_currency}
+            onChange={(value) => updateField("default_currency", value)}
+          />
+        </div>
+      </section>
+
+      <section className="mt-10">
+        <h3 className="text-lg font-semibold text-ink-gray-8">
+          Allocation Notifications
+        </h3>
+        <div className="mt-5 max-w-sm flex flex-col gap-5">
+          <Checkbox
+            label="Send Missing Allocation Reminder"
+            value={sendReminder}
+            onChange={(value) =>
+              updateField("send_missing_allocation_reminder", value ? 1 : 0)
+            }
+          />
+          {sendReminder && (
+            <>
+              <SettingsDaySelect
+                label="Remind On"
+                value={form.remind_on}
+                onChange={(value) => updateField("remind_on", value)}
+              />
+              <SettingsLinkField
+                label="Email Template"
+                doctype="Email Template"
+                value={form.allocation_email_template}
+                onChange={(value) =>
+                  updateField("allocation_email_template", value)
+                }
+              />
+              <SettingsMultiSelectField
+                label="Designations"
+                doctype="Designation"
+                value={(form.designations ?? [])
+                  .map((row) => row.designation)
+                  .filter((value): value is string => Boolean(value))}
+                onChange={(values) =>
+                  updateField(
+                    "designations",
+                    values.map((designation) => ({ designation })),
+                  )
+                }
+              />
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -26,14 +26,15 @@ import type { SystemTimesheetsPageProps } from "../types";
 
 function ApiKeyField() {
   const toast = useToasts();
-  const { value, isSaving, mutate, updateSystemApiKey } = usePMSSystemApiKey();
+  const { value, isSaving, error, mutate, updateSystemApiKey } =
+    usePMSSystemApiKey();
   const [draft, setDraft] = useState<string | null>(null);
 
   useEffect(() => {
     setDraft(value ?? "");
   }, [value]);
 
-  const isDirty = draft !== value;
+  const isDirty = draft !== null && draft !== (value ?? "");
 
   const save = async () => {
     if (!isDirty) {
@@ -43,10 +44,16 @@ function ApiKeyField() {
       await updateSystemApiKey(draft ?? "");
       await mutate();
       toast.success("PM Report API Key saved");
-    } catch (error) {
-      toast.error(parseFrappeErrorMsg(error as FrappeError));
+    } catch (saveError) {
+      toast.error(parseFrappeErrorMsg(saveError as FrappeError));
     }
   };
+
+  useEffect(() => {
+    if (error) {
+      toast.error(parseFrappeErrorMsg(error as FrappeError));
+    }
+  }, [error, toast]);
 
   return (
     <div>
@@ -63,6 +70,7 @@ function ApiKeyField() {
           variant="subtle"
           label="Save"
           loading={isSaving}
+          disabled={Boolean(error)}
           className="mt-2"
           onClick={save}
         />
@@ -272,20 +280,22 @@ export function SystemTimesheetsPage({
                   updateField("weekly_approval_reminder_template", value)
                 }
               />
-              <SettingsMultiSelectField
-                label="Allowed Departments"
-                doctype="Department"
-                value={(form.allowed_departments ?? [])
-                  .map((row) => row.department)
-                  .filter((value): value is string => Boolean(value))}
-                onChange={(values) =>
-                  updateField(
-                    "allowed_departments",
-                    values.map((department) => ({ department })),
-                  )
-                }
-              />
             </>
+          )}
+          {(dailyReminder || weeklyReminder) && (
+            <SettingsMultiSelectField
+              label="Allowed Departments"
+              doctype="Department"
+              value={(form.allowed_departments ?? [])
+                .map((row) => row.department)
+                .filter((value): value is string => Boolean(value))}
+              onChange={(values) =>
+                updateField(
+                  "allowed_departments",
+                  values.map((department) => ({ department })),
+                )
+              }
+            />
           )}
         </div>
       </section>

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -3,16 +3,20 @@
  */
 import { useEffect, useState } from "react";
 import {
+  Button,
   Checkbox,
   FormLabel,
   Password,
   TextInput,
+  useToasts,
 } from "@rtcamp/frappe-ui-react";
+import type { FrappeError } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
 import { usePMSSystemApiKey } from "@/hooks/usePMSSettings";
+import { parseFrappeErrorMsg } from "@/lib/utils";
 import {
   SettingsDaySelect,
   SettingsLinkField,
@@ -21,7 +25,8 @@ import {
 import type { SystemTimesheetsPageProps } from "../types";
 
 function ApiKeyField() {
-  const { value, isSaving, updateSystemApiKey } = usePMSSystemApiKey();
+  const toast = useToasts();
+  const { value, isSaving, mutate, updateSystemApiKey } = usePMSSystemApiKey();
   const [draft, setDraft] = useState<string | null>(null);
 
   useEffect(() => {
@@ -30,11 +35,17 @@ function ApiKeyField() {
 
   const isDirty = draft !== value;
 
-  const save = () => {
+  const save = async () => {
     if (!isDirty) {
       return;
     }
-    updateSystemApiKey(draft ?? "");
+    try {
+      await updateSystemApiKey(draft ?? "");
+      await mutate();
+      toast.success("PM Report API Key saved");
+    } catch (error) {
+      toast.error(parseFrappeErrorMsg(error as FrappeError));
+    }
   };
 
   return (
@@ -48,14 +59,13 @@ function ApiKeyField() {
         onChange={(event) => setDraft(event.target.value)}
       />
       {isDirty && (
-        <button
-          type="button"
-          disabled={isSaving}
+        <Button
+          variant="subtle"
+          label="Save"
+          loading={isSaving}
+          className="mt-2"
           onClick={save}
-          className="mt-2 text-base text-ink-gray-6 underline-offset-2 hover:text-ink-gray-9 hover:underline disabled:text-ink-gray-4 disabled:hover:no-underline"
-        >
-          Save
-        </button>
+        />
       )}
     </div>
   );

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -1,0 +1,293 @@
+/**
+ * External dependencies.
+ */
+import { useEffect, useState } from "react";
+import {
+  Checkbox,
+  FormLabel,
+  Password,
+  TextInput,
+} from "@rtcamp/frappe-ui-react";
+
+/**
+ * Internal dependencies.
+ */
+import { usePMSSystemApiKey } from "@/hooks/usePMSSettings";
+import {
+  SettingsDaySelect,
+  SettingsLinkField,
+  SettingsMultiSelectField,
+} from "../fields";
+import type { SystemTimesheetsPageProps } from "../types";
+
+function ApiKeyField() {
+  const { value, isSaving, updateSystemApiKey } = usePMSSystemApiKey();
+  const [draft, setDraft] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft(value ?? "");
+  }, [value]);
+
+  const isDirty = draft !== value;
+
+  const save = () => {
+    if (!isDirty) {
+      return;
+    }
+    updateSystemApiKey(draft ?? "");
+  };
+
+  return (
+    <div>
+      <FormLabel size="md" className="text-ink-gray-8!">
+        PM Report API Key
+      </FormLabel>
+      <Password
+        value={draft ?? ""}
+        placeholder="Enter API key"
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      {isDirty && (
+        <button
+          type="button"
+          disabled={isSaving}
+          onClick={save}
+          className="mt-2 text-base text-ink-gray-6 underline-offset-2 hover:text-ink-gray-9 hover:underline disabled:text-ink-gray-4 disabled:hover:no-underline"
+        >
+          Save
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function SystemTimesheetsPage({
+  form,
+  updateField,
+}: SystemTimesheetsPageProps) {
+  const backdated = Boolean(form.allow_backdated_entries);
+  const dailyReminder = Boolean(form.send_daily_reminder);
+  const approvalReminder = Boolean(form.send_reminder_on_approval_request);
+  const weeklyReminder = Boolean(form.send_weekly_approval_reminder);
+
+  return (
+    <div className="max-w-3xl">
+      <div>
+        <h2 className="text-xl font-semibold text-ink-gray-8">Timesheets</h2>
+        <p className="mt-1 text-p-sm text-ink-gray-6">
+          Configure global timesheet defaults.
+        </p>
+      </div>
+
+      <section className="mt-10">
+        <h3 className="text-lg font-semibold text-ink-gray-8">
+          Time Entry Rules
+        </h3>
+        <div className="mt-5 max-w-sm flex flex-col gap-5">
+          <Checkbox
+            label="Allow Backdated Entries"
+            value={backdated}
+            onChange={(value) =>
+              updateField("allow_backdated_entries", value ? 1 : 0)
+            }
+          />
+          {backdated && (
+            <>
+              <div>
+                <FormLabel size="md" className="text-ink-gray-8!">
+                  Allow Backdated Entries Till (Employee)
+                </FormLabel>
+                <TextInput
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={String(
+                    form.allow_backdated_entries_till_employee ?? "",
+                  )}
+                  className="mt-2"
+                  onChange={(event) =>
+                    updateField(
+                      "allow_backdated_entries_till_employee",
+                      Number(event.target.value),
+                    )
+                  }
+                />
+              </div>
+              <div>
+                <FormLabel size="md" className="text-ink-gray-8!">
+                  Allow Backdated Entries Till (Manager)
+                </FormLabel>
+                <TextInput
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={String(
+                    form.allow_backdated_entries_till_manager ?? "",
+                  )}
+                  className="mt-2"
+                  onChange={(event) =>
+                    updateField(
+                      "allow_backdated_entries_till_manager",
+                      Number(event.target.value),
+                    )
+                  }
+                />
+              </div>
+              <SettingsMultiSelectField
+                label="Ignored Roles"
+                doctype="Role"
+                value={(form.ignored_role ?? [])
+                  .map((row) => row.role)
+                  .filter((value): value is string => Boolean(value))}
+                onChange={(values) =>
+                  updateField(
+                    "ignored_role",
+                    values.map((role) => ({ role })),
+                  )
+                }
+              />
+            </>
+          )}
+          <Checkbox
+            label="Allow Future Entries"
+            value={Boolean(form.allow_future_entries)}
+            onChange={(value) =>
+              updateField("allow_future_entries", value ? 1 : 0)
+            }
+          />
+          <Checkbox
+            label="Allow Weekend Entries"
+            value={Boolean(form.allow_weekend_entries)}
+            onChange={(value) =>
+              updateField("allow_weekend_entries", value ? 1 : 0)
+            }
+          />
+          <div>
+            <FormLabel size="md" className="text-ink-gray-8!">
+              Auto Expand Weeks by Default
+            </FormLabel>
+            <TextInput
+              type="number"
+              min="0"
+              step="1"
+              value={String(form.auto_expand_weeks_by_default ?? "")}
+              className="mt-2"
+              onChange={(event) =>
+                updateField(
+                  "auto_expand_weeks_by_default",
+                  Number(event.target.value),
+                )
+              }
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-10">
+        <h3 className="text-lg font-semibold text-ink-gray-8">
+          Reminder Settings
+        </h3>
+        <div className="mt-5 max-w-sm flex flex-col gap-5">
+          <Checkbox
+            label="Send Daily Reminder"
+            value={dailyReminder}
+            onChange={(value) =>
+              updateField("send_daily_reminder", value ? 1 : 0)
+            }
+          />
+          {dailyReminder && (
+            <SettingsLinkField
+              label="Daily Reminder Template"
+              doctype="Email Template"
+              value={form.daily_reminder_template}
+              onChange={(value) =>
+                updateField("daily_reminder_template", value)
+              }
+            />
+          )}
+          <Checkbox
+            label="Send Reminder On Approval Request"
+            value={approvalReminder}
+            onChange={(value) =>
+              updateField("send_reminder_on_approval_request", value ? 1 : 0)
+            }
+          />
+          {approvalReminder && (
+            <SettingsLinkField
+              label="Approval Request Reminder Template"
+              doctype="Email Template"
+              value={form.approval_request_reminder_template}
+              onChange={(value) =>
+                updateField("approval_request_reminder_template", value)
+              }
+            />
+          )}
+          <SettingsLinkField
+            label="Timesheet Approval Template"
+            doctype="Email Template"
+            value={form.timesheet_approval_template}
+            clearable
+            onChange={(value) =>
+              updateField("timesheet_approval_template", value)
+            }
+          />
+          <SettingsLinkField
+            label="Timesheet Rejection Template"
+            doctype="Email Template"
+            value={form.timesheet_rejection_template}
+            clearable
+            onChange={(value) =>
+              updateField("timesheet_rejection_template", value)
+            }
+          />
+          <Checkbox
+            label="Send Weekly Approval Reminder"
+            value={weeklyReminder}
+            onChange={(value) =>
+              updateField("send_weekly_approval_reminder", value ? 1 : 0)
+            }
+          />
+          {weeklyReminder && (
+            <>
+              <SettingsDaySelect
+                label="Day To Send Weekly Reminder"
+                value={form.day_to_send_reminder}
+                onChange={(value) => updateField("day_to_send_reminder", value)}
+              />
+              <SettingsLinkField
+                label="Weekly Approval Reminder Template"
+                doctype="Email Template"
+                value={form.weekly_approval_reminder_template}
+                onChange={(value) =>
+                  updateField("weekly_approval_reminder_template", value)
+                }
+              />
+              <SettingsMultiSelectField
+                label="Allowed Departments"
+                doctype="Department"
+                value={(form.allowed_departments ?? [])
+                  .map((row) => row.department)
+                  .filter((value): value is string => Boolean(value))}
+                onChange={(values) =>
+                  updateField(
+                    "allowed_departments",
+                    values.map((department) => ({ department })),
+                  )
+                }
+              />
+            </>
+          )}
+        </div>
+      </section>
+
+      <section className="mt-10">
+        <h3 className="text-lg font-semibold text-ink-gray-8">
+          Report Configuration
+        </h3>
+        <div className="mt-5 max-w-sm">
+          <ApiKeyField />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -3,57 +3,45 @@
  */
 import { useEffect, useState } from "react";
 import {
-  Button,
   Checkbox,
   FormLabel,
   Password,
   TextInput,
-  useToasts,
 } from "@rtcamp/frappe-ui-react";
-import type { FrappeError } from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
 import { usePMSSystemApiKey } from "@/hooks/usePMSSettings";
-import { parseFrappeErrorMsg } from "@/lib/utils";
 import {
   SettingsDaySelect,
   SettingsLinkField,
   SettingsMultiSelectField,
 } from "../fields";
-import type { SystemTimesheetsPageProps } from "../types";
+import type {
+  FieldUpdater,
+  SystemSettings,
+  SystemTimesheetsPageProps,
+} from "../types";
 
-function ApiKeyField() {
-  const toast = useToasts();
-  const { value, isSaving, error, mutate, updateSystemApiKey } =
-    usePMSSystemApiKey();
+function ApiKeyField({
+  hasApiKey,
+  updateField,
+}: {
+  hasApiKey: boolean;
+  updateField: FieldUpdater<SystemSettings>;
+}) {
+  const { value } = usePMSSystemApiKey(hasApiKey);
   const [draft, setDraft] = useState<string | null>(null);
 
   useEffect(() => {
     setDraft(value ?? "");
   }, [value]);
 
-  const isDirty = draft !== null && draft !== (value ?? "");
-
-  const save = async () => {
-    if (!isDirty) {
-      return;
-    }
-    try {
-      await updateSystemApiKey(draft ?? "");
-      await mutate();
-      toast.success("PM Report API Key saved");
-    } catch (saveError) {
-      toast.error(parseFrappeErrorMsg(saveError as FrappeError));
-    }
+  const onChange = (next: string) => {
+    setDraft(next);
+    updateField("pm_report_api_key", next);
   };
-
-  useEffect(() => {
-    if (error) {
-      toast.error(parseFrappeErrorMsg(error as FrappeError));
-    }
-  }, [error, toast]);
 
   return (
     <div>
@@ -63,18 +51,8 @@ function ApiKeyField() {
       <Password
         value={draft ?? ""}
         placeholder="Enter API key"
-        onChange={(event) => setDraft(event.target.value)}
+        onChange={(event) => onChange(event.target.value)}
       />
-      {isDirty && (
-        <Button
-          variant="subtle"
-          label="Save"
-          loading={isSaving}
-          disabled={Boolean(error)}
-          className="mt-2"
-          onClick={save}
-        />
-      )}
     </div>
   );
 }
@@ -82,6 +60,7 @@ function ApiKeyField() {
 export function SystemTimesheetsPage({
   form,
   updateField,
+  hasApiKey,
 }: SystemTimesheetsPageProps) {
   const backdated = Boolean(form.allow_backdated_entries);
   const dailyReminder = Boolean(form.send_daily_reminder);
@@ -305,7 +284,7 @@ export function SystemTimesheetsPage({
           Report Configuration
         </h3>
         <div className="mt-5 max-w-sm">
-          <ApiKeyField />
+          <ApiKeyField hasApiKey={hasApiKey} updateField={updateField} />
         </div>
       </section>
     </div>

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -48,11 +48,13 @@ function ApiKeyField({
       <FormLabel size="md" className="text-ink-gray-8!">
         PM Report API Key
       </FormLabel>
-      <Password
-        value={draft ?? ""}
-        placeholder="Enter API key"
-        onChange={(event) => onChange(event.target.value)}
-      />
+      <div className="mt-2">
+        <Password
+          value={draft ?? ""}
+          placeholder="Enter API key"
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/packages/app/src/components/settings/types.ts
+++ b/frontend/packages/app/src/components/settings/types.ts
@@ -1,12 +1,63 @@
 import type { LucideIcon } from "lucide-react";
 
-export type SettingsPage = "profile" | "timesheets";
+export type SettingsPage =
+  "profile" | "timesheets" | "system-timesheets" | "system-resource-management";
+
+export type SettingsTab = {
+  id: SettingsPage;
+  label: string;
+  icon: LucideIcon;
+  showSave?: boolean;
+};
+
+export type SettingsSection = {
+  label: string;
+  tabs: SettingsTab[];
+};
 
 export type PMSSettings = {
   auto_expand_weeks_by_default: number | null;
   system_auto_expand_weeks_by_default: number;
   use_system_auto_expand_weeks: 0 | 1;
 };
+
+export type TimesheetSettings = {
+  allow_backdated_entries?: 0 | 1;
+  allow_backdated_entries_till_employee?: number;
+  allow_backdated_entries_till_manager?: number;
+  ignored_role?: Array<{ role?: string }>;
+  allow_future_entries?: 0 | 1;
+  allow_weekend_entries?: 0 | 1;
+  auto_expand_weeks_by_default?: number;
+  send_daily_reminder?: 0 | 1;
+  daily_reminder_template?: string | null;
+  send_reminder_on_approval_request?: 0 | 1;
+  approval_request_reminder_template?: string | null;
+  timesheet_approval_template?: string | null;
+  timesheet_rejection_template?: string | null;
+  send_weekly_approval_reminder?: 0 | 1;
+  day_to_send_reminder?: string;
+  weekly_approval_reminder_template?: string | null;
+  allowed_departments?: Array<{ department?: string }>;
+};
+
+export type ResourceManagementSettings = {
+  send_missing_allocation_reminder?: 0 | 1;
+  remind_on?: string;
+  allocation_email_template?: string | null;
+  designations?: Array<{ designation?: string }>;
+  default_currency?: string | null;
+};
+
+export type SystemSettings = TimesheetSettings &
+  ResourceManagementSettings & {
+    name: string;
+  };
+
+export type FieldUpdater<T> = <K extends keyof T>(
+  field: K,
+  value: T[K],
+) => void;
 
 export type SettingsModalProps = {
   open: boolean;
@@ -27,9 +78,12 @@ export type TimesheetsPageProps = {
   onUseSystemAutoExpandWeeksChange: (value: boolean) => void;
 };
 
-export type SettingsPageConfig = {
-  id: SettingsPage;
-  label: string;
-  icon: LucideIcon;
-  showSave?: boolean;
+export type SystemTimesheetsPageProps = {
+  form: TimesheetSettings;
+  updateField: FieldUpdater<SystemSettings>;
+};
+
+export type SystemResourceManagementPageProps = {
+  form: ResourceManagementSettings;
+  updateField: FieldUpdater<SystemSettings>;
 };

--- a/frontend/packages/app/src/components/settings/types.ts
+++ b/frontend/packages/app/src/components/settings/types.ts
@@ -52,6 +52,7 @@ export type ResourceManagementSettings = {
 export type SystemSettings = TimesheetSettings &
   ResourceManagementSettings & {
     name: string;
+    pm_report_api_key?: string | null;
   };
 
 export type FieldUpdater<T> = <K extends keyof T>(
@@ -81,6 +82,7 @@ export type TimesheetsPageProps = {
 export type SystemTimesheetsPageProps = {
   form: TimesheetSettings;
   updateField: FieldUpdater<SystemSettings>;
+  hasApiKey: boolean;
 };
 
 export type SystemResourceManagementPageProps = {

--- a/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
+++ b/frontend/packages/app/src/hooks/useDoctypeLinkLookup.ts
@@ -28,7 +28,7 @@ interface UseDoctypeLinkLookupOptions {
   /** Raw user search text before debounce is applied. */
   query: string;
   /** Keeps the current selection visible when it is not in the latest results. */
-  selectedOption?: LookupOption | null;
+  selectedOption?: LookupOption | LookupOption[] | null;
 }
 
 /**

--- a/frontend/packages/app/src/hooks/usePMSSettings.ts
+++ b/frontend/packages/app/src/hooks/usePMSSettings.ts
@@ -60,28 +60,24 @@ export function usePMSSystemSettings(enabled: boolean) {
   };
 }
 
-export function usePMSSystemApiKey() {
+export function usePMSSystemApiKey(hasApiKey: boolean) {
   const fieldname = "pm_report_api_key";
-  const { data, mutate, isLoading, error } = useFrappeGetCall<{
+  const method = "frappe.client.get_password";
+  const { data, isLoading, error } = useFrappeGetCall<{
     message: string;
-  }>("frappe.client.get_password", {
-    doctype: SYSTEM_SETTINGS_DOCTYPE,
-    name: SYSTEM_SETTINGS_DOCTYPE,
-    fieldname,
-  });
-  const { updateDoc, loading: isSaving } = useFrappeUpdateDoc();
-
-  const updateSystemApiKey = (value: string) =>
-    updateDoc(SYSTEM_SETTINGS_DOCTYPE, SYSTEM_SETTINGS_DOCTYPE, {
-      [fieldname]: value,
-    });
+  }>(
+    method,
+    {
+      doctype: SYSTEM_SETTINGS_DOCTYPE,
+      name: SYSTEM_SETTINGS_DOCTYPE,
+      fieldname,
+    },
+    hasApiKey ? `${method}:${fieldname}` : null,
+  );
 
   return {
     value: data?.message ?? null,
     isLoading,
-    isSaving,
     error,
-    mutate,
-    updateSystemApiKey,
   };
 }

--- a/frontend/packages/app/src/hooks/usePMSSettings.ts
+++ b/frontend/packages/app/src/hooks/usePMSSettings.ts
@@ -1,15 +1,21 @@
 /**
  * External dependencies.
  */
-import { useFrappeGetCall, useFrappePostCall } from "frappe-react-sdk";
+import {
+  useFrappeGetCall,
+  useFrappeGetDoc,
+  useFrappePostCall,
+  useFrappeUpdateDoc,
+} from "frappe-react-sdk";
 
 /**
  * Internal dependencies.
  */
-import type { PMSSettings } from "@/components/settings/types";
+import type { PMSSettings, SystemSettings } from "@/components/settings/types";
 
 const PMS_SETTINGS_API =
   "next_pms.next_pms.doctype.pms_user_setting.pms_user_setting";
+const SYSTEM_SETTINGS_DOCTYPE = "Timesheet Settings";
 
 export function usePMSSettings(enabled: boolean) {
   const { data, error, isLoading, mutate } = useFrappeGetCall<{
@@ -30,5 +36,52 @@ export function usePMSSettings(enabled: boolean) {
     pmsSettings: data?.message,
     mutate,
     updatePMSSettings,
+  };
+}
+
+export function usePMSSystemSettings(enabled: boolean) {
+  const { data, error, isLoading, mutate } = useFrappeGetDoc<SystemSettings>(
+    SYSTEM_SETTINGS_DOCTYPE,
+    SYSTEM_SETTINGS_DOCTYPE,
+    enabled ? undefined : null,
+  );
+  const { updateDoc, loading: isSaving } = useFrappeUpdateDoc();
+
+  const updateSystemSettings = (values: SystemSettings) =>
+    updateDoc(SYSTEM_SETTINGS_DOCTYPE, SYSTEM_SETTINGS_DOCTYPE, values);
+
+  return {
+    error,
+    isLoading,
+    isSaving,
+    systemSettings: data,
+    mutate,
+    updateSystemSettings,
+  };
+}
+
+export function usePMSSystemApiKey() {
+  const fieldname = "pm_report_api_key";
+  const { data, mutate, isLoading } = useFrappeGetCall<{ message: string }>(
+    "frappe.client.get_password",
+    {
+      doctype: SYSTEM_SETTINGS_DOCTYPE,
+      name: SYSTEM_SETTINGS_DOCTYPE,
+      fieldname,
+    },
+  );
+  const { updateDoc, loading: isSaving } = useFrappeUpdateDoc();
+
+  const updateSystemApiKey = (value: string) =>
+    updateDoc(SYSTEM_SETTINGS_DOCTYPE, SYSTEM_SETTINGS_DOCTYPE, {
+      [fieldname]: value,
+    });
+
+  return {
+    value: data?.message ?? null,
+    isLoading,
+    isSaving,
+    mutate,
+    updateSystemApiKey,
   };
 }

--- a/frontend/packages/app/src/hooks/usePMSSettings.ts
+++ b/frontend/packages/app/src/hooks/usePMSSettings.ts
@@ -62,14 +62,13 @@ export function usePMSSystemSettings(enabled: boolean) {
 
 export function usePMSSystemApiKey() {
   const fieldname = "pm_report_api_key";
-  const { data, mutate, isLoading } = useFrappeGetCall<{ message: string }>(
-    "frappe.client.get_password",
-    {
-      doctype: SYSTEM_SETTINGS_DOCTYPE,
-      name: SYSTEM_SETTINGS_DOCTYPE,
-      fieldname,
-    },
-  );
+  const { data, mutate, isLoading, error } = useFrappeGetCall<{
+    message: string;
+  }>("frappe.client.get_password", {
+    doctype: SYSTEM_SETTINGS_DOCTYPE,
+    name: SYSTEM_SETTINGS_DOCTYPE,
+    fieldname,
+  });
   const { updateDoc, loading: isSaving } = useFrappeUpdateDoc();
 
   const updateSystemApiKey = (value: string) =>
@@ -81,6 +80,7 @@ export function usePMSSystemApiKey() {
     value: data?.message ?? null,
     isLoading,
     isSaving,
+    error,
     mutate,
     updateSystemApiKey,
   };


### PR DESCRIPTION
## Description

- Adds a System Configuration section to the settings with 2 new tabs: Timesheets and Resource Management
- Fetches fields from the "Timesheet Settings" doctype and displays them accordingly in the respective pages
- Fields can be modified and changed from the settings modal
- Only the user with "System Manager" role can view the whole section to other users only "User Configuration" section will be visible (Issue states adding "Delivery Manager" role but in the "Timesheet Settings" permission settings only System Manager has any type of read/write access to the doctype)

## Relevant Technical Choices

- Extends the usePMSSettings hook using the useFrappeGetDoc, and useFrappeUpdateDoc to perform read and write on the "Timesheet Settings" doctype
- Added a separate `frappe.client.get_password` call to fetch the PM Report API Key
- Added optional props to the multiselect component of frappe-ui-react to add search and className support

## Testing Instructions

- Open PMS as a user with "System Manager" role
- Click on the Down arrow next to User name on left sidebar top to access dropdown
- Click on settings, the settings modal should open up
- System Configuration section should show up with two tabs Timesheets and Resource Management
- Check all values are populated and on updating are updated properly (Verify in desk by visiting the Timesheet Settings doctype)

## Screenshot/Screencast


https://github.com/user-attachments/assets/61de0761-a684-414e-a6b8-0c91e57f17f5




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

Fixes #2103 and #2102 
Depends on: https://github.com/rtCamp/frappe-ui-react/pull/348