### PR TITLE
fix: add upper limit to max weeks expanded in system and user settings

### DIFF
--- a/next_pms/next_pms/doctype/pms_user_setting/pms_user_setting.py
+++ b/next_pms/next_pms/doctype/pms_user_setting/pms_user_setting.py
@@ -19,7 +19,20 @@ class PMSUserSetting(Document):
         user: DF.Link
     # end: auto-generated types
 
-    pass
+    def validate(self):
+        _validate_user_auto_expand_weeks(self.auto_expand_weeks_by_default)
+
+
+MAX_USER_AUTO_EXPAND_WEEKS = 12
+
+
+def _validate_user_auto_expand_weeks(value: int) -> None:
+    """Reject a user Auto Expand Weeks value above the upper limit."""
+    if value is not None and value > MAX_USER_AUTO_EXPAND_WEEKS:
+        frappe.throw(
+            frappe._("Auto Expand Weeks by Default cannot exceed {0}.").format(MAX_USER_AUTO_EXPAND_WEEKS),
+            frappe.ValidationError,
+        )
 
 
 def _validate_non_negative_int(value: int | float | str | None) -> int | None:

--- a/next_pms/next_pms/doctype/pms_user_setting/test_pms_user_setting.py
+++ b/next_pms/next_pms/doctype/pms_user_setting/test_pms_user_setting.py
@@ -68,6 +68,16 @@ class TestPMSUserSetting(IntegrationTestCase):
         with self.assertRaises(frappe.ValidationError):
             update_pms_settings({"not_a_setting": 1})
 
+    def test_auto_expand_weeks_accepts_upper_limit(self):
+        get_pms_settings()
+        settings = update_pms_settings({"auto_expand_weeks_by_default": 12})
+        self.assertEqual(settings["auto_expand_weeks_by_default"], 12)
+
+    def test_auto_expand_weeks_rejects_beyond_upper_limit(self):
+        get_pms_settings()
+        with self.assertRaises(frappe.ValidationError):
+            update_pms_settings({"auto_expand_weeks_by_default": 13})
+
     def test_settings_are_scoped_to_the_current_user(self):
         get_pms_settings()
         update_pms_settings({"auto_expand_weeks_by_default": 3})

--- a/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.py
+++ b/next_pms/timesheet/doctype/timesheet_settings/timesheet_settings.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2024, rtCamp and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 from next_pms.resource_management.doctype.resource_allocation.resource_allocation import clear_cache
+
+MAX_SYSTEM_AUTO_EXPAND_WEEKS = 12
 
 
 class TimesheetSettings(Document):
@@ -50,3 +52,15 @@ class TimesheetSettings(Document):
             # The resource management views cache their payload with the rates already
             # restated in this currency, so a stale cache keeps serving the old one.
             clear_cache()
+
+    def validate(self):
+        _validate_system_auto_expand_weeks(self.auto_expand_weeks_by_default)
+
+
+def _validate_system_auto_expand_weeks(value: int) -> None:
+    """Reject an Auto Expand Weeks value above the system upper limit."""
+    if value is not None and value > MAX_SYSTEM_AUTO_EXPAND_WEEKS:
+        frappe.throw(
+            frappe._("Auto Expand Weeks by Default cannot exceed {0}.").format(MAX_SYSTEM_AUTO_EXPAND_WEEKS),
+            frappe.ValidationError,
+        )


### PR DESCRIPTION
## Description

- Adds an upper limit to the max weeks expanded in the timesheets in the PMS User settings and global settings

## Relevant Technical Choices

- Added a validate function to prevent users from saving values higher than 12 as stated in https://github.com/rtCamp/next-pms/issues/1776#issuecomment-5581550855

## Testing Instructions

- Go to PMS
- Open settings and User Configuration > Timesheets
- Try to save the "Default Expanded Weeks in Timesheet View" value to anything higher than 12
- Observe it will not let you save values higher than 12

## Screenshot/Screencast


https://github.com/user-attachments/assets/9c63b9d9-ae71-4a3a-81f4-54b1d6788d36




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

Part of: #1776 

Reported in: https://github.com/rtCamp/next-pms/issues/1776#issuecomment-5581358439