### PR TITLE
fix: hide unusable view options

### DIFF
--- a/frontend/packages/app/src/components/viewsDropdown.tsx
+++ b/frontend/packages/app/src/components/viewsDropdown.tsx
@@ -27,6 +27,7 @@ type ViewsDropdownProps = PropsWithChildren<{
   editView: ViewsContextProps["actions"]["editView"];
   updateView: ViewsContextProps["actions"]["updateView"];
   deleteView: ViewsContextProps["actions"]["deleteView"];
+  canManageView: ViewsContextProps["state"]["canManageView"];
   createView: () => void;
 }>;
 
@@ -50,6 +51,7 @@ function ViewsDropdown({
   editView,
   updateView,
   deleteView,
+  canManageView,
   createView,
   children,
 }: ViewsDropdownProps) {
@@ -103,6 +105,7 @@ function ViewsDropdown({
         if (!view) {
           return <div {...menuProps} />;
         }
+        const canManage = canManageView(view);
         const savedViewActions: DropdownOptions = [
           {
             group: "",
@@ -113,31 +116,39 @@ function ViewsDropdown({
                 icon: <Duplicate className="size-4 mr-2" />,
                 onClick: () => duplicateView(view),
               },
-              {
-                label: "Edit",
-                icon: <Edit className="size-4 mr-2" />,
-                onClick: () => editView(view),
-              },
-              {
-                label: view.public ? "Make Private" : "Make Public",
-                icon: <Lock className="size-4 mr-2" />,
-                onClick: () =>
-                  updateView({ ...view, public: view.public ? 0 : 1 }),
-              },
+              ...(canManage
+                ? [
+                    {
+                      label: "Edit",
+                      icon: <Edit className="size-4 mr-2" />,
+                      onClick: () => editView(view),
+                    },
+                    {
+                      label: view.public ? "Make Private" : "Make Public",
+                      icon: <Lock className="size-4 mr-2" />,
+                      onClick: () =>
+                        updateView({ ...view, public: view.public ? 0 : 1 }),
+                    },
+                  ]
+                : []),
             ],
           },
-          {
-            group: "",
-            key: "saved-view-danger-actions",
-            items: [
-              {
-                label: "Delete",
-                icon: <Delete className="size-4 mr-2" />,
-                theme: "red",
-                onClick: () => deleteView(view),
-              },
-            ],
-          },
+          ...(canManage
+            ? [
+                {
+                  group: "",
+                  key: "saved-view-danger-actions",
+                  items: [
+                    {
+                      label: "Delete",
+                      icon: <Delete className="size-4 mr-2" />,
+                      theme: "red" as const,
+                      onClick: () => deleteView(view),
+                    },
+                  ],
+                },
+              ]
+            : []),
         ];
 
         return (

--- a/frontend/packages/app/src/pages/projects/components/projectsHeader.tsx
+++ b/frontend/packages/app/src/pages/projects/components/projectsHeader.tsx
@@ -33,6 +33,7 @@ function ProjectsHeader({ label, children }: ProjectsHeaderProps) {
   const editView = useProjectViews((state) => state.actions.editView);
   const updateView = useProjectViews((state) => state.actions.updateView);
   const deleteView = useProjectViews((state) => state.actions.deleteView);
+  const canManageView = useProjectViews((state) => state.state.canManageView);
 
   if (isLoading || !activeView) {
     return <Spinner isFull />;
@@ -48,6 +49,7 @@ function ProjectsHeader({ label, children }: ProjectsHeaderProps) {
       editView={editView}
       updateView={updateView}
       deleteView={deleteView}
+      canManageView={canManageView}
       createView={() =>
         createView({
           type: activeView.type,

--- a/frontend/packages/app/src/providers/views/index.ts
+++ b/frontend/packages/app/src/providers/views/index.ts
@@ -20,6 +20,8 @@ export interface ViewsContextProps {
     activeView: View | undefined;
     /** Indicates whether views are still being fetched. */
     isLoading: boolean;
+    /** Whether the current user may edit, change the visibility of or delete the given view. */
+    canManageView: (view: View) => boolean;
   };
   actions: {
     /** Creates a new view for the provider's doctype and refreshes the list. */
@@ -49,6 +51,7 @@ export const ViewsContext = createContext<ViewsContextProps>({
     savedViews: [],
     activeView: undefined,
     isLoading: false,
+    canManageView: () => false,
   },
   actions: {
     createView: () => null,

--- a/frontend/packages/app/src/providers/views/provider.tsx
+++ b/frontend/packages/app/src/providers/views/provider.tsx
@@ -26,6 +26,7 @@ import {
 import CreateViewModal from "@/components/create-view";
 import EditViewModal from "@/components/edit-view";
 import { parseFrappeErrorMsg } from "@/lib/utils";
+import { useUser } from "@/providers/user";
 import type { View } from "@/types";
 import { ViewsContext } from ".";
 
@@ -38,6 +39,7 @@ export const ViewsProvider: FC<
 > = ({ doctype, defaultViews, filterParamKeys, children }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const toast = useToasts();
+  const currentUser = useUser(({ state }) => state.currentUser);
 
   const [isCreateViewModal, setIsCreateViewModal] = useState(false);
   const [type, settype] = useState("");
@@ -270,6 +272,13 @@ export const ViewsProvider: FC<
     [toast, deleteDoc, mutate],
   );
 
+  const canManageView = useCallback(
+    (view: View) =>
+      currentUser === "Administrator" ||
+      (!!currentUser && view.owner === currentUser),
+    [currentUser],
+  );
+
   const refresh = useCallback(async () => {
     await mutate();
   }, [mutate]);
@@ -283,6 +292,7 @@ export const ViewsProvider: FC<
         savedViews,
         activeView,
         isLoading,
+        canManageView,
       },
       actions: {
         createView,
@@ -301,6 +311,7 @@ export const ViewsProvider: FC<
       savedViews,
       activeView,
       isLoading,
+      canManageView,
       createView,
       applyView,
       duplicateView,

--- a/frontend/packages/app/src/types/index.ts
+++ b/frontend/packages/app/src/types/index.ts
@@ -103,6 +103,8 @@ export type Project = {
 export interface View {
   name: string;
   label: string;
+  /** User the view belongs to. Absent on client-side default views. */
+  owner?: string;
   icon?: string | ComponentType<{ className?: string }>;
   user?: string | null;
   default: 0 | 1;


### PR DESCRIPTION
## Description

Hides edit, make private/public and delete options from the users who are not owners of the view.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #2143 