### PR TITLE
Fix: rename backdated time limit labels and remove report config section from Settings modal

### DIFF
--- a/frontend/packages/app/src/components/settings/index.tsx
+++ b/frontend/packages/app/src/components/settings/index.tsx
@@ -209,7 +209,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
               <SystemTimesheetsPage
                 form={systemForm}
                 updateField={updateSystemField}
-                hasApiKey={Boolean(systemSettings?.pm_report_api_key)}
               />
             ) : activePage === "system-resource-management" ? (
               <SystemResourceManagementPage

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -94,7 +94,7 @@ export function SystemTimesheetsPage({
             <>
               <div>
                 <FormLabel size="md" className="text-ink-gray-8!">
-                  Allow Backdated Entries Till (Employee)
+                  Allow backdated time entry for days limit - Employee
                 </FormLabel>
                 <TextInput
                   type="number"
@@ -114,7 +114,7 @@ export function SystemTimesheetsPage({
               </div>
               <div>
                 <FormLabel size="md" className="text-ink-gray-8!">
-                  Allow Backdated Entries Till (Manager)
+                  Allow backdated time entry for days limit - Manager
                 </FormLabel>
                 <TextInput
                   type="number"
@@ -133,7 +133,7 @@ export function SystemTimesheetsPage({
                 />
               </div>
               <SettingsMultiSelectField
-                label="Ignored Roles"
+                label="Backdated Entry Limit - Exempted Roles"
                 doctype="Role"
                 value={(form.ignored_role ?? [])
                   .map((row) => row.role)

--- a/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
+++ b/frontend/packages/app/src/components/settings/pages/system-timesheets.tsx
@@ -1,68 +1,21 @@
 /**
  * External dependencies.
  */
-import { useEffect, useState } from "react";
-import {
-  Checkbox,
-  FormLabel,
-  Password,
-  TextInput,
-} from "@rtcamp/frappe-ui-react";
+import { Checkbox, FormLabel, TextInput } from "@rtcamp/frappe-ui-react";
 
 /**
  * Internal dependencies.
  */
-import { usePMSSystemApiKey } from "@/hooks/usePMSSettings";
 import {
   SettingsDaySelect,
   SettingsLinkField,
   SettingsMultiSelectField,
 } from "../fields";
-import type {
-  FieldUpdater,
-  SystemSettings,
-  SystemTimesheetsPageProps,
-} from "../types";
-
-function ApiKeyField({
-  hasApiKey,
-  updateField,
-}: {
-  hasApiKey: boolean;
-  updateField: FieldUpdater<SystemSettings>;
-}) {
-  const { value } = usePMSSystemApiKey(hasApiKey);
-  const [draft, setDraft] = useState<string | null>(null);
-
-  useEffect(() => {
-    setDraft(value ?? "");
-  }, [value]);
-
-  const onChange = (next: string) => {
-    setDraft(next);
-    updateField("pm_report_api_key", next);
-  };
-
-  return (
-    <div>
-      <FormLabel size="md" className="text-ink-gray-8!">
-        PM Report API Key
-      </FormLabel>
-      <div className="mt-2">
-        <Password
-          value={draft ?? ""}
-          placeholder="Enter API key"
-          onChange={(event) => onChange(event.target.value)}
-        />
-      </div>
-    </div>
-  );
-}
+import type { SystemTimesheetsPageProps } from "../types";
 
 export function SystemTimesheetsPage({
   form,
   updateField,
-  hasApiKey,
 }: SystemTimesheetsPageProps) {
   const backdated = Boolean(form.allow_backdated_entries);
   const dailyReminder = Boolean(form.send_daily_reminder);
@@ -278,15 +231,6 @@ export function SystemTimesheetsPage({
               }
             />
           )}
-        </div>
-      </section>
-
-      <section className="mt-10">
-        <h3 className="text-lg font-semibold text-ink-gray-8">
-          Report Configuration
-        </h3>
-        <div className="mt-5 max-w-sm">
-          <ApiKeyField hasApiKey={hasApiKey} updateField={updateField} />
         </div>
       </section>
     </div>

--- a/frontend/packages/app/src/components/settings/types.ts
+++ b/frontend/packages/app/src/components/settings/types.ts
@@ -82,7 +82,6 @@ export type TimesheetsPageProps = {
 export type SystemTimesheetsPageProps = {
   form: TimesheetSettings;
   updateField: FieldUpdater<SystemSettings>;
-  hasApiKey: boolean;
 };
 
 export type SystemResourceManagementPageProps = {

--- a/frontend/packages/app/src/hooks/usePMSSettings.ts
+++ b/frontend/packages/app/src/hooks/usePMSSettings.ts
@@ -59,25 +59,3 @@ export function usePMSSystemSettings(enabled: boolean) {
     updateSystemSettings,
   };
 }
-
-export function usePMSSystemApiKey(hasApiKey: boolean) {
-  const fieldname = "pm_report_api_key";
-  const method = "frappe.client.get_password";
-  const { data, isLoading, error } = useFrappeGetCall<{
-    message: string;
-  }>(
-    method,
-    {
-      doctype: SYSTEM_SETTINGS_DOCTYPE,
-      name: SYSTEM_SETTINGS_DOCTYPE,
-      fieldname,
-    },
-    hasApiKey ? `${method}:${fieldname}` : null,
-  );
-
-  return {
-    value: data?.message ?? null,
-    isLoading,
-    error,
-  };
-}


### PR DESCRIPTION
## Description

- Renames the labels in the Settings modal to: Allow backdated time entry for days limit - Employee, Allow backdated time entry for days limit - Manager and Backdated Entry Limit - Exempted Roles
- Removes the "Report Configuration" section, the label and password field from the settings modal

## Testing Instructions

- Open settings modal as a System Manager
- Go to System Configuration > Timesheets
- Observe the labels are renamed as: Allow backdated time entry for days limit - Employee, Allow backdated time entry for days limit - Manager and Backdated Entry Limit - Exempted Roles
- Observe the Report Configuration section is not available and the PM Report API Key label and password field as well

## Screenshot/Screencast

<img width="975" height="753" alt="image" src="https://github.com/user-attachments/assets/283eb5fc-6351-4ab4-a938-e60177c5c89e" />

<img width="1004" height="726" alt="image" src="https://github.com/user-attachments/assets/8c6b2469-d1e8-4af2-ad48-72bf766a937d" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

Fixes #2164 