### PR TITLE
feat: update edit schedule modal to support individual day selection

### DIFF
--- a/frontend/packages/app/src/pages/allocations/overrideUtils.ts
+++ b/frontend/packages/app/src/pages/allocations/overrideUtils.ts
@@ -15,9 +15,8 @@ interface AllocationScheduleContext {
   override?: AllocationOverrideEntry[];
 }
 
-interface AllocationEditRange {
-  startDate: string;
-  endDate: string;
+interface AllocationEditSelection {
+  dates: string[];
   hoursPerDay: number;
 }
 
@@ -46,33 +45,30 @@ const getDateKeysInRange = (startDate: string, endDate: string) =>
   }).map((date) => format(date, "yyyy-MM-dd"));
 
 /**
- * Orders a date range so the start is on or before the end.
- */
-const normalizeRange = (startDate: string, endDate: string) =>
-  startDate <= endDate
-    ? { startDate, endDate }
-    : { startDate: endDate, endDate: startDate };
-
-/**
- * Checks if the proposed edit range is the same as the allocation's current range, ignoring hours-per-day.
- * This is used to determine if the edit is a base-hours change or a day-override change.
+ * Checks whether the picked dates cover the allocation's whole range, which makes the edit a
+ * base-hours change rather than a day-override change. A leave day cannot be picked and the
+ * backend re-derives its hours from the base, so it counts as covered.
  */
 const isFullAllocationRangeEdit = ({
   allocation,
   next,
+  leaveOwnedDates,
 }: {
   allocation: AllocationScheduleContext;
-  next: Pick<AllocationEditRange, "startDate" | "endDate">;
+  next: Pick<AllocationEditSelection, "dates">;
+  leaveOwnedDates: Set<string>;
 }): boolean => {
-  const normalizedNextRange = normalizeRange(next.startDate, next.endDate);
-  const normalizedAllocationRange = normalizeRange(
-    allocation.allocationStartDate,
-    allocation.allocationEndDate,
-  );
+  const selectedDates = new Set(next.dates);
+  const [rangeStart, rangeEnd] =
+    allocation.allocationStartDate <= allocation.allocationEndDate
+      ? [allocation.allocationStartDate, allocation.allocationEndDate]
+      : [allocation.allocationEndDate, allocation.allocationStartDate];
 
   return (
-    normalizedNextRange.startDate === normalizedAllocationRange.startDate &&
-    normalizedNextRange.endDate === normalizedAllocationRange.endDate
+    selectedDates.size > 0 &&
+    getDateKeysInRange(rangeStart, rangeEnd).every(
+      (date) => selectedDates.has(date) || leaveOwnedDates.has(date),
+    )
   );
 };
 
@@ -155,19 +151,25 @@ const buildDayOverrideDiff = (
 };
 
 /**
- * Builds the payload for an Edit Schedule submission. Full-allocation range edits
- * update the allocation's base hours and partial edits become day-override diffs.
+ * Builds the payload for an Edit Schedule submission. Edits covering the whole allocation
+ * update its base hours and partial edits become day-override diffs.
  */
 export const buildScheduleSelectionPayload = ({
   allocation,
   next,
 }: {
   allocation: AllocationScheduleContext;
-  next: AllocationEditRange;
+  next: AllocationEditSelection;
 }): ScheduleSelectionPayload => {
+  const leaveOwnedDates = new Set(
+    (allocation.override ?? [])
+      .filter(isLeaveOwnedOverride)
+      .map((entry) => entry.date),
+  );
   const isBaseHoursEdit = isFullAllocationRangeEdit({
     allocation,
     next,
+    leaveOwnedDates,
   });
 
   if (
@@ -187,17 +189,8 @@ export const buildScheduleSelectionPayload = ({
 
   const currentHoursByDate = buildEffectiveHoursByDate(allocation);
   const desiredHoursByDate = new Map(currentHoursByDate);
-  const normalizedNextRange = normalizeRange(next.startDate, next.endDate);
-  const leaveOwnedDates = new Set(
-    (allocation.override ?? [])
-      .filter(isLeaveOwnedOverride)
-      .map((entry) => entry.date),
-  );
 
-  for (const date of getDateKeysInRange(
-    normalizedNextRange.startDate,
-    normalizedNextRange.endDate,
-  )) {
+  for (const date of next.dates) {
     // A leave day's hours are re-derived on save, so writing them here only produces a row the backend replaces with the value it already holds.
     if (leaveOwnedDates.has(date)) {
       continue;

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/index.tsx
@@ -292,6 +292,7 @@ function AddAllocationModal({
     hasAnyMember: projectHasAnyMember,
     hasAnyProject: employeeHasAnyProject,
     isValid: isProjectEmployeePairValid,
+    hasAnswer: hasProjectEmployeeAccess,
     isLoading: isProjectEmployeeAccessLoading,
   } = useProjectEmployeeAccess({
     projectId,
@@ -300,19 +301,15 @@ function AddAllocationModal({
   });
 
   const projectHasNoAssignedMembers =
-    Boolean(projectId) &&
-    !isProjectEmployeeAccessLoading &&
-    !projectHasAnyMember;
+    Boolean(projectId) && hasProjectEmployeeAccess && !projectHasAnyMember;
 
   const employeeHasNoAssignedProjects =
-    Boolean(employeeId) &&
-    !isProjectEmployeeAccessLoading &&
-    !employeeHasAnyProject;
+    Boolean(employeeId) && hasProjectEmployeeAccess && !employeeHasAnyProject;
 
   const isProjectEmployeeMismatch =
     Boolean(projectId) &&
     Boolean(employeeId) &&
-    !isProjectEmployeeAccessLoading &&
+    hasProjectEmployeeAccess &&
     !isProjectEmployeePairValid;
 
   const projectEmployeeMismatchError = isProjectEmployeeMismatch ? (

--- a/frontend/packages/app/src/pages/allocations/team/add-allocation/useProjectEmployeeAccess.ts
+++ b/frontend/packages/app/src/pages/allocations/team/add-allocation/useProjectEmployeeAccess.ts
@@ -32,11 +32,13 @@ export function useProjectEmployeeAccess({
     { project: projectId || undefined, employee: employeeId || undefined },
     enabled && (projectId || employeeId) ? undefined : null,
   );
+  const access = data?.message;
 
   return {
-    hasAnyMember: data?.message?.has_any_member ?? false,
-    hasAnyProject: data?.message?.has_any_project ?? false,
-    isValid: data?.message?.is_valid ?? false,
+    hasAnyMember: access?.has_any_member ?? false,
+    hasAnyProject: access?.has_any_project ?? false,
+    isValid: access?.is_valid ?? false,
+    hasAnswer: access !== undefined,
     isLoading,
   };
 }

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleDateSelectionField.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/components/scheduleDateSelectionField.tsx
@@ -9,13 +9,13 @@ import { ErrorMessage } from "@rtcamp/frappe-ui-react";
 /**
  * Internal dependencies.
  */
-import type { DayItem, NormalizedSelection } from "../types";
+import type { DayItem } from "../types";
 
 interface ScheduleDateSelectionFieldProps {
   days: DayItem[];
   headerRangeLabel: string;
   recurrenceHelperText?: string;
-  selection: NormalizedSelection | null;
+  selection: string[];
   onDayClick: (date: string) => void;
   error?: string;
 }
@@ -28,6 +28,7 @@ function ScheduleDateSelectionField({
   onDayClick,
   error,
 }: ScheduleDateSelectionFieldProps) {
+  const selectedDates = new Set(selection);
   const showInlineRecurrenceHelper =
     Boolean(recurrenceHelperText) && days.length <= 3;
 
@@ -85,9 +86,7 @@ function ScheduleDateSelectionField({
               state={
                 day.dayOffTooltip
                   ? "disabled"
-                  : selection &&
-                      day.date >= selection.startDate &&
-                      day.date <= selection.endDate
+                  : selectedDates.has(day.date)
                     ? "active"
                     : "default"
               }

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/index.tsx
@@ -59,7 +59,6 @@ function EditScheduleModal({
     "next_pms.resource_management.api.allocation.edit_allocation",
   );
   const today = useMemo(() => format(new Date(), "yyyy-MM-dd"), []);
-  const [selectionAnchor, setSelectionAnchor] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [applyMode, setApplyMode] =
     useState<EditScheduleApplyMode>("only_this");
@@ -172,7 +171,7 @@ function EditScheduleModal({
   const formDefaultValues = useMemo<EditScheduleFormValues>(
     () => ({
       schedule: {
-        selection: { startDate: "", endDate: "" },
+        selection: [],
         input: { value: defaultHoursPerDay, mode: "hoursPerDay" },
       },
     }),
@@ -201,12 +200,11 @@ function EditScheduleModal({
         availability,
         schedule: value.schedule,
       });
-      const schedulePayload = draft.selection
+      const schedulePayload = draft.hasSelection
         ? buildScheduleSelectionPayload({
             allocation: allocationContext,
             next: {
-              startDate: draft.selection.startDate,
-              endDate: draft.selection.endDate,
+              dates: draft.selection,
               hoursPerDay: draft.hoursPerDay,
             },
           })
@@ -280,12 +278,11 @@ function EditScheduleModal({
 
   const schedulePayload = useMemo(
     () =>
-      allocationContext && scheduleDraft.selection
+      allocationContext && scheduleDraft.hasSelection
         ? buildScheduleSelectionPayload({
             allocation: allocationContext,
             next: {
-              startDate: scheduleDraft.selection.startDate,
-              endDate: scheduleDraft.selection.endDate,
+              dates: scheduleDraft.selection,
               hoursPerDay: scheduleDraft.hoursPerDay,
             },
           })
@@ -317,14 +314,12 @@ function EditScheduleModal({
     }
 
     form.reset(formDefaultValues);
-    setSelectionAnchor(null);
     setApplyMode("only_this");
   }, [form, formDefaultValues, open]);
 
   const closeModal = useCallback(() => {
     onOpenChange(false);
     form.reset(formDefaultValues);
-    setSelectionAnchor(null);
     setApplyMode("only_this");
   }, [form, formDefaultValues, onOpenChange]);
 
@@ -370,42 +365,34 @@ function EditScheduleModal({
       }}
     >
       <div className="space-y-3">
-        <form.Field name="schedule.selection.startDate">
-          {(startField) => (
-            <form.Field name="schedule.selection.endDate">
-              {(endField) => (
-                <ScheduleDateSelectionField
-                  days={days}
-                  headerRangeLabel={scheduleDraft.headerRangeLabel}
-                  recurrenceHelperText={recurrenceHelperText}
-                  selection={scheduleDraft.selection}
-                  onDayClick={(date) => {
-                    const next = selectionAnchor
-                      ? normalizeRange(selectionAnchor, date)
-                      : { startDate: date, endDate: date };
+        <form.Field name="schedule.selection">
+          {(selectionField) => (
+            <ScheduleDateSelectionField
+              days={days}
+              headerRangeLabel={scheduleDraft.headerRangeLabel}
+              recurrenceHelperText={recurrenceHelperText}
+              selection={scheduleDraft.selection}
+              onDayClick={(date) => {
+                const current = selectionField.state.value;
+                const next = current.includes(date)
+                  ? current.filter((selected) => selected !== date)
+                  : [...current, date];
 
-                    setSelectionAnchor(selectionAnchor ? null : date);
-                    startField.handleChange(next.startDate);
-                    endField.handleChange(next.endDate);
-                    form.setFieldValue("schedule.input.mode", "hoursPerDay");
-                    form.setFieldValue(
-                      "schedule.input.value",
-                      getSeedHoursPerDay({
-                        ...next,
-                        anchorDate: selectionAnchor ?? date,
-                        defaultHoursPerDay,
-                        override: safeValues.override,
-                        availability,
-                      }),
-                    );
-                  }}
-                  error={
-                    getErrorMessage(startField.state.meta.errors[0]) ??
-                    getErrorMessage(endField.state.meta.errors[0])
-                  }
-                />
-              )}
-            </form.Field>
+                selectionField.handleChange(next);
+                form.setFieldValue("schedule.input.mode", "hoursPerDay");
+                form.setFieldValue(
+                  "schedule.input.value",
+                  getSeedHoursPerDay({
+                    dates: next,
+                    anchorDate: date,
+                    defaultHoursPerDay,
+                    override: safeValues.override,
+                    availability,
+                  }),
+                );
+              }}
+              error={getErrorMessage(selectionField.state.meta.errors[0])}
+            />
           )}
         </form.Field>
 

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/schema.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/schema.ts
@@ -1,41 +1,19 @@
 import { z } from "zod";
 
-export const editScheduleFormSchema = z
-  .object({
-    schedule: z.object({
-      selection: z.object({
-        startDate: z.string().trim(),
-        endDate: z.string().trim(),
-      }),
-      input: z.object({
-        value: z
-          .number({
-            required_error: "Please enter hours.",
-          })
-          .min(0, { message: "Must be greater than or equal to 0." }),
-        mode: z.enum(["hoursPerDay", "totalHours"]),
-      }),
+export const editScheduleFormSchema = z.object({
+  schedule: z.object({
+    selection: z
+      .array(z.string().trim())
+      .min(1, { message: "Please select a date." }),
+    input: z.object({
+      value: z
+        .number({
+          required_error: "Please enter hours.",
+        })
+        .min(0, { message: "Must be greater than or equal to 0." }),
+      mode: z.enum(["hoursPerDay", "totalHours"]),
     }),
-  })
-  .superRefine((value, ctx) => {
-    const { startDate, endDate } = value.schedule.selection;
-
-    if (!startDate || !endDate) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["schedule", "selection", "startDate"],
-        message: "Please select a date.",
-      });
-      return;
-    }
-
-    if (startDate > endDate) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["schedule", "selection", "endDate"],
-        message: "End date must be on or after start date.",
-      });
-    }
-  });
+  }),
+});
 
 export type EditScheduleFormValues = z.infer<typeof editScheduleFormSchema>;

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/types.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/types.ts
@@ -40,22 +40,16 @@ export type EmployeeAvailabilityResponse = {
   >;
 };
 
-export type NormalizedSelection = {
-  startDate: string;
-  endDate: string;
-};
-
 export type EditScheduleValueMode = "hoursPerDay" | "totalHours";
 export type EditScheduleApplyMode = "only_this" | "this_and_future";
 
 export type EditScheduleDraft = {
-  selection: NormalizedSelection | null;
+  selection: string[];
   hasSelection: boolean;
   hoursPerDay: number;
   totalHours: number;
   previewRows: PreviewRow[];
   headerRangeLabel: string;
-  hasMeaningfulChange: boolean;
 };
 
 export interface EditScheduleInitialValues {

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
@@ -71,7 +71,7 @@ export const normalizeRange = (startDate: string, endDate: string) =>
 /**
  * Returns the number of days in a date range, inclusive.
  */
-export const getDayCount = (startDate: string, endDate: string): number => {
+const getDayCount = (startDate: string, endDate: string): number => {
   const safe = normalizeRange(startDate, endDate);
   return (
     differenceInCalendarDays(parseISO(safe.endDate), parseISO(safe.startDate)) +
@@ -127,42 +127,34 @@ const resolveDayHours = (
 
 /**
  * Returns the hours per day to seed the input with, preferring the anchor date's value
- * if the range is not uniform.
+ * if the selected dates are not uniform.
  *
- * If the range is fully unavailable, returns the allocation default.
+ * If every selected date is unavailable, returns the allocation default.
  */
 export const getSeedHoursPerDay = ({
-  startDate,
-  endDate,
+  dates,
   anchorDate,
   defaultHoursPerDay,
   override = [],
   availability = {},
 }: {
-  startDate: string;
-  endDate: string;
+  dates: string[];
   anchorDate: string;
   defaultHoursPerDay: number;
   override?: AllocationOverrideEntry[];
   availability?: AvailabilityByDate;
 }): number => {
-  const safe = normalizeRange(startDate, endDate);
   const overrideByDate = new Map(override.map((entry) => [entry.date, entry]));
   const hoursByDate = new Map<string, number>();
 
-  for (const date of eachDayOfInterval({
-    start: parseISO(safe.startDate),
-    end: parseISO(safe.endDate),
-  })) {
-    const dateKey = format(date, "yyyy-MM-dd");
-
-    if (availability[dateKey]) {
+  for (const date of dates) {
+    if (availability[date]) {
       continue;
     }
 
     hoursByDate.set(
-      dateKey,
-      resolveDayHours(overrideByDate.get(dateKey), defaultHoursPerDay),
+      date,
+      resolveDayHours(overrideByDate.get(date), defaultHoursPerDay),
     );
   }
 
@@ -178,37 +170,30 @@ export const getSeedHoursPerDay = ({
 };
 
 /**
- * Counts the number of days in a range that are not marked as unavailable in the availability map.
+ * Sums the selected dates in whole-day terms. A day the employee is partly away books its
+ * share of the hours-per-day, so it weighs its availability factor rather than a full day,
+ * which keeps a total the user types and the total the allocation saves in step.
  */
-const getEditableDayCount = (
-  startDate: string,
-  endDate: string,
+const getEffectiveDayCount = (
+  dates: string[],
   availability: AvailabilityByDate = {},
-): number => {
-  const safe = normalizeRange(startDate, endDate);
-
-  return eachDayOfInterval({
-    start: parseISO(safe.startDate),
-    end: parseISO(safe.endDate),
-  }).filter((date) => !availability[format(date, "yyyy-MM-dd")]).length;
-};
+): number =>
+  dates.reduce(
+    (total, date) => total + (availability[date]?.availabilityFactor ?? 1),
+    0,
+  );
 
 /**
- * Calculates hours per day from a total hours value for a date range.
+ * Calculates hours per day from a total hours value for the selected dates.
  */
 export const getHoursPerDayFromTotalHours = (
-  startDate: string,
-  endDate: string,
+  dates: string[],
   totalHours: number,
   availability: AvailabilityByDate = {},
 ): number => {
-  const editableDayCount = getEditableDayCount(
-    startDate,
-    endDate,
-    availability,
-  );
+  const effectiveDayCount = getEffectiveDayCount(dates, availability);
 
-  return editableDayCount > 0 ? totalHours / editableDayCount : 0;
+  return effectiveDayCount > 0 ? totalHours / effectiveDayCount : 0;
 };
 
 /**
@@ -241,6 +226,35 @@ export const formatRange = (
   return isSameMonth(start, end)
     ? `${format(start, "MMM d")} - ${format(end, "d")}`
     : `${format(start, "MMM d")} - ${format(end, "MMM d")}`;
+};
+
+/**
+ * Formats a set of individually picked dates, collapsing consecutive dates into a range
+ * so a week-long pick still reads as "Sep 15 - 19".
+ */
+export const formatSelectedDates = (dates: string[]): string => {
+  const sorted = [...dates].sort();
+  const groups: string[][] = [];
+
+  for (const date of sorted) {
+    const currentGroup = groups[groups.length - 1];
+    const previous = currentGroup?.[currentGroup.length - 1];
+
+    if (
+      currentGroup &&
+      previous &&
+      differenceInCalendarDays(parseISO(date), parseISO(previous)) === 1
+    ) {
+      currentGroup.push(date);
+      continue;
+    }
+
+    groups.push([date]);
+  }
+
+  return groups
+    .map((group) => formatRange(group[0], group[group.length - 1]))
+    .join(", ");
 };
 
 /**
@@ -277,6 +291,27 @@ export const buildDays = (
 };
 
 /**
+ * Whether the picked dates cover every day the strip lets the user pick, which makes the edit
+ * a change of the allocation's base hours. A day the employee is away is never selectable and
+ * the backend re-derives its hours from that base, so it counts as covered.
+ */
+const coversEverySelectableDay = (
+  rangeStart: string,
+  rangeEnd: string,
+  selectedDates: Set<string>,
+  availability: AvailabilityByDate,
+): boolean =>
+  selectedDates.size > 0 &&
+  eachDayOfInterval({
+    start: parseISO(rangeStart),
+    end: parseISO(rangeEnd),
+  }).every((date) => {
+    const dateKey = format(date, "yyyy-MM-dd");
+
+    return selectedDates.has(dateKey) || Boolean(availability[dateKey]);
+  });
+
+/**
  * Builds preview rows for the schedule summary, applying stored overrides first and
  * then layering the current in-modal selection on top.
  *
@@ -298,17 +333,18 @@ export const buildPreviewRows = ({
   override?: AllocationOverrideEntry[];
   availability?: AvailabilityByDate;
   selection?: {
-    startDate: string;
-    endDate: string;
+    dates: string[];
     hoursPerDay: number;
   } | null;
 }): PreviewRow[] => {
   const rows: PreviewRow[] = [];
   const overrideByDate = new Map(override.map((entry) => [entry.date, entry]));
-  const isBaseHoursEdit = Boolean(
-    selection &&
-    selection.startDate <= rangeStart &&
-    selection.endDate >= rangeEnd,
+  const selectedDates = new Set(selection?.dates ?? []);
+  const isBaseHoursEdit = coversEverySelectableDay(
+    rangeStart,
+    rangeEnd,
+    selectedDates,
+    availability,
   );
 
   let currentRow: PreviewRow | null = null;
@@ -321,21 +357,15 @@ export const buildPreviewRows = ({
     const dayOverride = overrideByDate.get(dateKey);
     const dayOff = availability[dateKey];
     const dayOffLabel = dayOff ? getDayOffLabel(dayOff) : undefined;
-    const inSelection =
-      !dayOff &&
-      selection !== null &&
-      selection !== undefined &&
-      dateKey >= selection.startDate &&
-      dateKey <= selection.endDate;
+    const inSelection = !dayOff && selectedDates.has(dateKey);
     // The hours-per-day the allocation books for this day, ignoring the selection.
     const baseHoursPerDay =
       isBaseHoursEdit && selection ? selection.hoursPerDay : defaultHoursPerDay;
     const currentHoursPerDay = dayOff
       ? baseHoursPerDay * dayOff.availabilityFactor
       : resolveDayHours(dayOverride, defaultHoursPerDay);
-    const hoursPerDay = inSelection
-      ? selection.hoursPerDay
-      : currentHoursPerDay;
+    const hoursPerDay =
+      inSelection && selection ? selection.hoursPerDay : currentHoursPerDay;
     const isModified = inSelection && hoursPerDay !== currentHoursPerDay;
 
     if (
@@ -381,40 +411,28 @@ export const buildScheduleDraft = ({
   override?: AllocationOverrideEntry[];
   availability?: AvailabilityByDate;
   schedule: {
-    selection: {
-      startDate: string;
-      endDate: string;
-    };
+    selection: string[];
     input: {
       value: number;
       mode: EditScheduleValueMode;
     };
   };
 }): EditScheduleDraft => {
-  const hasSelection = Boolean(
-    schedule.selection.startDate && schedule.selection.endDate,
-  );
-  const selection = hasSelection
-    ? normalizeRange(schedule.selection.startDate, schedule.selection.endDate)
-    : null;
-  const hoursPerDay = selection
+  const selection = [...schedule.selection].sort();
+  const hasSelection = selection.length > 0;
+  const hoursPerDay = hasSelection
     ? schedule.input.mode === "totalHours"
       ? getHoursPerDayFromTotalHours(
-          selection.startDate,
-          selection.endDate,
+          selection,
           schedule.input.value,
           availability,
         )
       : schedule.input.value
     : defaultHoursPerDay;
-  const totalHours = selection
+  const totalHours = hasSelection
     ? schedule.input.mode === "totalHours"
       ? schedule.input.value
-      : getEditableDayCount(
-          selection.startDate,
-          selection.endDate,
-          availability,
-        ) * schedule.input.value
+      : getEffectiveDayCount(selection, availability) * schedule.input.value
     : getRangeHours(rangeStart, rangeEnd, defaultHoursPerDay);
   const previewRows = buildPreviewRows({
     rangeStart,
@@ -422,13 +440,7 @@ export const buildScheduleDraft = ({
     defaultHoursPerDay,
     override,
     availability,
-    selection: selection
-      ? {
-          startDate: selection.startDate,
-          endDate: selection.endDate,
-          hoursPerDay,
-        }
-      : null,
+    selection: hasSelection ? { dates: selection, hoursPerDay } : null,
   });
 
   return {
@@ -437,9 +449,8 @@ export const buildScheduleDraft = ({
     hoursPerDay,
     totalHours,
     previewRows,
-    headerRangeLabel: selection
-      ? formatRange(selection.startDate, selection.endDate)
+    headerRangeLabel: hasSelection
+      ? formatSelectedDates(selection)
       : formatRange(rangeStart, rangeEnd),
-    hasMeaningfulChange: previewRows.some((row) => row.isModified),
   };
 };

--- a/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/edit-schedule/utils.ts
@@ -80,6 +80,15 @@ const getDayCount = (startDate: string, endDate: string): number => {
 };
 
 /**
+ * Lists every calendar date in an inclusive range as `yyyy-MM-dd` strings.
+ */
+const getDateKeysInRange = (startDate: string, endDate: string): string[] =>
+  eachDayOfInterval({
+    start: parseISO(startDate),
+    end: parseISO(endDate),
+  }).map((date) => format(date, "yyyy-MM-dd"));
+
+/**
  * Calculates the total hours for a given date range and hours per day.
  */
 export const getRangeHours = (
@@ -170,7 +179,7 @@ export const getSeedHoursPerDay = ({
 };
 
 /**
- * Sums the selected dates in whole-day terms. A day the employee is partly away books its
+ * Sums the given dates in whole-day terms. A day the employee is partly away books its
  * share of the hours-per-day, so it weighs its availability factor rather than a full day,
  * which keeps a total the user types and the total the allocation saves in step.
  */
@@ -184,17 +193,12 @@ const getEffectiveDayCount = (
   );
 
 /**
- * Calculates hours per day from a total hours value for the selected dates.
+ * Calculates hours per day from a total hours value spread over the days it covers.
  */
-export const getHoursPerDayFromTotalHours = (
-  dates: string[],
+const getHoursPerDayFromTotalHours = (
   totalHours: number,
-  availability: AvailabilityByDate = {},
-): number => {
-  const effectiveDayCount = getEffectiveDayCount(dates, availability);
-
-  return effectiveDayCount > 0 ? totalHours / effectiveDayCount : 0;
-};
+  effectiveDayCount: number,
+): number => (effectiveDayCount > 0 ? totalHours / effectiveDayCount : 0);
 
 /**
  * Formats a date range into a human-readable string.
@@ -302,14 +306,9 @@ const coversEverySelectableDay = (
   availability: AvailabilityByDate,
 ): boolean =>
   selectedDates.size > 0 &&
-  eachDayOfInterval({
-    start: parseISO(rangeStart),
-    end: parseISO(rangeEnd),
-  }).every((date) => {
-    const dateKey = format(date, "yyyy-MM-dd");
-
-    return selectedDates.has(dateKey) || Boolean(availability[dateKey]);
-  });
+  getDateKeysInRange(rangeStart, rangeEnd).every(
+    (date) => selectedDates.has(date) || Boolean(availability[date]),
+  );
 
 /**
  * Builds preview rows for the schedule summary, applying stored overrides first and
@@ -326,6 +325,7 @@ export const buildPreviewRows = ({
   override = [],
   availability = {},
   selection,
+  isBaseHoursEdit,
 }: {
   rangeStart: string;
   rangeEnd: string;
@@ -336,24 +336,15 @@ export const buildPreviewRows = ({
     dates: string[];
     hoursPerDay: number;
   } | null;
+  isBaseHoursEdit: boolean;
 }): PreviewRow[] => {
   const rows: PreviewRow[] = [];
   const overrideByDate = new Map(override.map((entry) => [entry.date, entry]));
   const selectedDates = new Set(selection?.dates ?? []);
-  const isBaseHoursEdit = coversEverySelectableDay(
-    rangeStart,
-    rangeEnd,
-    selectedDates,
-    availability,
-  );
 
   let currentRow: PreviewRow | null = null;
 
-  for (const currentDate of eachDayOfInterval({
-    start: parseISO(rangeStart),
-    end: parseISO(rangeEnd),
-  })) {
-    const dateKey = format(currentDate, "yyyy-MM-dd");
+  for (const dateKey of getDateKeysInRange(rangeStart, rangeEnd)) {
     const dayOverride = overrideByDate.get(dateKey);
     const dayOff = availability[dateKey];
     const dayOffLabel = dayOff ? getDayOffLabel(dayOff) : undefined;
@@ -420,19 +411,25 @@ export const buildScheduleDraft = ({
 }): EditScheduleDraft => {
   const selection = [...schedule.selection].sort();
   const hasSelection = selection.length > 0;
+  const isBaseHoursEdit = coversEverySelectableDay(
+    rangeStart,
+    rangeEnd,
+    new Set(selection),
+    availability,
+  );
+  const effectiveDayCount = getEffectiveDayCount(
+    isBaseHoursEdit ? getDateKeysInRange(rangeStart, rangeEnd) : selection,
+    availability,
+  );
   const hoursPerDay = hasSelection
     ? schedule.input.mode === "totalHours"
-      ? getHoursPerDayFromTotalHours(
-          selection,
-          schedule.input.value,
-          availability,
-        )
+      ? getHoursPerDayFromTotalHours(schedule.input.value, effectiveDayCount)
       : schedule.input.value
     : defaultHoursPerDay;
   const totalHours = hasSelection
     ? schedule.input.mode === "totalHours"
       ? schedule.input.value
-      : getEffectiveDayCount(selection, availability) * schedule.input.value
+      : effectiveDayCount * schedule.input.value
     : getRangeHours(rangeStart, rangeEnd, defaultHoursPerDay);
   const previewRows = buildPreviewRows({
     rangeStart,
@@ -441,6 +438,7 @@ export const buildScheduleDraft = ({
     override,
     availability,
     selection: hasSelection ? { dates: selection, hoursPerDay } : null,
+    isBaseHoursEdit,
   });
 
   return {

--- a/frontend/packages/app/src/pages/allocations/team/utils.ts
+++ b/frontend/packages/app/src/pages/allocations/team/utils.ts
@@ -126,14 +126,8 @@ export function mapTeamAllocationToMembers(
   response: TeamAllocationResponse,
   managerNameMap?: ManagerNameMap,
 ): Member[] {
-  const {
-    employees,
-    resource_allocations,
-    customer,
-    leaves,
-    employee_leaves,
-    holidays,
-  } = response;
+  const { employees, resource_allocations, customer, leaves, holidays } =
+    response;
 
   const employeeList = employees ?? [];
   const allocationList = resource_allocations ?? [];
@@ -171,27 +165,6 @@ export function mapTeamAllocationToMembers(
         : {}),
     });
     leavesByEmployee.set(leave.employee, employeeLeaves);
-  }
-
-  // Holidays never reach the grid through leave applications, and they carry a name worth
-  // showing, so each one stays its own single-day range.
-  for (const [employeeId, daysOff] of Object.entries(employee_leaves ?? {})) {
-    const holidays = Object.entries(daysOff)
-      .filter(([, dayOff]) => dayOff.is_holiday)
-      .map(([date, dayOff]) => ({
-        startDate: parseISO(date),
-        endDate: parseISO(date),
-        label: dayOff.holiday_name || "Holiday",
-      }));
-
-    if (holidays.length === 0) {
-      continue;
-    }
-
-    leavesByEmployee.set(employeeId, [
-      ...(leavesByEmployee.get(employeeId) ?? []),
-      ...holidays,
-    ]);
   }
 
   for (const alloc of allocationList) {


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR updates the Edit Schedule modal to move from range selection to individual day selection, allowing more granular control over allocation changes.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
- Replaces range-based day selection with individual day selection in the Edit Schedule modal.
- Also fixes an error flash in the Add Allocation modal when the Edit Schedule modal is opened.


## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
1. Open an existing allocation and click Edit Schedule.
2. Select individual days in the modal.
3. Confirm that each day can be selected independently and that selecting a continuous date range is no longer required.

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/2842f7e2-b1de-441e-b335-918340d69a71



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #1732 