### PR TITLE
fix(pm-report): include only billable timesheet hours in report breakdown

### DIFF
--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -494,41 +494,34 @@ def get_hours_breakdown(project, from_date, to_date):
         if not timesheet_details:
             return []
 
-        # Group by task - sum hours_consumed
+        # Group billable hours by task ID
         task_map = {}
         for entry in timesheet_details:
-            task = entry.get("task") or "No Task"
-            if task not in task_map:
-                task_map[task] = {"hours_consumed": 0.0}
-            task_map[task]["hours_consumed"] += entry.get("hours") or 0
+            task_id = entry.get("task")
+            if task_id:
+                task_map[task_id] = task_map.get(task_id, 0.0) + (entry.get("hours") or 0)
 
-        task_ids = list(set(t for t in task_map if t != "No Task"))
-        task_titles = {}
-        if task_ids:
-            task_data = frappe.db.get_all(
-                "Task",
-                filters={"name": ["in", task_ids]},
-                fields=["name", "subject", "custom_is_billable"],
-            )
-            # Exclude tasks explicitly marked as non-billable
-            non_billable_task_ids = {t["name"] for t in task_data if t.get("custom_is_billable") == 0}
-            for non_billable_id in non_billable_task_ids:
-                task_map.pop(non_billable_id, None)
+        if not task_map:
+            return []
 
-            task_titles = {t["name"]: t["subject"] for t in task_data if t["name"] not in non_billable_task_ids}
+        # Fetch only billable tasks matching the timesheets
+        task_data = frappe.db.get_all(
+            "Task",
+            filters={"name": ["in", list(task_map.keys())], "custom_is_billable": 1},
+            fields=["name", "subject"],
+        )
+        task_titles = {t["name"]: t["subject"] for t in task_data}
 
         breakdown = []
-        for task_id, data in task_map.items():
-            hours = round(data["hours_consumed"], 2)
-            if hours <= 0:
-                continue
-            task_title = "No Task" if task_id == "No Task" else (task_titles.get(task_id) or task_id)
-            breakdown.append(
-                {
-                    "task_title": task_title,
-                    "hours_consumed": hours,
-                }
-            )
+        for task_id, title in task_titles.items():
+            hours = round(task_map[task_id], 2)
+            if hours > 0:
+                breakdown.append(
+                    {
+                        "task_title": title,
+                        "hours_consumed": hours,
+                    }
+                )
 
         return breakdown
 

--- a/next_pms/api/generate_pm_report.py
+++ b/next_pms/api/generate_pm_report.py
@@ -473,10 +473,10 @@ def get_github_metadata(project_doc, selected_repo: str | None = None, selected_
 
 def get_hours_breakdown(project, from_date, to_date):
     """
-    Fetch timesheet hours grouped by task for the report period.
+    Fetch timesheet hours grouped by task for the report period (billable hours only).
     """
     try:
-        # Fetch all timesheet details for this project in date range
+        # Fetch all billable timesheet details for this project in date range
         timesheet_details = frappe.db.get_all(
             "Timesheet Detail",
             filters={
@@ -486,6 +486,7 @@ def get_hours_breakdown(project, from_date, to_date):
                     [f"{from_date} 00:00:00", f"{to_date} 23:59:59"],
                 ],
                 "docstatus": ["in", [0, 1]],
+                "is_billable": 1,
             },
             fields=["task", "hours"],
         )
@@ -504,16 +505,28 @@ def get_hours_breakdown(project, from_date, to_date):
         task_ids = list(set(t for t in task_map if t != "No Task"))
         task_titles = {}
         if task_ids:
-            task_data = frappe.db.get_all("Task", filters={"name": ["in", task_ids]}, fields=["name", "subject"])
-            task_titles = {t["name"]: t["subject"] for t in task_data}
+            task_data = frappe.db.get_all(
+                "Task",
+                filters={"name": ["in", task_ids]},
+                fields=["name", "subject", "custom_is_billable"],
+            )
+            # Exclude tasks explicitly marked as non-billable
+            non_billable_task_ids = {t["name"] for t in task_data if t.get("custom_is_billable") == 0}
+            for non_billable_id in non_billable_task_ids:
+                task_map.pop(non_billable_id, None)
+
+            task_titles = {t["name"]: t["subject"] for t in task_data if t["name"] not in non_billable_task_ids}
 
         breakdown = []
         for task_id, data in task_map.items():
+            hours = round(data["hours_consumed"], 2)
+            if hours <= 0:
+                continue
             task_title = "No Task" if task_id == "No Task" else (task_titles.get(task_id) or task_id)
             breakdown.append(
                 {
                     "task_title": task_title,
-                    "hours_consumed": round(data["hours_consumed"], 2),
+                    "hours_consumed": hours,
                 }
             )
 

--- a/next_pms/tests/test_pm_report.py
+++ b/next_pms/tests/test_pm_report.py
@@ -5,6 +5,7 @@ from requests.models import Response
 
 from next_pms.api.generate_pm_report import (
     generate_pm_report,
+    get_hours_breakdown,
     get_repository_project_boards,
     resync_report,
 )
@@ -14,6 +15,9 @@ from next_pms.tests import TestNextPms
 class TestPmReport(TestNextPms):
     def setUp(self):
         super().setUp()
+
+        self.test_timesheets = []
+        self.test_tasks = []
 
         # Bypass link validation to prevent failures on missing DocTypes (e.g. Slack Channel) in CI
         self.link_patcher = patch("frappe.model.base_document.BaseDocument.get_invalid_links", return_value=([], []))
@@ -58,6 +62,17 @@ class TestPmReport(TestNextPms):
         frappe.conf.llm_status_url = "https://mock-status-url"
 
     def tearDown(self):
+        for ts_name in getattr(self, "test_timesheets", []):
+            if frappe.db.exists("Timesheet", ts_name):
+                doc = frappe.get_doc("Timesheet", ts_name)
+                if doc.docstatus == 1:
+                    doc.cancel()
+                frappe.delete_doc("Timesheet", ts_name, force=True, ignore_permissions=True)
+        for task_name in getattr(self, "test_tasks", []):
+            if frappe.db.exists("Task", task_name):
+                frappe.delete_doc("Task", task_name, force=True, ignore_permissions=True)
+        frappe.db.commit()
+
         if getattr(self, "project_name", None) and getattr(self, "_original_project_fields", None):
             frappe.db.set_value("Project", self.project_name, self._original_project_fields)
             frappe.db.commit()
@@ -227,6 +242,198 @@ class TestPmReport(TestNextPms):
         mock_repo = MagicMock()
         mock_repo.get.return_value = [MagicMock(board_name="Board A"), MagicMock(board_name="Board B")]
 
-        with patch("frappe.get_doc", return_value=mock_repo):
+        with (
+            patch("frappe.has_permission"),
+            patch("frappe.get_doc", return_value=mock_repo),
+        ):
             res = get_repository_project_boards("mock-repo")
             self.assertEqual(res, ["Board A", "Board B"])
+
+    # ------------------------------------------------------------------ #
+    # get_hours_breakdown — Billable Hours Only (Issue #183)
+    # ------------------------------------------------------------------ #
+
+    def _create_test_timesheet(self, time_logs):
+        employee = frappe.db.get_value("Employee", {"user_id": "next-employee@example.com"}, "name")
+        for log in time_logs:
+            if not log.get("description"):
+                log["description"] = "Test timesheet description"
+        ts = frappe.get_doc(
+            {
+                "doctype": "Timesheet",
+                "employee": employee,
+                "note": "Test PM Report Timesheet",
+                "time_logs": time_logs,
+            }
+        )
+        ts.flags.ignore_validate = True
+        ts.insert(ignore_permissions=True)
+        self.test_timesheets.append(ts.name)
+        return ts
+
+    def test_get_hours_breakdown_only_billable_hours(self):
+        """Verify that get_hours_breakdown returns only billable hours and excludes non-billable entries"""
+        # Create a billable task
+        billable_task = frappe.get_doc(
+            {
+                "doctype": "Task",
+                "subject": "Billable Task Alpha",
+                "project": self.project_name,
+                "custom_is_billable": 1,
+            }
+        ).insert(ignore_permissions=True)
+        self.test_tasks.append(billable_task.name)
+
+        # Create a non-billable task
+        non_billable_task = frappe.get_doc(
+            {
+                "doctype": "Task",
+                "subject": "Non-Billable Internal Sync",
+                "project": self.project_name,
+                "custom_is_billable": 0,
+            }
+        ).insert(ignore_permissions=True)
+        self.test_tasks.append(non_billable_task.name)
+
+        # Log timesheet with:
+        # 1. Billable log in range (5.0 hrs)
+        # 2. Billable log in range (3.0 hrs)
+        # 3. Non-billable log in range (4.0 hrs) -> must be excluded
+        # 4. Billable log outside range (2.0 hrs) -> must be excluded
+        self._create_test_timesheet(
+            [
+                {
+                    "task": billable_task.name,
+                    "project": self.project_name,
+                    "hours": 5.0,
+                    "from_time": "2026-06-05 09:00:00",
+                    "to_time": "2026-06-05 14:00:00",
+                    "is_billable": 1,
+                },
+                {
+                    "task": billable_task.name,
+                    "project": self.project_name,
+                    "hours": 3.0,
+                    "from_time": "2026-06-06 09:00:00",
+                    "to_time": "2026-06-06 12:00:00",
+                    "is_billable": 1,
+                },
+                {
+                    "task": non_billable_task.name,
+                    "project": self.project_name,
+                    "hours": 4.0,
+                    "from_time": "2026-06-05 14:00:00",
+                    "to_time": "2026-06-05 18:00:00",
+                    "is_billable": 0,
+                },
+                {
+                    "task": billable_task.name,
+                    "project": self.project_name,
+                    "hours": 2.0,
+                    "from_time": "2026-05-20 09:00:00",
+                    "to_time": "2026-05-20 11:00:00",
+                    "is_billable": 1,
+                },
+            ]
+        )
+
+        breakdown = get_hours_breakdown(self.project_name, "2026-06-01", "2026-06-15")
+
+        # Expect only 1 entry: Billable Task Alpha with 8.0 hours (5.0 + 3.0)
+        self.assertEqual(len(breakdown), 1)
+        self.assertEqual(breakdown[0]["task_title"], "Billable Task Alpha")
+        self.assertEqual(breakdown[0]["hours_consumed"], 8.0)
+
+    def test_get_hours_breakdown_excludes_task_marked_non_billable(self):
+        """Verify that tasks marked custom_is_billable=0 on Task doctype are excluded even if Timesheet Detail has is_billable=1"""
+        task = frappe.get_doc(
+            {
+                "doctype": "Task",
+                "subject": "Changed To Non-Billable Task",
+                "project": self.project_name,
+                "custom_is_billable": 0,
+            }
+        ).insert(ignore_permissions=True)
+        self.test_tasks.append(task.name)
+
+        self._create_test_timesheet(
+            [
+                {
+                    "task": task.name,
+                    "project": self.project_name,
+                    "hours": 3.0,
+                    "from_time": "2026-06-05 09:00:00",
+                    "to_time": "2026-06-05 12:00:00",
+                    "is_billable": 1,
+                }
+            ]
+        )
+
+        breakdown = get_hours_breakdown(self.project_name, "2026-06-01", "2026-06-15")
+        self.assertEqual(breakdown, [])
+
+    def test_get_hours_breakdown_empty(self):
+        """Verify get_hours_breakdown returns empty list when no timesheets exist in range"""
+        breakdown = get_hours_breakdown(self.project_name, "2026-01-01", "2026-01-05")
+        self.assertEqual(breakdown, [])
+
+    def test_generate_pm_report_payload_contains_only_billable_hours(self):
+        """Verify that generate_pm_report passes the billable hours breakdown into the LLM payload"""
+        billable_task = frappe.get_doc(
+            {
+                "doctype": "Task",
+                "subject": "Billable Task Beta",
+                "project": self.project_name,
+                "custom_is_billable": 1,
+            }
+        ).insert(ignore_permissions=True)
+        self.test_tasks.append(billable_task.name)
+
+        non_billable_task = frappe.get_doc(
+            {
+                "doctype": "Task",
+                "subject": "Non-Billable Internal Retro",
+                "project": self.project_name,
+                "custom_is_billable": 0,
+            }
+        ).insert(ignore_permissions=True)
+        self.test_tasks.append(non_billable_task.name)
+
+        self._create_test_timesheet(
+            [
+                {
+                    "task": billable_task.name,
+                    "project": self.project_name,
+                    "hours": 6.5,
+                    "from_time": "2026-06-05 09:00:00",
+                    "to_time": "2026-06-05 15:30:00",
+                    "is_billable": 1,
+                },
+                {
+                    "task": non_billable_task.name,
+                    "project": self.project_name,
+                    "hours": 3.0,
+                    "from_time": "2026-06-05 15:30:00",
+                    "to_time": "2026-06-05 18:30:00",
+                    "is_billable": 0,
+                },
+            ]
+        )
+
+        mock_resp = Response()
+        mock_resp.status_code = 200
+        mock_resp._content = b'{"run_ids": ["mock-run-id-456"], "status": "triggered"}'
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            generate_pm_report(self.project_name, "2026-06-01", "2026-06-15")
+
+            mock_post.assert_called_once()
+            call_kwargs = mock_post.call_args.kwargs
+            import json
+
+            payload = json.loads(call_kwargs.get("data"))
+            hours_breakdown = payload.get("hours_breakdown", [])
+
+            self.assertEqual(len(hours_breakdown), 1)
+            self.assertEqual(hours_breakdown[0]["task_title"], "Billable Task Beta")
+            self.assertEqual(hours_breakdown[0]["hours_consumed"], 6.5)


### PR DESCRIPTION
## Description

Currently, when generating a PM Project Report, `get_hours_breakdown` fetches all timesheet entries within the selected date range and aggregates them by task regardless of whether they are billable. As a result, non-billable hours were included in client-facing report summaries.
This PR ensures that `get_hours_breakdown` strictly filters and returns only **billable hours** (`is_billable = 1`), excluding any internal or non-billable hours from the report breakdown payload sent to the LLM.

## Relevant Technical Choices

* **Database-Level Filter**: Added `"is_billable": 1` to the `Timesheet Detail` query filter so non-billable logs are excluded directly at the database level.
* **Double-Layer Task Validation**: Added a check against `custom_is_billable` on the `Task` doctype. If a task is explicitly marked as non-billable (`custom_is_billable == 0`), it is removed from the hours breakdown even if a timesheet row was logged with `is_billable = 1`.
* **Zero-Hour Guard**: Added a check (`if hours <= 0: continue`) to avoid sending non-positive hours to the LLM payload, preserving 2-decimal float precision.
* **Comprehensive Unit Tests**: Added test cases in `next_pms/tests/test_pm_report.py`:
  - `test_get_hours_breakdown_only_billable_hours`: Verifies only billable logs are aggregated and non-billable/out-of-range logs are excluded.
  - `test_get_hours_breakdown_excludes_task_marked_non_billable`: Verifies task-level `custom_is_billable = 0` override.
  - `test_get_hours_breakdown_empty`: Verifies empty list return when no matching logs exist.
  - `test_generate_pm_report_payload_contains_only_billable_hours`: Verifies end-to-end payload structure sent to the LLM endpoint.


## Testing Instructions

1. Navigate to a Project in Next PMS.
2. Create/ensure two tasks exist:
3. Task A: Billable (custom_is_billable = 1, e.g., "Feature Development")
4. Task B: Non-Billable (custom_is_billable = 0, e.g., "Internal Team Sync")
5. Log timesheet hours against both tasks within a date range.
6. Go to the project's Reports tab and click Generate Project Report for that date range.
7. Verify that the report hours breakdown only includes Task A and completely excludes Task B.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [x] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
- [ ] I have reviewed and updated the documentation as needed.

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes [#183 rt-report-automation](https://github.com/rtCamp/rt-report-automation/issues/183)